### PR TITLE
Microsoft.WindowsApp.Resources.Projection should be targeting 10.0.17763.0

### DIFF
--- a/build/publish-mrt.yml
+++ b/build/publish-mrt.yml
@@ -64,7 +64,7 @@ steps:
     Contents: |
       net5.0\Microsoft.WindowsApp.Resources.Projection.pdb
       net5.0\Microsoft.WindowsApp.Resources.Projection.dll
-    TargetFolder: '$(Build.ArtifactStagingDirectory)\fullnuget\lib\net5.0-windows\'
+    TargetFolder: '$(Build.ArtifactStagingDirectory)\fullnuget\lib\net5.0-windows10.0.17763.0\'
     flattenFolders: true
 
 - task: CopyFiles@2
@@ -73,7 +73,7 @@ steps:
     SourceFolder: '${{ parameters.MRTSourcesDirectory }}\packaging\Intellisense'
     Contents: |
       Microsoft.WindowsApp.Resources.Projection.xml
-    TargetFolder: '$(Build.ArtifactStagingDirectory)\fullnuget\lib\net5.0-windows\'
+    TargetFolder: '$(Build.ArtifactStagingDirectory)\fullnuget\lib\net5.0-windows10.0.17763.0\'
     flattenFolders: true
 
 - task: CopyFiles@2

--- a/dev/MRTCore/mrt/Microsoft.WindowsApp.Resources/projection/Microsoft.WindowsApp.Resources.Projection.csproj
+++ b/dev/MRTCore/mrt/Microsoft.WindowsApp.Resources/projection/Microsoft.WindowsApp.Resources.Projection.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   
   <PropertyGroup>
-    <TargetFramework>net5.0-windows10.0.18362.0</TargetFramework>
+    <TargetFramework>net5.0-windows10.0.17763.0</TargetFramework>
     <TargetPlatformMinVersion>10.0.17763.0</TargetPlatformMinVersion>
     <Platforms>x64;x86</Platforms>
     <PlatformTarget>AnyCPU</PlatformTarget>

--- a/dev/MRTCore/mrt/Microsoft.WindowsApp.Resources/projection/Microsoft.WindowsApp.Resources.Projection.csproj
+++ b/dev/MRTCore/mrt/Microsoft.WindowsApp.Resources/projection/Microsoft.WindowsApp.Resources.Projection.csproj
@@ -2,7 +2,7 @@
   
   <PropertyGroup>
     <TargetFramework>net5.0-windows10.0.18362.0</TargetFramework>
-    <TargetPlatformMinVersion>10.0.17134.0</TargetPlatformMinVersion>
+    <TargetPlatformMinVersion>10.0.17763.0</TargetPlatformMinVersion>
     <Platforms>x64;x86</Platforms>
     <PlatformTarget>AnyCPU</PlatformTarget>
   </PropertyGroup>

--- a/dev/MRTCore/mrt/Microsoft.WindowsApp.Resources/projection/Microsoft.WindowsApp.Resources.Projection.csproj
+++ b/dev/MRTCore/mrt/Microsoft.WindowsApp.Resources/projection/Microsoft.WindowsApp.Resources.Projection.csproj
@@ -17,7 +17,7 @@
 
   <PropertyGroup>
     <CSWinRTIncludes>Microsoft.WindowsApp.Resources</CSWinRTIncludes>
-    <CSWinRTWindowsMetadata>10.0.18362.0</CSWinRTWindowsMetadata>
+    <CSWinRTWindowsMetadata>10.0.17763.0</CSWinRTWindowsMetadata>
     <NoWarn>MSB3271</NoWarn>
   </PropertyGroup>
 


### PR DESCRIPTION
Microsoft.WindowsApp.Resources.Projection should be targeting 10.0.17763.0. This is to get inalign with the RS5 support. This will also allow us to merge the thin packages into one. 