### PR TITLE
Adding PathExt appending and removal + New removal logic.

### DIFF
--- a/dev/ChangeTracker/ChangeTracker.vcxitems
+++ b/dev/ChangeTracker/ChangeTracker.vcxitems
@@ -16,8 +16,12 @@
   <ItemGroup>
     <ClInclude Include="$(MSBuildThisFileDirectory)EnvironmentVariableChangeTracker.h" />
     <ClInclude Include="$(MSBuildThisFileDirectory)IChangeTracker.h" />
+    <ClInclude Include="$(MSBuildThisFileDirectory)PathChangeTracker.h" />
+    <ClInclude Include="$(MSBuildThisFileDirectory)PathExtChangeTracker.h" />
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="$(MSBuildThisFileDirectory)EnvironmentVariableChangeTracker.cpp" />
+    <ClCompile Include="$(MSBuildThisFileDirectory)PathChangeTracker.cpp" />
+    <ClCompile Include="$(MSBuildThisFileDirectory)PathExtChangeTracker.cpp" />
   </ItemGroup>
 </Project>

--- a/dev/ChangeTracker/EnvironmentVariableChangeTracker.cpp
+++ b/dev/ChangeTracker/EnvironmentVariableChangeTracker.cpp
@@ -45,22 +45,13 @@ namespace winrt::Microsoft::ProjectReunion::implementation
     {
         if (m_ShouldTrackChange)
         {
-            wil::unique_hkey regLocationToWriteChange{ GetKeyForTrackingChange() };
-            // It is possible that the same package in the same scope
-            // will update an EV.  If this is the case we don't need to store
-            // the previous value since we already did that.
-            // All we need to do is record the new value and a new insertion time.
-            bool isCreatingEVForPackage{ IsEVBeingCreated(regLocationToWriteChange.get()) };
+            wil::unique_hkey regLocationToWriteChange{ GetKeyForTrackingChange(nullptr) };
 
-            if (isCreatingEVForPackage)
-            {
-                std::wstring originalValue{ GetOriginalValueOfEV() };
-                RETURN_IF_FAILED(HRESULT_FROM_WIN32(RegSetValueEx(regLocationToWriteChange.get(),
-                    L"PreviousValue", 0, REG_SZ,
-                    reinterpret_cast<const BYTE*>(originalValue.c_str()),
-                    static_cast<DWORD>((originalValue.size() + 1) * sizeof(wchar_t)))));
-
-            }
+            std::wstring originalValue{ GetOriginalValueOfEV() };
+            RETURN_IF_FAILED(HRESULT_FROM_WIN32(RegSetValueEx(regLocationToWriteChange.get(),
+                L"PreviousValue", 0, REG_SZ,
+                reinterpret_cast<const BYTE*>(originalValue.c_str()),
+                static_cast<DWORD>((originalValue.size() + 1) * sizeof(wchar_t)))));
 
             RETURN_IF_FAILED(HRESULT_FROM_WIN32(RegSetValueEx(regLocationToWriteChange.get(),
                 L"CurrentValue", 0, REG_SZ,

--- a/dev/ChangeTracker/EnvironmentVariableChangeTracker.cpp
+++ b/dev/ChangeTracker/EnvironmentVariableChangeTracker.cpp
@@ -1,34 +1,33 @@
-﻿#include <pch.h>
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+#include <pch.h>
 #include <EnvironmentVariableChangeTracker.h>
 
 namespace winrt::Microsoft::ProjectReunion::implementation
 {
-
-    EnvironmentVariableChangeTracker::EnvironmentVariableChangeTracker(std::wstring const& key, std::wstring const& valueToSet, EnvironmentManager::Scope scope)
+    EnvironmentVariableChangeTracker::EnvironmentVariableChangeTracker(const std::wstring& key, const std::wstring& valueToSet, EnvironmentManager::Scope scope)
     {
         THROW_HR_IF(E_INVALIDARG, key.empty());
 
         // Check if we need to track the changes.
         // If we do need to track the changes get the Package Full Name
-        UINT32 sizeOfBuffer{};
-        long fullNameResult{ ::GetCurrentPackageFullName(&sizeOfBuffer, nullptr) };
+        WCHAR packageFullName[PACKAGE_FULL_NAME_MAX_LENGTH + 1]{};
+        UINT32 packageFullNameLength{ static_cast<UINT32>(ARRAYSIZE(packageFullName)) };
+        const long getPackageFullNameRC{ ::GetCurrentPackageFullName(&packageFullNameLength, packageFullName) };
 
-        if (scope == EnvironmentManager::Scope::Process || fullNameResult == APPMODEL_ERROR_NO_PACKAGE)
+
+        if (scope == EnvironmentManager::Scope::Process || getPackageFullNameRC == APPMODEL_ERROR_NO_PACKAGE)
         {
             m_ShouldTrackChange = false;
         }
-        else if (fullNameResult == ERROR_INSUFFICIENT_BUFFER)
+        else if (getPackageFullNameRC == ERROR_SUCCESS)
         {
-            std::unique_ptr<WCHAR> packageFullName(new WCHAR[sizeOfBuffer]);
-
-            LONG getNameResult{ ::GetCurrentPackageFullName(&sizeOfBuffer, packageFullName.get()) };
-            THROW_IF_FAILED(HRESULT_FROM_WIN32(getNameResult));
-            m_PackageFullName = std::wstring(packageFullName.get());
+            m_PackageFullName = std::wstring(packageFullName);
             m_ShouldTrackChange = true;
         }
         else
         {
-            THROW_HR(HRESULT_FROM_WIN32(fullNameResult));
+            THROW_WIN32(getPackageFullNameRC);
         }
 
         m_Scope = scope;
@@ -36,7 +35,7 @@ namespace winrt::Microsoft::ProjectReunion::implementation
         m_Value = valueToSet;
     }
 
-    std::wstring EnvironmentVariableChangeTracker::KeyName()
+    PCWSTR EnvironmentVariableChangeTracker::KeyName() const
     {
         return L"EnvironmentVariables";
     }
@@ -48,22 +47,22 @@ namespace winrt::Microsoft::ProjectReunion::implementation
             wil::unique_hkey regLocationToWriteChange{ GetKeyForTrackingChange(nullptr) };
 
             std::wstring originalValue{ GetOriginalValueOfEV() };
-            RETURN_IF_FAILED(HRESULT_FROM_WIN32(RegSetValueEx(regLocationToWriteChange.get(),
+            RETURN_IF_WIN32_ERROR(RegSetValueEx(regLocationToWriteChange.get(),
                 L"PreviousValue", 0, REG_SZ,
                 reinterpret_cast<const BYTE*>(originalValue.c_str()),
-                static_cast<DWORD>((originalValue.size() + 1) * sizeof(wchar_t)))));
+                static_cast<DWORD>((originalValue.size() + 1) * sizeof(wchar_t))));
 
-            RETURN_IF_FAILED(HRESULT_FROM_WIN32(RegSetValueEx(regLocationToWriteChange.get(),
+            RETURN_IF_WIN32_ERROR(RegSetValueEx(regLocationToWriteChange.get(),
                 L"CurrentValue", 0, REG_SZ,
                 reinterpret_cast<const BYTE*>(m_Value.c_str()),
-                static_cast<DWORD>((m_Value.size() + 1) * sizeof(wchar_t)))));
+                static_cast<DWORD>((m_Value.size() + 1) * sizeof(wchar_t))));
 
             std::chrono::nanoseconds insertionTime{ std::chrono::duration_cast<std::chrono::nanoseconds>(std::chrono::system_clock::now().time_since_epoch()) };
             long long nanoSecondTicks{ insertionTime.count() };
-            RETURN_IF_FAILED(HRESULT_FROM_WIN32(RegSetValueEx(regLocationToWriteChange.get(),
+            RETURN_IF_WIN32_ERROR(RegSetValueEx(regLocationToWriteChange.get(),
                 L"InsertionTime", 0, REG_QWORD,
                 reinterpret_cast<const BYTE*>(&nanoSecondTicks),
-                sizeof(long long))));
+                sizeof(long long)));
         }
 
         return callback();

--- a/dev/ChangeTracker/EnvironmentVariableChangeTracker.h
+++ b/dev/ChangeTracker/EnvironmentVariableChangeTracker.h
@@ -25,11 +25,11 @@ namespace winrt::Microsoft::ProjectReunion::implementation
             wil::unique_hkey environmentVariablesHKey{};
             if (m_Scope == EnvironmentManager::Scope::User)
             {
-                THROW_IF_FAILED(HRESULT_FROM_WIN32(RegOpenKeyEx(HKEY_CURRENT_USER, c_userEvRegLocation.c_str(), 0, KEY_READ, environmentVariablesHKey.addressof())));
+                THROW_IF_FAILED(HRESULT_FROM_WIN32(RegOpenKeyEx(HKEY_CURRENT_USER, c_UserEvRegLocation.c_str(), 0, KEY_READ, environmentVariablesHKey.addressof())));
             }
             else //Scope is Machine
             {
-                THROW_IF_FAILED(HRESULT_FROM_WIN32(RegOpenKeyEx(HKEY_LOCAL_MACHINE, c_machineEvRegLocation.c_str(), 0, KEY_READ, environmentVariablesHKey.addressof())));
+                THROW_IF_FAILED(HRESULT_FROM_WIN32(RegOpenKeyEx(HKEY_LOCAL_MACHINE, c_MachineEvRegLocation.c_str(), 0, KEY_READ, environmentVariablesHKey.addressof())));
             }
 
             return environmentVariablesHKey;

--- a/dev/ChangeTracker/IChangeTracker.h
+++ b/dev/ChangeTracker/IChangeTracker.h
@@ -10,8 +10,8 @@ namespace winrt::Microsoft::ProjectReunion::implementation
         virtual HRESULT TrackChange(std::function<HRESULT(void)> callBack) = 0;
 
         bool m_ShouldTrackChange{ false };
-        const std::wstring c_userEvRegLocation{ L"Environment" };
-        const std::wstring c_machineEvRegLocation{ L"SYSTEM\\CurrentControlSet\\Control\\Session Manager\\Environment" };
+        const std::wstring c_UserEvRegLocation{ L"Environment" };
+        const std::wstring c_MachineEvRegLocation{ L"SYSTEM\\CurrentControlSet\\Control\\Session Manager\\Environment" };
         std::wstring m_PackageFullName;
 
         enum PathOperation

--- a/dev/ChangeTracker/IChangeTracker.h
+++ b/dev/ChangeTracker/IChangeTracker.h
@@ -1,4 +1,6 @@
-﻿#pragma once
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+#pragma once
 #include <string>
 #include <functional>
 #include <windows.h>
@@ -9,9 +11,9 @@ namespace winrt::Microsoft::ProjectReunion::implementation
     public:
         virtual HRESULT TrackChange(std::function<HRESULT(void)> callBack) = 0;
 
-        bool m_ShouldTrackChange{ false };
-        const std::wstring c_UserEvRegLocation{ L"Environment" };
-        const std::wstring c_MachineEvRegLocation{ L"SYSTEM\\CurrentControlSet\\Control\\Session Manager\\Environment" };
+        bool m_ShouldTrackChange{};
+        static inline const std::wstring c_UserEvRegLocation{ L"Environment" };
+        static inline const std::wstring c_MachineEvRegLocation{ L"SYSTEM\\CurrentControlSet\\Control\\Session Manager\\Environment" };
         std::wstring m_PackageFullName;
 
         enum PathOperation
@@ -20,8 +22,9 @@ namespace winrt::Microsoft::ProjectReunion::implementation
             Remove
         };
 
+        virtual PCWSTR KeyName() const = 0;
+
     private:
-        virtual std::wstring KeyName() = 0;
 
     };
 }

--- a/dev/ChangeTracker/IChangeTracker.h
+++ b/dev/ChangeTracker/IChangeTracker.h
@@ -10,7 +10,15 @@ namespace winrt::Microsoft::ProjectReunion::implementation
         virtual HRESULT TrackChange(std::function<HRESULT(void)> callBack) = 0;
 
         bool m_ShouldTrackChange{ false };
+        const std::wstring c_userEvRegLocation{ L"Environment" };
+        const std::wstring c_machineEvRegLocation{ L"SYSTEM\\CurrentControlSet\\Control\\Session Manager\\Environment" };
         std::wstring m_PackageFullName;
+
+        enum PathOperation
+        {
+            Append,
+            Remove
+        };
 
     private:
         virtual std::wstring KeyName() = 0;

--- a/dev/ChangeTracker/PathChangeTracker.cpp
+++ b/dev/ChangeTracker/PathChangeTracker.cpp
@@ -1,0 +1,119 @@
+﻿#include <pch.h>
+#include <PathChangeTracker.h>
+
+
+namespace winrt::Microsoft::ProjectReunion::implementation
+{
+
+    PathChangeTracker::PathChangeTracker(std::wstring const& pathPart, EnvironmentManager::Scope scope, PathOperation operation)
+    {
+        THROW_HR_IF(E_INVALIDARG, pathPart.empty());
+
+        // Check if we need to track the changes.
+        // If we do need to track the changes get the Package Full Name
+        UINT32 sizeOfBuffer{};
+        long fullNameResult{ ::GetCurrentPackageFullName(&sizeOfBuffer, nullptr) };
+
+        if (scope == EnvironmentManager::Scope::Process || fullNameResult == APPMODEL_ERROR_NO_PACKAGE)
+        {
+            m_ShouldTrackChange = false;
+        }
+        else if (fullNameResult == ERROR_INSUFFICIENT_BUFFER)
+        {
+            std::unique_ptr<WCHAR> packageFullName(new WCHAR[sizeOfBuffer]);
+
+            LONG getNameResult{ ::GetCurrentPackageFullName(&sizeOfBuffer, packageFullName.get()) };
+            THROW_IF_FAILED(HRESULT_FROM_WIN32(getNameResult));
+            m_PackageFullName = std::wstring(packageFullName.get());
+            m_ShouldTrackChange = true;
+        }
+        else
+        {
+            THROW_HR(HRESULT_FROM_WIN32(fullNameResult));
+        }
+
+        m_Scope = scope;
+        m_PathPart = pathPart;
+        m_Operation = operation;
+    }
+
+    std::wstring PathChangeTracker::KeyName()
+    {
+        return L"PATH";
+    }
+
+    HRESULT PathChangeTracker::TrackChange(std::function<HRESULT(void)> callback)
+    {
+        if (m_ShouldTrackChange)
+        {
+            if (m_PathPart.back() != L';')
+            {
+                m_PathPart += L';';
+            }
+
+            wil::unique_hkey regLocationToWriteChange{ GetKeyForTrackingChange(nullptr) };
+
+            if (m_Operation == PathOperation::Append)
+            {
+                std::wstring previouslyAppendedValues{ GetValueFromTracking(std::wstring(L"AppendedValues"))};
+
+                previouslyAppendedValues += m_PathPart;
+
+                RETURN_IF_FAILED(HRESULT_FROM_WIN32(RegSetValueEx(regLocationToWriteChange.get(),
+                    L"AppendedValues", 0, REG_SZ,
+                    reinterpret_cast<const BYTE*>(previouslyAppendedValues.c_str()),
+                    static_cast<DWORD>((previouslyAppendedValues.size() + 1) * sizeof(wchar_t)))));
+            }
+            else
+            {
+                // Find the index of the path part to remove.
+                // The index allows the DEH best-effort to add the
+                // removed value at its correct location.
+                std::wstring existingPath{ QueryEvFromRegistry(L"Path", GetKeyForEnvironmentVariable().get())};
+
+                int index{ -1 };
+
+                wchar_t* token;
+                wchar_t* tokenizationState;
+                token = wcstok_s(existingPath.data(), L";", &tokenizationState);
+                bool foundPathPart{ false };
+                while (token != nullptr && !foundPathPart)
+                {
+                    std::wstring pathPartToken{ token };
+
+                    pathPartToken += L';';
+
+                    if (CompareStringOrdinal(m_PathPart.c_str(), -1,
+                        pathPartToken.c_str(), -1,
+                        TRUE) == CSTR_EQUAL)
+                    {
+                        foundPathPart = true;
+                    }
+
+                    index++;
+                    token = wcstok_s(NULL, L";", &tokenizationState);
+                }
+
+
+                if (foundPathPart)
+                {
+                    std::wstring previouslyRemovedValues{ GetValueFromTracking(std::wstring(L"RemovedValues")) };
+
+                    std::wstring removalInformation{ m_PathPart };
+                    removalInformation += L",";
+                    removalInformation += std::to_wstring(index);
+                    removalInformation += L"\t";
+
+                    previouslyRemovedValues += removalInformation;
+
+                    RETURN_IF_FAILED(HRESULT_FROM_WIN32(RegSetValueEx(regLocationToWriteChange.get(),
+                        L"RemovedValues", 0, REG_SZ,
+                        reinterpret_cast<const BYTE*>(previouslyRemovedValues.c_str()),
+                        static_cast<DWORD>((previouslyRemovedValues.size() + 1) * sizeof(wchar_t)))));
+                }
+            }
+        }
+
+        return callback();
+    }
+}

--- a/dev/ChangeTracker/PathChangeTracker.h
+++ b/dev/ChangeTracker/PathChangeTracker.h
@@ -24,11 +24,11 @@ namespace winrt::Microsoft::ProjectReunion::implementation
             wil::unique_hkey environmentVariablesHKey{};
             if (m_Scope == EnvironmentManager::Scope::User)
             {
-                THROW_IF_FAILED(HRESULT_FROM_WIN32(RegOpenKeyEx(HKEY_CURRENT_USER, c_userEvRegLocation.c_str(), 0, KEY_READ, environmentVariablesHKey.addressof())));
+                THROW_IF_FAILED(HRESULT_FROM_WIN32(RegOpenKeyEx(HKEY_CURRENT_USER, c_UserEvRegLocation.c_str(), 0, KEY_READ, environmentVariablesHKey.addressof())));
             }
             else //Scope is Machine
             {
-                THROW_IF_FAILED(HRESULT_FROM_WIN32(RegOpenKeyEx(HKEY_LOCAL_MACHINE, c_machineEvRegLocation.c_str(), 0, KEY_READ, environmentVariablesHKey.addressof())));
+                THROW_IF_FAILED(HRESULT_FROM_WIN32(RegOpenKeyEx(HKEY_LOCAL_MACHINE, c_MachineEvRegLocation.c_str(), 0, KEY_READ, environmentVariablesHKey.addressof())));
             }
 
             return environmentVariablesHKey;

--- a/dev/ChangeTracker/PathExtChangeTracker.cpp
+++ b/dev/ChangeTracker/PathExtChangeTracker.cpp
@@ -1,0 +1,117 @@
+﻿#include <pch.h>
+#include <PathExtChangeTracker.h>
+
+
+namespace winrt::Microsoft::ProjectReunion::implementation
+{
+
+    PathExtChangeTracker::PathExtChangeTracker(std::wstring const& pathPart, EnvironmentManager::Scope scope, PathOperation operation)
+    {
+        THROW_HR_IF(E_INVALIDARG, pathPart.empty());
+
+        // Check if we need to track the changes.
+        // If we do need to track the changes get the Package Full Name
+        UINT32 sizeOfBuffer{};
+        long fullNameResult{ ::GetCurrentPackageFullName(&sizeOfBuffer, nullptr) };
+
+        if (scope == EnvironmentManager::Scope::Process || fullNameResult == APPMODEL_ERROR_NO_PACKAGE)
+        {
+            m_ShouldTrackChange = false;
+        }
+        else if (fullNameResult == ERROR_INSUFFICIENT_BUFFER)
+        {
+            std::unique_ptr<WCHAR> packageFullName(new WCHAR[sizeOfBuffer]);
+
+            LONG getNameResult{ ::GetCurrentPackageFullName(&sizeOfBuffer, packageFullName.get()) };
+            THROW_IF_FAILED(HRESULT_FROM_WIN32(getNameResult));
+            m_PackageFullName = std::wstring(packageFullName.get());
+            m_ShouldTrackChange = true;
+        }
+        else
+        {
+            THROW_HR(HRESULT_FROM_WIN32(fullNameResult));
+        }
+
+        m_Scope = scope;
+        m_PathPart = pathPart;
+        m_Operation = operation;
+    }
+
+    std::wstring PathExtChangeTracker::KeyName()
+    {
+        return L"PATHEXT";
+    }
+
+    HRESULT PathExtChangeTracker::TrackChange(std::function<HRESULT(void)> callback)
+    {
+        if (m_ShouldTrackChange)
+        {
+            if (m_PathPart.back() != L';')
+            {
+                m_PathPart += L';';
+            }
+
+            wil::unique_hkey regLocationToWriteChange{ GetKeyForTrackingChange(nullptr) };
+
+            if (m_Operation == PathOperation::Append)
+            {
+                std::wstring previouslyAppendedValues{ GetValueFromTracking(std::wstring(L"AppendedValues")) };
+
+                previouslyAppendedValues += m_PathPart;
+
+                RETURN_IF_FAILED(HRESULT_FROM_WIN32(RegSetValueEx(regLocationToWriteChange.get(),
+                    L"AppendedValues", 0, REG_SZ,
+                    reinterpret_cast<const BYTE*>(previouslyAppendedValues.c_str()),
+                    static_cast<DWORD>((previouslyAppendedValues.size() + 1) * sizeof(wchar_t)))));
+            }
+            else
+            {
+                // Find the index of the path part to remove.
+                // The index allows the DEH best-effort to add the
+                // removed value at its correct location.
+                std::wstring existingPath{ QueryEvFromRegistry(L"Path", GetKeyForEnvironmentVariable().get()) };
+
+                int index{ -1 };
+
+                wchar_t* token;
+                wchar_t* tokenizationState;
+                token = wcstok_s(existingPath.data(), L";", &tokenizationState);
+                bool foundPathPart{ false };
+                while (token != nullptr && !foundPathPart)
+                {
+                    std::wstring pathPartToken{ token };
+
+                    pathPartToken += L';';
+
+                    if (CompareStringOrdinal(m_PathPart.c_str(), -1,
+                        pathPartToken.c_str(), -1,
+                        TRUE) == CSTR_EQUAL)
+                    {
+                        foundPathPart = true;
+                    }
+
+                    index++;
+                    token = wcstok_s(NULL, L";", &tokenizationState);
+                }
+
+                std::wstring previouslyRemovedValues{ GetValueFromTracking(std::wstring(L"RemovedValues")) };
+
+                std::wstring removalInformation{ m_PathPart };
+                removalInformation += L",";
+                removalInformation += std::to_wstring(index);
+                removalInformation += L"\t";
+
+                previouslyRemovedValues += removalInformation;
+
+                previouslyRemovedValues += m_PathPart;
+
+                RETURN_IF_FAILED(HRESULT_FROM_WIN32(RegSetValueEx(regLocationToWriteChange.get(),
+                    L"RemovedValues", 0, REG_SZ,
+                    reinterpret_cast<const BYTE*>(previouslyRemovedValues.c_str()),
+                    static_cast<DWORD>((previouslyRemovedValues.size() + 1) * sizeof(wchar_t)))));
+            }
+        }
+
+        return callback();
+    }
+}

--- a/dev/ChangeTracker/PathExtChangeTracker.h
+++ b/dev/ChangeTracker/PathExtChangeTracker.h
@@ -25,11 +25,11 @@ namespace winrt::Microsoft::ProjectReunion::implementation
             wil::unique_hkey environmentVariablesHKey{};
             if (m_Scope == EnvironmentManager::Scope::User)
             {
-                THROW_IF_FAILED(HRESULT_FROM_WIN32(RegOpenKeyEx(HKEY_CURRENT_USER, c_userEvRegLocation.c_str(), 0, KEY_READ, environmentVariablesHKey.addressof())));
+                THROW_IF_FAILED(HRESULT_FROM_WIN32(RegOpenKeyEx(HKEY_CURRENT_USER, c_UserEvRegLocation.c_str(), 0, KEY_READ, environmentVariablesHKey.addressof())));
             }
             else //Scope is Machine
             {
-                THROW_IF_FAILED(HRESULT_FROM_WIN32(RegOpenKeyEx(HKEY_LOCAL_MACHINE, c_machineEvRegLocation.c_str(), 0, KEY_READ, environmentVariablesHKey.addressof())));
+                THROW_IF_FAILED(HRESULT_FROM_WIN32(RegOpenKeyEx(HKEY_LOCAL_MACHINE, c_MachineEvRegLocation.c_str(), 0, KEY_READ, environmentVariablesHKey.addressof())));
             }
 
             return environmentVariablesHKey;

--- a/dev/ChangeTracker/PathExtChangeTracker.h
+++ b/dev/ChangeTracker/PathExtChangeTracker.h
@@ -1,4 +1,6 @@
-﻿#pragma once
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+#pragma once
 #include "IChangeTracker.h"
 #include <EnvironmentManager.h>
 #include <wil/registry.h>
@@ -7,35 +9,33 @@ namespace winrt::Microsoft::ProjectReunion::implementation
 {
     struct PathExtChangeTracker : public IChangeTracker
     {
-
-        PathExtChangeTracker(std::wstring const& pathExtPart, EnvironmentManager::Scope scope, PathOperation operation);
+        PathExtChangeTracker(const std::wstring& pathExtPart, EnvironmentManager::Scope scope, PathOperation operation);
         HRESULT TrackChange(std::function<HRESULT(void)> callBack);
-
 
     private:
         EnvironmentManager::Scope m_Scope;
         std::wstring m_PathExtPart{};
-        std::wstring KeyName();
+        PCWSTR KeyName() const;
         PathOperation m_Operation;
 
-        wil::unique_hkey GetKeyForEnvironmentVariable()
+        wil::unique_hkey GetKeyForEnvironmentVariable() const
         {
             FAIL_FAST_HR_IF(E_INVALIDARG, m_Scope == EnvironmentManager::Scope::Process);
 
             wil::unique_hkey environmentVariablesHKey{};
             if (m_Scope == EnvironmentManager::Scope::User)
             {
-                THROW_IF_FAILED(HRESULT_FROM_WIN32(RegOpenKeyEx(HKEY_CURRENT_USER, c_UserEvRegLocation.c_str(), 0, KEY_READ, environmentVariablesHKey.addressof())));
+                THROW_IF_WIN32_ERROR(RegOpenKeyEx(HKEY_CURRENT_USER, c_UserEvRegLocation.c_str(), 0, KEY_READ, environmentVariablesHKey.addressof()));
             }
             else //Scope is Machine
             {
-                THROW_IF_FAILED(HRESULT_FROM_WIN32(RegOpenKeyEx(HKEY_LOCAL_MACHINE, c_MachineEvRegLocation.c_str(), 0, KEY_READ, environmentVariablesHKey.addressof())));
+                THROW_IF_WIN32_ERROR(RegOpenKeyEx(HKEY_LOCAL_MACHINE, c_MachineEvRegLocation.c_str(), 0, KEY_READ, environmentVariablesHKey.addressof()));
             }
 
             return environmentVariablesHKey;
         }
 
-        wil::unique_hkey GetKeyForTrackingChange(LPDWORD disposition)
+        wil::unique_hkey GetKeyForTrackingChange(DWORD* disposition) const
         {
             HKEY topLevelKey{};
 
@@ -49,17 +49,17 @@ namespace winrt::Microsoft::ProjectReunion::implementation
             }
 
             auto subKey{ wil::str_printf<wil::unique_cotaskmem_string>(
-                L"Software\\ChangeTracker\\%ws\\%ws\\", KeyName().c_str(), m_PackageFullName.c_str()) };
+                L"Software\\ChangeTracker\\%ws\\%ws\\", KeyName(), m_PackageFullName.c_str()) };
 
             wil::unique_hkey keyToTrackChanges{};
-            THROW_IF_FAILED(HRESULT_FROM_WIN32(RegCreateKeyEx(HKEY_CURRENT_USER,
+            THROW_IF_WIN32_ERROR(RegCreateKeyEx(HKEY_CURRENT_USER,
                 subKey.get(), 0, nullptr, REG_OPTION_NON_VOLATILE,
-                KEY_ALL_ACCESS | KEY_WOW64_64KEY, nullptr, keyToTrackChanges.put(), disposition)));
+                KEY_ALL_ACCESS | KEY_WOW64_64KEY, nullptr, keyToTrackChanges.put(), disposition));
 
             return keyToTrackChanges;
         }
 
-        std::wstring GetValueFromTracking(std::wstring valueName)
+        std::wstring GetValueFromTracking(const std::wstring& valueName) const
         {
             wil::unique_hkey changeTrackingKey{ GetKeyForTrackingChange(nullptr) };
             DWORD sizeOfEnvironmentValue;
@@ -73,24 +73,24 @@ namespace winrt::Microsoft::ProjectReunion::implementation
             {
                 if (queryResult == ERROR_FILE_NOT_FOUND)
                 {
-                    return L"";
+                    return {};
                 }
 
-                THROW_HR(HRESULT_FROM_WIN32((queryResult)));
+                THROW_WIN32(queryResult);
             }
 
             std::unique_ptr<wchar_t[]> environmentValue(new wchar_t[sizeOfEnvironmentValue]);
             THROW_IF_FAILED(HRESULT_FROM_WIN32((RegQueryValueEx(
                 changeTrackingKey.get(), valueName.c_str(), 0, nullptr,
-                (LPBYTE)environmentValue.get(),
+                reinterpret_cast<BYTE*>(environmentValue.get()),
                 &sizeOfEnvironmentValue))));
 
             return std::wstring(environmentValue.get());
         }
 
-        std::wstring QueryEvFromRegistry(std::wstring variableKey, HKEY KeyToOpen)
+        std::wstring QueryEvFromRegistry(const std::wstring& variableKey, const HKEY KeyToOpen) const
         {
-            DWORD sizeOfEnvironmentValue;
+            DWORD sizeOfEnvironmentValue{};
 
             // See how big we need the buffer to be
             LSTATUS queryResult{ RegQueryValueEx(KeyToOpen,
@@ -101,17 +101,17 @@ namespace winrt::Microsoft::ProjectReunion::implementation
             {
                 if (queryResult == ERROR_FILE_NOT_FOUND)
                 {
-                    return L"";
+                    return {};
                 }
 
-                THROW_HR(HRESULT_FROM_WIN32((queryResult)));
+                THROW_WIN32(queryResult);
             }
 
             std::unique_ptr<wchar_t[]> environmentValue(new wchar_t[sizeOfEnvironmentValue]);
-            THROW_IF_FAILED(HRESULT_FROM_WIN32((RegQueryValueEx(
+            THROW_IF_WIN32_ERROR(RegQueryValueEx(
                 KeyToOpen, variableKey.c_str(), 0, nullptr,
-                (LPBYTE)environmentValue.get(),
-                &sizeOfEnvironmentValue))));
+                reinterpret_cast<BYTE*>(environmentValue.get()),
+                &sizeOfEnvironmentValue));
 
             return std::wstring(environmentValue.get());
         }

--- a/dev/ChangeTracker/PathExtChangeTracker.h
+++ b/dev/ChangeTracker/PathExtChangeTracker.h
@@ -8,13 +8,13 @@ namespace winrt::Microsoft::ProjectReunion::implementation
     struct PathExtChangeTracker : public IChangeTracker
     {
 
-        PathExtChangeTracker(std::wstring const& pathPart, EnvironmentManager::Scope scope, PathOperation operation);
+        PathExtChangeTracker(std::wstring const& pathExtPart, EnvironmentManager::Scope scope, PathOperation operation);
         HRESULT TrackChange(std::function<HRESULT(void)> callBack);
 
 
     private:
         EnvironmentManager::Scope m_Scope;
-        std::wstring m_PathPart{};
+        std::wstring m_PathExtPart{};
         std::wstring KeyName();
         PathOperation m_Operation;
 

--- a/dev/ChangeTracker/PathExtChangeTracker.h
+++ b/dev/ChangeTracker/PathExtChangeTracker.h
@@ -3,20 +3,20 @@
 #include <EnvironmentManager.h>
 #include <wil/registry.h>
 
-using namespace winrt::Windows::Foundation::Collections;
 namespace winrt::Microsoft::ProjectReunion::implementation
 {
-    struct EnvironmentVariableChangeTracker : public IChangeTracker
+    struct PathExtChangeTracker : public IChangeTracker
     {
-        EnvironmentVariableChangeTracker(std::wstring const& key, std::wstring const& valueToSet, EnvironmentManager::Scope scope);
+
+        PathExtChangeTracker(std::wstring const& pathPart, EnvironmentManager::Scope scope, PathOperation operation);
         HRESULT TrackChange(std::function<HRESULT(void)> callBack);
+
 
     private:
         EnvironmentManager::Scope m_Scope;
-        std::wstring m_Key;
-        std::wstring m_Value;
-
+        std::wstring m_PathPart{};
         std::wstring KeyName();
+        PathOperation m_Operation;
 
         wil::unique_hkey GetKeyForEnvironmentVariable()
         {
@@ -49,7 +49,7 @@ namespace winrt::Microsoft::ProjectReunion::implementation
             }
 
             auto subKey{ wil::str_printf<wil::unique_cotaskmem_string>(
-                L"Software\\ChangeTracker\\%ws\\%ws\\%ws\\", KeyName().c_str(), m_PackageFullName.c_str(), m_Key.c_str()) };
+                L"Software\\ChangeTracker\\%ws\\%ws\\", KeyName().c_str(), m_PackageFullName.c_str()) };
 
             wil::unique_hkey keyToTrackChanges{};
             THROW_IF_FAILED(HRESULT_FROM_WIN32(RegCreateKeyEx(HKEY_CURRENT_USER,
@@ -59,29 +59,33 @@ namespace winrt::Microsoft::ProjectReunion::implementation
             return keyToTrackChanges;
         }
 
-        bool IsEVBeingCreated(HKEY keyToChangeTracker)
+        std::wstring GetValueFromTracking(std::wstring valueName)
         {
-            LSTATUS queryStatus{ RegQueryValueEx(keyToChangeTracker,
-                L"PreviousValue", 0, nullptr, nullptr, nullptr) };
+            wil::unique_hkey changeTrackingKey{ GetKeyForTrackingChange(nullptr) };
+            DWORD sizeOfEnvironmentValue;
 
-            if (queryStatus == ERROR_FILE_NOT_FOUND)
-            {
-                return true;
-            }
-            else if (queryStatus == ERROR_SUCCESS)
-            {
-                return false;
-            }
-            else
-            {
-                THROW_HR(HRESULT_FROM_WIN32(queryStatus));
-            }
-        }
+            // See how big we need the buffer to be
+            LSTATUS queryResult{ RegQueryValueEx(changeTrackingKey.get(),
+                valueName.c_str(), 0, nullptr, nullptr,
+                &sizeOfEnvironmentValue) };
 
-        std::wstring GetOriginalValueOfEV()
-        {
-            wil::unique_hkey environmentVariableHKey{ GetKeyForEnvironmentVariable() };
-            return QueryEvFromRegistry(m_Key, environmentVariableHKey.get());
+            if (queryResult != ERROR_SUCCESS)
+            {
+                if (queryResult == ERROR_FILE_NOT_FOUND)
+                {
+                    return L"";
+                }
+
+                THROW_HR(HRESULT_FROM_WIN32((queryResult)));
+            }
+
+            std::unique_ptr<wchar_t[]> environmentValue(new wchar_t[sizeOfEnvironmentValue]);
+            THROW_IF_FAILED(HRESULT_FROM_WIN32((RegQueryValueEx(
+                changeTrackingKey.get(), valueName.c_str(), 0, nullptr,
+                (LPBYTE)environmentValue.get(),
+                &sizeOfEnvironmentValue))));
+
+            return std::wstring(environmentValue.get());
         }
 
         std::wstring QueryEvFromRegistry(std::wstring variableKey, HKEY KeyToOpen)

--- a/dev/Microsoft.Process.Environment/EnvironmentManager.cpp
+++ b/dev/Microsoft.Process.Environment/EnvironmentManager.cpp
@@ -69,11 +69,6 @@ namespace winrt::Microsoft::ProjectReunion::implementation
         }
     }
 
-    bool EnvironmentManager::IsSupported()
-    {
-        throw hresult_not_implemented();
-    }
-
     void EnvironmentManager::SetEnvironmentVariable(hstring const& name, hstring const& value)
     {
         auto setEV = [&, name, value, this]()

--- a/dev/Microsoft.Process.Environment/EnvironmentManager.cpp
+++ b/dev/Microsoft.Process.Environment/EnvironmentManager.cpp
@@ -327,7 +327,7 @@ namespace winrt::Microsoft::ProjectReunion::implementation
             return S_OK;
         };
 
-        PathExtChangeTracker changeTracker(std::wstring(newPathExt), m_Scope, IChangeTracker::PathOperation::Append);
+        PathExtChangeTracker changeTracker(std::wstring(pathExt), m_Scope, IChangeTracker::PathOperation::Append);
 
         THROW_IF_FAILED(changeTracker.TrackChange(setPathExt));
     }
@@ -409,7 +409,7 @@ namespace winrt::Microsoft::ProjectReunion::implementation
 
         if (foundPathExtPart)
         {
-            PathExtChangeTracker changeTracker(std::wstring(currentPathExt), m_Scope, IChangeTracker::PathOperation::Remove);
+            PathExtChangeTracker changeTracker(std::wstring(pathExt), m_Scope, IChangeTracker::PathOperation::Remove);
 
             THROW_IF_FAILED(changeTracker.TrackChange(removeFromPathExt));
         }
@@ -468,7 +468,7 @@ namespace winrt::Microsoft::ProjectReunion::implementation
             DWORD sizeOfEnvironmentValue{};
 
             // See how big we need the buffer to be
-            LSTATUS queryResult{ RegQueryValueEx(environmentVariableKey.get(), c_PathName, 0, nullptr, nullptr, &sizeOfEnvironmentValue) };
+            LSTATUS queryResult{ RegQueryValueEx(environmentVariableKey.get(), c_PathExtName, 0, nullptr, nullptr, &sizeOfEnvironmentValue) };
 
             if (queryResult == ERROR_FILE_NOT_FOUND)
             {
@@ -480,7 +480,7 @@ namespace winrt::Microsoft::ProjectReunion::implementation
             }
 
             std::unique_ptr<wchar_t[]> environmentValue(new wchar_t[sizeOfEnvironmentValue]);
-            THROW_IF_FAILED(HRESULT_FROM_WIN32((RegQueryValueEx(environmentVariableKey.get(), c_PathName, 0, nullptr, (LPBYTE)environmentValue.get(), &sizeOfEnvironmentValue))));
+            THROW_IF_FAILED(HRESULT_FROM_WIN32((RegQueryValueEx(environmentVariableKey.get(), c_PathExtName, 0, nullptr, (LPBYTE)environmentValue.get(), &sizeOfEnvironmentValue))));
 
             pathExt = std::wstring(environmentValue.get());
         }

--- a/dev/Microsoft.Process.Environment/EnvironmentManager.cpp
+++ b/dev/Microsoft.Process.Environment/EnvironmentManager.cpp
@@ -162,13 +162,13 @@ namespace winrt::Microsoft::ProjectReunion::implementation
             {
                 wil::unique_hkey environmentVariableKey{ GetRegHKeyForEVUserAndMachineScope(true) };
 
-                THROW_IF_FAILED(HRESULT_FROM_WIN32(RegSetValueEx(
+                THROW_IF_WIN32_ERROR(RegSetValueEx(
                     environmentVariableKey.get()
                     , c_PathName
                     , 0
                     , REG_EXPAND_SZ
                     , reinterpret_cast<const BYTE*>(newPath.c_str())
-                    , static_cast<DWORD>((newPath.size() + 1) * sizeof(wchar_t)))));
+                    , static_cast<DWORD>((newPath.size() + 1) * sizeof(wchar_t))));
 
                 LRESULT broadcastResult{ SendMessageTimeout(HWND_BROADCAST, WM_SETTINGCHANGE,
                     reinterpret_cast<WPARAM>(nullptr), reinterpret_cast<LPARAM>(L"Environment"),
@@ -176,7 +176,7 @@ namespace winrt::Microsoft::ProjectReunion::implementation
 
                 if (broadcastResult == 0)
                 {
-                    THROW_HR(HRESULT_FROM_WIN32(GetLastError()));
+                    THROW_WIN32(GetLastError());
                 }
             }
 
@@ -242,13 +242,13 @@ namespace winrt::Microsoft::ProjectReunion::implementation
             {
                 wil::unique_hkey environmentVariableKey{ GetRegHKeyForEVUserAndMachineScope(true) };
 
-                THROW_IF_FAILED(HRESULT_FROM_WIN32(RegSetValueEx(
+                THROW_IF_WIN32_ERROR(RegSetValueEx(
                     environmentVariableKey.get()
                     , c_PathName
                     , 0
                     , REG_EXPAND_SZ
                     , reinterpret_cast<const BYTE*>(currentPath.c_str())
-                    , static_cast<DWORD>((currentPath.size() + 1) * sizeof(wchar_t)))));
+                    , static_cast<DWORD>((currentPath.size() + 1) * sizeof(wchar_t))));
 
                 LRESULT broadcastResult{ SendMessageTimeout(HWND_BROADCAST, WM_SETTINGCHANGE,
                     reinterpret_cast<WPARAM>(nullptr), reinterpret_cast<LPARAM>(L"Environment"),
@@ -256,7 +256,7 @@ namespace winrt::Microsoft::ProjectReunion::implementation
 
                 if (broadcastResult == 0)
                 {
-                    THROW_HR(HRESULT_FROM_WIN32(GetLastError()));
+                    THROW_WIN32(GetLastError());
                 }
             }
 
@@ -301,13 +301,13 @@ namespace winrt::Microsoft::ProjectReunion::implementation
             {
                 wil::unique_hkey environmentVariableKey{ GetRegHKeyForEVUserAndMachineScope(true) };
 
-                THROW_IF_FAILED(HRESULT_FROM_WIN32(RegSetValueEx(
+                THROW_IF_WIN32_ERROR(RegSetValueEx(
                     environmentVariableKey.get()
                     , c_PathExtName
                     , 0
                     , REG_EXPAND_SZ
                     , reinterpret_cast<const BYTE*>(newPathExt.c_str())
-                    , static_cast<DWORD>((newPathExt.size() + 1) * sizeof(wchar_t)))));
+                    , static_cast<DWORD>((newPathExt.size() + 1) * sizeof(wchar_t))));
 
                 LRESULT broadcastResult{ SendMessageTimeout(HWND_BROADCAST, WM_SETTINGCHANGE,
                     reinterpret_cast<WPARAM>(nullptr), reinterpret_cast<LPARAM>(L"Environment"),
@@ -315,7 +315,7 @@ namespace winrt::Microsoft::ProjectReunion::implementation
 
                 if (broadcastResult == 0)
                 {
-                    THROW_HR(HRESULT_FROM_WIN32(GetLastError()));
+                    THROW_WIN32(GetLastError());
                 }
             }
 
@@ -381,13 +381,13 @@ namespace winrt::Microsoft::ProjectReunion::implementation
             {
                 wil::unique_hkey environmentVariableKey{ GetRegHKeyForEVUserAndMachineScope(true) };
 
-                THROW_IF_FAILED(HRESULT_FROM_WIN32(RegSetValueEx(
+                THROW_IF_WIN32_ERROR(RegSetValueEx(
                     environmentVariableKey.get()
                     , c_PathExtName
                     , 0
                     , REG_EXPAND_SZ
                     , reinterpret_cast<const BYTE*>(currentPathExt.c_str())
-                    , static_cast<DWORD>((currentPathExt.size() + 1) * sizeof(wchar_t)))));
+                    , static_cast<DWORD>((currentPathExt.size() + 1) * sizeof(wchar_t))));
 
                 LRESULT broadcastResult{ SendMessageTimeout(HWND_BROADCAST, WM_SETTINGCHANGE,
                     reinterpret_cast<WPARAM>(nullptr), reinterpret_cast<LPARAM>(L"Environment"),
@@ -395,7 +395,7 @@ namespace winrt::Microsoft::ProjectReunion::implementation
 
                 if (broadcastResult == 0)
                 {
-                    THROW_HR(HRESULT_FROM_WIN32(GetLastError()));
+                    THROW_WIN32(GetLastError());
                 }
             }
 
@@ -432,11 +432,11 @@ namespace winrt::Microsoft::ProjectReunion::implementation
             }
             else if (queryResult != ERROR_SUCCESS)
             {
-                THROW_HR(HRESULT_FROM_WIN32((queryResult)));
+                THROW_WIN32(queryResult);
             }
 
             std::unique_ptr<wchar_t[]> environmentValue(new wchar_t[sizeOfEnvironmentValue]);
-            THROW_IF_FAILED(HRESULT_FROM_WIN32((RegQueryValueEx(environmentVariableKey.get(), c_PathName, 0, nullptr, (LPBYTE)environmentValue.get(), &sizeOfEnvironmentValue))));
+            THROW_IF_WIN32_ERROR(RegQueryValueEx(environmentVariableKey.get(), c_PathName, 0, nullptr, (LPBYTE)environmentValue.get(), &sizeOfEnvironmentValue));
 
             path = std::wstring(environmentValue.get());
         }
@@ -471,11 +471,11 @@ namespace winrt::Microsoft::ProjectReunion::implementation
             }
             else if (queryResult != ERROR_SUCCESS)
             {
-                THROW_HR(HRESULT_FROM_WIN32((queryResult)));
+                THROW_WIN32(queryResult);
             }
 
             std::unique_ptr<wchar_t[]> environmentValue(new wchar_t[sizeOfEnvironmentValue]);
-            THROW_IF_FAILED(HRESULT_FROM_WIN32((RegQueryValueEx(environmentVariableKey.get(), c_PathExtName, 0, nullptr, (LPBYTE)environmentValue.get(), &sizeOfEnvironmentValue))));
+            THROW_IF_WIN32_ERROR(RegQueryValueEx(environmentVariableKey.get(), c_PathExtName, 0, nullptr, (LPBYTE)environmentValue.get(), &sizeOfEnvironmentValue));
 
             pathExt = std::wstring(environmentValue.get());
         }
@@ -556,7 +556,7 @@ namespace winrt::Microsoft::ProjectReunion::implementation
             // If there was an error getting the value
             if (enumerationStatus != ERROR_SUCCESS && enumerationStatus != ERROR_NO_MORE_ITEMS)
             {
-                THROW_HR(HRESULT_FROM_WIN32(enumerationStatus));
+                THROW_WIN32(enumerationStatus);
             }
             environmentVariableValue.get()[valueSize] = L'\0';
             environmentVariables.Insert(environmentVariableName.get(), reinterpret_cast<PWSTR>(environmentVariableValue.get()));
@@ -595,7 +595,7 @@ namespace winrt::Microsoft::ProjectReunion::implementation
 
         if (getResult == 0)
         {
-            THROW_HR(HRESULT_FROM_WIN32(GetLastError()));
+            THROW_WIN32(GetLastError());
         }
 
         return environmentVariableValue;
@@ -615,11 +615,11 @@ namespace winrt::Microsoft::ProjectReunion::implementation
         wil::unique_hkey environmentVariablesHKey{};
         if (m_Scope == Scope::User)
         {
-            THROW_IF_FAILED(HRESULT_FROM_WIN32(RegOpenKeyEx(HKEY_CURRENT_USER, c_UserEvRegLocation, 0, registrySecurity, environmentVariablesHKey.addressof())));
+            THROW_IF_WIN32_ERROR(RegOpenKeyEx(HKEY_CURRENT_USER, c_UserEvRegLocation, 0, registrySecurity, environmentVariablesHKey.addressof()));
         }
         else //Scope is Machine
         {
-            THROW_IF_FAILED(HRESULT_FROM_WIN32(RegOpenKeyEx(HKEY_LOCAL_MACHINE, c_MachineEvRegLocation, 0, registrySecurity, environmentVariablesHKey.addressof())));
+            THROW_IF_WIN32_ERROR(RegOpenKeyEx(HKEY_LOCAL_MACHINE, c_MachineEvRegLocation, 0, registrySecurity, environmentVariablesHKey.addressof()));
         }
 
         return environmentVariablesHKey;
@@ -641,11 +641,11 @@ namespace winrt::Microsoft::ProjectReunion::implementation
                 return L"";
             }
 
-            THROW_HR(HRESULT_FROM_WIN32((queryResult)));
+            THROW_WIN32(queryResult);
         }
 
         std::unique_ptr<wchar_t[]> environmentValue{ new wchar_t[sizeOfEnvironmentValue] };
-        THROW_IF_FAILED(HRESULT_FROM_WIN32((RegQueryValueEx(environmentVariableHKey.get(), variableName.c_str(), 0, nullptr, (LPBYTE)environmentValue.get(), &sizeOfEnvironmentValue))));
+        THROW_IF_WIN32_ERROR(RegQueryValueEx(environmentVariableHKey.get(), variableName.c_str(), 0, nullptr, (LPBYTE)environmentValue.get(), &sizeOfEnvironmentValue));
 
         return std::wstring(environmentValue.get());
     }
@@ -654,6 +654,6 @@ namespace winrt::Microsoft::ProjectReunion::implementation
     {
         const auto deleteResult{ RegDeleteValue(hkey, name.c_str()) };
 
-        THROW_HR_IF(HRESULT_FROM_WIN32(deleteResult), (deleteResult != ERROR_SUCCESS) && (deleteResult != ERROR_FILE_NOT_FOUND));
+        THROW_IF_WIN32_ERROR(deleteResult, (deleteResult != ERROR_SUCCESS) && (deleteResult != ERROR_FILE_NOT_FOUND));
     }
 }

--- a/dev/Microsoft.Process.Environment/EnvironmentManager.h
+++ b/dev/Microsoft.Process.Environment/EnvironmentManager.h
@@ -24,7 +24,6 @@ namespace winrt::Microsoft::ProjectReunion::implementation
         static Microsoft::ProjectReunion::EnvironmentManager GetForMachine();
         Windows::Foundation::Collections::IMapView<hstring, hstring> GetEnvironmentVariables();
         hstring GetEnvironmentVariable(hstring const& variableName);
-        bool IsSupported();
         void SetEnvironmentVariable(hstring const& name, hstring const& value);
         void AppendToPath(hstring const& path);
         void RemoveFromPath(hstring const& path);

--- a/dev/Microsoft.Process.Environment/EnvironmentManager.h
+++ b/dev/Microsoft.Process.Environment/EnvironmentManager.h
@@ -37,6 +37,7 @@ namespace winrt::Microsoft::ProjectReunion::implementation
         PCWSTR c_UserEvRegLocation{ L"Environment" };
         PCWSTR c_MachineEvRegLocation{ L"SYSTEM\\CurrentControlSet\\Control\\Session Manager\\Environment" };
         PCWSTR c_PathName{ L"PATH" };
+        PCWSTR c_PathExtName{ L"PATHEXT" };
 
         StringMap GetProcessEnvironmentVariables() const;
         StringMap GetUserOrMachineEnvironmentVariables() const;
@@ -47,6 +48,7 @@ namespace winrt::Microsoft::ProjectReunion::implementation
         wil::unique_hkey GetRegHKeyForEVUserAndMachineScope(bool needsWriteAccess = false) const;
 
         std::wstring GetPath() const;
+        std::wstring GetPathExt() const;
 
         void DeleteEnvironmentVariableIfExists(const HKEY hkey, const std::wstring name) const;
     };

--- a/dev/Microsoft.Process.Environment/EnvironmentManager.idl
+++ b/dev/Microsoft.Process.Environment/EnvironmentManager.idl
@@ -11,9 +11,6 @@ namespace Microsoft.ProjectReunion
 
         IMapView<String, String> GetEnvironmentVariables();
         String GetEnvironmentVariable(String name);
-
-        Boolean IsSupported{ get; };
-
         void SetEnvironmentVariable(String name, String value);
 
         // Path manipulation

--- a/test/EnvironmentManagerTests/ChangeTrackerHelper.h
+++ b/test/EnvironmentManagerTests/ChangeTrackerHelper.h
@@ -10,7 +10,7 @@ inline wil::unique_hkey GetKeyForTrackingChange(bool isUser)
             , 0
             , nullptr
             , REG_OPTION_NON_VOLATILE
-            , KEY_ALL_ACCESS
+            , KEY_ALL_ACCESS | KEY_WOW64_64KEY
             , nullptr
             , keyToTrackChanges.put()
             , nullptr));
