### PR TITLE
MRTCore use CSWinRT 1.3.3 (#1125)

### DIFF
--- a/dev/MRTCore/build/versions.props
+++ b/dev/MRTCore/build/versions.props
@@ -20,8 +20,8 @@
     <CurrentLiftedIXPPackageVersion>10.0.20170.1001-200713-1000.rs-onecore-dep-ixp1</CurrentLiftedIXPPackageVersion>
     <CurrentWilPackageVersion>1.0.190716.2</CurrentWilPackageVersion>
     <MuxCustomBuildTasksPackageVersion>1.0.83-winui3</MuxCustomBuildTasksPackageVersion>
-    <DotNetCoreSdkVersion>5.0.202</DotNetCoreSdkVersion>
-    <DotNetCoreRuntimeVersion>5.0.5</DotNetCoreRuntimeVersion>
+    <DotNetCoreSdkVersion>5.0.302</DotNetCoreSdkVersion>
+    <DotNetCoreRuntimeVersion>5.0.8</DotNetCoreRuntimeVersion>
     <DetoursVersion>4.0.1</DetoursVersion>
     <CppWinRTVersion>2.0.191217.1</CppWinRTVersion>
     <MicrosoftSourceLinkAzureReposVersion>1.0.0</MicrosoftSourceLinkAzureReposVersion>

--- a/dev/MRTCore/global.json
+++ b/dev/MRTCore/global.json
@@ -1,6 +1,6 @@
 {
     "sdk": {
-        "version": "5.0.202"
+        "version": "5.0.302"
     },
     "msbuild-sdks": {
         "Microsoft.Build.NoTargets" : "1.0.88"

--- a/dev/MRTCore/mrt/Microsoft.ApplicationModel.Resources/projection/Microsoft.ApplicationModel.Resources.Projection.csproj
+++ b/dev/MRTCore/mrt/Microsoft.ApplicationModel.Resources/projection/Microsoft.ApplicationModel.Resources.Projection.csproj
@@ -11,12 +11,6 @@
     <PackageReference Include="Microsoft.Windows.CsWinRT" Version="1.3.3" />
   </ItemGroup>
 
-  <!-- For consistency across Reunion, explicitly reference .NET 5.0.5 SDK (5.0.202 train for VS 16.9.3) -->
-  <ItemGroup>
-    <FrameworkReference Update="Microsoft.Windows.SDK.NET.Ref" RuntimeFrameworkVersion="10.0.18362.16" />
-    <FrameworkReference Update="Microsoft.Windows.SDK.NET.Ref" TargetingPackVersion="10.0.18362.16" />
-  </ItemGroup>
-
   <ItemGroup>
     <ProjectReference Include="..\src\Microsoft.ApplicationModel.Resources.vcxproj" />
   </ItemGroup>

--- a/dev/MRTCore/mrt/Microsoft.ApplicationModel.Resources/projection/Microsoft.ApplicationModel.Resources.Projection.csproj
+++ b/dev/MRTCore/mrt/Microsoft.ApplicationModel.Resources/projection/Microsoft.ApplicationModel.Resources.Projection.csproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Windows.CsWinRT" Version="1.2.2" />
+    <PackageReference Include="Microsoft.Windows.CsWinRT" Version="1.3.3" />
   </ItemGroup>
 
   <!-- For consistency across Reunion, explicitly reference .NET 5.0.5 SDK (5.0.202 train for VS 16.9.3) -->


### PR DESCRIPTION
cherry pick https://github.com/microsoft/WindowsAppSDK/pull/1125. And remove an obsolete SDK ref, which had been removed in main, but not in release branch.