### PR TITLE
Restore Privacy notice lost in a merge

### DIFF
--- a/privacy.md
+++ b/privacy.md
@@ -1,0 +1,14 @@
+# Data Collection
+
+The software may collect information about you and your use of the software and send it
+to Microsoft. Microsoft may use this information to provide services and improve our
+products and services. You may turn off the telemetry as described in the repository.
+There are also some features in the software that may enable you and Microsoft to collect
+data from users of your applications. If you use these features, you must comply with
+applicable law, including providing appropriate notices to users of your applications
+together with a copy of Microsoft's privacy statement. Our privacy statement is located
+at https://go.microsoft.com/fwlink/?LinkID=824704. You can learn more about data collection
+and use in the help documentation and our privacy statement. Your use of the software
+operates as your consent to these practices.
+
+For more information on telemetry implementation see the [developer guide](docs/developer_guide.md#Telemetry).


### PR DESCRIPTION
A previous edit to the README attempted to move the privacy data into a specific file, but failed to add the new file.