@@ -22,7 +22,7 @@ inline wil::unique_hkey GetKeyForTrackingChange(bool isUser)
             , 0
             , nullptr
             , REG_OPTION_NON_VOLATILE
-            , KEY_WRITE
+            , KEY_ALL_ACCESS | KEY_WOW64_64KEY
             , nullptr
             , keyToTrackChanges.put()
             , nullptr));
@@ -37,16 +37,24 @@ inline wil::unique_hkey GetKeyForTrackingChange(bool isUser, LPCWSTR subKey)
 
     wil::unique_hkey keyToTrackChanges{};
     THROW_IF_WIN32_ERROR(RegCreateKeyEx(HKEY_CURRENT_USER,
-        subKey, 0, nullptr, REG_OPTION_NON_VOLATILE, KEY_ALL_ACCESS,
+        subKey, 0, nullptr, REG_OPTION_NON_VOLATILE, KEY_ALL_ACCESS | KEY_WOW64_64KEY,
         nullptr, keyToTrackChanges.put(), nullptr));
 
     return keyToTrackChanges;
 }
 
+inline wil::unique_hkey GetKeyForPathTrackingChange(bool isUser, std::wstring packageFullName)
+{
+    auto subKey{ wil::str_printf<wil::unique_cotaskmem_string>(
+    L"Software\\ChangeTracker\\%ws\\%ws\\", L"PATH", packageFullName.c_str())};
+
+    return GetKeyForTrackingChange(isUser, subKey.get());
+}
+
 inline wil::unique_hkey GetKeyForEVTrackingChange(bool isUser, std::wstring packageFullName, LPCWSTR EVKeyName)
 {
     auto subKey{ wil::str_printf<wil::unique_cotaskmem_string>(
-        L"Software\\ChangeTracker\\%ws\\%ws\\%ws\\", L"EnvironmentVariables", packageFullName.c_str(), EVKeyName) };
+        L"Software\\ChangeTracker\\%ws\\%ws\\%ws\\", L"EnvironmentVariables", packageFullName.c_str(), EVKeyName)};
 
     return GetKeyForTrackingChange(isUser, subKey.get());
 }

--- a/test/EnvironmentManagerTests/ChangeTrackerHelper.h
+++ b/test/EnvironmentManagerTests/ChangeTrackerHelper.h
@@ -51,6 +51,14 @@ inline wil::unique_hkey GetKeyForPathTrackingChange(bool isUser, std::wstring pa
     return GetKeyForTrackingChange(isUser, subKey.get());
 }
 
+inline wil::unique_hkey GetKeyForPathExtTrackingChange(bool isUser, std::wstring packageFullName)
+{
+    auto subKey{ wil::str_printf<wil::unique_cotaskmem_string>(
+    L"Software\\ChangeTracker\\%ws\\%ws\\", L"PATHEXT", packageFullName.c_str()) };
+
+    return GetKeyForTrackingChange(isUser, subKey.get());
+}
+
 inline wil::unique_hkey GetKeyForEVTrackingChange(bool isUser, std::wstring packageFullName, LPCWSTR EVKeyName)
 {
     auto subKey{ wil::str_printf<wil::unique_cotaskmem_string>(

--- a/test/EnvironmentManagerTests/EnvironmentManagerCentennialTests.cpp
+++ b/test/EnvironmentManagerTests/EnvironmentManagerCentennialTests.cpp
@@ -64,9 +64,9 @@ namespace ProjectReunionEnvironmentManagerTests
     {
         ProcessSetup();
         EnvironmentManager environmentManager{ EnvironmentManager::GetForProcess() };
-        winrt::hstring environmentValue{ environmentManager.GetEnvironmentVariable(c_evKeyName) };
+        winrt::hstring environmentValue{ environmentManager.GetEnvironmentVariable(c_EvKeyName) };
 
-        VERIFY_ARE_EQUAL(std::wstring{ c_evValueName }, environmentValue);
+        VERIFY_ARE_EQUAL(std::wstring{ c_EvValueName }, environmentValue);
 
         ProcessCleanup();
     }
@@ -74,37 +74,37 @@ namespace ProjectReunionEnvironmentManagerTests
     void EnvironmentManagerCentennialTests::CentennialTestGetEnvironmentVariableForUser()
     {
         EnvironmentManager environmentManager{ EnvironmentManager::GetForUser() };
-        winrt::hstring environmentValue{ environmentManager.GetEnvironmentVariable(c_evKeyNameForGet) };
+        winrt::hstring environmentValue{ environmentManager.GetEnvironmentVariable(c_EvKeyNameForGet) };
 
-        VERIFY_ARE_EQUAL(std::wstring{ c_evValueName }, environmentValue);
+        VERIFY_ARE_EQUAL(std::wstring{ c_EvValueName }, environmentValue);
     }
 
     void EnvironmentManagerCentennialTests::CentennialTestGetEnvironmentVariableForMachine()
     {
         EnvironmentManager environmentManager{ EnvironmentManager::GetForMachine() };
-        winrt::hstring environmentValue{ environmentManager.GetEnvironmentVariable(c_evKeyNameForGet) };
+        winrt::hstring environmentValue{ environmentManager.GetEnvironmentVariable(c_EvKeyNameForGet) };
 
-        VERIFY_ARE_EQUAL(std::wstring{ c_evValueName }, environmentValue);
+        VERIFY_ARE_EQUAL(std::wstring{ c_EvValueName }, environmentValue);
     }
 
     void EnvironmentManagerCentennialTests::CentennialTestSetEnvironmentVariableForProcess()
     {
         EnvironmentManager environmentManager{ EnvironmentManager::GetForProcess() };
-        VERIFY_NO_THROW(environmentManager.SetEnvironmentVariable(c_evKeyName, c_evValueName));
+        VERIFY_NO_THROW(environmentManager.SetEnvironmentVariable(c_EvKeyName, c_EvValueName));
 
-        std::wstring writtenEV{ GetEnvironmentVariableForProcess(c_evKeyName) };
-        VERIFY_ARE_EQUAL(std::wstring{ c_evValueName }, writtenEV);
+        std::wstring writtenEV{ GetEnvironmentVariableForProcess(c_EvKeyName) };
+        VERIFY_ARE_EQUAL(std::wstring{ c_EvValueName }, writtenEV);
 
         // Update the environment variable
-        VERIFY_NO_THROW(environmentManager.SetEnvironmentVariable(c_evKeyName, c_evValueName2));
-        writtenEV = GetEnvironmentVariableForProcess(c_evKeyName);
-        VERIFY_ARE_EQUAL(std::wstring{ c_evValueName2 }, writtenEV);
+        VERIFY_NO_THROW(environmentManager.SetEnvironmentVariable(c_EvKeyName, c_EvValueName2));
+        writtenEV = GetEnvironmentVariableForProcess(c_EvKeyName);
+        VERIFY_ARE_EQUAL(std::wstring{ c_EvValueName2 }, writtenEV);
 
 
         // Remove the value
         // setting the value to empty is the same as deleting the variable
-        VERIFY_NO_THROW(environmentManager.SetEnvironmentVariable(c_evKeyName, L""));
-        VERIFY_ARE_EQUAL(0, ::GetEnvironmentVariable(c_evKeyName, nullptr, 0));
+        VERIFY_NO_THROW(environmentManager.SetEnvironmentVariable(c_EvKeyName, L""));
+        VERIFY_ARE_EQUAL(0, ::GetEnvironmentVariable(c_EvKeyName, nullptr, 0));
     }
 
     void EnvironmentManagerCentennialTests::CentennialTestSetEnvironmentVariableForUser()
@@ -113,30 +113,30 @@ namespace ProjectReunionEnvironmentManagerTests
 
         if (!IsILAtOrAbove(ProcessRunLevel::Standard))
         {
-            VERIFY_THROWS(environmentManager.SetEnvironmentVariable(c_evKeyName, c_evValueName), winrt::hresult_access_denied);
+            VERIFY_THROWS(environmentManager.SetEnvironmentVariable(c_EvKeyName, c_EvValueName), winrt::hresult_access_denied);
             return;
         }
 
-        VERIFY_NO_THROW(environmentManager.SetEnvironmentVariable(c_evKeyName, c_evValueName));
-        std::wstring writtenEV{ GetEnvironmentVariableForUser(c_evKeyName) };
-        VERIFY_ARE_EQUAL(std::wstring{ c_evValueName }, writtenEV);
+        VERIFY_NO_THROW(environmentManager.SetEnvironmentVariable(c_EvKeyName, c_EvValueName));
+        std::wstring writtenEV{ GetEnvironmentVariableForUser(c_EvKeyName) };
+        VERIFY_ARE_EQUAL(std::wstring{ c_EvValueName }, writtenEV);
 
         // Update the environment variable
-        VERIFY_NO_THROW(environmentManager.SetEnvironmentVariable(c_evKeyName, c_evValueName2));
-        writtenEV = GetEnvironmentVariableForUser(c_evKeyName);
-        VERIFY_ARE_EQUAL(std::wstring{ c_evValueName2 }, writtenEV);
+        VERIFY_NO_THROW(environmentManager.SetEnvironmentVariable(c_EvKeyName, c_EvValueName2));
+        writtenEV = GetEnvironmentVariableForUser(c_EvKeyName);
+        VERIFY_ARE_EQUAL(std::wstring{ c_EvValueName2 }, writtenEV);
 
         // Remove the value
         // setting the value to empty is the same as deleting the variable
-        VERIFY_NO_THROW(environmentManager.SetEnvironmentVariable(c_evKeyName, L""));
-        VERIFY_ARE_EQUAL(L"", GetEnvironmentVariableForUser(c_evKeyName));
+        VERIFY_NO_THROW(environmentManager.SetEnvironmentVariable(c_EvKeyName, L""));
+        VERIFY_ARE_EQUAL(L"", GetEnvironmentVariableForUser(c_EvKeyName));
 
         // Check the values in Change Tracker.
         // Both values should be empty.
         // Previous Value is empty because the EV did not exist.
         // Current value is empty because it was deleted.
-        wil::unique_hkey keyChangeTracker{ GetKeyForEVTrackingChange(true, GetPackageFullName(), c_evKeyName) };
-        VERIFY_ARE_EQUAL(c_evValueName2, GetEnvironmentVariableFromRegistry(L"PreviousValue", keyChangeTracker.get()));
+        wil::unique_hkey keyChangeTracker{ GetKeyForEVTrackingChange(true, GetPackageFullName(), c_EvKeyName) };
+        VERIFY_ARE_EQUAL(c_EvValueName2, GetEnvironmentVariableFromRegistry(L"PreviousValue", keyChangeTracker.get()));
         VERIFY_ARE_EQUAL(L"", GetEnvironmentVariableFromRegistry(L"CurrentValue", keyChangeTracker.get()));
     }
 
@@ -146,31 +146,31 @@ namespace ProjectReunionEnvironmentManagerTests
 
         if (!IsILAtOrAbove(ProcessRunLevel::Elevated))
         {
-            VERIFY_THROWS(environmentManager.SetEnvironmentVariable(c_evKeyName, c_evValueName), winrt::hresult_access_denied);
+            VERIFY_THROWS(environmentManager.SetEnvironmentVariable(c_EvKeyName, c_EvValueName), winrt::hresult_access_denied);
             return;
         }
 
-        VERIFY_NO_THROW(environmentManager.SetEnvironmentVariable(c_evKeyName, c_evValueName));
+        VERIFY_NO_THROW(environmentManager.SetEnvironmentVariable(c_EvKeyName, c_EvValueName));
 
-        std::wstring writtenEV{ GetEnvironmentVariableForMachine(c_evKeyName) };
-        VERIFY_ARE_EQUAL(std::wstring{ c_evValueName }, writtenEV);
+        std::wstring writtenEV{ GetEnvironmentVariableForMachine(c_EvKeyName) };
+        VERIFY_ARE_EQUAL(std::wstring{ c_EvValueName }, writtenEV);
 
         // Update the environment variable
-        VERIFY_NO_THROW(environmentManager.SetEnvironmentVariable(c_evKeyName, c_evValueName2));
-        writtenEV = GetEnvironmentVariableForMachine(c_evKeyName);
-        VERIFY_ARE_EQUAL(std::wstring{ c_evValueName2 }, writtenEV);
+        VERIFY_NO_THROW(environmentManager.SetEnvironmentVariable(c_EvKeyName, c_EvValueName2));
+        writtenEV = GetEnvironmentVariableForMachine(c_EvKeyName);
+        VERIFY_ARE_EQUAL(std::wstring{ c_EvValueName2 }, writtenEV);
 
         // Remove the value
         // setting the value to empty is the same as deleting the variable
-        VERIFY_NO_THROW(environmentManager.SetEnvironmentVariable(c_evKeyName, L""));
-        VERIFY_ARE_EQUAL(L"", GetEnvironmentVariableForMachine(c_evKeyName));
+        VERIFY_NO_THROW(environmentManager.SetEnvironmentVariable(c_EvKeyName, L""));
+        VERIFY_ARE_EQUAL(L"", GetEnvironmentVariableForMachine(c_EvKeyName));
 
         // Check the values in Change Tracker.
         // Both values should be empty.
         // Previous Value is empty because the EV did not exist.
         // Current value is empty because it was deleted.
-        wil::unique_hkey keyChangeTracker{ GetKeyForEVTrackingChange(false, GetPackageFullName(), c_evKeyName) };
-        VERIFY_ARE_EQUAL(c_evValueName2, GetEnvironmentVariableFromRegistry(L"PreviousValue", keyChangeTracker.get()));
+        wil::unique_hkey keyChangeTracker{ GetKeyForEVTrackingChange(false, GetPackageFullName(), c_EvKeyName) };
+        VERIFY_ARE_EQUAL(c_EvValueName2, GetEnvironmentVariableFromRegistry(L"PreviousValue", keyChangeTracker.get()));
         VERIFY_ARE_EQUAL(L"", GetEnvironmentVariableFromRegistry(L"CurrentValue", keyChangeTracker.get()));
     }
 
@@ -178,20 +178,20 @@ namespace ProjectReunionEnvironmentManagerTests
     {
         ProcessSetup();
         // Keep a local string to match all operations to PATH
-        std::wstring pathToManipulate{ GetEnvironmentVariableForProcess(c_pathName) };
+        std::wstring pathToManipulate{ GetEnvironmentVariableForProcess(c_PathName) };
 
         EnvironmentManager environmentManager{ EnvironmentManager::GetForProcess() };
 
-        VERIFY_NO_THROW(environmentManager.AppendToPath(c_evValueName));
+        VERIFY_NO_THROW(environmentManager.AppendToPath(c_EvValueName));
 
         // Current path should have the semi-colon
-        std::wstring currentPath{ GetEnvironmentVariableForProcess(c_pathName) };
+        std::wstring currentPath{ GetEnvironmentVariableForProcess(c_PathName) };
         if (pathToManipulate.back() != L';')
         {
             pathToManipulate += L";";
         }
 
-        pathToManipulate += c_evValueName;
+        pathToManipulate += c_EvValueName;
         pathToManipulate += L";";
 
         ProcessCleanup();
@@ -203,7 +203,7 @@ namespace ProjectReunionEnvironmentManagerTests
     void EnvironmentManagerCentennialTests::CentennialTestAppendToPathForUser()
     {
         // Store PATH so it can be restored
-        std::wstring pathToRestore{ GetEnvironmentVariableForUser(c_pathName) };
+        std::wstring pathToRestore{ GetEnvironmentVariableForUser(c_PathName) };
 
         // Keep a local string to match all operations to PATH
         std::wstring pathToManipulate{ pathToRestore };
@@ -212,28 +212,28 @@ namespace ProjectReunionEnvironmentManagerTests
 
         if (!IsILAtOrAbove(ProcessRunLevel::Standard))
         {
-            VERIFY_THROWS(environmentManager.AppendToPath(c_evValueName), winrt::hresult_access_denied);
+            VERIFY_THROWS(environmentManager.AppendToPath(c_EvValueName), winrt::hresult_access_denied);
             return;
         }
 
-        VERIFY_NO_THROW(environmentManager.AppendToPath(c_evValueName));
+        VERIFY_NO_THROW(environmentManager.AppendToPath(c_EvValueName));
 
         // Current path should have the semi-colon
-        std::wstring currentPath{ GetEnvironmentVariableForUser(c_pathName) };
+        std::wstring currentPath{ GetEnvironmentVariableForUser(c_PathName) };
 
         if (pathToManipulate.back() != L';')
         {
             pathToManipulate += L";";
         }
 
-        pathToManipulate += c_evValueName;
+        pathToManipulate += c_EvValueName;
         pathToManipulate += L";";
 
         VERIFY_ARE_EQUAL(currentPath, pathToManipulate);
 
         VERIFY_THROWS(environmentManager.AppendToPath(L""), winrt::hresult_invalid_argument);
 
-        std::wstring expectedValue{ c_evValueName };
+        std::wstring expectedValue{ c_EvValueName };
         expectedValue += L';';
 
         wil::unique_hkey keyChangeTracker{ GetKeyForPathTrackingChange(true, GetPackageFullName()) };
@@ -243,34 +243,34 @@ namespace ProjectReunionEnvironmentManagerTests
     void EnvironmentManagerCentennialTests::CentennialTestAppendToPathForMachine()
     {
         // Keep a local string to match all operations to PATH
-        std::wstring pathToManipulate{ GetEnvironmentVariableForMachine(c_pathName) };
+        std::wstring pathToManipulate{ GetEnvironmentVariableForMachine(c_PathName) };
 
         EnvironmentManager environmentManager{ EnvironmentManager::GetForMachine() };
 
         if (!IsILAtOrAbove(ProcessRunLevel::Elevated))
         {
-            VERIFY_THROWS(environmentManager.AppendToPath(c_evValueName), winrt::hresult_access_denied);
+            VERIFY_THROWS(environmentManager.AppendToPath(c_EvValueName), winrt::hresult_access_denied);
             return;
         }
 
-        VERIFY_NO_THROW(environmentManager.AppendToPath(c_evValueName));
+        VERIFY_NO_THROW(environmentManager.AppendToPath(c_EvValueName));
 
         // Current path should have the semi-colon
-        std::wstring currentPath{ GetEnvironmentVariableForUser(c_pathName) };
+        std::wstring currentPath{ GetEnvironmentVariableForUser(c_PathName) };
 
         if (pathToManipulate.back() != L';')
         {
             pathToManipulate += L";";
         }
 
-        pathToManipulate += c_evValueName;
+        pathToManipulate += c_EvValueName;
         pathToManipulate += L";";
 
         VERIFY_ARE_EQUAL(currentPath, pathToManipulate);
 
         VERIFY_THROWS(environmentManager.AppendToPath(L""), winrt::hresult_invalid_argument);
 
-        std::wstring expectedValue{ c_evValueName };
+        std::wstring expectedValue{ c_EvValueName };
         expectedValue += L';';
 
         wil::unique_hkey keyChangeTracker{ GetKeyForPathTrackingChange(false, GetPackageFullName()) };
@@ -282,7 +282,7 @@ namespace ProjectReunionEnvironmentManagerTests
         ProcessSetup();
 
         // Keep a local string to match all operations to PATH
-        std::wstring pathToManipulate{ GetEnvironmentVariableForProcess(c_pathName) };
+        std::wstring pathToManipulate{ GetEnvironmentVariableForProcess(c_PathName) };
 
         if (pathToManipulate.back() != L';')
         {
@@ -291,10 +291,10 @@ namespace ProjectReunionEnvironmentManagerTests
 
         EnvironmentManager environmentManager{ EnvironmentManager::GetForProcess() };
 
-        InjectIntoPath(true, false, c_evValueName, 5);
-        environmentManager.RemoveFromPath(c_evValueName);
+        InjectIntoPath(true, false, c_EvValueName, 5);
+        environmentManager.RemoveFromPath(c_EvValueName);
 
-        std::wstring currentPath{ GetEnvironmentVariableForProcess(c_pathName) };
+        std::wstring currentPath{ GetEnvironmentVariableForProcess(c_PathName) };
 
         ProcessCleanup();
 
@@ -308,7 +308,7 @@ namespace ProjectReunionEnvironmentManagerTests
     void EnvironmentManagerCentennialTests::CentennialTestRemoveFromPathForUser()
     {
         // Keep a local string to match all operations to PATH
-        std::wstring pathToManipulate{ GetEnvironmentVariableForUser(c_pathName) };
+        std::wstring pathToManipulate{ GetEnvironmentVariableForUser(c_PathName) };
 
         EnvironmentManager environmentManager{ EnvironmentManager::GetForUser() };
 
@@ -319,10 +319,10 @@ namespace ProjectReunionEnvironmentManagerTests
             return;
         }
 
-        InjectIntoPath(false, true, c_evValueName, 5);
-        environmentManager.RemoveFromPath(c_evValueName);
+        InjectIntoPath(false, true, c_EvValueName, 5);
+        environmentManager.RemoveFromPath(c_EvValueName);
 
-        std::wstring currentPath{ GetEnvironmentVariableForUser(c_pathName) };
+        std::wstring currentPath{ GetEnvironmentVariableForUser(c_PathName) };
 
         VERIFY_ARE_EQUAL(currentPath, pathToManipulate);
 
@@ -330,7 +330,7 @@ namespace ProjectReunionEnvironmentManagerTests
 
         VERIFY_ARE_EQUAL(currentPath, pathToManipulate);
 
-        std::wstring expectedValue{ c_evValueName };
+        std::wstring expectedValue{ c_EvValueName };
         expectedValue += L";,5\t";
 
         wil::unique_hkey keyChangeTracker{ GetKeyForPathTrackingChange(true, GetPackageFullName()) };
@@ -340,7 +340,7 @@ namespace ProjectReunionEnvironmentManagerTests
     void EnvironmentManagerCentennialTests::CentennialTestRemoveFromPathForMachine()
     {
         // Keep a local string to match all operations to PATH
-        std::wstring pathToManipulate{ GetEnvironmentVariableForMachine(c_pathName) };
+        std::wstring pathToManipulate{ GetEnvironmentVariableForMachine(c_PathName) };
 
         EnvironmentManager environmentManager{ EnvironmentManager::GetForMachine() };
 
@@ -351,9 +351,9 @@ namespace ProjectReunionEnvironmentManagerTests
             return;
         }
 
-        environmentManager.RemoveFromPath(c_evValueName);
+        environmentManager.RemoveFromPath(c_EvValueName);
 
-        std::wstring currentPath{ GetEnvironmentVariableForMachine(c_pathName) };
+        std::wstring currentPath{ GetEnvironmentVariableForMachine(c_PathName) };
 
         VERIFY_ARE_EQUAL(currentPath, pathToManipulate);
 
@@ -361,7 +361,7 @@ namespace ProjectReunionEnvironmentManagerTests
 
         VERIFY_ARE_EQUAL(currentPath, pathToManipulate);
 
-        std::wstring expectedValue{ c_evValueName };
+        std::wstring expectedValue{ c_EvValueName };
         expectedValue += L";,5\t";
 
         wil::unique_hkey keyChangeTracker{ GetKeyForPathTrackingChange(false, GetPackageFullName()) };
@@ -372,20 +372,20 @@ namespace ProjectReunionEnvironmentManagerTests
     {
         ProcessSetup();
         // Keep a local string to match all operations to PATH
-        std::wstring pathToManipulate{ GetEnvironmentVariableForProcess(c_pathExtName) };
+        std::wstring pathToManipulate{ GetEnvironmentVariableForProcess(c_PathExtName) };
 
         EnvironmentManager environmentManager{ EnvironmentManager::GetForProcess() };
 
-        VERIFY_NO_THROW(environmentManager.AddExecutableFileExtension(c_evValueName));
+        VERIFY_NO_THROW(environmentManager.AddExecutableFileExtension(c_EvValueName));
 
         // Current path should have the semi-colon
-        std::wstring currentPath{ GetEnvironmentVariableForProcess(c_pathExtName) };
+        std::wstring currentPath{ GetEnvironmentVariableForProcess(c_PathExtName) };
         if (pathToManipulate.back() != L';')
         {
             pathToManipulate += L";";
         }
 
-        pathToManipulate += c_evValueName;
+        pathToManipulate += c_EvValueName;
         pathToManipulate += L";";
 
         ProcessCleanup();
@@ -397,34 +397,34 @@ namespace ProjectReunionEnvironmentManagerTests
     void EnvironmentManagerCentennialTests::CentennialTestAppendToPathExtForUser()
     {
         // Keep a local string to match all operations to PATH
-        std::wstring pathToManipulate{ GetEnvironmentVariableForUser(c_pathExtName) };
+        std::wstring pathToManipulate{ GetEnvironmentVariableForUser(c_PathExtName) };
 
         EnvironmentManager environmentManager{ EnvironmentManager::GetForUser() };
 
         if (!IsILAtOrAbove(ProcessRunLevel::Standard))
         {
-            VERIFY_THROWS(environmentManager.AddExecutableFileExtension(c_evValueName), winrt::hresult_access_denied);
+            VERIFY_THROWS(environmentManager.AddExecutableFileExtension(c_EvValueName), winrt::hresult_access_denied);
             return;
         }
 
-        VERIFY_NO_THROW(environmentManager.AddExecutableFileExtension(c_evValueName));
+        VERIFY_NO_THROW(environmentManager.AddExecutableFileExtension(c_EvValueName));
 
         // Current path should have the semi-colon
-        std::wstring currentPath{ GetEnvironmentVariableForUser(c_pathExtName) };
+        std::wstring currentPath{ GetEnvironmentVariableForUser(c_PathExtName) };
 
         if (pathToManipulate.back() != L';')
         {
             pathToManipulate += L";";
         }
 
-        pathToManipulate += c_evValueName;
+        pathToManipulate += c_EvValueName;
         pathToManipulate += L";";
 
         VERIFY_ARE_EQUAL(currentPath, pathToManipulate);
 
         VERIFY_THROWS(environmentManager.AddExecutableFileExtension(L""), winrt::hresult_invalid_argument);
 
-        std::wstring expectedValue{ c_evValueName };
+        std::wstring expectedValue{ c_EvValueName };
         expectedValue += L';';
 
         wil::unique_hkey keyChangeTracker{ GetKeyForPathExtTrackingChange(true, GetPackageFullName()) };
@@ -434,34 +434,34 @@ namespace ProjectReunionEnvironmentManagerTests
     void EnvironmentManagerCentennialTests::CentennialTestAppendToPathExtForMachine()
     {
         // Keep a local string to match all operations to PATH
-        std::wstring pathToManipulate{ GetEnvironmentVariableForMachine(c_pathExtName) };
+        std::wstring pathToManipulate{ GetEnvironmentVariableForMachine(c_PathExtName) };
 
         EnvironmentManager environmentManager{ EnvironmentManager::GetForMachine() };
 
         if (!IsILAtOrAbove(ProcessRunLevel::Elevated))
         {
-            VERIFY_THROWS(environmentManager.AddExecutableFileExtension(c_evValueName), winrt::hresult_access_denied);
+            VERIFY_THROWS(environmentManager.AddExecutableFileExtension(c_EvValueName), winrt::hresult_access_denied);
             return;
         }
 
-        VERIFY_NO_THROW(environmentManager.AddExecutableFileExtension(c_evValueName));
+        VERIFY_NO_THROW(environmentManager.AddExecutableFileExtension(c_EvValueName));
 
         // Current path should have the semi-colon
-        std::wstring currentPath{ GetEnvironmentVariableForUser(c_pathExtName) };
+        std::wstring currentPath{ GetEnvironmentVariableForUser(c_PathExtName) };
 
         if (pathToManipulate.back() != L';')
         {
             pathToManipulate += L";";
         }
 
-        pathToManipulate += c_evValueName;
+        pathToManipulate += c_EvValueName;
         pathToManipulate += L";";
 
         VERIFY_ARE_EQUAL(currentPath, pathToManipulate);
 
         VERIFY_THROWS(environmentManager.AddExecutableFileExtension(L""), winrt::hresult_invalid_argument);
 
-        std::wstring expectedValue{ c_evValueName };
+        std::wstring expectedValue{ c_EvValueName };
         expectedValue += L';';
 
         wil::unique_hkey keyChangeTracker{ GetKeyForPathExtTrackingChange(false, GetPackageFullName()) };
@@ -473,14 +473,14 @@ namespace ProjectReunionEnvironmentManagerTests
         ProcessSetup();
 
         // Keep a local string to match all operations to PATH
-        std::wstring pathToManipulate{ GetEnvironmentVariableForProcess(c_pathExtName) };
+        std::wstring pathToManipulate{ GetEnvironmentVariableForProcess(c_PathExtName) };
 
         EnvironmentManager environmentManager{ EnvironmentManager::GetForProcess() };
 
-        InjectIntoPath(true, false, c_evValueName, 5);
-        environmentManager.RemoveExecutableFileExtension(c_evValueName);
+        InjectIntoPath(true, false, c_EvValueName, 5);
+        environmentManager.RemoveExecutableFileExtension(c_EvValueName);
 
-        std::wstring currentPath{ GetEnvironmentVariableForProcess(c_pathExtName) };
+        std::wstring currentPath{ GetEnvironmentVariableForProcess(c_PathExtName) };
 
         ProcessCleanup();
 
@@ -494,7 +494,7 @@ namespace ProjectReunionEnvironmentManagerTests
     void EnvironmentManagerCentennialTests::CentennialTestRemoveFromPathExtForUser()
     {
         // Keep a local string to match all operations to PATH
-        std::wstring pathToManipulate{ GetEnvironmentVariableForUser(c_pathExtName) };
+        std::wstring pathToManipulate{ GetEnvironmentVariableForUser(c_PathExtName) };
 
         if (pathToManipulate.back() != L';')
         {
@@ -510,10 +510,10 @@ namespace ProjectReunionEnvironmentManagerTests
             return;
         }
 
-        InjectIntoPathExt(false, true, c_evValueName, 5);
-        environmentManager.RemoveExecutableFileExtension(c_evValueName);
+        InjectIntoPathExt(false, true, c_EvValueName, 5);
+        environmentManager.RemoveExecutableFileExtension(c_EvValueName);
 
-        std::wstring currentPath{ GetEnvironmentVariableForUser(c_pathExtName) };
+        std::wstring currentPath{ GetEnvironmentVariableForUser(c_PathExtName) };
 
         VERIFY_ARE_EQUAL(currentPath, pathToManipulate);
 
@@ -521,7 +521,7 @@ namespace ProjectReunionEnvironmentManagerTests
 
         VERIFY_ARE_EQUAL(currentPath, pathToManipulate);
 
-        std::wstring expectedValue{ c_evValueName };
+        std::wstring expectedValue{ c_EvValueName };
         expectedValue += L";,5\t";
 
         wil::unique_hkey keyChangeTracker{ GetKeyForPathExtTrackingChange(true, GetPackageFullName()) };
@@ -531,7 +531,7 @@ namespace ProjectReunionEnvironmentManagerTests
     void EnvironmentManagerCentennialTests::CentennialTestRemoveFromPathExtForMachine()
     {
         // Keep a local string to match all operations to PATH
-        std::wstring pathToManipulate{ GetEnvironmentVariableForMachine(c_pathExtName) };
+        std::wstring pathToManipulate{ GetEnvironmentVariableForMachine(c_PathExtName) };
 
         EnvironmentManager environmentManager{ EnvironmentManager::GetForMachine() };
 
@@ -542,9 +542,9 @@ namespace ProjectReunionEnvironmentManagerTests
             return;
         }
 
-        environmentManager.RemoveExecutableFileExtension(c_evValueName);
+        environmentManager.RemoveExecutableFileExtension(c_EvValueName);
 
-        std::wstring currentPath{ GetEnvironmentVariableForMachine(c_pathExtName) };
+        std::wstring currentPath{ GetEnvironmentVariableForMachine(c_PathExtName) };
 
         VERIFY_ARE_EQUAL(currentPath, pathToManipulate);
 
@@ -552,7 +552,7 @@ namespace ProjectReunionEnvironmentManagerTests
 
         VERIFY_ARE_EQUAL(currentPath, pathToManipulate);
 
-        std::wstring expectedValue{ c_evValueName };
+        std::wstring expectedValue{ c_EvValueName };
         expectedValue += L";,5\t";
 
         wil::unique_hkey keyChangeTracker{ GetKeyForPathExtTrackingChange(false, GetPackageFullName()) };

--- a/test/EnvironmentManagerTests/EnvironmentManagerCentennialTests.cpp
+++ b/test/EnvironmentManagerTests/EnvironmentManagerCentennialTests.cpp
@@ -284,6 +284,11 @@ namespace ProjectReunionEnvironmentManagerTests
         // Keep a local string to match all operations to PATH
         std::wstring pathToManipulate{ GetEnvironmentVariableForProcess(c_pathName) };
 
+        if (pathToManipulate.back() != L';')
+        {
+            pathToManipulate += L';';
+        }
+
         EnvironmentManager environmentManager{ EnvironmentManager::GetForProcess() };
 
         InjectIntoPath(true, false, c_evValueName, 5);
@@ -360,6 +365,197 @@ namespace ProjectReunionEnvironmentManagerTests
         expectedValue += L";,5\t";
 
         wil::unique_hkey keyChangeTracker{ GetKeyForPathTrackingChange(false, GetPackageFullName()) };
+        VERIFY_ARE_EQUAL(expectedValue, GetEnvironmentVariableFromRegistry(L"RemovedValues", keyChangeTracker.get()));
+    }
+
+    void EnvironmentManagerCentennialTests::CentennialTestAppendToPathExtForProcess()
+    {
+        ProcessSetup();
+        // Keep a local string to match all operations to PATH
+        std::wstring pathToManipulate{ GetEnvironmentVariableForProcess(c_pathExtName) };
+
+        EnvironmentManager environmentManager{ EnvironmentManager::GetForProcess() };
+
+        VERIFY_NO_THROW(environmentManager.AddExecutableFileExtension(c_evValueName));
+
+        // Current path should have the semi-colon
+        std::wstring currentPath{ GetEnvironmentVariableForProcess(c_pathExtName) };
+        if (pathToManipulate.back() != L';')
+        {
+            pathToManipulate += L";";
+        }
+
+        pathToManipulate += c_evValueName;
+        pathToManipulate += L";";
+
+        ProcessCleanup();
+        VERIFY_ARE_EQUAL(currentPath, pathToManipulate);
+
+        VERIFY_THROWS(environmentManager.AddExecutableFileExtension(L""), winrt::hresult_invalid_argument);
+    }
+
+    void EnvironmentManagerCentennialTests::CentennialTestAppendToPathExtForUser()
+    {
+        // Keep a local string to match all operations to PATH
+        std::wstring pathToManipulate{ GetEnvironmentVariableForUser(c_pathExtName) };
+
+        EnvironmentManager environmentManager{ EnvironmentManager::GetForUser() };
+
+        if (!IsILAtOrAbove(ProcessRunLevel::Standard))
+        {
+            VERIFY_THROWS(environmentManager.AddExecutableFileExtension(c_evValueName), winrt::hresult_access_denied);
+            return;
+        }
+
+        VERIFY_NO_THROW(environmentManager.AddExecutableFileExtension(c_evValueName));
+
+        // Current path should have the semi-colon
+        std::wstring currentPath{ GetEnvironmentVariableForUser(c_pathExtName) };
+
+        if (pathToManipulate.back() != L';')
+        {
+            pathToManipulate += L";";
+        }
+
+        pathToManipulate += c_evValueName;
+        pathToManipulate += L";";
+
+        VERIFY_ARE_EQUAL(currentPath, pathToManipulate);
+
+        VERIFY_THROWS(environmentManager.AddExecutableFileExtension(L""), winrt::hresult_invalid_argument);
+
+        std::wstring expectedValue{ c_evValueName };
+        expectedValue += L';';
+
+        wil::unique_hkey keyChangeTracker{ GetKeyForPathExtTrackingChange(true, GetPackageFullName()) };
+        VERIFY_ARE_EQUAL(expectedValue, GetEnvironmentVariableFromRegistry(L"AppendedValues", keyChangeTracker.get()));
+    }
+
+    void EnvironmentManagerCentennialTests::CentennialTestAppendToPathExtForMachine()
+    {
+        // Keep a local string to match all operations to PATH
+        std::wstring pathToManipulate{ GetEnvironmentVariableForMachine(c_pathExtName) };
+
+        EnvironmentManager environmentManager{ EnvironmentManager::GetForMachine() };
+
+        if (!IsILAtOrAbove(ProcessRunLevel::Elevated))
+        {
+            VERIFY_THROWS(environmentManager.AddExecutableFileExtension(c_evValueName), winrt::hresult_access_denied);
+            return;
+        }
+
+        VERIFY_NO_THROW(environmentManager.AddExecutableFileExtension(c_evValueName));
+
+        // Current path should have the semi-colon
+        std::wstring currentPath{ GetEnvironmentVariableForUser(c_pathExtName) };
+
+        if (pathToManipulate.back() != L';')
+        {
+            pathToManipulate += L";";
+        }
+
+        pathToManipulate += c_evValueName;
+        pathToManipulate += L";";
+
+        VERIFY_ARE_EQUAL(currentPath, pathToManipulate);
+
+        VERIFY_THROWS(environmentManager.AddExecutableFileExtension(L""), winrt::hresult_invalid_argument);
+
+        std::wstring expectedValue{ c_evValueName };
+        expectedValue += L';';
+
+        wil::unique_hkey keyChangeTracker{ GetKeyForPathExtTrackingChange(false, GetPackageFullName()) };
+        VERIFY_ARE_EQUAL(expectedValue, GetEnvironmentVariableFromRegistry(L"AppendedValues", keyChangeTracker.get()));
+    }
+
+    void EnvironmentManagerCentennialTests::CentennialTestRemoveFromPathExtForProcess()
+    {
+        ProcessSetup();
+
+        // Keep a local string to match all operations to PATH
+        std::wstring pathToManipulate{ GetEnvironmentVariableForProcess(c_pathExtName) };
+
+        EnvironmentManager environmentManager{ EnvironmentManager::GetForProcess() };
+
+        InjectIntoPath(true, false, c_evValueName, 5);
+        environmentManager.RemoveExecutableFileExtension(c_evValueName);
+
+        std::wstring currentPath{ GetEnvironmentVariableForProcess(c_pathExtName) };
+
+        ProcessCleanup();
+
+        VERIFY_ARE_EQUAL(currentPath, pathToManipulate);
+
+        VERIFY_NO_THROW(environmentManager.RemoveExecutableFileExtension(L"I do not exist"));
+
+        VERIFY_ARE_EQUAL(currentPath, pathToManipulate);
+    }
+
+    void EnvironmentManagerCentennialTests::CentennialTestRemoveFromPathExtForUser()
+    {
+        // Keep a local string to match all operations to PATH
+        std::wstring pathToManipulate{ GetEnvironmentVariableForUser(c_pathExtName) };
+
+        if (pathToManipulate.back() != L';')
+        {
+            pathToManipulate += L';';
+        }
+
+        EnvironmentManager environmentManager{ EnvironmentManager::GetForUser() };
+
+        if (!IsILAtOrAbove(ProcessRunLevel::Standard))
+        {
+            std::wstring pathPart{ GetSecondValueFromPathExt(false, true) };
+            VERIFY_THROWS(environmentManager.RemoveExecutableFileExtension(pathPart), winrt::hresult_access_denied);
+            return;
+        }
+
+        InjectIntoPathExt(false, true, c_evValueName, 5);
+        environmentManager.RemoveExecutableFileExtension(c_evValueName);
+
+        std::wstring currentPath{ GetEnvironmentVariableForUser(c_pathExtName) };
+
+        VERIFY_ARE_EQUAL(currentPath, pathToManipulate);
+
+        VERIFY_NO_THROW(environmentManager.RemoveExecutableFileExtension(L"I do not exist"));
+
+        VERIFY_ARE_EQUAL(currentPath, pathToManipulate);
+
+        std::wstring expectedValue{ c_evValueName };
+        expectedValue += L";,5\t";
+
+        wil::unique_hkey keyChangeTracker{ GetKeyForPathExtTrackingChange(true, GetPackageFullName()) };
+        VERIFY_ARE_EQUAL(expectedValue, GetEnvironmentVariableFromRegistry(L"RemovedValues", keyChangeTracker.get()));
+    }
+
+    void EnvironmentManagerCentennialTests::CentennialTestRemoveFromPathExtForMachine()
+    {
+        // Keep a local string to match all operations to PATH
+        std::wstring pathToManipulate{ GetEnvironmentVariableForMachine(c_pathExtName) };
+
+        EnvironmentManager environmentManager{ EnvironmentManager::GetForMachine() };
+
+        if (!IsILAtOrAbove(ProcessRunLevel::Elevated))
+        {
+            std::wstring pathPart{ GetSecondValueFromPathExt(false, false) };
+            VERIFY_THROWS(environmentManager.RemoveExecutableFileExtension(pathPart), winrt::hresult_access_denied);
+            return;
+        }
+
+        environmentManager.RemoveExecutableFileExtension(c_evValueName);
+
+        std::wstring currentPath{ GetEnvironmentVariableForMachine(c_pathExtName) };
+
+        VERIFY_ARE_EQUAL(currentPath, pathToManipulate);
+
+        VERIFY_NO_THROW(environmentManager.RemoveExecutableFileExtension(L"I do not exist"));
+
+        VERIFY_ARE_EQUAL(currentPath, pathToManipulate);
+
+        std::wstring expectedValue{ c_evValueName };
+        expectedValue += L";,5\t";
+
+        wil::unique_hkey keyChangeTracker{ GetKeyForPathExtTrackingChange(false, GetPackageFullName()) };
         VERIFY_ARE_EQUAL(expectedValue, GetEnvironmentVariableFromRegistry(L"RemovedValues", keyChangeTracker.get()));
     }
 }

--- a/test/EnvironmentManagerTests/EnvironmentManagerCentennialTests.h
+++ b/test/EnvironmentManagerTests/EnvironmentManagerCentennialTests.h
@@ -51,6 +51,15 @@ namespace ProjectReunionEnvironmentManagerTests
         TEST_METHOD(CentennialTestRemoveFromPathForProcess);
         TEST_METHOD(CentennialTestRemoveFromPathForUser);
         TEST_METHOD(CentennialTestRemoveFromPathForMachine);
+
+        TEST_METHOD(CentennialTestAppendToPathExtForProcess);
+        TEST_METHOD(CentennialTestAppendToPathExtForUser);
+        TEST_METHOD(CentennialTestAppendToPathExtForMachine);
+
+        TEST_METHOD(CentennialTestRemoveFromPathExtForProcess);
+        TEST_METHOD(CentennialTestRemoveFromPathExtForUser);
+        TEST_METHOD(CentennialTestRemoveFromPathExtForMachine);
+
     };
 
 }

--- a/test/EnvironmentManagerTests/EnvironmentManagerCentennialTests.h
+++ b/test/EnvironmentManagerTests/EnvironmentManagerCentennialTests.h
@@ -10,18 +10,18 @@ namespace ProjectReunionEnvironmentManagerTests
         BEGIN_TEST_CLASS(EnvironmentManagerCentennialTests)
             TEST_CLASS_PROPERTY(L"RunAs", L"UAP")
             TEST_CLASS_PROPERTY(L"RunFixtureAs", L"ElevatedUser")
-            TEST_CLASS_PROPERTY(L"UAP:Host", L"PackagedCwa")
-            TEST_CLASS_PROPERTY(L"UAP:AppXManifest", L"{PackagedCwaFullTrust,PackagedCwaPartialTrust}")
+            // PackagedCwaFullTrust is standard.  Not elevated
+            TEST_CLASS_PROPERTY(L"UAP:AppXManifest", L"{PackagedCwaFullTrust, PackagedCwaPartialTrust}")
             END_TEST_CLASS()
 
-        TEST_CLASS_SETUP(CentennialWriteEVs)
+        TEST_METHOD_SETUP(CentennialWriteEVs)
         {
             UserSetup();
             MachineSetup();
             return true;
         }
 
-        TEST_CLASS_CLEANUP(CentennialRemoveEVs)
+        TEST_METHOD_CLEANUP(CentennialRemoveEVs)
         {
             UserCleanup();
             MachineCleanup();

--- a/test/EnvironmentManagerTests/EnvironmentManagerCentennialTests.h
+++ b/test/EnvironmentManagerTests/EnvironmentManagerCentennialTests.h
@@ -10,7 +10,6 @@ namespace ProjectReunionEnvironmentManagerTests
         BEGIN_TEST_CLASS(EnvironmentManagerCentennialTests)
             TEST_CLASS_PROPERTY(L"RunAs", L"UAP")
             TEST_CLASS_PROPERTY(L"RunFixtureAs", L"ElevatedUser")
-            // PackagedCwaFullTrust is standard.  Not elevated
             TEST_CLASS_PROPERTY(L"UAP:AppXManifest", L"{PackagedCwaFullTrust, PackagedCwaPartialTrust}")
             END_TEST_CLASS()
 

--- a/test/EnvironmentManagerTests/EnvironmentManagerUWPTests.cpp
+++ b/test/EnvironmentManagerTests/EnvironmentManagerUWPTests.cpp
@@ -65,6 +65,8 @@ namespace ProjectReunionEnvironmentManagerTests
         EnvironmentManager environmentManager{ EnvironmentManager::GetForProcess() };
         winrt::hstring environmentValue{ environmentManager.GetEnvironmentVariable(c_evKeyName) };
 
+        ProcessCleanup();
+
         VERIFY_ARE_EQUAL(std::wstring{ c_evValueName }, environmentValue);
     }
 
@@ -120,11 +122,10 @@ namespace ProjectReunionEnvironmentManagerTests
 
     void EnvironmentManagerUWPTests::UWPTestAppendToPathForProcess()
     {
-        // Store PATH so it can be restored
-        std::wstring pathToRestore{ GetEnvironmentVariableForProcess(c_pathName) };
+        ProcessSetup();
 
         // Keep a local string to match all operations to PATH
-        std::wstring pathToManipulate{ pathToRestore };
+        std::wstring pathToManipulate{ GetEnvironmentVariableForProcess(c_pathName) };
 
         EnvironmentManager environmentManager{ EnvironmentManager::GetForProcess() };
 
@@ -140,11 +141,11 @@ namespace ProjectReunionEnvironmentManagerTests
         pathToManipulate += c_evValueName;
         pathToManipulate += L";";
 
+        ProcessCleanup();
+
         VERIFY_ARE_EQUAL(currentPath, pathToManipulate);
 
         VERIFY_THROWS(environmentManager.AppendToPath(L""), winrt::hresult_invalid_argument);
-
-        RestoreProcessPath(pathToRestore);
     }
 
     void EnvironmentManagerUWPTests::UWPTestAppendToPathForUser()
@@ -161,33 +162,18 @@ namespace ProjectReunionEnvironmentManagerTests
 
     void EnvironmentManagerUWPTests::UWPTestRemoveFromPathForProcess()
     {
-        // Store PATH so it can be restored
-        std::wstring pathToRestore{ GetEnvironmentVariableForProcess(c_pathName) };
+        ProcessSetup();
 
         // Keep a local string to match all operations to PATH
-        std::wstring pathToManipulate{ pathToRestore };
+        std::wstring pathToManipulate{ GetEnvironmentVariableForProcess(c_pathName) };
 
         EnvironmentManager environmentManager{ EnvironmentManager::GetForProcess() };
 
-        // This will append c_evValueName to the path with a semi-colon.
-        VERIFY_NO_THROW(environmentManager.AppendToPath(c_evValueName));
-        if (pathToManipulate.back() != L';')
-        {
-            pathToManipulate += L';';
-        }
-
-        pathToManipulate += c_evValueName;
-        pathToManipulate += L";";
+        environmentManager.RemoveFromPath(c_evValueName);
 
         std::wstring currentPath{ GetEnvironmentVariableForProcess(c_pathName) };
 
-        VERIFY_ARE_EQUAL(currentPath, pathToManipulate);
-
-        std::wstring pathPart{ currentPath, 0, currentPath.find(L';') + 1 };
-        environmentManager.RemoveFromPath(pathPart);
-        currentPath = GetEnvironmentVariableForProcess(c_pathName);
-
-        pathToManipulate.erase(pathToManipulate.rfind(pathPart), pathPart.length());
+        ProcessCleanup();
 
         VERIFY_ARE_EQUAL(currentPath, pathToManipulate);
 
@@ -195,9 +181,6 @@ namespace ProjectReunionEnvironmentManagerTests
 
         VERIFY_ARE_EQUAL(currentPath, pathToManipulate);
 
-        VERIFY_THROWS(environmentManager.AppendToPath(L""), winrt::hresult_invalid_argument);
-
-        RestoreProcessPath(pathToRestore);
     }
 
     void EnvironmentManagerUWPTests::UWPTestRemoveFromPathForUser()

--- a/test/EnvironmentManagerTests/EnvironmentManagerUWPTests.cpp
+++ b/test/EnvironmentManagerTests/EnvironmentManagerUWPTests.cpp
@@ -63,61 +63,61 @@ namespace ProjectReunionEnvironmentManagerTests
     {
         ProcessSetup();
         EnvironmentManager environmentManager{ EnvironmentManager::GetForProcess() };
-        winrt::hstring environmentValue{ environmentManager.GetEnvironmentVariable(c_evKeyName) };
+        winrt::hstring environmentValue{ environmentManager.GetEnvironmentVariable(c_EvKeyName) };
 
         ProcessCleanup();
 
-        VERIFY_ARE_EQUAL(std::wstring{ c_evValueName }, environmentValue);
+        VERIFY_ARE_EQUAL(std::wstring{ c_EvValueName }, environmentValue);
     }
 
     void EnvironmentManagerUWPTests::UWPTestGetEnvironmentVariableForUser()
     {
         EnvironmentManager environmentManager{ EnvironmentManager::GetForUser() };
-        winrt::hstring environmentValue{ environmentManager.GetEnvironmentVariable(c_evKeyNameForGet) };
+        winrt::hstring environmentValue{ environmentManager.GetEnvironmentVariable(c_EvKeyNameForGet) };
 
-        VERIFY_ARE_EQUAL(std::wstring{ c_evValueName }, environmentValue);
+        VERIFY_ARE_EQUAL(std::wstring{ c_EvValueName }, environmentValue);
     }
 
     void EnvironmentManagerUWPTests::UWPTestGetEnvironmentVariableForMachine()
     {
         EnvironmentManager environmentManager{ EnvironmentManager::GetForUser() };
-        winrt::hstring environmentValue{ environmentManager.GetEnvironmentVariable(c_evKeyNameForGet) };
+        winrt::hstring environmentValue{ environmentManager.GetEnvironmentVariable(c_EvKeyNameForGet) };
 
-        VERIFY_ARE_EQUAL(std::wstring{ c_evValueName }, environmentValue);
+        VERIFY_ARE_EQUAL(std::wstring{ c_EvValueName }, environmentValue);
     }
 
 
     void EnvironmentManagerUWPTests::UWPTestSetEnvironmentVariableForProcess()
     {
         EnvironmentManager environmentManager{ EnvironmentManager::GetForProcess() };
-        VERIFY_NO_THROW(environmentManager.SetEnvironmentVariable(c_evKeyName, c_evValueName));
+        VERIFY_NO_THROW(environmentManager.SetEnvironmentVariable(c_EvKeyName, c_EvValueName));
 
-        std::wstring writtenEV = GetEnvironmentVariableForProcess(c_evKeyName);
-        VERIFY_ARE_EQUAL(std::wstring{ c_evValueName }, writtenEV);
+        std::wstring writtenEV = GetEnvironmentVariableForProcess(c_EvKeyName);
+        VERIFY_ARE_EQUAL(std::wstring{ c_EvValueName }, writtenEV);
 
         // Update the environment variable
-        VERIFY_NO_THROW(environmentManager.SetEnvironmentVariable(c_evKeyName, c_evValueName2));
-        writtenEV = GetEnvironmentVariableForProcess(c_evKeyName);
-        VERIFY_ARE_EQUAL(std::wstring{ c_evValueName2 }, writtenEV);
+        VERIFY_NO_THROW(environmentManager.SetEnvironmentVariable(c_EvKeyName, c_EvValueName2));
+        writtenEV = GetEnvironmentVariableForProcess(c_EvKeyName);
+        VERIFY_ARE_EQUAL(std::wstring{ c_EvValueName2 }, writtenEV);
 
 
         // Remove the value
         // setting the value to empty is the same as deleting the variable
-        VERIFY_NO_THROW(environmentManager.SetEnvironmentVariable(c_evKeyName, L""));
-        VERIFY_ARE_EQUAL(0, ::GetEnvironmentVariable(c_evKeyName, nullptr, 0));
+        VERIFY_NO_THROW(environmentManager.SetEnvironmentVariable(c_EvKeyName, L""));
+        VERIFY_ARE_EQUAL(0, ::GetEnvironmentVariable(c_EvKeyName, nullptr, 0));
         VERIFY_ARE_EQUAL(ERROR_ENVVAR_NOT_FOUND, GetLastError());
     }
 
     void EnvironmentManagerUWPTests::UWPTestSetEnvironmentVariableForUser()
     {
         EnvironmentManager environmentMananger{ EnvironmentManager::GetForUser() };
-        VERIFY_THROWS(environmentMananger.SetEnvironmentVariable(c_evKeyName, c_evValueName), winrt::hresult_access_denied);
+        VERIFY_THROWS(environmentMananger.SetEnvironmentVariable(c_EvKeyName, c_EvValueName), winrt::hresult_access_denied);
     }
 
     void EnvironmentManagerUWPTests::UWPTestSetEnvironmentVariableForMachine()
     {
         EnvironmentManager environmentMananger{ EnvironmentManager::GetForMachine() };
-        VERIFY_THROWS(environmentMananger.SetEnvironmentVariable(c_evKeyName, c_evValueName), winrt::hresult_access_denied);
+        VERIFY_THROWS(environmentMananger.SetEnvironmentVariable(c_EvKeyName, c_EvValueName), winrt::hresult_access_denied);
     }
 
     void EnvironmentManagerUWPTests::UWPTestAppendToPathForProcess()
@@ -125,20 +125,20 @@ namespace ProjectReunionEnvironmentManagerTests
         ProcessSetup();
 
         // Keep a local string to match all operations to PATH
-        std::wstring pathToManipulate{ GetEnvironmentVariableForProcess(c_pathName) };
+        std::wstring pathToManipulate{ GetEnvironmentVariableForProcess(c_PathName) };
 
         EnvironmentManager environmentManager{ EnvironmentManager::GetForProcess() };
 
-        VERIFY_NO_THROW(environmentManager.AppendToPath(c_evValueName));
+        VERIFY_NO_THROW(environmentManager.AppendToPath(c_EvValueName));
 
         // Current path should have the semi-colon
-        std::wstring currentPath{ GetEnvironmentVariableForProcess(c_pathName) };
+        std::wstring currentPath{ GetEnvironmentVariableForProcess(c_PathName) };
         if (pathToManipulate.back() != L';')
         {
             pathToManipulate += L";";
         }
 
-        pathToManipulate += c_evValueName;
+        pathToManipulate += c_EvValueName;
         pathToManipulate += L";";
 
         ProcessCleanup();
@@ -151,13 +151,13 @@ namespace ProjectReunionEnvironmentManagerTests
     void EnvironmentManagerUWPTests::UWPTestAppendToPathForUser()
     {
         EnvironmentManager environmentManager{ EnvironmentManager::GetForUser() };
-        VERIFY_THROWS(environmentManager.AppendToPath(c_evValueName), winrt::hresult_access_denied);
+        VERIFY_THROWS(environmentManager.AppendToPath(c_EvValueName), winrt::hresult_access_denied);
     }
 
     void EnvironmentManagerUWPTests::UWPTestAppendToPathForMachine()
     {
         EnvironmentManager environmentManager{ EnvironmentManager::GetForMachine() };
-        VERIFY_THROWS(environmentManager.AppendToPath(c_evValueName), winrt::hresult_access_denied);
+        VERIFY_THROWS(environmentManager.AppendToPath(c_EvValueName), winrt::hresult_access_denied);
     }
 
     void EnvironmentManagerUWPTests::UWPTestRemoveFromPathForProcess()
@@ -165,13 +165,13 @@ namespace ProjectReunionEnvironmentManagerTests
         ProcessSetup();
 
         // Keep a local string to match all operations to PATH
-        std::wstring pathToManipulate{ GetEnvironmentVariableForProcess(c_pathName) };
+        std::wstring pathToManipulate{ GetEnvironmentVariableForProcess(c_PathName) };
 
         EnvironmentManager environmentManager{ EnvironmentManager::GetForProcess() };
 
-        environmentManager.RemoveFromPath(c_evValueName);
+        environmentManager.RemoveFromPath(c_EvValueName);
 
-        std::wstring currentPath{ GetEnvironmentVariableForProcess(c_pathName) };
+        std::wstring currentPath{ GetEnvironmentVariableForProcess(c_PathName) };
 
         ProcessCleanup();
 
@@ -186,33 +186,33 @@ namespace ProjectReunionEnvironmentManagerTests
     void EnvironmentManagerUWPTests::UWPTestRemoveFromPathForUser()
     {
         EnvironmentManager environmentManager{ EnvironmentManager::GetForUser() };
-        VERIFY_THROWS(environmentManager.AppendToPath(c_evValueName), winrt::hresult_access_denied);
+        VERIFY_THROWS(environmentManager.AppendToPath(c_EvValueName), winrt::hresult_access_denied);
     }
 
     void EnvironmentManagerUWPTests::UWPTestRemoveFromPathForMachine()
     {
         EnvironmentManager environmentManager{ EnvironmentManager::GetForMachine() };
-        VERIFY_THROWS(environmentManager.AppendToPath(c_evValueName), winrt::hresult_access_denied);
+        VERIFY_THROWS(environmentManager.AppendToPath(c_EvValueName), winrt::hresult_access_denied);
     }
 
     void EnvironmentManagerUWPTests::UWPTestAppendToPathExtForProcess()
     {
         ProcessSetup();
         // Keep a local string to match all operations to PATH
-        std::wstring pathToManipulate{ GetEnvironmentVariableForProcess(c_pathExtName) };
+        std::wstring pathToManipulate{ GetEnvironmentVariableForProcess(c_PathExtName) };
 
         EnvironmentManager environmentManager{ EnvironmentManager::GetForProcess() };
 
-        VERIFY_NO_THROW(environmentManager.AddExecutableFileExtension(c_evValueName));
+        VERIFY_NO_THROW(environmentManager.AddExecutableFileExtension(c_EvValueName));
 
         // Current path should have the semi-colon
-        std::wstring currentPath{ GetEnvironmentVariableForProcess(c_pathExtName) };
+        std::wstring currentPath{ GetEnvironmentVariableForProcess(c_PathExtName) };
         if (pathToManipulate.back() != L';')
         {
             pathToManipulate += L";";
         }
 
-        pathToManipulate += c_evValueName;
+        pathToManipulate += c_EvValueName;
         pathToManipulate += L";";
 
         ProcessCleanup();
@@ -225,14 +225,14 @@ namespace ProjectReunionEnvironmentManagerTests
     {
         EnvironmentManager environmentManager{ EnvironmentManager::GetForUser() };
 
-        VERIFY_THROWS(environmentManager.AddExecutableFileExtension(c_evValueName), winrt::hresult_access_denied);
+        VERIFY_THROWS(environmentManager.AddExecutableFileExtension(c_EvValueName), winrt::hresult_access_denied);
     }
 
     void EnvironmentManagerUWPTests::UWPTestAppendToPathExtForMachine()
     {
         EnvironmentManager environmentManager{ EnvironmentManager::GetForMachine() };
 
-        VERIFY_THROWS(environmentManager.AddExecutableFileExtension(c_evValueName), winrt::hresult_access_denied);
+        VERIFY_THROWS(environmentManager.AddExecutableFileExtension(c_EvValueName), winrt::hresult_access_denied);
     }
 
     void EnvironmentManagerUWPTests::UWPTestRemoveFromPathExtForProcess()
@@ -240,14 +240,14 @@ namespace ProjectReunionEnvironmentManagerTests
         ProcessSetup();
 
         // Keep a local string to match all operations to PATH
-        std::wstring pathToManipulate{ GetEnvironmentVariableForProcess(c_pathExtName) };
+        std::wstring pathToManipulate{ GetEnvironmentVariableForProcess(c_PathExtName) };
 
         EnvironmentManager environmentManager{ EnvironmentManager::GetForProcess() };
 
-        InjectIntoPath(true, false, c_evValueName, 5);
-        environmentManager.RemoveExecutableFileExtension(c_evValueName);
+        InjectIntoPath(true, false, c_EvValueName, 5);
+        environmentManager.RemoveExecutableFileExtension(c_EvValueName);
 
-        std::wstring currentPath{ GetEnvironmentVariableForProcess(c_pathExtName) };
+        std::wstring currentPath{ GetEnvironmentVariableForProcess(c_PathExtName) };
 
         ProcessCleanup();
 

--- a/test/EnvironmentManagerTests/EnvironmentManagerUWPTests.cpp
+++ b/test/EnvironmentManagerTests/EnvironmentManagerUWPTests.cpp
@@ -194,4 +194,81 @@ namespace ProjectReunionEnvironmentManagerTests
         EnvironmentManager environmentManager{ EnvironmentManager::GetForMachine() };
         VERIFY_THROWS(environmentManager.AppendToPath(c_evValueName), winrt::hresult_access_denied);
     }
+
+    void EnvironmentManagerUWPTests::UWPTestAppendToPathExtForProcess()
+    {
+        ProcessSetup();
+        // Keep a local string to match all operations to PATH
+        std::wstring pathToManipulate{ GetEnvironmentVariableForProcess(c_pathExtName) };
+
+        EnvironmentManager environmentManager{ EnvironmentManager::GetForProcess() };
+
+        VERIFY_NO_THROW(environmentManager.AddExecutableFileExtension(c_evValueName));
+
+        // Current path should have the semi-colon
+        std::wstring currentPath{ GetEnvironmentVariableForProcess(c_pathExtName) };
+        if (pathToManipulate.back() != L';')
+        {
+            pathToManipulate += L";";
+        }
+
+        pathToManipulate += c_evValueName;
+        pathToManipulate += L";";
+
+        ProcessCleanup();
+        VERIFY_ARE_EQUAL(currentPath, pathToManipulate);
+
+        VERIFY_THROWS(environmentManager.AddExecutableFileExtension(L""), winrt::hresult_invalid_argument);
+    }
+
+    void EnvironmentManagerUWPTests::UWPTestAppendToPathExtForUser()
+    {
+        EnvironmentManager environmentManager{ EnvironmentManager::GetForUser() };
+
+        VERIFY_THROWS(environmentManager.AddExecutableFileExtension(c_evValueName), winrt::hresult_access_denied);
+    }
+
+    void EnvironmentManagerUWPTests::UWPTestAppendToPathExtForMachine()
+    {
+        EnvironmentManager environmentManager{ EnvironmentManager::GetForMachine() };
+
+        VERIFY_THROWS(environmentManager.AddExecutableFileExtension(c_evValueName), winrt::hresult_access_denied);
+    }
+
+    void EnvironmentManagerUWPTests::UWPTestRemoveFromPathExtForProcess()
+    {
+        ProcessSetup();
+
+        // Keep a local string to match all operations to PATH
+        std::wstring pathToManipulate{ GetEnvironmentVariableForProcess(c_pathExtName) };
+
+        EnvironmentManager environmentManager{ EnvironmentManager::GetForProcess() };
+
+        InjectIntoPath(true, false, c_evValueName, 5);
+        environmentManager.RemoveExecutableFileExtension(c_evValueName);
+
+        std::wstring currentPath{ GetEnvironmentVariableForProcess(c_pathExtName) };
+
+        ProcessCleanup();
+
+        VERIFY_ARE_EQUAL(currentPath, pathToManipulate);
+
+        VERIFY_NO_THROW(environmentManager.RemoveExecutableFileExtension(L"I do not exist"));
+
+        VERIFY_ARE_EQUAL(currentPath, pathToManipulate);
+    }
+
+    void EnvironmentManagerUWPTests::UWPTestRemoveFromPathExtForUser()
+    {
+        EnvironmentManager environmentManager{ EnvironmentManager::GetForUser() };
+        std::wstring pathPart{ GetSecondValueFromPathExt(false, true) };
+        VERIFY_THROWS(environmentManager.RemoveExecutableFileExtension(pathPart), winrt::hresult_access_denied);
+    }
+
+    void EnvironmentManagerUWPTests::UWPTestRemoveFromPathExtForMachine()
+    {
+        EnvironmentManager environmentManager{ EnvironmentManager::GetForMachine() };
+        std::wstring pathPart{ GetSecondValueFromPathExt(false, false) };
+        VERIFY_THROWS(environmentManager.RemoveExecutableFileExtension(pathPart), winrt::hresult_access_denied);
+    }
 }

--- a/test/EnvironmentManagerTests/EnvironmentManagerUWPTests.h
+++ b/test/EnvironmentManagerTests/EnvironmentManagerUWPTests.h
@@ -12,14 +12,14 @@ namespace ProjectReunionEnvironmentManagerTests
             TEST_CLASS_PROPERTY(L"RunFixtureAs", L"ElevatedUser")
             END_TEST_CLASS()
 
-        TEST_CLASS_SETUP(UWPWriteEVs)
+        TEST_METHOD_SETUP(UWPWriteEVs)
         {
             UserSetup();
             MachineSetup();
             return true;
         }
 
-        TEST_CLASS_CLEANUP(UWPRemoveEVs)
+        TEST_METHOD_CLEANUP(UWPRemoveEVs)
         {
             UserCleanup();
             MachineCleanup();

--- a/test/EnvironmentManagerTests/EnvironmentManagerUWPTests.h
+++ b/test/EnvironmentManagerTests/EnvironmentManagerUWPTests.h
@@ -49,5 +49,13 @@ namespace ProjectReunionEnvironmentManagerTests
         TEST_METHOD(UWPTestRemoveFromPathForProcess);
         TEST_METHOD(UWPTestRemoveFromPathForUser);
         TEST_METHOD(UWPTestRemoveFromPathForMachine);
+
+        TEST_METHOD(UWPTestAppendToPathExtForProcess);
+        TEST_METHOD(UWPTestAppendToPathExtForUser);
+        TEST_METHOD(UWPTestAppendToPathExtForMachine);
+
+        TEST_METHOD(UWPTestRemoveFromPathExtForProcess);
+        TEST_METHOD(UWPTestRemoveFromPathExtForUser);
+        TEST_METHOD(UWPTestRemoveFromPathExtForMachine);
     };
 }

--- a/test/EnvironmentManagerTests/EnvironmentManagerWin32Tests.cpp
+++ b/test/EnvironmentManagerTests/EnvironmentManagerWin32Tests.cpp
@@ -62,47 +62,47 @@ namespace ProjectReunionEnvironmentManagerTests
         ProcessSetup();
 
         EnvironmentManager environmentManager{ EnvironmentManager::GetForProcess() };
-        winrt::hstring environmentValue{ environmentManager.GetEnvironmentVariable(c_evKeyName) };
+        winrt::hstring environmentValue{ environmentManager.GetEnvironmentVariable(c_EvKeyName) };
 
         ProcessCleanup();
 
-        VERIFY_ARE_EQUAL(std::wstring{ c_evValueName }, environmentValue);
+        VERIFY_ARE_EQUAL(std::wstring{ c_EvValueName }, environmentValue);
     }
 
     void EnvironmentManagerWin32Tests::TestGetEnvironmentVariableForUser()
     {
         EnvironmentManager environmentManager{ EnvironmentManager::GetForUser() };
-        winrt::hstring environmentValue{ environmentManager.GetEnvironmentVariable(c_evKeyNameForGet) };
+        winrt::hstring environmentValue{ environmentManager.GetEnvironmentVariable(c_EvKeyNameForGet) };
 
-        VERIFY_ARE_EQUAL(std::wstring{ c_evValueName }, environmentValue);
+        VERIFY_ARE_EQUAL(std::wstring{ c_EvValueName }, environmentValue);
     }
 
     void EnvironmentManagerWin32Tests::TestGetEnvironmentVariableForMachine()
     {
         EnvironmentManager environmentManager{ EnvironmentManager::GetForMachine() };
-        winrt::hstring environmentValue{ environmentManager.GetEnvironmentVariable(c_evKeyNameForGet) };
+        winrt::hstring environmentValue{ environmentManager.GetEnvironmentVariable(c_EvKeyNameForGet) };
 
-        VERIFY_ARE_EQUAL(std::wstring{ c_evValueName }, environmentValue);
+        VERIFY_ARE_EQUAL(std::wstring{ c_EvValueName }, environmentValue);
     }
 
     void EnvironmentManagerWin32Tests::TestSetEnvironmentVariableForProcess()
     {
         EnvironmentManager environmentManager{ EnvironmentManager::GetForProcess() };
-        VERIFY_NO_THROW(environmentManager.SetEnvironmentVariable(c_evKeyName, c_evValueName));
+        VERIFY_NO_THROW(environmentManager.SetEnvironmentVariable(c_EvKeyName, c_EvValueName));
 
-        std::wstring writtenEV = GetEnvironmentVariableForProcess(c_evKeyName);
-        VERIFY_ARE_EQUAL(std::wstring{ c_evValueName }, writtenEV);
+        std::wstring writtenEV = GetEnvironmentVariableForProcess(c_EvKeyName);
+        VERIFY_ARE_EQUAL(std::wstring{ c_EvValueName }, writtenEV);
 
         // Update the environment variable
-        VERIFY_NO_THROW(environmentManager.SetEnvironmentVariable(c_evKeyName, c_evValueName2));
-        writtenEV = GetEnvironmentVariableForProcess(c_evKeyName);
-        VERIFY_ARE_EQUAL(std::wstring{ c_evValueName2 }, writtenEV);
+        VERIFY_NO_THROW(environmentManager.SetEnvironmentVariable(c_EvKeyName, c_EvValueName2));
+        writtenEV = GetEnvironmentVariableForProcess(c_EvKeyName);
+        VERIFY_ARE_EQUAL(std::wstring{ c_EvValueName2 }, writtenEV);
 
 
         // Remove the value
         // setting the value to empty is the same as deleting the variable
-        VERIFY_NO_THROW(environmentManager.SetEnvironmentVariable(c_evKeyName, L""));
-        VERIFY_ARE_EQUAL(0, ::GetEnvironmentVariable(c_evKeyName, nullptr, 0));
+        VERIFY_NO_THROW(environmentManager.SetEnvironmentVariable(c_EvKeyName, L""));
+        VERIFY_ARE_EQUAL(0, ::GetEnvironmentVariable(c_EvKeyName, nullptr, 0));
     }
 
     void EnvironmentManagerWin32Tests::TestSetEnvironmentVariableForUser()
@@ -111,25 +111,25 @@ namespace ProjectReunionEnvironmentManagerTests
 
         if (!IsILAtOrAbove(ProcessRunLevel::Standard))
         {
-            VERIFY_THROWS(environmentManager.SetEnvironmentVariable(c_evKeyName, c_evValueName), winrt::hresult_access_denied);
+            VERIFY_THROWS(environmentManager.SetEnvironmentVariable(c_EvKeyName, c_EvValueName), winrt::hresult_access_denied);
             return;
         }
 
-        VERIFY_NO_THROW(environmentManager.SetEnvironmentVariable(c_evKeyName, c_evValueName));
+        VERIFY_NO_THROW(environmentManager.SetEnvironmentVariable(c_EvKeyName, c_EvValueName));
 
-        std::wstring writtenEV = GetEnvironmentVariableForUser(c_evKeyName);
-        VERIFY_ARE_EQUAL(std::wstring{ c_evValueName }, writtenEV);
+        std::wstring writtenEV = GetEnvironmentVariableForUser(c_EvKeyName);
+        VERIFY_ARE_EQUAL(std::wstring{ c_EvValueName }, writtenEV);
 
         // Update the environment variable
-        VERIFY_NO_THROW(environmentManager.SetEnvironmentVariable(c_evKeyName, c_evValueName2));
-        writtenEV = GetEnvironmentVariableForUser(c_evKeyName);
-        VERIFY_ARE_EQUAL(std::wstring{ c_evValueName2 }, writtenEV);
+        VERIFY_NO_THROW(environmentManager.SetEnvironmentVariable(c_EvKeyName, c_EvValueName2));
+        writtenEV = GetEnvironmentVariableForUser(c_EvKeyName);
+        VERIFY_ARE_EQUAL(std::wstring{ c_EvValueName2 }, writtenEV);
 
 
         // Remove the value
         // setting the value to empty is the same as deleting the variable
-        VERIFY_NO_THROW(environmentManager.SetEnvironmentVariable(c_evKeyName, L""));
-        VERIFY_ARE_EQUAL(L"", GetEnvironmentVariableForUser(c_evKeyName));
+        VERIFY_NO_THROW(environmentManager.SetEnvironmentVariable(c_EvKeyName, L""));
+        VERIFY_ARE_EQUAL(L"", GetEnvironmentVariableForUser(c_EvKeyName));
     }
 
     void EnvironmentManagerWin32Tests::TestSetEnvironmentVariableForMachine()
@@ -138,25 +138,25 @@ namespace ProjectReunionEnvironmentManagerTests
 
         if (!IsILAtOrAbove(ProcessRunLevel::Elevated))
         {
-            VERIFY_THROWS(environmentManager.SetEnvironmentVariable(c_evKeyName, c_evValueName), winrt::hresult_access_denied);
+            VERIFY_THROWS(environmentManager.SetEnvironmentVariable(c_EvKeyName, c_EvValueName), winrt::hresult_access_denied);
             return;
         }
 
-        VERIFY_NO_THROW(environmentManager.SetEnvironmentVariable(c_evKeyName, c_evValueName));
+        VERIFY_NO_THROW(environmentManager.SetEnvironmentVariable(c_EvKeyName, c_EvValueName));
 
-        std::wstring writtenEV{ GetEnvironmentVariableForMachine(c_evKeyName) };
-        VERIFY_ARE_EQUAL(std::wstring{ c_evValueName }, writtenEV);
+        std::wstring writtenEV{ GetEnvironmentVariableForMachine(c_EvKeyName) };
+        VERIFY_ARE_EQUAL(std::wstring{ c_EvValueName }, writtenEV);
 
         // Update the environment variable
-        VERIFY_NO_THROW(environmentManager.SetEnvironmentVariable(c_evKeyName, c_evValueName2));
-        writtenEV = GetEnvironmentVariableForMachine(c_evKeyName);
-        VERIFY_ARE_EQUAL(std::wstring{ c_evValueName2 }, writtenEV);
+        VERIFY_NO_THROW(environmentManager.SetEnvironmentVariable(c_EvKeyName, c_EvValueName2));
+        writtenEV = GetEnvironmentVariableForMachine(c_EvKeyName);
+        VERIFY_ARE_EQUAL(std::wstring{ c_EvValueName2 }, writtenEV);
 
 
         // Remove the value
         // setting the value to empty is the same as deleting the variable
-        VERIFY_NO_THROW(environmentManager.SetEnvironmentVariable(c_evKeyName, L""));
-        VERIFY_ARE_EQUAL(L"", GetEnvironmentVariableForMachine(c_evKeyName));
+        VERIFY_NO_THROW(environmentManager.SetEnvironmentVariable(c_EvKeyName, L""));
+        VERIFY_ARE_EQUAL(L"", GetEnvironmentVariableForMachine(c_EvKeyName));
 
     }
 
@@ -164,20 +164,20 @@ namespace ProjectReunionEnvironmentManagerTests
     {
         ProcessSetup();
         // Keep a local string to match all operations to PATH
-        std::wstring pathToManipulate{ GetEnvironmentVariableForProcess(c_pathName) };
+        std::wstring pathToManipulate{ GetEnvironmentVariableForProcess(c_PathName) };
 
         EnvironmentManager environmentManager{ EnvironmentManager::GetForProcess() };
 
-        VERIFY_NO_THROW(environmentManager.AppendToPath(c_evValueName));
+        VERIFY_NO_THROW(environmentManager.AppendToPath(c_EvValueName));
 
         // Current path should have the semi-colon
-        std::wstring currentPath{ GetEnvironmentVariableForProcess(c_pathName) };
+        std::wstring currentPath{ GetEnvironmentVariableForProcess(c_PathName) };
         if (pathToManipulate.back() != L';')
         {
             pathToManipulate += L";";
         }
 
-        pathToManipulate += c_evValueName;
+        pathToManipulate += c_EvValueName;
         pathToManipulate += L";";
 
         ProcessCleanup();
@@ -190,26 +190,26 @@ namespace ProjectReunionEnvironmentManagerTests
     void EnvironmentManagerWin32Tests::TestAppendToPathForUser()
     {
         // Keep a local string to match all operations to PATH
-        std::wstring pathToManipulate{ GetEnvironmentVariableForUser(c_pathName) };
+        std::wstring pathToManipulate{ GetEnvironmentVariableForUser(c_PathName) };
 
         EnvironmentManager environmentManager{ EnvironmentManager::GetForUser() };
 
         if (!IsILAtOrAbove(ProcessRunLevel::Standard))
         {
-            VERIFY_THROWS(environmentManager.AppendToPath(c_evValueName), winrt::hresult_access_denied);
+            VERIFY_THROWS(environmentManager.AppendToPath(c_EvValueName), winrt::hresult_access_denied);
             return;
         }
 
-        VERIFY_NO_THROW(environmentManager.AppendToPath(c_evValueName));
+        VERIFY_NO_THROW(environmentManager.AppendToPath(c_EvValueName));
 
         // Current path should have the semi-colon
-        std::wstring currentPath{ GetEnvironmentVariableForUser(c_pathName) };
+        std::wstring currentPath{ GetEnvironmentVariableForUser(c_PathName) };
         if (pathToManipulate.back() != L';')
         {
             pathToManipulate += L";";
         }
 
-        pathToManipulate += c_evValueName;
+        pathToManipulate += c_EvValueName;
         pathToManipulate += L";";
 
         VERIFY_ARE_EQUAL(currentPath, pathToManipulate);
@@ -220,26 +220,26 @@ namespace ProjectReunionEnvironmentManagerTests
     void EnvironmentManagerWin32Tests::TestAppendToPathForMachine()
     {
         // Keep a local string to match all operations to PATH
-        std::wstring pathToManipulate{ GetEnvironmentVariableForMachine(c_pathName) };
+        std::wstring pathToManipulate{ GetEnvironmentVariableForMachine(c_PathName) };
 
         EnvironmentManager environmentManager{ EnvironmentManager::GetForMachine() };
 
         if (!IsILAtOrAbove(ProcessRunLevel::Elevated))
         {
-            VERIFY_THROWS(environmentManager.AppendToPath(c_evValueName), winrt::hresult_access_denied);
+            VERIFY_THROWS(environmentManager.AppendToPath(c_EvValueName), winrt::hresult_access_denied);
             return;
         }
 
-        VERIFY_NO_THROW(environmentManager.AppendToPath(c_evValueName));
+        VERIFY_NO_THROW(environmentManager.AppendToPath(c_EvValueName));
 
         // Current path should have the semi-colon
-        std::wstring currentPath{ GetEnvironmentVariableForMachine(c_pathName) };
+        std::wstring currentPath{ GetEnvironmentVariableForMachine(c_PathName) };
         if (pathToManipulate.back() != L';')
         {
             pathToManipulate += L";";
         }
 
-        pathToManipulate += c_evValueName;
+        pathToManipulate += c_EvValueName;
         pathToManipulate += L";";;
 
         VERIFY_ARE_EQUAL(currentPath, pathToManipulate);
@@ -252,13 +252,13 @@ namespace ProjectReunionEnvironmentManagerTests
         ProcessSetup();
 
         // Keep a local string to match all operations to PATH
-        std::wstring pathToManipulate{ GetEnvironmentVariableForProcess(c_pathName) };
+        std::wstring pathToManipulate{ GetEnvironmentVariableForProcess(c_PathName) };
 
         EnvironmentManager environmentManager{ EnvironmentManager::GetForProcess() };
 
-        environmentManager.RemoveFromPath(c_evValueName);
+        environmentManager.RemoveFromPath(c_EvValueName);
 
-        std::wstring currentPath{ GetEnvironmentVariableForProcess(c_pathName) };
+        std::wstring currentPath{ GetEnvironmentVariableForProcess(c_PathName) };
 
         ProcessCleanup();
 
@@ -272,20 +272,20 @@ namespace ProjectReunionEnvironmentManagerTests
     void EnvironmentManagerWin32Tests::TestRemoveFromPathForUser()
     {
         // Keep a local string to match all operations to PATH
-        std::wstring pathToManipulate{ GetEnvironmentVariableForUser(c_pathName) };
+        std::wstring pathToManipulate{ GetEnvironmentVariableForUser(c_PathName) };
 
         EnvironmentManager environmentManager{ EnvironmentManager::GetForUser() };
 
         if (!IsILAtOrAbove(ProcessRunLevel::LegacyLowIL))
         {
             std::wstring pathPart{ GetSecondValueFromPath(false, true) };
-            VERIFY_THROWS(environmentManager.RemoveFromPath(c_evValueName), winrt::hresult_access_denied);
+            VERIFY_THROWS(environmentManager.RemoveFromPath(c_EvValueName), winrt::hresult_access_denied);
             return;
         }
 
-        environmentManager.RemoveFromPath(c_evValueName);
+        environmentManager.RemoveFromPath(c_EvValueName);
 
-        std::wstring currentPath{ GetEnvironmentVariableForUser(c_pathName) };
+        std::wstring currentPath{ GetEnvironmentVariableForUser(c_PathName) };
 
         VERIFY_ARE_EQUAL(currentPath, pathToManipulate);
 
@@ -297,7 +297,7 @@ namespace ProjectReunionEnvironmentManagerTests
     void EnvironmentManagerWin32Tests::TestRemoveFromPathForMachine()
     {        
         // Keep a local string to match all operations to PATH
-        std::wstring pathToManipulate{ GetEnvironmentVariableForMachine(c_pathName) };
+        std::wstring pathToManipulate{ GetEnvironmentVariableForMachine(c_PathName) };
 
         EnvironmentManager environmentManager{ EnvironmentManager::GetForMachine() };
 
@@ -308,9 +308,9 @@ namespace ProjectReunionEnvironmentManagerTests
             return;
         }
 
-        environmentManager.RemoveFromPath(c_evValueName);
+        environmentManager.RemoveFromPath(c_EvValueName);
 
-        std::wstring currentPath{ GetEnvironmentVariableForMachine(c_pathName) };
+        std::wstring currentPath{ GetEnvironmentVariableForMachine(c_PathName) };
 
         VERIFY_ARE_EQUAL(currentPath, pathToManipulate);
 
@@ -323,20 +323,20 @@ namespace ProjectReunionEnvironmentManagerTests
     {
         ProcessSetup();
         // Keep a local string to match all operations to PATH
-        std::wstring pathToManipulate{ GetEnvironmentVariableForProcess(c_pathExtName) };
+        std::wstring pathToManipulate{ GetEnvironmentVariableForProcess(c_PathExtName) };
 
         EnvironmentManager environmentManager{ EnvironmentManager::GetForProcess() };
 
-        VERIFY_NO_THROW(environmentManager.AddExecutableFileExtension(c_evValueName));
+        VERIFY_NO_THROW(environmentManager.AddExecutableFileExtension(c_EvValueName));
 
         // Current path should have the semi-colon
-        std::wstring currentPath{ GetEnvironmentVariableForProcess(c_pathExtName) };
+        std::wstring currentPath{ GetEnvironmentVariableForProcess(c_PathExtName) };
         if (pathToManipulate.back() != L';')
         {
             pathToManipulate += L";";
         }
 
-        pathToManipulate += c_evValueName;
+        pathToManipulate += c_EvValueName;
         pathToManipulate += L";";
 
         ProcessCleanup();
@@ -348,27 +348,27 @@ namespace ProjectReunionEnvironmentManagerTests
     void EnvironmentManagerWin32Tests::TestAppendToPathExtForUser()
     {
         // Keep a local string to match all operations to PATH
-        std::wstring pathToManipulate{ GetEnvironmentVariableForUser(c_pathExtName) };
+        std::wstring pathToManipulate{ GetEnvironmentVariableForUser(c_PathExtName) };
 
         EnvironmentManager environmentManager{ EnvironmentManager::GetForUser() };
 
         if (!IsILAtOrAbove(ProcessRunLevel::Standard))
         {
-            VERIFY_THROWS(environmentManager.AddExecutableFileExtension(c_evValueName), winrt::hresult_access_denied);
+            VERIFY_THROWS(environmentManager.AddExecutableFileExtension(c_EvValueName), winrt::hresult_access_denied);
             return;
         }
 
-        VERIFY_NO_THROW(environmentManager.AddExecutableFileExtension(c_evValueName));
+        VERIFY_NO_THROW(environmentManager.AddExecutableFileExtension(c_EvValueName));
 
         // Current path should have the semi-colon
-        std::wstring currentPath{ GetEnvironmentVariableForUser(c_pathExtName) };
+        std::wstring currentPath{ GetEnvironmentVariableForUser(c_PathExtName) };
 
         if (pathToManipulate.back() != L';')
         {
             pathToManipulate += L";";
         }
 
-        pathToManipulate += c_evValueName;
+        pathToManipulate += c_EvValueName;
         pathToManipulate += L";";
 
         VERIFY_ARE_EQUAL(currentPath, pathToManipulate);
@@ -379,27 +379,27 @@ namespace ProjectReunionEnvironmentManagerTests
     void EnvironmentManagerWin32Tests::TestAppendToPathExtForMachine()
     {
         // Keep a local string to match all operations to PATH
-        std::wstring pathToManipulate{ GetEnvironmentVariableForMachine(c_pathExtName) };
+        std::wstring pathToManipulate{ GetEnvironmentVariableForMachine(c_PathExtName) };
 
         EnvironmentManager environmentManager{ EnvironmentManager::GetForMachine() };
 
         if (!IsILAtOrAbove(ProcessRunLevel::Elevated))
         {
-            VERIFY_THROWS(environmentManager.AddExecutableFileExtension(c_evValueName), winrt::hresult_access_denied);
+            VERIFY_THROWS(environmentManager.AddExecutableFileExtension(c_EvValueName), winrt::hresult_access_denied);
             return;
         }
 
-        VERIFY_NO_THROW(environmentManager.AddExecutableFileExtension(c_evValueName));
+        VERIFY_NO_THROW(environmentManager.AddExecutableFileExtension(c_EvValueName));
 
         // Current path should have the semi-colon
-        std::wstring currentPath{ GetEnvironmentVariableForMachine(c_pathExtName) };
+        std::wstring currentPath{ GetEnvironmentVariableForMachine(c_PathExtName) };
 
         if (pathToManipulate.back() != L';')
         {
             pathToManipulate += L";";
         }
 
-        pathToManipulate += c_evValueName;
+        pathToManipulate += c_EvValueName;
         pathToManipulate += L";";
 
         VERIFY_ARE_EQUAL(currentPath, pathToManipulate);
@@ -412,14 +412,14 @@ namespace ProjectReunionEnvironmentManagerTests
         ProcessSetup();
 
         // Keep a local string to match all operations to PATH
-        std::wstring pathToManipulate{ GetEnvironmentVariableForProcess(c_pathExtName) };
+        std::wstring pathToManipulate{ GetEnvironmentVariableForProcess(c_PathExtName) };
 
         EnvironmentManager environmentManager{ EnvironmentManager::GetForProcess() };
 
-        InjectIntoPath(true, false, c_evValueName, 5);
-        environmentManager.RemoveExecutableFileExtension(c_evValueName);
+        InjectIntoPath(true, false, c_EvValueName, 5);
+        environmentManager.RemoveExecutableFileExtension(c_EvValueName);
 
-        std::wstring currentPath{ GetEnvironmentVariableForProcess(c_pathExtName) };
+        std::wstring currentPath{ GetEnvironmentVariableForProcess(c_PathExtName) };
 
         ProcessCleanup();
 
@@ -433,7 +433,7 @@ namespace ProjectReunionEnvironmentManagerTests
     void EnvironmentManagerWin32Tests::TestRemoveFromPathExtForUser()
     {
         // Keep a local string to match all operations to PATH
-        std::wstring pathToManipulate{ GetEnvironmentVariableForUser(c_pathExtName) };
+        std::wstring pathToManipulate{ GetEnvironmentVariableForUser(c_PathExtName) };
 
         if (pathToManipulate.back() != L';')
         {
@@ -449,10 +449,10 @@ namespace ProjectReunionEnvironmentManagerTests
             return;
         }
 
-        InjectIntoPathExt(false, true, c_evValueName, 5);
-        environmentManager.RemoveExecutableFileExtension(c_evValueName);
+        InjectIntoPathExt(false, true, c_EvValueName, 5);
+        environmentManager.RemoveExecutableFileExtension(c_EvValueName);
 
-        std::wstring currentPath{ GetEnvironmentVariableForUser(c_pathExtName) };
+        std::wstring currentPath{ GetEnvironmentVariableForUser(c_PathExtName) };
 
         VERIFY_ARE_EQUAL(currentPath, pathToManipulate);
 
@@ -464,7 +464,7 @@ namespace ProjectReunionEnvironmentManagerTests
     void EnvironmentManagerWin32Tests::TestRemoveFromPathExtForMachine()
     {
         // Keep a local string to match all operations to PATH
-        std::wstring pathToManipulate{ GetEnvironmentVariableForMachine(c_pathExtName) };
+        std::wstring pathToManipulate{ GetEnvironmentVariableForMachine(c_PathExtName) };
 
         EnvironmentManager environmentManager{ EnvironmentManager::GetForMachine() };
 
@@ -475,9 +475,9 @@ namespace ProjectReunionEnvironmentManagerTests
             return;
         }
 
-        environmentManager.RemoveExecutableFileExtension(c_evValueName);
+        environmentManager.RemoveExecutableFileExtension(c_EvValueName);
 
-        std::wstring currentPath{ GetEnvironmentVariableForMachine(c_pathExtName) };
+        std::wstring currentPath{ GetEnvironmentVariableForMachine(c_PathExtName) };
 
         VERIFY_ARE_EQUAL(currentPath, pathToManipulate);
 

--- a/test/EnvironmentManagerTests/EnvironmentManagerWin32Tests.h
+++ b/test/EnvironmentManagerTests/EnvironmentManagerWin32Tests.h
@@ -51,5 +51,13 @@ namespace ProjectReunionEnvironmentManagerTests
         TEST_METHOD(TestRemoveFromPathForProcess);
         TEST_METHOD(TestRemoveFromPathForUser);
         TEST_METHOD(TestRemoveFromPathForMachine);
+
+        TEST_METHOD(TestAppendToPathExtForProcess);
+        TEST_METHOD(TestAppendToPathExtForUser);
+        TEST_METHOD(TestAppendToPathExtForMachine);
+
+        TEST_METHOD(TestRemoveFromPathExtForProcess);
+        TEST_METHOD(TestRemoveFromPathExtForUser);
+        TEST_METHOD(TestRemoveFromPathExtForMachine);
     };
 }

--- a/test/EnvironmentManagerTests/EnvironmentManagerWin32Tests.h
+++ b/test/EnvironmentManagerTests/EnvironmentManagerWin32Tests.h
@@ -14,14 +14,14 @@ namespace ProjectReunionEnvironmentManagerTests
             TEST_CLASS_PROPERTY(L"RunAs", L"{ElevatedUser,RestrictedUser,LowIL}")
         END_TEST_CLASS()
 
-            TEST_CLASS_SETUP(WriteEVs)
+            TEST_METHOD_SETUP(WriteEVs)
         {
             UserSetup();
             MachineSetup();
             return true;
         }
 
-        TEST_CLASS_CLEANUP(RemoveEVs)
+        TEST_METHOD_CLEANUP(RemoveEVs)
         {
             UserCleanup();
             MachineCleanup();

--- a/test/EnvironmentManagerTests/EnvironmentVariableHelper.h
+++ b/test/EnvironmentManagerTests/EnvironmentVariableHelper.h
@@ -101,11 +101,11 @@ inline wil::unique_hkey GetKeyToEnvironmentVariables(bool isUser)
     wil::unique_hkey environmentVariablesHKey{};
     if (isUser)
     {
-        THROW_IF_WIN32_ERROR(RegOpenKeyEx(HKEY_CURRENT_USER, c_userEvRegLocation, 0, KEY_ALL_ACCESS, environmentVariablesHKey.addressof()));
+        THROW_IF_WIN32_ERROR(RegOpenKeyEx(HKEY_CURRENT_USER, c_UserEvRegLocation, 0, KEY_ALL_ACCESS, environmentVariablesHKey.addressof()));
     }
     else
     {
-        THROW_IF_WIN32_ERROR(RegOpenKeyEx(HKEY_LOCAL_MACHINE, c_machineEvRegLocation, 0, KEY_ALL_ACCESS, environmentVariablesHKey.addressof()));
+        THROW_IF_WIN32_ERROR(RegOpenKeyEx(HKEY_LOCAL_MACHINE, c_MachineEvRegLocation, 0, KEY_ALL_ACCESS, environmentVariablesHKey.addressof()));
     }
 
     return environmentVariablesHKey;
@@ -114,21 +114,21 @@ inline wil::unique_hkey GetKeyToEnvironmentVariables(bool isUser)
 inline EnvironmentVariables GetEnvironmentVariablesForUser()
 {
     wil::unique_hkey environmentVariablesHKey{};
-    THROW_IF_WIN32_ERROR(RegOpenKeyEx(HKEY_CURRENT_USER, c_userEvRegLocation, 0, KEY_READ, environmentVariablesHKey.addressof()));
+    THROW_IF_WIN32_ERROR(RegOpenKeyEx(HKEY_CURRENT_USER, c_UserEvRegLocation, 0, KEY_READ, environmentVariablesHKey.addressof()));
     return GetEnvironmentVariablesFromRegistry(environmentVariablesHKey.get());
 }
 
 inline std::wstring GetEnvironmentVariableForUser(const std::wstring variableName)
 {
     wil::unique_hkey environmentVariableHKey{};
-    THROW_IF_WIN32_ERROR(RegOpenKeyEx(HKEY_CURRENT_USER, c_userEvRegLocation, 0, KEY_READ, environmentVariableHKey.addressof()));
+    THROW_IF_WIN32_ERROR(RegOpenKeyEx(HKEY_CURRENT_USER, c_UserEvRegLocation, 0, KEY_READ, environmentVariableHKey.addressof()));
     return GetEnvironmentVariableFromRegistry(variableName, environmentVariableHKey.get());
 }
 
 inline std::wstring GetEnvironmentVariableForMachine(const std::wstring variableName)
 {
     wil::unique_hkey environmentVariableHKey{};
-    THROW_IF_WIN32_ERROR(RegOpenKeyEx(HKEY_LOCAL_MACHINE, c_machineEvRegLocation, 0, KEY_READ, environmentVariableHKey.addressof()));
+    THROW_IF_WIN32_ERROR(RegOpenKeyEx(HKEY_LOCAL_MACHINE, c_MachineEvRegLocation, 0, KEY_READ, environmentVariableHKey.addressof()));
     return GetEnvironmentVariableFromRegistry(variableName, environmentVariableHKey.get());
 }
 
@@ -171,15 +171,15 @@ inline void InjectIntoPath(bool isProcess, bool isUser, const std::wstring& cons
 
     if (isProcess)
     {
-        existingPath = GetEnvironmentVariableForProcess(c_pathName);
+        existingPath = GetEnvironmentVariableForProcess(c_PathName);
     }
     else if (isUser)
     {
-        existingPath = GetEnvironmentVariableForUser(c_pathName);
+        existingPath = GetEnvironmentVariableForUser(c_PathName);
     }
     else
     {
-        existingPath = GetEnvironmentVariableForMachine(c_pathName);
+        existingPath = GetEnvironmentVariableForMachine(c_PathName);
     }
 
     std::list<std::wstring> pathParts{};
@@ -226,13 +226,13 @@ inline void InjectIntoPath(bool isProcess, bool isUser, const std::wstring& cons
 
     if (isProcess)
     {
-        SetEnvironmentVariable(c_pathName, newPath.c_str());
+        SetEnvironmentVariable(c_PathName, newPath.c_str());
     }
     else
     {
         THROW_IF_WIN32_ERROR(RegSetValueEx(
             GetKeyToEnvironmentVariables(isUser).get()
-            , c_pathName
+            , c_PathName
             , 0
             , REG_EXPAND_SZ
             , reinterpret_cast<const BYTE*>(newPath.c_str())
@@ -247,15 +247,15 @@ inline void InjectIntoPathExt(bool isProcess, bool isUser, const std::wstring& c
 
     if (isProcess)
     {
-        existingPathExt = GetEnvironmentVariableForProcess(c_pathExtName);
+        existingPathExt = GetEnvironmentVariableForProcess(c_PathExtName);
     }
     else if (isUser)
     {
-        existingPathExt = GetEnvironmentVariableForUser(c_pathExtName);
+        existingPathExt = GetEnvironmentVariableForUser(c_PathExtName);
     }
     else
     {
-        existingPathExt = GetEnvironmentVariableForMachine(c_pathExtName);
+        existingPathExt = GetEnvironmentVariableForMachine(c_PathExtName);
     }
 
     std::list<std::wstring> pathExtParts{};
@@ -302,13 +302,13 @@ inline void InjectIntoPathExt(bool isProcess, bool isUser, const std::wstring& c
 
     if (isProcess)
     {
-        SetEnvironmentVariable(c_pathExtName, newPath.c_str());
+        SetEnvironmentVariable(c_PathExtName, newPath.c_str());
     }
     else
     {
         THROW_IF_WIN32_ERROR(RegSetValueEx(
             GetKeyToEnvironmentVariables(isUser).get()
-            , c_pathExtName
+            , c_PathExtName
             , 0
             , REG_EXPAND_SZ
             , reinterpret_cast<const BYTE*>(newPath.c_str())
@@ -323,15 +323,15 @@ inline std::wstring GetSecondValueFromPath(bool isProcess, bool isUser)
 
     if (isProcess)
     {
-        existingPath = GetEnvironmentVariableForProcess(c_pathName);
+        existingPath = GetEnvironmentVariableForProcess(c_PathName);
     }
     else if (isUser)
     {
-        existingPath = GetEnvironmentVariableForUser(c_pathName);
+        existingPath = GetEnvironmentVariableForUser(c_PathName);
     }
     else
     {
-        existingPath = GetEnvironmentVariableForMachine(c_pathName);
+        existingPath = GetEnvironmentVariableForMachine(c_PathName);
     }
 
     int index{ 0 };
@@ -362,15 +362,15 @@ inline std::wstring GetSecondValueFromPathExt(bool isProcess, bool isUser)
 
     if (isProcess)
     {
-        existingPath = GetEnvironmentVariableForProcess(c_pathExtName);
+        existingPath = GetEnvironmentVariableForProcess(c_PathExtName);
     }
     else if (isUser)
     {
-        existingPath = GetEnvironmentVariableForUser(c_pathExtName);
+        existingPath = GetEnvironmentVariableForUser(c_PathExtName);
     }
     else
     {
-        existingPath = GetEnvironmentVariableForMachine(c_pathExtName);
+        existingPath = GetEnvironmentVariableForMachine(c_PathExtName);
     }
 
     int index{ 0 };
@@ -399,7 +399,7 @@ inline std::wstring GetSecondValueFromPathExt(bool isProcess, bool isUser)
 inline EnvironmentVariables GetEnvironmentVariablesForMachine()
 {
     wil::unique_hkey environmentVariablesHKey{};
-    THROW_IF_WIN32_ERROR(RegOpenKeyEx(HKEY_LOCAL_MACHINE, c_machineEvRegLocation, 0, KEY_READ, environmentVariablesHKey.addressof()));
+    THROW_IF_WIN32_ERROR(RegOpenKeyEx(HKEY_LOCAL_MACHINE, c_MachineEvRegLocation, 0, KEY_READ, environmentVariablesHKey.addressof()));
     return GetEnvironmentVariablesFromRegistry(environmentVariablesHKey.get());
 }
 

--- a/test/EnvironmentManagerTests/TestCommon.h
+++ b/test/EnvironmentManagerTests/TestCommon.h
@@ -1,18 +1,16 @@
 ﻿#pragma once
 #include "pch.h"
 
-inline constexpr PCWSTR c_userEvRegLocation = L"Environment";
-inline constexpr PCWSTR c_machineEvRegLocation = L"SYSTEM\\CurrentControlSet\\Control\\Session Manager\\Environment";
+inline constexpr PCWSTR c_UserEvRegLocation = L"Environment";
+inline constexpr PCWSTR c_MachineEvRegLocation = L"SYSTEM\\CurrentControlSet\\Control\\Session Manager\\Environment";
 
-inline constexpr PCWSTR c_evKeyName = L"TheBestTestKey";
-inline constexpr PCWSTR c_evKeyNameForGet = L"TheBestTestKey2";
-inline constexpr PCWSTR c_evValueName = L"TheBestTestValue";
-inline constexpr PCWSTR c_evValueName2 = L"TheBestTestValue2";
+inline constexpr PCWSTR c_EvKeyName = L"TheBestTestKey";
+inline constexpr PCWSTR c_EvKeyNameForGet = L"TheBestTestKey2";
+inline constexpr PCWSTR c_EvValueName = L"TheBestTestValue";
+inline constexpr PCWSTR c_EvValueName2 = L"TheBestTestValue2";
 
-inline constexpr PCWSTR c_packageFullName = L"TAEF.TailoredApplication.HostProcess_1.0.0.0_neutral_en-us_8wekyb3d8bbwe";
-
-inline constexpr PCWSTR c_pathName = L"PATH";
-inline constexpr PCWSTR c_pathExtName = L"PATHEXT";
+inline constexpr PCWSTR c_PathName = L"PATH";
+inline constexpr PCWSTR c_PathExtName = L"PATHEXT";
 
 enum class ProcessRunLevel
 {

--- a/test/EnvironmentManagerTests/TestCommon.h
+++ b/test/EnvironmentManagerTests/TestCommon.h
@@ -11,7 +11,8 @@ inline constexpr PCWSTR c_evValueName2 = L"TheBestTestValue2";
 
 inline constexpr PCWSTR c_packageFullName = L"TAEF.TailoredApplication.HostProcess_1.0.0.0_neutral_en-us_8wekyb3d8bbwe";
 
-inline constexpr PCWSTR c_pathName = L"Path";
+inline constexpr PCWSTR c_pathName = L"PATH";
+inline constexpr PCWSTR c_pathExtName = L"PATHEXT";
 
 enum class ProcessRunLevel
 {

--- a/test/EnvironmentManagerTests/TestCommon.h
+++ b/test/EnvironmentManagerTests/TestCommon.h
@@ -22,7 +22,7 @@ enum class ProcessRunLevel
     Elevated
 };
 
-inline bool ValidateTokenRunLevel(ProcessRunLevel expectedRunLevel)
+inline bool IsILAtOrAbove(ProcessRunLevel minimumIL)
 {
     HANDLE processToken;
     VERIFY_WIN32_BOOL_SUCCEEDED(OpenProcessToken(GetCurrentProcess(), MAXIMUM_ALLOWED, &processToken));
@@ -31,23 +31,23 @@ inline bool ValidateTokenRunLevel(ProcessRunLevel expectedRunLevel)
     LONG levelRid = static_cast<SID*>(mandatoryLabel->Label.Sid)->SubAuthority[0];
 
     bool isExpectedRunLevel = false;
-    switch (expectedRunLevel)
+    switch (minimumIL)
     {
     case ProcessRunLevel::UntrustedIL:
-        isExpectedRunLevel = SECURITY_MANDATORY_UNTRUSTED_RID ==levelRid;
+        isExpectedRunLevel = levelRid >= SECURITY_MANDATORY_UNTRUSTED_RID;
         break;
 
     case ProcessRunLevel::AppContainer:
     case ProcessRunLevel::LegacyLowIL:
-        isExpectedRunLevel = SECURITY_MANDATORY_LOW_RID == levelRid;
+        isExpectedRunLevel = levelRid >= SECURITY_MANDATORY_LOW_RID;
         break;
 
     case ProcessRunLevel::Standard:
-        isExpectedRunLevel == SECURITY_MANDATORY_MEDIUM_RID == levelRid;
+        isExpectedRunLevel = levelRid >= SECURITY_MANDATORY_MEDIUM_RID;
         break;
 
     case ProcessRunLevel::Elevated:
-        isExpectedRunLevel = SECURITY_MANDATORY_HIGH_RID == levelRid;
+        isExpectedRunLevel = levelRid >= SECURITY_MANDATORY_HIGH_RID;
         break;
 
     default:

--- a/test/EnvironmentManagerTests/TestSetupAndTeardownHelper.h
+++ b/test/EnvironmentManagerTests/TestSetupAndTeardownHelper.h
@@ -1,54 +1,11 @@
 ﻿#pragma once
 #include "TestCommon.h"
+#include "EnvironmentVariableHelper.h"
+#include "ChangeTrackerHelper.h"
 
-inline void UserSetup()
-{
-    wil::unique_hkey userEnvironmentVariablesHKey{};
-    VERIFY_WIN32_SUCCEEDED(RegOpenKeyEx(HKEY_CURRENT_USER, c_userEvRegLocation, 0, KEY_WRITE, userEnvironmentVariablesHKey.addressof()));
-    VERIFY_WIN32_SUCCEEDED(RegSetValueExW(userEnvironmentVariablesHKey.get(), c_evKeyNameForGet, 0, REG_SZ, (LPBYTE)c_evValueName, static_cast<DWORD>((wcslen(c_evValueName) + 1) * sizeof(wchar_t))));
-}
-
-inline void UserCleanup()
-{
-    wil::unique_hkey userEnvironmentVariablesHKey{};
-    VERIFY_WIN32_SUCCEEDED(RegOpenKeyEx(HKEY_CURRENT_USER, c_userEvRegLocation, 0, KEY_WRITE, userEnvironmentVariablesHKey.addressof()));
-    LSTATUS deleteResult = RegDeleteValueW(userEnvironmentVariablesHKey.get(), c_evKeyNameForGet);
-
-    if (deleteResult != ERROR_SUCCESS && deleteResult != ERROR_FILE_NOT_FOUND)
-    {
-        FAILED(HRESULT_FROM_WIN32(deleteResult));
-    }
-}
-
-inline void MachineSetup()
-{
-    wil::unique_hkey machineEnvironmentVariablesHKey{};
-    VERIFY_WIN32_SUCCEEDED(RegOpenKeyEx(HKEY_LOCAL_MACHINE, c_machineEvRegLocation, 0, KEY_WRITE, machineEnvironmentVariablesHKey.addressof()));
-    VERIFY_WIN32_SUCCEEDED(RegSetValueExW(machineEnvironmentVariablesHKey.get(), c_evKeyNameForGet, 0, REG_SZ, (LPBYTE)c_evValueName, static_cast<DWORD>((wcslen(c_evValueName) + 1) * sizeof(wchar_t))));
-}
-
-inline void MachineCleanup()
-{
-    wil::unique_hkey machineEnvironmentVariablesHKey{};
-    VERIFY_WIN32_SUCCEEDED(RegOpenKeyEx(HKEY_LOCAL_MACHINE, c_machineEvRegLocation, 0, KEY_WRITE, machineEnvironmentVariablesHKey.addressof()));
-    LSTATUS deleteResult{ RegDeleteValueW(machineEnvironmentVariablesHKey.get(), c_evKeyNameForGet) };
-
-    if (deleteResult != ERROR_SUCCESS && deleteResult != ERROR_FILE_NOT_FOUND)
-    {
-        FAILED(HRESULT_FROM_WIN32(deleteResult));
-    }
-
-}
-
-inline void RestoreProcessPath(std::wstring originalPath)
-{
-    BOOL result{ ::SetEnvironmentVariable(L"Path", originalPath.c_str()) };
-
-    if (result == 0)
-    {
-        FAILED(HRESULT_FROM_WIN32(GetLastError()));
-    }
-}
+inline std::wstring processPath{};
+inline std::wstring userPath{};
+inline std::wstring machinePath{};
 
 inline void RestoreUserPath(std::wstring originalPath)
 {
@@ -64,8 +21,20 @@ inline void RestoreMachinePath(std::wstring originalPath)
     VERIFY_WIN32_SUCCEEDED(RegSetValueExW(machineEnvironmentVariablesHKey.get(), c_pathName, 0, REG_EXPAND_SZ, (LPBYTE)originalPath.c_str(), static_cast<DWORD>(wcslen(originalPath.c_str()) * sizeof(wchar_t))));
 }
 
+inline void RestoreProcessPath(std::wstring originalPath)
+{
+    BOOL result{ ::SetEnvironmentVariable(L"Path", originalPath.c_str()) };
+
+    if (result == 0)
+    {
+        FAILED(HRESULT_FROM_WIN32(GetLastError()));
+    }
+}
+
 inline void ProcessSetup()
 {
+    processPath = GetEnvironmentVariableForProcess(L"PATH");
+
     BOOL setResult{ SetEnvironmentVariable(c_evKeyName, c_evValueName) };
 
     if (!setResult)
@@ -74,3 +43,55 @@ inline void ProcessSetup()
     }
 }
 
+inline void ProcessCleanup()
+{
+    RestoreProcessPath(processPath);
+}
+
+inline void UserSetup()
+{
+    userPath = GetEnvironmentVariableForUser(L"PATH");
+
+    wil::unique_hkey userEnvironmentVariablesHKey{};
+    VERIFY_WIN32_SUCCEEDED(RegOpenKeyEx(HKEY_CURRENT_USER, c_userEvRegLocation, 0, KEY_WRITE, userEnvironmentVariablesHKey.addressof()));
+    VERIFY_WIN32_SUCCEEDED(RegSetValueExW(userEnvironmentVariablesHKey.get(), c_evKeyNameForGet, 0, REG_SZ, (LPBYTE)c_evValueName, static_cast<DWORD>((wcslen(c_evValueName) + 1) * sizeof(wchar_t))));
+}
+
+inline void UserCleanup()
+{
+    RestoreUserPath(userPath);
+    wil::unique_hkey userEnvironmentVariablesHKey{};
+    VERIFY_WIN32_SUCCEEDED(RegOpenKeyEx(HKEY_CURRENT_USER, c_userEvRegLocation, 0, KEY_WRITE, userEnvironmentVariablesHKey.addressof()));
+    LSTATUS deleteResult = RegDeleteValueW(userEnvironmentVariablesHKey.get(), c_evKeyNameForGet);
+
+    if (deleteResult != ERROR_SUCCESS && deleteResult != ERROR_FILE_NOT_FOUND)
+    {
+        FAILED(HRESULT_FROM_WIN32(deleteResult));
+    }
+
+    RemoveUserChangeTracking();
+}
+
+inline void MachineSetup()
+{
+    machinePath = GetEnvironmentVariableForMachine(L"PATH");
+    wil::unique_hkey machineEnvironmentVariablesHKey{};
+    VERIFY_WIN32_SUCCEEDED(RegOpenKeyEx(HKEY_LOCAL_MACHINE, c_machineEvRegLocation, 0, KEY_WRITE, machineEnvironmentVariablesHKey.addressof()));
+    VERIFY_WIN32_SUCCEEDED(RegSetValueExW(machineEnvironmentVariablesHKey.get(), c_evKeyNameForGet, 0, REG_SZ, (LPBYTE)c_evValueName, static_cast<DWORD>((wcslen(c_evValueName) + 1) * sizeof(wchar_t))));
+}
+
+inline void MachineCleanup()
+{
+    RestoreMachinePath(machinePath);
+    wil::unique_hkey machineEnvironmentVariablesHKey{};
+    VERIFY_WIN32_SUCCEEDED(RegOpenKeyEx(HKEY_LOCAL_MACHINE, c_machineEvRegLocation, 0, KEY_WRITE, machineEnvironmentVariablesHKey.addressof()));
+    LSTATUS deleteResult{ RegDeleteValueW(machineEnvironmentVariablesHKey.get(), c_evKeyNameForGet) };
+
+    if (deleteResult != ERROR_SUCCESS && deleteResult != ERROR_FILE_NOT_FOUND)
+    {
+        FAILED(HRESULT_FROM_WIN32(deleteResult));
+    }
+
+    RemoveMachineChangeTracking();
+
+}

--- a/test/EnvironmentManagerTests/TestSetupAndTeardownHelper.h
+++ b/test/EnvironmentManagerTests/TestSetupAndTeardownHelper.h
@@ -15,34 +15,34 @@ inline std::wstring machinePathExt{};
 inline void RestoreUserPath(std::wstring originalPath)
 {
     wil::unique_hkey userEnvironmentVariablesHKey{};
-    VERIFY_WIN32_SUCCEEDED(RegOpenKeyEx(HKEY_CURRENT_USER, c_userEvRegLocation, 0, KEY_WRITE, userEnvironmentVariablesHKey.addressof()));
-    VERIFY_WIN32_SUCCEEDED(RegSetValueExW(userEnvironmentVariablesHKey.get(), c_pathName, 0, REG_EXPAND_SZ, (LPBYTE)originalPath.c_str(), static_cast<DWORD>(wcslen(originalPath.c_str()) * sizeof(wchar_t))));
+    VERIFY_WIN32_SUCCEEDED(RegOpenKeyEx(HKEY_CURRENT_USER, c_UserEvRegLocation, 0, KEY_WRITE, userEnvironmentVariablesHKey.addressof()));
+    VERIFY_WIN32_SUCCEEDED(RegSetValueExW(userEnvironmentVariablesHKey.get(), c_PathName, 0, REG_EXPAND_SZ, (LPBYTE)originalPath.c_str(), static_cast<DWORD>(wcslen(originalPath.c_str()) * sizeof(wchar_t))));
 }
 
 inline void RestoreUserPathExt(std::wstring originalPathExt)
 {
     wil::unique_hkey userEnvironmentVariablesHKey{};
-    VERIFY_WIN32_SUCCEEDED(RegOpenKeyEx(HKEY_CURRENT_USER, c_userEvRegLocation, 0, KEY_WRITE, userEnvironmentVariablesHKey.addressof()));
-    VERIFY_WIN32_SUCCEEDED(RegSetValueExW(userEnvironmentVariablesHKey.get(), c_pathExtName, 0, REG_EXPAND_SZ, (LPBYTE)originalPathExt.c_str(), static_cast<DWORD>(wcslen(originalPathExt.c_str()) * sizeof(wchar_t))));
+    VERIFY_WIN32_SUCCEEDED(RegOpenKeyEx(HKEY_CURRENT_USER, c_UserEvRegLocation, 0, KEY_WRITE, userEnvironmentVariablesHKey.addressof()));
+    VERIFY_WIN32_SUCCEEDED(RegSetValueExW(userEnvironmentVariablesHKey.get(), c_PathExtName, 0, REG_EXPAND_SZ, (LPBYTE)originalPathExt.c_str(), static_cast<DWORD>(wcslen(originalPathExt.c_str()) * sizeof(wchar_t))));
 }
 
 inline void RestoreMachinePath(std::wstring originalPath)
 {
     wil::unique_hkey machineEnvironmentVariablesHKey{};
-    VERIFY_WIN32_SUCCEEDED(RegOpenKeyEx(HKEY_LOCAL_MACHINE, c_machineEvRegLocation, 0, KEY_WRITE, machineEnvironmentVariablesHKey.addressof()));
-    VERIFY_WIN32_SUCCEEDED(RegSetValueExW(machineEnvironmentVariablesHKey.get(), c_pathName, 0, REG_EXPAND_SZ, (LPBYTE)originalPath.c_str(), static_cast<DWORD>(wcslen(originalPath.c_str()) * sizeof(wchar_t))));
+    VERIFY_WIN32_SUCCEEDED(RegOpenKeyEx(HKEY_LOCAL_MACHINE, c_MachineEvRegLocation, 0, KEY_WRITE, machineEnvironmentVariablesHKey.addressof()));
+    VERIFY_WIN32_SUCCEEDED(RegSetValueExW(machineEnvironmentVariablesHKey.get(), c_PathName, 0, REG_EXPAND_SZ, (LPBYTE)originalPath.c_str(), static_cast<DWORD>(wcslen(originalPath.c_str()) * sizeof(wchar_t))));
 }
 
 inline void RestoreMachinePathExt(std::wstring originalPathExt)
 {
     wil::unique_hkey machineEnvironmentVariablesHKey{};
-    VERIFY_WIN32_SUCCEEDED(RegOpenKeyEx(HKEY_LOCAL_MACHINE, c_machineEvRegLocation, 0, KEY_WRITE, machineEnvironmentVariablesHKey.addressof()));
-    VERIFY_WIN32_SUCCEEDED(RegSetValueExW(machineEnvironmentVariablesHKey.get(), c_pathExtName, 0, REG_EXPAND_SZ, (LPBYTE)originalPathExt.c_str(), static_cast<DWORD>(wcslen(originalPathExt.c_str()) * sizeof(wchar_t))));
+    VERIFY_WIN32_SUCCEEDED(RegOpenKeyEx(HKEY_LOCAL_MACHINE, c_MachineEvRegLocation, 0, KEY_WRITE, machineEnvironmentVariablesHKey.addressof()));
+    VERIFY_WIN32_SUCCEEDED(RegSetValueExW(machineEnvironmentVariablesHKey.get(), c_PathExtName, 0, REG_EXPAND_SZ, (LPBYTE)originalPathExt.c_str(), static_cast<DWORD>(wcslen(originalPathExt.c_str()) * sizeof(wchar_t))));
 }
 
 inline void RestoreProcessPath(std::wstring originalPath)
 {
-    BOOL result{ ::SetEnvironmentVariable(c_pathName, originalPath.c_str()) };
+    BOOL result{ ::SetEnvironmentVariable(c_PathName, originalPath.c_str()) };
 
     if (result == 0)
     {
@@ -52,7 +52,7 @@ inline void RestoreProcessPath(std::wstring originalPath)
 
 inline void RestoreProcessPathExt(std::wstring originalPathExt)
 {
-    BOOL result{ ::SetEnvironmentVariable(c_pathExtName, originalPathExt.c_str()) };
+    BOOL result{ ::SetEnvironmentVariable(c_PathExtName, originalPathExt.c_str()) };
 
     if (result == 0)
     {
@@ -62,11 +62,11 @@ inline void RestoreProcessPathExt(std::wstring originalPathExt)
 
 inline void ProcessSetup()
 {
-    processPath = GetEnvironmentVariableForProcess(c_pathName);
+    processPath = GetEnvironmentVariableForProcess(c_PathName);
 
-    processPathExt = GetEnvironmentVariableForProcess(c_pathExtName);
+    processPathExt = GetEnvironmentVariableForProcess(c_PathExtName);
 
-    BOOL setResult{ SetEnvironmentVariable(c_evKeyName, c_evValueName) };
+    BOOL setResult{ SetEnvironmentVariable(c_EvKeyName, c_EvValueName) };
 
     if (!setResult)
     {
@@ -82,13 +82,13 @@ inline void ProcessCleanup()
 
 inline void UserSetup()
 {
-    userPath = GetEnvironmentVariableForUser(c_pathName);
+    userPath = GetEnvironmentVariableForUser(c_PathName);
 
-    userPathExt = GetEnvironmentVariableForUser(c_pathExtName);
+    userPathExt = GetEnvironmentVariableForUser(c_PathExtName);
 
     wil::unique_hkey userEnvironmentVariablesHKey{};
-    VERIFY_WIN32_SUCCEEDED(RegOpenKeyEx(HKEY_CURRENT_USER, c_userEvRegLocation, 0, KEY_WRITE, userEnvironmentVariablesHKey.addressof()));
-    VERIFY_WIN32_SUCCEEDED(RegSetValueExW(userEnvironmentVariablesHKey.get(), c_evKeyNameForGet, 0, REG_SZ, (LPBYTE)c_evValueName, static_cast<DWORD>((wcslen(c_evValueName) + 1) * sizeof(wchar_t))));
+    VERIFY_WIN32_SUCCEEDED(RegOpenKeyEx(HKEY_CURRENT_USER, c_UserEvRegLocation, 0, KEY_WRITE, userEnvironmentVariablesHKey.addressof()));
+    VERIFY_WIN32_SUCCEEDED(RegSetValueExW(userEnvironmentVariablesHKey.get(), c_EvKeyNameForGet, 0, REG_SZ, (LPBYTE)c_EvValueName, static_cast<DWORD>((wcslen(c_EvValueName) + 1) * sizeof(wchar_t))));
 }
 
 inline void UserCleanup()
@@ -96,8 +96,8 @@ inline void UserCleanup()
     RestoreUserPath(userPath);
     RestoreUserPathExt(userPathExt);
     wil::unique_hkey userEnvironmentVariablesHKey{};
-    VERIFY_WIN32_SUCCEEDED(RegOpenKeyEx(HKEY_CURRENT_USER, c_userEvRegLocation, 0, KEY_WRITE, userEnvironmentVariablesHKey.addressof()));
-    LSTATUS deleteResult = RegDeleteValueW(userEnvironmentVariablesHKey.get(), c_evKeyNameForGet);
+    VERIFY_WIN32_SUCCEEDED(RegOpenKeyEx(HKEY_CURRENT_USER, c_UserEvRegLocation, 0, KEY_WRITE, userEnvironmentVariablesHKey.addressof()));
+    LSTATUS deleteResult = RegDeleteValueW(userEnvironmentVariablesHKey.get(), c_EvKeyNameForGet);
 
     if (deleteResult != ERROR_SUCCESS && deleteResult != ERROR_FILE_NOT_FOUND)
     {
@@ -109,13 +109,13 @@ inline void UserCleanup()
 
 inline void MachineSetup()
 {
-    machinePath = GetEnvironmentVariableForMachine(c_pathName);
+    machinePath = GetEnvironmentVariableForMachine(c_PathName);
 
-    machinePathExt = GetEnvironmentVariableForMachine(c_pathExtName);
+    machinePathExt = GetEnvironmentVariableForMachine(c_PathExtName);
 
     wil::unique_hkey machineEnvironmentVariablesHKey{};
-    VERIFY_WIN32_SUCCEEDED(RegOpenKeyEx(HKEY_LOCAL_MACHINE, c_machineEvRegLocation, 0, KEY_WRITE, machineEnvironmentVariablesHKey.addressof()));
-    VERIFY_WIN32_SUCCEEDED(RegSetValueExW(machineEnvironmentVariablesHKey.get(), c_evKeyNameForGet, 0, REG_SZ, (LPBYTE)c_evValueName, static_cast<DWORD>((wcslen(c_evValueName) + 1) * sizeof(wchar_t))));
+    VERIFY_WIN32_SUCCEEDED(RegOpenKeyEx(HKEY_LOCAL_MACHINE, c_MachineEvRegLocation, 0, KEY_WRITE, machineEnvironmentVariablesHKey.addressof()));
+    VERIFY_WIN32_SUCCEEDED(RegSetValueExW(machineEnvironmentVariablesHKey.get(), c_EvKeyNameForGet, 0, REG_SZ, (LPBYTE)c_EvValueName, static_cast<DWORD>((wcslen(c_EvValueName) + 1) * sizeof(wchar_t))));
 }
 
 inline void MachineCleanup()
@@ -123,8 +123,8 @@ inline void MachineCleanup()
     RestoreMachinePath(machinePath);
     RestoreMachinePathExt(machinePathExt);
     wil::unique_hkey machineEnvironmentVariablesHKey{};
-    VERIFY_WIN32_SUCCEEDED(RegOpenKeyEx(HKEY_LOCAL_MACHINE, c_machineEvRegLocation, 0, KEY_WRITE, machineEnvironmentVariablesHKey.addressof()));
-    LSTATUS deleteResult{ RegDeleteValueW(machineEnvironmentVariablesHKey.get(), c_evKeyNameForGet) };
+    VERIFY_WIN32_SUCCEEDED(RegOpenKeyEx(HKEY_LOCAL_MACHINE, c_MachineEvRegLocation, 0, KEY_WRITE, machineEnvironmentVariablesHKey.addressof()));
+    LSTATUS deleteResult{ RegDeleteValueW(machineEnvironmentVariablesHKey.get(), c_EvKeyNameForGet) };
 
     if (deleteResult != ERROR_SUCCESS && deleteResult != ERROR_FILE_NOT_FOUND)
     {


### PR DESCRIPTION
Includes implementation and testing for adding and removing parts for PATHEXT.

The change trackers were split up into
* EnvironmentVariableChangeTracker
* PathChangeTracker
* PathExtChangeTracker

The reason for the split is because tracking for PATH/PATHEXT are treated differently than EnvironmentVariables.  The reason for the difference is because PATH and PATHEXT allows for partial removals and deletions.

The second reason for the split was because KeyName() is used to keep the changes separated in the registry.