### PR TITLE
AppLifecycle Restart API

### DIFF
--- a/specs/AppLifecycle/Restart/restartApi.markdown
+++ b/specs/AppLifecycle/Restart/restartApi.markdown
@@ -32,8 +32,8 @@ cannot restart immediately on-command with specific arguments/state. This applie
 
 ### Reunion Restart API components 
 
-1.  Expose a new function: **RequestRestartNow** function to enable any
-    app (win32/packaged win32, UWP, WinUI apps) to terminate and restart itself on command, and to provide an
+1.  Expose a new function: **RequestRestartNow** function to enable any packaged or unpackaged Win32
+    app to terminate and restart itself on command, and to provide an
     arbitrary command-line string for the restarted instance.
 
 

--- a/specs/AppLifecycle/Restart/restartApi.markdown
+++ b/specs/AppLifecycle/Restart/restartApi.markdown
@@ -28,18 +28,11 @@ goals of this specific API are the following:
 
 Addressing the gaps that exist today: at a high-level, Win32 apps can
 register with the OS to restart in update/hang/reboot scenarios but
-cannot restart immediately on-command with specific arguments/state. UWP
-apps can restart on-command with command-line restart arguments but
-cannot register with the OS Restart Manager for update/hang/reboot
-scenarios. These are the gaps we need to address.
+cannot restart immediately on-command with specific arguments/state. This applies to packaged (Centennial) and unpackaged apps. These are the gaps we need to address.
 
 ### Reunion Restart API components 
 
-1.  Expose a new function: **RegisterForRestart**, which allows any app (win32/packaged win32, UWP, WinUI apps)
-    to register itself for restart if it was running when a system
-    update occurs or if an app hangs/crashes unexpectedly.
-
-2.  Expose a new function: **RequestRestartNow** function to enable any
+1.  Expose a new function: **RequestRestartNow** function to enable any
     app (win32/packaged win32, UWP, WinUI apps) to terminate and restart itself on command, and to provide an
     arbitrary command-line string for the restarted instance.
 
@@ -280,53 +273,6 @@ string launchArguments);</td>
 
 ### New API Details
 
-#### RegisterForRestart
-
-<table>
-<colgroup>
-<col style="width: 40%" />
-<col style="width: 51%" />
-<col style="width: 8%" />
-</colgroup>
-<thead>
-<tr class="header">
-<th>New API </th>
-<th>Description</th>
-<th>Priority</th>
-</tr>
-</thead>
-<tbody>
-<tr class="odd">
-<td>static bool RegisterForRestart(string restartArguments, RestartContext context)</td>
-<td><p>Equivalent to the Win32 RegisterApplicationRestart function.</p>
-<p>restartArguments is the same as the pwzCommandline parameter in the Win32 RegisterApplicationRestart. It is a string of command-line arguments which will be passed as restart arguments.</p>
-<p>restartArguments become the restarted/new instance’s LaunchActivatedEventArgs.</p></td>
-<td>P3</td>
-</tr>
-<tr class="even">
-<td>[Flags] enum RestartContext</td>
-<td><p>The values passed for RestartContext indicate which cases</p>
-<p>the app <em>should be restarted.<br />
-<br />
-</em>The possible cases are the same as dwFlag values listed above in Win32’s RegisterApplicationRestart<strong>:</strong></p>
-<ul>
-<li><p>-1: ALL</p></li>
-<li><p>1: CRASH</p></li>
-<li><p>2: HANG</p></li>
-<li><p>4: PATCH</p></li>
-<li><p>8: REBOOT</p></li>
-</ul>
-<p>[Flags] enum RestartContext { All = -1, Crash = 1, Hang = 2, Patch = 4, Reboot = 8 }</p></td>
-<td>P3</td>
-</tr>
-<tr class="odd">
-<td>static bool UnregisterForRestart()</td>
-<td>Equivalent to the Win32 UnregisterApplicationRestart function.</td>
-<td>P3</td>
-</tr>
-</tbody>
-</table>
-
 #### RequestRestartNow
 
 <table>
@@ -362,40 +308,6 @@ string launchArguments);</td>
 </table>
 
 ### API Sample Code
-
-#### RegisterForRestart Sample
-```c#
-public class App {
-
-        // App was just launched
-        protected override void OnLaunched(LaunchActivatedEventArgs args)
-        {
-            // If the application was terminated for example and has now been restarted
-            if (args != NULL)
-            {
-                if (args.PreviousExecutionState == ApplicationExecutionState.Terminated)
-                {
-                    Telemetry::WriteLine("Restart activated: " + args.Arguments);
-                }
-            }
-        }
-
-        // We want to register the app for restart if termination happens only after crash
-        protected bool restartOnUpdate(){
-            bool result = AppLifecycle::RegisterForRestart("args for new instance", RestartContext::Crash);
-            Telemetry::WriteLine("RegisterForRestart: Restart Context: " + RestartContext::Crash.ToString() 
-            + ". Result: " + result ? "success" : "fail");
-
-            // Do normal app behavior
-        }
-
-        // We want to unregister for post-crash restarts
-        protected bool removeRestartOnUpdate(){
-            bool result = AppLifecycle::UnregisterForRestart();
-            Telemetry::WriteLine("UnregisterForRestart: Result: " + result ? "success" : "fail");
-        }
-}
-```
 
 ### RequestRestartNow Sample
 
@@ -440,7 +352,6 @@ Event Name: **AppRestart**
 
 | Metadata                | Description                                                                                       | Data type |
 |-------------------------|---------------------------------------------------------------------------------------------------|-----------|
-| RestartContext          | Reason for an App to register for restart and then attempt to restart                             | Enum      |
 | AppRestartFailureReason | Reason an app restart failed. This will be collected when an app requests a restart now but fails | Enum      |
 | AppName                 | Name of the app which restarted                                                                   | String    |
 | AppType                 | UWP App or Centennial App or Win32 app                                                            | String    |

--- a/specs/AppLifecycle/Restart/restartApi.markdown
+++ b/specs/AppLifecycle/Restart/restartApi.markdown
@@ -5,30 +5,35 @@
 - [Restart API](#restart-api)
 - [Contents](#contents)
 - [Background](#background)
-  - [Description](#description)
+  - [Purpose](#purpose)
 - [API](#api)
-  - [Existing API Summary](#existing-api-summary)
+  - [Existing API](#existing-api)
+    - [Summary](#summary)
   - [Existing API Details](#existing-api-details)
+    - [Existing API](#existing-api-1)
   - [New API Details](#new-api-details)
-    - [RequestRestartNow](#requestrestartnow)
-  - [Examples and Scenarios](#examples-and-scenarios)
-- [Telemetry](#telemetry)
+    - [New API](#new-api)
+    - [Description](#description)
+    - [Mechanism](#mechanism)
+    - [Examples](#examples)
 
 # Background
 
-This spec addresses the **Restart APIs** in the AppLifecycle component. At a high-level, Win32 apps can
-register with the OS to restart in update/hang/reboot scenarios but cannot restart immediately on-command 
-with specific arguments/state. This applies to packaged (Desktop Bridge/Centennial) and unpackaged apps. This API will address
+This spec addresses the **Restart APIs** in the AppInstance component. At a high-level, Win32 apps can
+register with the OS to restart in update/hang/reboot scenarios but cannot initiate an explicit restart
+with specific arguments/state. This applies to packaged (Desktop Bridge) and unpackaged apps. This API will address
 these gaps and provide the ability for any Win32 app to restart immediately.
 
-## Description
+## Purpose
 
-The goal of this feature is the new function: **RequestRestartNow**, which will enable any packaged or unpackaged Win32
-app (including Console, WinMain, Windows Forms, WPF and WinUI) to terminate and restart itself on command, and to provide an arbitrary command-line string for the restarted instance.
+The goal of this feature is the new function: **Restart**, which will enable any packaged or unpackaged Win32
+app (including Console, WinMain, Windows Forms, WPFI) to terminate and restart itself on command, and to provide an arbitrary command-line string for the restarted instance. 
+
+This behavior (restarting an app immediately) is not currently available to Win32 applications. This new method will fill the gap for Win32 applications and align with CoreApplication's existing ``CoreApplication.RequestRestartAsync``.
 
 # API
 
-## Existing API Summary
+## Existing API
 
 1.  **Restart-me-now**. CoreApplication exposes the
     [RequestRestartAsync](https://docs.microsoft.com/en-us/uwp/api/windows.applicationmodel.core.coreapplication.requestrestartasync?view=winrt-18362)
@@ -64,135 +69,177 @@ There are 2 related Win32 APIs that focus on recovery prior to restart:
     \-- if it doesn't call within the registered ping interval, WER will
     terminate the process.
 
-| App Type                                                            | Applicable Restart Mechanism                                           | Gap                                                                                                                  |
-| ------------------------------------------------------------------- | ---------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------- |
-| Win32 (unpackaged), Win32/Centennial (packaged), WinUI (Centennial) | RegisterApplicationRestart for OS + app update/restart/crash scenarios | Apps can register with the OS to restart in specific app/OS states, but cannot restart on-command in a healthy state |
+### Summary
+
+For Win32 apps (packaged or unpackaged):
+- Applicable restart mechanism: **RegisterApplicationRestart** for OS + app update/restart/crash scenarios
+- Gap: Apps can register with the OS to restart in specific app/OS states, but cannot initiate a restart from a healthy state
+
 
 ## Existing API Details
 
-<table>
-<colgroup>
-<col style="width: 41%" />
-<col style="width: 58%" />
-</colgroup>
-<thead>
-<tr class="header">
-<th>Existing API</th>
-<th>Details</th>
-</tr>
-</thead>
-<tbody>
-<tr class="odd">
-<td><p>HRESULT <strong>RegisterApplicationRestart</strong>(PCWSTR pwzCommandline, DWORD dwFlags);</p></td>
-<td><p>The pwzCommandline parameter is passed into the new instance as its command-line arguments string. The dwFlags can be 0 or one or more of the (flags) values:</p>
-<ul>
-<li>
-<p>1: RESTART_NO_CRASH - Do not restart the process if it terminates due to an unhandled exception.</p>
-</li>
-<li>
-<p>2: RESTART_NO_HANG - Do not restart the process if it terminates due to the application not responding.</p>
-</li>
-<li>
-<p>4: RESTART_NO_PATCH - Do not restart the process if it terminates due to the installation of an OS update.</p>
-</li>
-<li>
-<p>8: RESTART_NO_REBOOT - Do not restart the process if the computer is restarted as the result of an OS update.</p>
-</li>
-</ul></td>
-</tr>
-<tr class="even">
-<td>HRESULT <strong>UnregisterApplicationRestart</strong>();</td>
-<td>Unregisters the app for restart, where the app had previously called RegisterApplicationRestart.</td>
-</tr>
-<tr class="odd">
-<td>public static IAsyncOperation&lt;AppRestartFailureReason&gt; <strong>RequestRestartAsync</strong>(<br />
-string launchArguments);</td>
-<td><p>Static function in CoreApplication. Requests immediate termination and restart.</p>
-<ul>
-<li>
-<p>The launchArguments string is passed into the new instance as the Arguments property on LaunchActivatedEventArgs.</p>
-</li>
-<li>
-<p>Also sets LaunchActivatedEventArgs.PreviousExecutionState to Terminated.</p>
-</li>
-</ul></td>
-</tr>
-<tr class="even">
-<td>public enum <strong>AppRestartFailureReason</strong></td>
-<td><ul>
-<li>
-<p>0: RestartPending - a restart is already in progress.</p>
-</li>
-<li>
-<p>1: NotInForeground - an app must be visible and in the foreground when it calls the restart API.</p>
-</li>
-<li>
-<p>2: InvalidUser - could not restart for the specified user.</p>
-</li>
-<li>
-<p>3: Other - unspecified failure.</p>
-</li>
-</ul></td>
-</tr>
-<tr class="odd">
-<td>class <strong>LaunchActivatedEventArg</strong></td>
-<td><p>Relevant Properties:</p>
-<ul>
-<li><p>Arguments: gets the arguments that are passed to the app during its launch activation.</p></li>
-<li><p>Kind: Gets the reason that this app is being activated. This is of type enum ActivationKind</p></li>
-</ul>
-<p>PreviousExecutionState: Gets the execution state of the app before this activation.</p></td>
-</tr>
-</tbody>
-</table>
+### Existing API
+
+```cpp
+HRESULT RegisterApplicationRestart(PCWSTR pwzCommandline, DWORD dwFlags)
+```
+Registers an app for restart. More details on the [MSDN page](https://docs.microsoft.com/en-us/windows/win32/api/winbase/nf-winbase-registerapplicationrestart).
+
+```cpp
+HRESULT UnregisterApplicationRestart()
+```
+Unregisters the app for restart, where the app had previously called RegisterApplicationRestart. More details on the [MSDN page](https://docs.microsoft.com/en-us/windows/win32/api/winbase/nf-winbase-unregisterapplicationrestart).
+
+```cpp
+public static IAsyncOperation<AppRestartFailureReason> RequestRestartAsync(
+string launchArguments)
+```
+Static function in CoreApplication. Requests immediate termination and restart. More details on the [MSDN page](https://docs.microsoft.com/en-us/uwp/api/windows.applicationmodel.core.coreapplication.requestrestartasync?view=winrt-22000).
+
+```cpp
+public enum AppRestartFailureReason
+```
+An existing enum with the following values:
+- 0: RestartPending - a restart is already in progress.
+- 1: NotInForeground - an app must be visible and in the foreground when it calls the restart API.
+- 2: InvalidUser - could not restart for the specified user.
+- 3: Other - unspecified failure.
+
+```cpp
+class LaunchActivatedEventArg
+```
+	
+Relevant Properties:
+- Arguments: gets the arguments that are passed to the app during its launch activation.
+- Kind: Gets the reason that this app is being activated. This is of type enum ActivationKind
+- PreviousExecutionState: Gets the execution state of the app before this activation.
 
 ## New API Details
 
-### RequestRestartNow
+### New API
 
-<table>
-<colgroup>
-<col style="width: 41%" />
-<col style="width: 53%" />
-<col style="width: 5%" />
-</colgroup>
-<thead>
-<tr class="header">
-<th>New API </th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr class="odd">
-<td>static AppRestartFailureReason <strong>RequestRestartNow</strong>(string restartArguments)</td>
-<td><p>Equivalent to CoreApplication.RequestRestartAsync, except that it is <em>not</em> async.
-<ul>
-<li>If the restart fails, but the user subsequently launches the app manually, the app will launch normally and no restart arguments will be passed. </li>
-<li>If the app has any in-process background tasks running when it calls this API, those tasks will be cancelled in the normal way. Out-of-process background tasks will not be affected. </li>
-</ul>
- The restarted instance will be activated with Windows.ApplicationModel.Activation.LaunchActivatedEventArgs.</p>
- <ul>
-<li>When the app is restarted, LaunchActivatedEventArgs.PreviousExecutionState will have the value Terminated so that the app can distinguish between a resume and a restart. </li>
-</ul>
-<p>If the request to restart is successful, the application will be restarted immediately. The user does not have to do anything else/handle a return value in any way.
+```c#
+static  AppRestartFailureReason Restart(String arguments)
+```
+
+```c#
+namespace Microsoft.Windows.AppLifecycle
+{
+    enum ExtendedActivationKind
+    {
+        Launch = 0,
+        Search,
+        ShareTarget,
+        File,
+        Protocol,
+        FileOpenPicker,
+        FileSavePicker,
+        CachedFileUpdater,
+        ContactPicker,
+        Device,
+        PrintTaskSettings,
+        CameraSettings,
+        RestrictedLaunch,
+        AppointmentsProvider,
+        Contact,
+        LockScreenCall,
+        VoiceCommand,
+        LockScreen,
+        PickerReturned = 1000,
+        WalletAction,
+        PickFileContinuation,
+        PickSaveFileContinuation,
+        PickFolderContinuation,
+        WebAuthenticationBrokerContinuation,
+        WebAccountProvider,
+        ComponentUI,
+        ProtocolForResults = 1009,
+        ToastNotification,
+        Print3DWorkflow,
+        DialReceiver,
+        DevicePairing,
+        UserDataAccountsProvider,
+        FilePickerExperience,
+        LockScreenComponent,
+        ContactPanel,
+        PrintWorkflowForegroundTask,
+        GameUIProvider,
+        StartupTask,
+        CommandLineLaunch,
+        BarcodeScannerProvider,
+        PrintSupportJobUI,
+        PrintSupportSettingsUI,
+        PhoneCallActivation,
+        VpnForeground,
+        // NOTE: Values below 5000 are designated for the platform.  The above list is kept in sync with
+        // Windows.ApplicationModel.Activation.ActivationKind.
+
+        Push = 5000,
+    };
+
+    runtimeclass AppActivationArguments
+    {
+        ExtendedActivationKind Kind { get; };
+        IInspectable Data{ get; };
+    };
+
+    runtimeclass AppInstance
+    {
+        static AppInstance GetCurrent();
+        static Windows.Foundation.Collections.IVector<AppInstance> GetInstances();
+        static AppInstance FindOrRegisterForKey(String key);
+        static Windows.ApplicationModel.Core.AppRestartFailureReason Restart(String arguments);
+
+        void UnregisterKey();
+        Windows.Foundation.IAsyncAction RedirectActivationToAsync(Microsoft.Windows.AppLifecycle.AppActivationArguments args);
+        Microsoft.Windows.AppLifecycle.AppActivationArguments GetActivatedEventArgs();
+        event Windows.Foundation.EventHandler<Microsoft.Windows.AppLifecycle.AppActivationArguments> Activated;
+
+        String Key{ get; };
+        Boolean IsCurrent{ get; };
+        UInt32 ProcessId{ get; };
+    }
+
+    static runtimeclass ActivationRegistrationManager
+    {
+        static void RegisterForFileTypeActivation(String[] supportedFileTypes, String logo,
+            String displayName, String[] supportedVerbs, String exePath);
+        static void RegisterForProtocolActivation(String scheme, String logo, String displayName,
+            String exePath);
+        static void RegisterForStartupActivation(String taskId, String exePath);
+
+        static void UnregisterForFileTypeActivation(String[] fileTypes, String exePath);
+        static void UnregisterForProtocolActivation(String scheme, String exePath);
+        static void UnregisterForStartupActivation(String taskId);
+    };
+}
+```
+
+### Description
+
+Equivalent to CoreApplication.RequestRestartAsync, except that it is *not* async.
+- If the restart fails, but the user subsequently launches the app manually, the app will launch normally and no restart arguments will be passed.
+- If the app has any in-process background tasks running when it calls this API, those tasks will be cancelled in the normal way. Out-of-process background tasks will not be affected.
+
+The restarted instance will be activated with Windows.ApplicationModel.Activation.LaunchActivatedEventArgs.
+- When the app is restarted, LaunchActivatedEventArgs.PreviousExecutionState will have the value Terminated so that the app can distinguish between a resume and a restart.
+- The elevation state of the app is also maintained in the new restarted process.
+
+If the request to restart is successful, the application will be restarted immediately with no return value. The user does not have to do anything else/handle a return value in any way.
 
 If the request fails due to a nonfatal reason, a failure reason is returned for why the restart didn’t successfully complete. This method leverages an existing enum (AppRestartFailureReason) which has the following relevant return fields.
-<ul>
-<li> InvalidUser: Could not restart for the specified user.</li>
-<li> RestartPending: A restart is already in progress.</li>
-<li> Other: Unspecified failure.</li>
-</ul>
-</p></td>
-</tr>
-</tbody>
-</table>
+- InvalidUser: Could not restart for the specified user.
+- RestartPending: A restart is already in progress.
+- Other: Unspecified failure.
 
-When an application calls RequestRestartNow, the mechanism for restart will be as follows:
-1. Application calls RequestRestartNow API.
-2. The API will CreateProcess with the Agent (a helper EXE in the framework package containing the API) and will then wait for an an acknowledgment (ACK) from the Agent.
-3. The Agent will get the executable path of the application and signal an ACK to the API. The Agent will then then terminate the application and then CreateProcess with the application (restarted).
+### Mechanism
 
-## Examples and Scenarios
+When an application calls Restart, the mechanism for restart will be as follows:
+1. Application calls Restart API.
+2. The API calls CreateProcess to launch the agent (a helper EXE in the framework package containing the API)
+3. The Agent will get the executable path of the application. The Agent will then then terminate the application and then call CreateProcess with the application (restarted).
+
+### Examples
 
 ```c#
 public class App 
@@ -204,16 +251,16 @@ public class App
         // Checking if the assets have updated successfully and there are no pending updates
         if (!CheckForUpdate())
         {
-            AppRestartFailureReason result = AppLifecycle::RequestRestartNow("args for new instance");
-            switch (result)
+            AppRestartFailureReason reason = AppInstance.Restart("/RestartCalled");
+            switch (reason)
             {
-                case AppRestartFailureReason::RestartPending:
-                    // In this case the restart could not be completed because another restart is pending and we can try to restart again after a period of time
+                case AppRestartFailureReason.RestartPending:
+                    // In this case the restart could not be completed because another restart is pending and we can try to restart again after a period of time.
                     RetryRestartAfterXSeconds();
                     break;
-                case AppRestartFailureReason::Other:
+                case AppRestartFailureReason.Other:
                     // In this case, a dialog box will appear informing of an error requesting restart
-                    ShowErrorMessage();
+                    ShowErrorMessage("Something went wrong. Restart was not successful");
                     break;
             }
         }
@@ -223,37 +270,21 @@ public class App
     // The app displays an error dialog, and after the user clicks OK on the dialog the app must restart immediately.
     // This scenario simply displays logging for these use cases
     protected void HandleInitializationError()
-    {
-        AppRestartFailureReason result = AppLifecycle::RequestRestartNow("args for new instance");
-        switch (result)
+    {   
+        // Restart in safe mode to avoid whatever made initialization fail
+        AppRestartFailureReason reason = AppInstance.Restart("/safemode");
+        switch (reason)
         {
-            case AppRestartFailureReason::RestartPending:
-                Telemetry::WriteLine("Another restart is currently pending.");
+            case AppRestartFailureReason.RestartPending:
+                Telemetry.WriteLine("Another restart is currently pending.");
                 break;
-            case AppRestartFailureReason::InvalidUser:
-                Telemetry::WriteLine("Current user is not signed in or not a valid user.");
+            case AppRestartFailureReason.InvalidUser:
+                Telemetry.WriteLine("Current user is not signed in or not a valid user.");
                 break;
-            case AppRestartFailureReason::Other:
-                Telemetry::WriteLine("Failure restarting.");
+            case AppRestartFailureReason.Other:
+                Telemetry.WriteLine("Failure restarting.");
                 break;
         }
     }
 }
 ```
-
-# Telemetry
-
-This section explores the telemetry needs for the Restart feature in
-four dimensions – Usage, Reliability, Performance and Failure
-Investigation. The telemetry will include the metadata that are needed
-not only for measuring quality but also for helping with investigations
-of failures. Following is the event which can be used to capture
-telemetry information:
-
-Event Name: **AppRestart**
-
-| Metadata                | Description                                                                                       | Data type |
-| ----------------------- | ------------------------------------------------------------------------------------------------- | --------- |
-| AppRestartFailureReason | Reason an app restart failed. This will be collected when an app requests a restart now but fails | Enum      |
-| AppName                 | Name of the app which restarted                                                                   | String    |
-| AppType                 | UWP App or Centennial App or Win32 app                                                            | String    |

--- a/specs/AppLifecycle/Restart/restartApi.markdown
+++ b/specs/AppLifecycle/Restart/restartApi.markdown
@@ -19,17 +19,21 @@
 
 # Background
 
-This spec addresses the **Restart APIs** in the AppInstance component. At a high-level, Win32 apps can
-register with the OS to restart in update/hang/reboot scenarios but cannot initiate an explicit restart
-with specific arguments/state. This applies to packaged (Desktop Bridge) and unpackaged apps. This API will address
-these gaps and provide the ability for any Win32 app to restart immediately.
+This spec addresses the **Restart APIs** in the AppInstance component. At a high-level, Win32 apps
+can register with the OS to restart in update/hang/reboot scenarios but cannot initiate an explicit
+restart with specific arguments/state. This applies to packaged (Desktop Bridge) and unpackaged
+apps. This API will address these gaps and provide the ability for any Win32 app to restart
+immediately.
 
 ## Purpose
 
-The goal of this feature is the new function: **Restart**, which will enable any packaged or unpackaged Win32
-app (including Console, WinMain, Windows Forms, WPFI) to terminate and restart itself on command, and to provide an arbitrary command-line string for the restarted instance. 
+The goal of this feature is the new function: **Restart**, which will enable any packaged or
+unpackaged Win32 app (including Console, WinMain, Windows Forms, WPFI) to terminate and restart
+itself on command, and to provide an arbitrary command-line string for the restarted instance. 
 
-This behavior (restarting an app immediately) is not currently available to Win32 applications. This new method will fill the gap for Win32 applications and align with CoreApplication's existing ``CoreApplication.RequestRestartAsync``.
+This behavior (restarting an app immediately) is not currently available to Win32 applications. This
+new method will fill the gap for Win32 applications and align with CoreApplication's existing
+``CoreApplication.RequestRestartAsync``.
 
 # API
 
@@ -37,15 +41,14 @@ This behavior (restarting an app immediately) is not currently available to Win3
 
 1.  **Restart-me-now**. CoreApplication exposes the
     [RequestRestartAsync](https://docs.microsoft.com/en-us/uwp/api/windows.applicationmodel.core.coreapplication.requestrestartasync?view=winrt-18362)
-    method, which allows an app to terminate and restart itself, and to
-    provide an arbitrary command-line string for the restarted instance.
+    method, which allows an app to terminate and restart itself, and to provide an arbitrary
+    command-line string for the restarted instance.
 
 2.  **Restart-me-after-termination**. The Win32 API
     [RegisterApplicationRestart](https://docs.microsoft.com/en-us/windows/win32/api/winbase/nf-winbase-registerapplicationrestart)
-    enables an app to register itself to be restarted after termination,
-    and to provide an arbitrary command-line string for the restarted
-    instance. The reasons for termination include app crash or hang, app
-    update, or system update. There's also a matching
+    enables an app to register itself to be restarted after termination, and to provide an arbitrary
+    command-line string for the restarted instance. The reasons for termination include app crash or
+    hang, app update, or system update. There's also a matching
     [UnregisterApplicationRestart](https://docs.microsoft.com/en-us/windows/win32/api/winbase/nf-winbase-unregisterapplicationrestart)
     API.
 
@@ -53,27 +56,26 @@ There are 2 related Win32 APIs that focus on recovery prior to restart:
 
 1.  **Let-me-do-something-before-termination**. An app can call
     [RegisterApplicationRecoveryCallback](https://docs.microsoft.com/en-us/windows/win32/api/winbase/nf-winbase-registerapplicationrecoverycallback)
-    to register a callback for the system to call before terminating the
-    app. If an application encounters an unhandled exception or becomes
-    unresponsive, Windows Error Reporting (WER) calls the specified
-    recovery callback, where the app can save state information. The
-    system pings the app every n seconds to make sure that it hasn't
-    hung in its callback. The app can specify the ping interval when it
-    registers the callback. In its recovery callback, the app can call
-    RegisterApplicationRestart a second time, to update the
-    command-line.
+    to register a callback for the system to call before terminating the app. If an application
+    encounters an unhandled exception or becomes unresponsive, Windows Error Reporting (WER) calls
+    the specified recovery callback, where the app can save state information. The system pings the
+    app every n seconds to make sure that it hasn't hung in its callback. The app can specify the
+    ping interval when it registers the callback. In its recovery callback, the app can call
+    RegisterApplicationRestart a second time, to update the command-line.
 
-2.  **Recovery-in-progress**. While the app is doing work in its
-    recovery callback, the app must periodically call
+2.  **Recovery-in-progress**. While the app is doing work in its recovery callback, the app must
+    periodically call
     [ApplicationRecoveryInProgress](https://docs.microsoft.com/en-us/windows/win32/api/winbase/nf-winbase-applicationrecoveryinprogress)
-    \-- if it doesn't call within the registered ping interval, WER will
-    terminate the process.
+    \-- if it doesn't call within the registered ping interval, WER will terminate the process.
 
 ### Summary
 
 For Win32 apps (packaged or unpackaged):
-- Applicable restart mechanism: **RegisterApplicationRestart** for OS + app update/restart/crash scenarios
-- Gap: Apps can register with the OS to restart in specific app/OS states, but cannot initiate a restart from a healthy state
+
+- Applicable restart mechanism: **RegisterApplicationRestart** for OS + app update/restart/crash
+  scenarios
+- Gap: Apps can register with the OS to restart in specific app/OS states, but cannot initiate a
+  restart from a healthy state
 
 
 ## Existing API Details
@@ -83,23 +85,29 @@ For Win32 apps (packaged or unpackaged):
 ```cpp
 HRESULT RegisterApplicationRestart(PCWSTR pwzCommandline, DWORD dwFlags)
 ```
-Registers an app for restart. More details on the [MSDN page](https://docs.microsoft.com/en-us/windows/win32/api/winbase/nf-winbase-registerapplicationrestart).
+Registers an app for restart. More details on the [MSDN
+page](https://docs.microsoft.com/en-us/windows/win32/api/winbase/nf-winbase-registerapplicationrestart).
 
 ```cpp
 HRESULT UnregisterApplicationRestart()
 ```
-Unregisters the app for restart, where the app had previously called RegisterApplicationRestart. More details on the [MSDN page](https://docs.microsoft.com/en-us/windows/win32/api/winbase/nf-winbase-unregisterapplicationrestart).
+Unregisters the app for restart, where the app had previously called RegisterApplicationRestart.
+More details on the [MSDN
+page](https://docs.microsoft.com/en-us/windows/win32/api/winbase/nf-winbase-unregisterapplicationrestart).
 
 ```cpp
 public static IAsyncOperation<AppRestartFailureReason> RequestRestartAsync(
 string launchArguments)
 ```
-Static function in CoreApplication. Requests immediate termination and restart. More details on the [MSDN page](https://docs.microsoft.com/en-us/uwp/api/windows.applicationmodel.core.coreapplication.requestrestartasync?view=winrt-22000).
+Static function in CoreApplication. Requests immediate termination and restart. More details on the
+[MSDN
+page](https://docs.microsoft.com/en-us/uwp/api/windows.applicationmodel.core.coreapplication.requestrestartasync?view=winrt-22000).
 
 ```cpp
 public enum AppRestartFailureReason
 ```
 An existing enum with the following values:
+
 - 0: RestartPending - a restart is already in progress.
 - 1: NotInForeground - an app must be visible and in the foreground when it calls the restart API.
 - 2: InvalidUser - could not restart for the specified user.
@@ -110,6 +118,7 @@ class LaunchActivatedEventArg
 ```
 	
 Relevant Properties:
+
 - Arguments: gets the arguments that are passed to the app during its launch activation.
 - Kind: Gets the reason that this app is being activated. This is of type enum ActivationKind
 - PreviousExecutionState: Gets the execution state of the app before this activation.
@@ -188,6 +197,8 @@ namespace Microsoft.Windows.AppLifecycle
         static AppInstance GetCurrent();
         static Windows.Foundation.Collections.IVector<AppInstance> GetInstances();
         static AppInstance FindOrRegisterForKey(String key);
+        
+        // This is the new method exposed by this feature
         static Windows.ApplicationModel.Core.AppRestartFailureReason Restart(String arguments);
 
         void UnregisterKey();
@@ -214,20 +225,31 @@ namespace Microsoft.Windows.AppLifecycle
     };
 }
 ```
+There is no relevant RtCop output for this feature.
 
 ### Description
 
 Equivalent to CoreApplication.RequestRestartAsync, except that it is *not* async.
-- If the restart fails, but the user subsequently launches the app manually, the app will launch normally and no restart arguments will be passed.
-- If the app has any in-process background tasks running when it calls this API, those tasks will be cancelled in the normal way. Out-of-process background tasks will not be affected.
 
-The restarted instance will be activated with Windows.ApplicationModel.Activation.LaunchActivatedEventArgs.
-- When the app is restarted, LaunchActivatedEventArgs.PreviousExecutionState will have the value Terminated so that the app can distinguish between a resume and a restart.
+- If the restart fails, but the user subsequently launches the app manually, the app will launch
+  normally and no restart arguments will be passed.
+- If the app has any in-process background tasks running when it calls this API, those tasks will be
+  cancelled in the normal way. Out-of-process background tasks will not be affected.
+
+The restarted instance will be activated with
+Windows.ApplicationModel.Activation.LaunchActivatedEventArgs.
+
+- When the app is restarted, LaunchActivatedEventArgs.PreviousExecutionState will have the value
+  Terminated so that the app can distinguish between a resume and a restart.
 - The elevation state of the app is also maintained in the new restarted process.
 
-If the request to restart is successful, the application will be restarted immediately with no return value. The user does not have to do anything else/handle a return value in any way.
+If the request to restart is successful, the application will be restarted immediately with no
+return value. The user does not have to do anything else/handle a return value in any way.
 
-If the request fails due to a nonfatal reason, a failure reason is returned for why the restart didn’t successfully complete. This method leverages an existing enum (AppRestartFailureReason) which has the following relevant return fields.
+If the request fails due to a nonfatal reason, a failure reason is returned for why the restart
+didn’t successfully complete. This method leverages an existing enum (AppRestartFailureReason) which
+has the following relevant return fields.
+
 - InvalidUser: Could not restart for the specified user.
 - RestartPending: A restart is already in progress.
 - Other: Unspecified failure.
@@ -235,9 +257,12 @@ If the request fails due to a nonfatal reason, a failure reason is returned for 
 ### Mechanism
 
 When an application calls Restart, the mechanism for restart will be as follows:
+
 1. Application calls Restart API.
-2. The API calls CreateProcess to launch the agent (a helper EXE in the framework package containing the API)
-3. The Agent will get the executable path of the application. The Agent will then then terminate the application and then call CreateProcess with the application (restarted).
+2. The API calls CreateProcess to launch the agent (a helper EXE in the framework package containing
+   the API)
+3. The Agent will get the executable path of the application. The Agent will then then terminate the
+   application and then call CreateProcess with the application (restarted).
 
 ### Examples
 
@@ -255,7 +280,8 @@ public class App
             switch (reason)
             {
                 case AppRestartFailureReason.RestartPending:
-                    // In this case the restart could not be completed because another restart is pending and we can try to restart again after a period of time.
+                    // In this case the restart could not be completed because another restart is
+                    // pending and we can try to restart again after a period of time.
                     RetryRestartAfterXSeconds();
                     break;
                 case AppRestartFailureReason.Other:
@@ -267,7 +293,7 @@ public class App
     } 
 
     // In this scenario, assume the app encounters an error during initialization.
-    // The app displays an error dialog, and after the user clicks OK on the dialog the app must restart immediately.
+    // The app displays an error dialog, and after the user clicks OK on the dialog the app must restart.
     // This scenario simply displays logging for these use cases
     protected void HandleInitializationError()
     {   

--- a/specs/AppLifecycle/Restart/restartApi.markdown
+++ b/specs/AppLifecycle/Restart/restartApi.markdown
@@ -1,47 +1,36 @@
-# Reunion Restart API Spec
+# Restart API
 
-## Contents
+# Contents
 
-[1. Overview](#overview)
-- [Reunion Restart API components](#reunion-restart-api-components)
+- [Restart API](#restart-api)
+- [Contents](#contents)
+- [Background](#background)
+  - [Description](#description)
+- [API](#api)
+  - [Existing API Summary](#existing-api-summary)
+  - [Existing API Details](#existing-api-details)
+  - [New API Details](#new-api-details)
+    - [RequestRestartNow](#requestrestartnow)
+  - [Examples and Scenarios](#examples-and-scenarios)
+- [Telemetry](#telemetry)
 
-[2. API](#api)
+# Background
 
-- [Existing API Summary](#existing-api-summary)
+This spec addresses the **Restart APIs** in the AppLifecycle component. At a high-level, Win32 apps can
+register with the OS to restart in update/hang/reboot scenarios but cannot restart immediately on-command 
+with specific arguments/state. This applies to packaged (Centennial) and unpackaged apps. This API will address
+these gaps and provide the ability for any Win32 app to restart immediately.
 
-- [All Existing Scenarios](#all-existing-scenarios)
+## Description
 
-- [Existing API Details](#existing-api-details)
+The goal of this feature is the new function: **RequestRestartNow**, which will enable any packaged or unpackaged Win32
+app to terminate and restart itself on command, and to provide an arbitrary command-line string for the restarted instance.
 
-- [New API Details](#new-api-details)
+# API
 
-- [API Sample Code](#api-sample-code)
+## Existing API Summary
 
-[3. Telemetry](##restartApi\telemetry)
-
-[4. Resources](#resources)
-
-## Overview 
-
-This spec addresses the **Restart APIs** in the AppLifecycle component. The main
-goals of this specific API are the following:
-
-Addressing the gaps that exist today: at a high-level, Win32 apps can
-register with the OS to restart in update/hang/reboot scenarios but
-cannot restart immediately on-command with specific arguments/state. This applies to packaged (Centennial) and unpackaged apps. These are the gaps we need to address.
-
-### Reunion Restart API components 
-
-1.  Expose a new function: **RequestRestartNow** function to enable any packaged or unpackaged Win32
-    app to terminate and restart itself on command, and to provide an
-    arbitrary command-line string for the restarted instance.
-
-
-## API
-
-### Existing API Summary
-
-1.  **Restart-me-now**. UWP CoreApplication exposes the
+1.  **Restart-me-now**. CoreApplication exposes the
     [RequestRestartAsync](https://docs.microsoft.com/en-us/uwp/api/windows.applicationmodel.core.coreapplication.requestrestartasync?view=winrt-18362)
     method, which allows an app to terminate and restart itself, and to
     provide an arbitrary command-line string for the restarted instance.
@@ -72,87 +61,12 @@ There are 2 related Win32 APIs that focus on recovery prior to restart:
 2.  **Recovery-in-progress**. While the app is doing work in its
     recovery callback, the app must periodically call
     [ApplicationRecoveryInProgress](https://docs.microsoft.com/en-us/windows/win32/api/winbase/nf-winbase-applicationrecoveryinprogress)
-    -- if it doesn't call within the registered ping interval, WER will
+    \-- if it doesn't call within the registered ping interval, WER will
     terminate the process.
 
-
-<table>
-<colgroup>
-<col style="width: 24%" />
-<col style="width: 45%" />
-<col style="width: 30%" />
-</colgroup>
-<thead>
-<tr class="header">
-<th>App Type</th>
-<th>Applicable Restart Mechanism</th>
-<th>Gap</th>
-</tr>
-</thead>
-<tbody>
-<tr class="odd">
-<td>Win32 (unpackaged)</td>
-<td><ul>
-<li><p>RegisterApplicationRestart for OS + app update/restart/crash scenarios </p></li>
-</ul></td>
-<td><ul>
-<li><p>Apps can register with the OS to restart in specific app/OS states, but cannot restart on-command in a healthy state </p></li>
-</ul></td>
-</tr>
-<tr class="even">
-<td>Win32/Centennial (packaged)</td>
-<td><ul>
-<li><p>RegisterApplicationRestart for OS + app update/restart/crash scenarios </p></li>
-</ul></td>
-<td><ul>
-<li><p>Apps can register with the OS to restart in specific app/OS states, but cannot restart on-command in a healthy state <br />
- </p></li>
-</ul></td>
-</tr>
-<tr class="odd">
-<td>UWP</td>
-<td><ul>
-<li>
-<p>RequestRestartAsync for restarting on demand in a healthy state </p>
-</li>
-</ul>
-<ul>
-<li><p>Automatically registered to restart in restart scenario by Explorer/shell using RestartUwpApp </p></li>
-</ul></td>
-<td><ul>
-<li>
-<p>Apps can restart on-command asynchronously when healthy/active but do not have the ability to ensure restart in app crash/hang scenarios </p>
-</li>
-</ul>
-</tr>
-<tr class="even">
-<td>WinUI (UWP)</td>
-<td><ul>
-<li>
-<p>RequestRestartAsync for restarting on demand in a healthy state </p>
-</li>
-</ul>
-<ul>
-<li><p>Automatically registered to restart in restart scenario by Explorer/shell using RestartUwpApp </p></li>
-</ul></td>
-<td><ul>
-<li>
-<p>Apps can restart on-command asynchronously when healthy/active but do not have the ability to ensure restart in app crash/hang scenarios </p>
-</li>
-</ul>
-</td>
-</tr>
-<tr class="odd">
-<td>WinUI (Centennial)</td>
-<td><ul>
-<li><p>RegisterApplicationRestart for OS + app update/restart/crash scenarios </p></li>
-</ul></td>
-<td><ul>
-<li><p>Apps can register with the OS to restart in specific app/OS states, but cannot restart on-command in a healthy state </p></li>
-</ul></td>
-</tr>
-</tbody>
-</table>
+| App Type                                                            | Applicable Restart Mechanism                                           | Gap                                                                                                                  |
+| ------------------------------------------------------------------- | ---------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------- |
+| Win32 (unpackaged), Win32/Centennial (packaged), WinUI (Centennial) | RegisterApplicationRestart for OS + app update/restart/crash scenarios | Apps can register with the OS to restart in specific app/OS states, but cannot restart on-command in a healthy state |
 
 ## Existing API Details
 
@@ -163,15 +77,13 @@ There are 2 related Win32 APIs that focus on recovery prior to restart:
 </colgroup>
 <thead>
 <tr class="header">
-<th>Existing API for Win32 Apps</th>
+<th>Existing API</th>
 <th>Details</th>
 </tr>
 </thead>
 <tbody>
 <tr class="odd">
-<td><p>HRESULT <strong>RegisterApplicationRestart</strong>(</p>
-<p>PCWSTR pwzCommandline,</p>
-<p>DWORD dwFlags);</p></td>
+<td><p>HRESULT <strong>RegisterApplicationRestart</strong>(PCWSTR pwzCommandline, DWORD dwFlags);</p></td>
 <td><p>The pwzCommandline parameter is passed into the new instance as its command-line arguments string. The dwFlags can be 0 or one or more of the (flags) values:</p>
 <ul>
 <li>
@@ -192,21 +104,6 @@ There are 2 related Win32 APIs that focus on recovery prior to restart:
 <td>HRESULT <strong>UnregisterApplicationRestart</strong>();</td>
 <td>Unregisters the app for restart, where the app had previously called RegisterApplicationRestart.</td>
 </tr>
-</tbody>
-</table>
-
-<table>
-<colgroup>
-<col style="width: 41%" />
-<col style="width: 58%" />
-</colgroup>
-<thead>
-<tr class="header">
-<th>Existing API for UWP Apps</th>
-<th>Details</th>
-</tr>
-</thead>
-<tbody>
 <tr class="odd">
 <td>public static IAsyncOperation&lt;AppRestartFailureReason&gt; <strong>RequestRestartAsync</strong>(<br />
 string launchArguments);</td>
@@ -238,28 +135,6 @@ string launchArguments);</td>
 </ul></td>
 </tr>
 <tr class="odd">
-<td>void <strong>RestartUwpApp</strong>(const wchar_t* const appUserModelId)</td>
-<td>Internal-only function in shell/explorer added as of 20H1 allowing UWP apps to be restarted in a minimized state</td>
-</tr>
-<tr class="even">
-<td>public enum <strong>AppRestartFailureReason</strong></td>
-<td><p>Enum which will be used in the new API detailed below to indicate the reason for a failed restart <em>now.</em></p>
-<ul>
-<li>
-<p>0: RestartPending - a restart is already in progress.</p>
-</li>
-<li>
-<p>1: NotInForeground - an app must be visible and in the foreground when it calls the restart API.</p>
-</li>
-<li>
-<p>2: InvalidUser - could not restart for the specified user.</p>
-</li>
-<li>
-<p>3: Other - unspecified failure.</p>
-</li>
-</ul></td>
-</tr>
-<tr class="odd">
 <td>class <strong>LaunchActivatedEventArg</strong></td>
 <td><p>Relevant Properties:</p>
 <ul>
@@ -271,9 +146,9 @@ string launchArguments);</td>
 </tbody>
 </table>
 
-### New API Details
+## New API Details
 
-#### RequestRestartNow
+### RequestRestartNow
 
 <table>
 <colgroup>
@@ -285,15 +160,13 @@ string launchArguments);</td>
 <tr class="header">
 <th>New API </th>
 <th>Description</th>
-<th>Priority</th>
 </tr>
 </thead>
 <tbody>
 <tr class="odd">
-<td>static AppRestartFailureReason RequestRestartNow(string restartArguments)</td>
+<td>static AppRestartFailureReason <strong>RequestRestartNow</strong>(string restartArguments)</td>
 <td><p>Equivalent to CoreApplication.RequestRestartAsync, except that it is <em>not</em> async.
 <ul>
-<li>The app must be visible and foreground when it calls this API.</li>
 <li>If the restart fails, but the user subsequently launches the app manually, the app will launch normally and no restart arguments will be passed. </li>
 <li>If the app has any in-process background tasks running when it calls this API, those tasks will be cancelled in the normal way. Out-of-process background tasks will not be affected. </li>
 </ul>
@@ -301,45 +174,64 @@ string launchArguments);</td>
  <ul>
 <li>When the app is restarted, LaunchActivatedEventArgs.PreviousExecutionState will have the value Terminated so that the app can distinguish between a resume and a restart. </li>
 </ul>
-<p>Returns a failure reason for why the restart didn’t successfully complete.</p></td>
-<td>P1</td>
+<p>Returns a failure reason for why the restart didn’t successfully complete (AppRestartFailureReason).
+<ul>
+<li>This API does not require for the app to be in foreground, and so AppRestartFailureReason::NotInForeground will never be returned </li>
+</ul>
+</p></td>
 </tr>
 </tbody>
 </table>
 
-### API Sample Code
+When an application calls RequestRestartNow, the mechanism for restart will be as follows:
+1. Application calls RequestRestartNow API.
+2. The API will CreateProcess with the Agent (a helper EXE in the framework package containing the API) and will then wait for an an acknowledgment (ACK) from the Agent.
+3. The Agent will get the executable path of the application and signal an ACK to the API. The Agent will then wait for termination of the application.
+4. The API will terminate the application.
+5. The Agent will CreateProcess with the application (restarted).
 
-### RequestRestartNow Sample
+## Examples and Scenarios
 
 ```c#
 public class App {
        // Let's assume this method is run when an app updates assets.
-       // The new assets have downloaded and installed, and now the app has to restart immediately
+       // The new assets have downloaded and installed, and now the app has to request a restart immediately
        protected void updateInstallComplete(){
-           // code here that checks the app update has installed
+           // Checking if the assets have updated successfully and there are no pending updates
+           if (!CheckForUpdate()){
+               AppRestartFailureReason result = AppLifecycle::RequestRestartNow("args for new instance");
+               switch (result){
+                    case AppRestartFailureReason::RestartPending:
+                        // An example of how to handle this case is updating a progress bar to the user
+                        // indicating immediate restart
+                        UpdateProgressBar();
+                        break;
+                    case AppRestartFailureReason::Other:
+                        // In this case, a dialog box will appear informing of an error requesting restart
+                        ShowErrorMessage();
+                        break;
+               }
+           }
+       } 
 
-           WCHAR buffer\[1024\]; 
-           AppRestartFailureReason result = AppLifecycle::RequestRestartNow("args for new instance");
-
-           switch (result){
-                case AppRestartFailureReason::RestartPending:
-                    Telemetry::WriteLine("Restart request successful.");
-                    break;
-                case AppRestartFailureReason::NotInForeground:
-                    wcscpy_s(buffer, L"App must be in the foreground to request restart.");
-                    break;
-                case AppRestartFailureReason::InvalidUser:
-                    wcscpy_s(buffer, L"Cannot restart for this user.");
-                    break;
-                case AppRestartFailureReason::Other:
-                    wcscpy_s(buffer, L"Unknown failure.");
-                    break;
+    // In this scenario, assume the app encounters an error during initialization.
+    // The app displays an error dialogue, and after the user clicks OK on the dialog the app must restart immediately.
+    // This scenario simply displays logging for these use cases
+    protected void handleInitializationError(){
+        AppRestartFailureReason result = AppLifecycle::RequestRestartNow("args for new instance");
+        switch (result){
+            case AppRestartFailureReason::RestartPending:
+                Telemetry::WriteLine("Restart request successful.");
+                break;
+            case AppRestartFailureReason::Other:
+                Telemetry::WriteLine("Failure restarting.");
+                break;
            }
-       }               
+    }
 }
 ```
 
-## Telemetry 
+# Telemetry
 
 This section explores the telemetry needs for the Restart feature in
 four dimensions – Usage, Reliability, Performance and Failure
@@ -351,7 +243,7 @@ telemetry information:
 Event Name: **AppRestart**
 
 | Metadata                | Description                                                                                       | Data type |
-|-------------------------|---------------------------------------------------------------------------------------------------|-----------|
+| ----------------------- | ------------------------------------------------------------------------------------------------- | --------- |
 | AppRestartFailureReason | Reason an app restart failed. This will be collected when an app requests a restart now but fails | Enum      |
 | AppName                 | Name of the app which restarted                                                                   | String    |
 | AppType                 | UWP App or Centennial App or Win32 app                                                            | String    |

--- a/specs/AppLifecycle/Restart/restartApi.markdown
+++ b/specs/AppLifecycle/Restart/restartApi.markdown
@@ -186,9 +186,7 @@ string launchArguments);</td>
 When an application calls RequestRestartNow, the mechanism for restart will be as follows:
 1. Application calls RequestRestartNow API.
 2. The API will CreateProcess with the Agent (a helper EXE in the framework package containing the API) and will then wait for an an acknowledgment (ACK) from the Agent.
-3. The Agent will get the executable path of the application and signal an ACK to the API. The Agent will then wait for termination of the application.
-4. The API will terminate the application.
-5. The Agent will CreateProcess with the application (restarted).
+3. The Agent will get the executable path of the application and signal an ACK to the API. The Agent will then then terminate the application and then CreateProcess with the application (restarted).
 
 ## Examples and Scenarios
 

--- a/specs/AppLifecycle/Restart/restartApi.markdown
+++ b/specs/AppLifecycle/Restart/restartApi.markdown
@@ -226,7 +226,7 @@ public class App {
             case AppRestartFailureReason::Other:
                 Telemetry::WriteLine("Failure restarting.");
                 break;
-           }
+        }
     }
 }
 ```

--- a/specs/AppLifecycle/Restart/restartApi.markdown
+++ b/specs/AppLifecycle/Restart/restartApi.markdown
@@ -21,19 +21,6 @@
 
 [4. Resources](#resources)
 
-## Contacts
-
-### Program Managers                
-
-Hamza Usmani (mousma)\
-Andrew Whitechapel (andreww)
-
-### Developers
-Scott Darnell (scodar)
-
-### Data                            
-TBD
-
 ## Overview 
 
 We are creating a new AppLifecycle component that provides a core set of

--- a/specs/AppLifecycle/Restart/restartApi.markdown
+++ b/specs/AppLifecycle/Restart/restartApi.markdown
@@ -35,20 +35,14 @@ scenarios. These are the gaps we need to address.
 
 ### Reunion Restart API components 
 
-1.  Expose a new function: **RegisterForRestart**, which allows any app
+1.  Expose a new function: **RegisterForRestart**, which allows any app (win32/packaged win32, UWP, WinUI apps)
     to register itself for restart if it was running when a system
     update occurs or if an app hangs/crashes unexpectedly.
 
-    a.  This is an existing Win32 API (RegisterApplicationRestart) which
-        we want UWP parity with
-
 2.  Expose a new function: **RequestRestartNow** function to enable any
-    app to terminate and restart itself on command, and to provide an
+    app (win32/packaged win32, UWP, WinUI apps) to terminate and restart itself on command, and to provide an
     arbitrary command-line string for the restarted instance.
 
-    a.  Mirror the functionality of an existing WinRT API
-        (RequestRestartAsync) which we want to work with Win32, UWP
-        applications + WinUI
 
 ## API
 

--- a/specs/AppLifecycle/Restart/restartApi.markdown
+++ b/specs/AppLifecycle/Restart/restartApi.markdown
@@ -163,9 +163,6 @@ There are 2 related Win32 APIs that focus on recovery prior to restart:
 <p>Apps can restart on-command asynchronously when healthy/active but do not have the ability to ensure restart in app crash/hang scenarios </p>
 </li>
 </ul>
-<ul>
-<li><p> </p></li>
-</ul></td>
 </tr>
 <tr class="even">
 <td>WinUI (UWP)</td>
@@ -182,9 +179,7 @@ There are 2 related Win32 APIs that focus on recovery prior to restart:
 <p>Apps can restart on-command asynchronously when healthy/active but do not have the ability to ensure restart in app crash/hang scenarios </p>
 </li>
 </ul>
-<ul>
-<li><p> </p></li>
-</ul></td>
+</td>
 </tr>
 <tr class="odd">
 <td>WinUI (Centennial)</td>
@@ -401,65 +396,68 @@ string launchArguments);</td>
 ### API Sample Code
 
 #### RegisterForRestart Sample
+```c#
+public class App {
 
-    public class App {
+        // App was just launched
+        protected override void OnLaunched(LaunchActivatedEventArgs args)
+        {
+            // If the application was terminated for example and has now been restarted
+            if (args != NULL)
+            {
+                if (args.PreviousExecutionState == ApplicationExecutionState.Terminated)
+                {
+                    Telemetry::WriteLine("Restart activated: " + args.Arguments);
+                }
+            }
+        }
 
-            // App was just launched
-            protected override void OnLaunched(LaunchActivatedEventArgs args)
-            {
-                // If the application was terminated for example and has now been restarted
-                if (args != NULL)
-                {
-                    if (args.PreviousExecutionState == ApplicationExecutionState.Terminated)
-                    {
-                        Telemetry::WriteLine("Restart activated: " + args.Arguments);
-                    }
-                }
-            }
+        // We want to register the app for restart if termination happens only after crash
+        protected bool restartOnUpdate(){
+            bool result = AppLifecycle::RegisterForRestart("args for new instance", RestartContext::Crash);
+            Telemetry::WriteLine("RegisterForRestart: Restart Context: " + RestartContext::Crash.ToString() 
+            + ". Result: " + result ? "success" : "fail");
 
-            // We want to register the app for restart if termination happens only after crash
-            protected bool restartOnUpdate(){
-                bool result = AppLifecycle::RegisterForRestart("args for new instance", RestartContext::Crash);
-                Telemetry::WriteLine("RegisterForRestart: Restart Context: " + RestartContext::Crash.ToString() 
-                + ". Result: " + result ? "success" : "fail");
+            // Do normal app behavior
+        }
 
-                // Do normal app behavior
-            }
-
-            // We want to unregister for post-crash restarts
-            protected bool removeRestartOnUpdate(){
-                bool result = AppLifecycle::UnregisterForRestart();
-                Telemetry::WriteLine("UnregisterForRestart: Result: " + result ? "success" : "fail");
-            }
-    }
+        // We want to unregister for post-crash restarts
+        protected bool removeRestartOnUpdate(){
+            bool result = AppLifecycle::UnregisterForRestart();
+            Telemetry::WriteLine("UnregisterForRestart: Result: " + result ? "success" : "fail");
+        }
+}
+```
 
 ### RequestRestartNow Sample
 
-    public class App {
-           // Let's assume this method is run when an app updates assets.
-           // The new assets have downloaded and installed, and now the app has to restart immediately
-           protected void updateInstallComplete(){
-               // code here that checks the app update has installed
+```c#
+public class App {
+       // Let's assume this method is run when an app updates assets.
+       // The new assets have downloaded and installed, and now the app has to restart immediately
+       protected void updateInstallComplete(){
+           // code here that checks the app update has installed
 
-               WCHAR buffer\[1024\]; 
-               AppRestartFailureReason result = AppLifecycle::RequestRestartNow("args for new instance");
+           WCHAR buffer\[1024\]; 
+           AppRestartFailureReason result = AppLifecycle::RequestRestartNow("args for new instance");
 
-               switch (result){
-                    case AppRestartFailureReason::RestartPending:
-                        Telemetry::WriteLine("Restart request successful.");
-                        break;
-                    case AppRestartFailureReason::NotInForeground:
-                        wcscpy_s(buffer, L"App must be in the foreground to request restart.");
-                        break;
-                    case AppRestartFailureReason::InvalidUser:
-                        wcscpy_s(buffer, L"Cannot restart for this user.");
-                        break;
-                    case AppRestartFailureReason::Other:
-                        wcscpy_s(buffer, L"Unknown failure.");
-                        break;
-               }
-           }               
-    }  
+           switch (result){
+                case AppRestartFailureReason::RestartPending:
+                    Telemetry::WriteLine("Restart request successful.");
+                    break;
+                case AppRestartFailureReason::NotInForeground:
+                    wcscpy_s(buffer, L"App must be in the foreground to request restart.");
+                    break;
+                case AppRestartFailureReason::InvalidUser:
+                    wcscpy_s(buffer, L"Cannot restart for this user.");
+                    break;
+                case AppRestartFailureReason::Other:
+                    wcscpy_s(buffer, L"Unknown failure.");
+                    break;
+           }
+       }               
+}
+```
 
 ## Telemetry 
 

--- a/specs/AppLifecycle/Restart/restartApi.markdown
+++ b/specs/AppLifecycle/Restart/restartApi.markdown
@@ -23,20 +23,7 @@
 
 ## Overview 
 
-We are creating a new AppLifecycle component that provides a core set of
-functionality related to app activation and lifecycle. The 3 key goals
-of this component are:
-
--   it is undocked from the OS; that is, it will release out-of-band
-    from the OS;
-
--   it provides a centralized place for core app lifecycle functionality
-    that *all* apps can easily consume, whether traditional unpackaged
-    Win32, Winforms, WPF, packaged (Centennial) Win32, or UWP.
-
--   it will be made available as open-source.
-
-This spec addresses the **Restart APIs** in the component. The main
+This spec addresses the **Restart APIs** in the AppLifecycle component. The main
 goals of this specific API are the following:
 
 Addressing the gaps that exist today: at a high-level, Win32 apps can

--- a/specs/AppLifecycle/Restart/restartApi.markdown
+++ b/specs/AppLifecycle/Restart/restartApi.markdown
@@ -1,0 +1,492 @@
+# Reunion Restart API Spec
+
+## Contents
+
+[1. Overview](#overview)
+- [Reunion Restart API components](#reunion-restart-api-components)
+
+[2. API](#api)
+
+- [Existing API Summary](#existing-api-summary)
+
+- [All Existing Scenarios](#all-existing-scenarios)
+
+- [Existing API Details](#existing-api-details)
+
+- [New API Details](#new-api-details)
+
+- [API Sample Code](#api-sample-code)
+
+[3. Telemetry](##restartApi\telemetry)
+
+[4. Resources](#resources)
+
+## Contacts
+
+### Program Managers                
+
+Hamza Usmani (mousma)\
+Andrew Whitechapel (andreww)
+
+### Developers
+Scott Darnell (scodar)
+
+### Data                            
+TBD
+
+## Overview 
+
+We are creating a new AppLifecycle component that provides a core set of
+functionality related to app activation and lifecycle. The 3 key goals
+of this component are:
+
+-   it is undocked from the OS; that is, it will release out-of-band
+    from the OS;
+
+-   it provides a centralized place for core app lifecycle functionality
+    that *all* apps can easily consume, whether traditional unpackaged
+    Win32, Winforms, WPF, packaged (Centennial) Win32, or UWP.
+
+-   it will be made available as open-source.
+
+This spec addresses the **Restart APIs** in the component. The main
+goals of this specific API are the following:
+
+Addressing the gaps that exist today: at a high-level, Win32 apps can
+register with the OS to restart in update/hang/reboot scenarios but
+cannot restart immediately on-command with specific arguments/state. UWP
+apps can restart on-command with command-line restart arguments but
+cannot register with the OS Restart Manager for update/hang/reboot
+scenarios. These are the gaps we need to address.
+
+### Reunion Restart API components 
+
+1.  Expose a new function: **RegisterForRestart**, which allows any app
+    to register itself for restart if it was running when a system
+    update occurs or if an app hangs/crashes unexpectedly.
+
+    a.  This is an existing Win32 API (RegisterApplicationRestart) which
+        we want UWP parity with
+
+2.  Expose a new function: **RequestRestartNow** function to enable any
+    app to terminate and restart itself on command, and to provide an
+    arbitrary command-line string for the restarted instance.
+
+    a.  Mirror the functionality of an existing WinRT API
+        (RequestRestartAsync) which we want to work with Win32, UWP
+        applications + WinUI
+
+## API
+
+### Existing API Summary
+
+1.  **Restart-me-now**. UWP CoreApplication exposes the
+    [RequestRestartAsync](https://docs.microsoft.com/en-us/uwp/api/windows.applicationmodel.core.coreapplication.requestrestartasync?view=winrt-18362)
+    method, which allows an app to terminate and restart itself, and to
+    provide an arbitrary command-line string for the restarted instance.
+
+2.  **Restart-me-after-termination**. The Win32 API
+    [RegisterApplicationRestart](https://docs.microsoft.com/en-us/windows/win32/api/winbase/nf-winbase-registerapplicationrestart)
+    enables an app to register itself to be restarted after termination,
+    and to provide an arbitrary command-line string for the restarted
+    instance. The reasons for termination include app crash or hang, app
+    update, or system update. There's also a matching
+    [UnregisterApplicationRestart](https://docs.microsoft.com/en-us/windows/win32/api/winbase/nf-winbase-unregisterapplicationrestart)
+    API.
+
+There are 2 related Win32 APIs that focus on recovery prior to restart:
+
+1.  **Let-me-do-something-before-termination**. An app can call
+    [RegisterApplicationRecoveryCallback](https://docs.microsoft.com/en-us/windows/win32/api/winbase/nf-winbase-registerapplicationrecoverycallback)
+    to register a callback for the system to call before terminating the
+    app. If an application encounters an unhandled exception or becomes
+    unresponsive, Windows Error Reporting (WER) calls the specified
+    recovery callback, where the app can save state information. The
+    system pings the app every n seconds to make sure that it hasn't
+    hung in its callback. The app can specify the ping interval when it
+    registers the callback. In its recovery callback, the app can call
+    RegisterApplicationRestart a second time, to update the
+    command-line.
+
+2.  **Recovery-in-progress**. While the app is doing work in its
+    recovery callback, the app must periodically call
+    [ApplicationRecoveryInProgress](https://docs.microsoft.com/en-us/windows/win32/api/winbase/nf-winbase-applicationrecoveryinprogress)
+    -- if it doesn't call within the registered ping interval, WER will
+    terminate the process.
+
+
+<table>
+<colgroup>
+<col style="width: 24%" />
+<col style="width: 45%" />
+<col style="width: 30%" />
+</colgroup>
+<thead>
+<tr class="header">
+<th>App Type</th>
+<th>Applicable Restart Mechanism</th>
+<th>Gap</th>
+</tr>
+</thead>
+<tbody>
+<tr class="odd">
+<td>Win32 (unpackaged)</td>
+<td><ul>
+<li><p>RegisterApplicationRestart for OS + app update/restart/crash scenarios </p></li>
+</ul></td>
+<td><ul>
+<li><p>Apps can register with the OS to restart in specific app/OS states, but cannot restart on-command in a healthy state </p></li>
+</ul></td>
+</tr>
+<tr class="even">
+<td>Win32/Centennial (packaged)</td>
+<td><ul>
+<li><p>RegisterApplicationRestart for OS + app update/restart/crash scenarios </p></li>
+</ul></td>
+<td><ul>
+<li><p>Apps can register with the OS to restart in specific app/OS states, but cannot restart on-command in a healthy state <br />
+ </p></li>
+</ul></td>
+</tr>
+<tr class="odd">
+<td>UWP</td>
+<td><ul>
+<li>
+<p>RequestRestartAsync for restarting on demand in a healthy state </p>
+</li>
+</ul>
+<ul>
+<li><p>Automatically registered to restart in restart scenario by Explorer/shell using RestartUwpApp </p></li>
+</ul></td>
+<td><ul>
+<li>
+<p>Apps can restart on-command asynchronously when healthy/active but do not have the ability to ensure restart in app crash/hang scenarios </p>
+</li>
+</ul>
+<ul>
+<li><p> </p></li>
+</ul></td>
+</tr>
+<tr class="even">
+<td>WinUI (UWP)</td>
+<td><ul>
+<li>
+<p>RequestRestartAsync for restarting on demand in a healthy state </p>
+</li>
+</ul>
+<ul>
+<li><p>Automatically registered to restart in restart scenario by Explorer/shell using RestartUwpApp </p></li>
+</ul></td>
+<td><ul>
+<li>
+<p>Apps can restart on-command asynchronously when healthy/active but do not have the ability to ensure restart in app crash/hang scenarios </p>
+</li>
+</ul>
+<ul>
+<li><p> </p></li>
+</ul></td>
+</tr>
+<tr class="odd">
+<td>WinUI (Centennial)</td>
+<td><ul>
+<li><p>RegisterApplicationRestart for OS + app update/restart/crash scenarios </p></li>
+</ul></td>
+<td><ul>
+<li><p>Apps can register with the OS to restart in specific app/OS states, but cannot restart on-command in a healthy state </p></li>
+</ul></td>
+</tr>
+</tbody>
+</table>
+
+## Existing API Details
+
+<table>
+<colgroup>
+<col style="width: 41%" />
+<col style="width: 58%" />
+</colgroup>
+<thead>
+<tr class="header">
+<th>Existing API for Win32 Apps</th>
+<th>Details</th>
+</tr>
+</thead>
+<tbody>
+<tr class="odd">
+<td><p>HRESULT <strong>RegisterApplicationRestart</strong>(</p>
+<p>PCWSTR pwzCommandline,</p>
+<p>DWORD dwFlags);</p></td>
+<td><p>The pwzCommandline parameter is passed into the new instance as its command-line arguments string. The dwFlags can be 0 or one or more of the (flags) values:</p>
+<ul>
+<li>
+<p>1: RESTART_NO_CRASH - Do not restart the process if it terminates due to an unhandled exception.</p>
+</li>
+<li>
+<p>2: RESTART_NO_HANG - Do not restart the process if it terminates due to the application not responding.</p>
+</li>
+<li>
+<p>4: RESTART_NO_PATCH - Do not restart the process if it terminates due to the installation of an OS update.</p>
+</li>
+<li>
+<p>8: RESTART_NO_REBOOT - Do not restart the process if the computer is restarted as the result of an OS update.</p>
+</li>
+</ul></td>
+</tr>
+<tr class="even">
+<td>HRESULT <strong>UnregisterApplicationRestart</strong>();</td>
+<td>Unregisters the app for restart, where the app had previously called RegisterApplicationRestart.</td>
+</tr>
+</tbody>
+</table>
+
+<table>
+<colgroup>
+<col style="width: 41%" />
+<col style="width: 58%" />
+</colgroup>
+<thead>
+<tr class="header">
+<th>Existing API for UWP Apps</th>
+<th>Details</th>
+</tr>
+</thead>
+<tbody>
+<tr class="odd">
+<td>public static IAsyncOperation&lt;AppRestartFailureReason&gt; <strong>RequestRestartAsync</strong>(<br />
+string launchArguments);</td>
+<td><p>Static function in CoreApplication. Requests immediate termination and restart.</p>
+<ul>
+<li>
+<p>The launchArguments string is passed into the new instance as the Arguments property on LaunchActivatedEventArgs.</p>
+</li>
+<li>
+<p>Also sets LaunchActivatedEventArgs.PreviousExecutionState to Terminated.</p>
+</li>
+</ul></td>
+</tr>
+<tr class="even">
+<td>public enum <strong>AppRestartFailureReason</strong></td>
+<td><ul>
+<li>
+<p>0: RestartPending - a restart is already in progress.</p>
+</li>
+<li>
+<p>1: NotInForeground - an app must be visible and in the foreground when it calls the restart API.</p>
+</li>
+<li>
+<p>2: InvalidUser - could not restart for the specified user.</p>
+</li>
+<li>
+<p>3: Other - unspecified failure.</p>
+</li>
+</ul></td>
+</tr>
+<tr class="odd">
+<td>void <strong>RestartUwpApp</strong>(const wchar_t* const appUserModelId)</td>
+<td>Internal-only function in shell/explorer added as of 20H1 allowing UWP apps to be restarted in a minimized state</td>
+</tr>
+<tr class="even">
+<td>public enum <strong>AppRestartFailureReason</strong></td>
+<td><p>Enum which will be used in the new API detailed below to indicate the reason for a failed restart <em>now.</em></p>
+<ul>
+<li>
+<p>0: RestartPending - a restart is already in progress.</p>
+</li>
+<li>
+<p>1: NotInForeground - an app must be visible and in the foreground when it calls the restart API.</p>
+</li>
+<li>
+<p>2: InvalidUser - could not restart for the specified user.</p>
+</li>
+<li>
+<p>3: Other - unspecified failure.</p>
+</li>
+</ul></td>
+</tr>
+<tr class="odd">
+<td>class <strong>LaunchActivatedEventArg</strong></td>
+<td><p>Relevant Properties:</p>
+<ul>
+<li><p>Arguments: gets the arguments that are passed to the app during its launch activation.</p></li>
+<li><p>Kind: Gets the reason that this app is being activated. This is of type enum ActivationKind</p></li>
+</ul>
+<p>PreviousExecutionState: Gets the execution state of the app before this activation.</p></td>
+</tr>
+</tbody>
+</table>
+
+### New API Details
+
+#### RegisterForRestart
+
+<table>
+<colgroup>
+<col style="width: 40%" />
+<col style="width: 51%" />
+<col style="width: 8%" />
+</colgroup>
+<thead>
+<tr class="header">
+<th>New API </th>
+<th>Description</th>
+<th>Priority</th>
+</tr>
+</thead>
+<tbody>
+<tr class="odd">
+<td>static bool RegisterForRestart(string restartArguments, RestartContext context)</td>
+<td><p>Equivalent to the Win32 RegisterApplicationRestart function.</p>
+<p>restartArguments is the same as the pwzCommandline parameter in the Win32 RegisterApplicationRestart. It is a string of command-line arguments which will be passed as restart arguments.</p>
+<p>restartArguments become the restarted/new instance’s LaunchActivatedEventArgs.</p></td>
+<td>P3</td>
+</tr>
+<tr class="even">
+<td>[Flags] enum RestartContext</td>
+<td><p>The values passed for RestartContext indicate which cases</p>
+<p>the app <em>should be restarted.<br />
+<br />
+</em>The possible cases are the same as dwFlag values listed above in Win32’s RegisterApplicationRestart<strong>:</strong></p>
+<ul>
+<li><p>-1: ALL</p></li>
+<li><p>1: CRASH</p></li>
+<li><p>2: HANG</p></li>
+<li><p>4: PATCH</p></li>
+<li><p>8: REBOOT</p></li>
+</ul>
+<p>[Flags] enum RestartContext { All = -1, Crash = 1, Hang = 2, Patch = 4, Reboot = 8 }</p></td>
+<td>P3</td>
+</tr>
+<tr class="odd">
+<td>static bool UnregisterForRestart()</td>
+<td>Equivalent to the Win32 UnregisterApplicationRestart function.</td>
+<td>P3</td>
+</tr>
+</tbody>
+</table>
+
+#### RequestRestartNow
+
+<table>
+<colgroup>
+<col style="width: 41%" />
+<col style="width: 53%" />
+<col style="width: 5%" />
+</colgroup>
+<thead>
+<tr class="header">
+<th>New API </th>
+<th>Description</th>
+<th>Priority</th>
+</tr>
+</thead>
+<tbody>
+<tr class="odd">
+<td>static AppRestartFailureReason RequestRestartNow(string restartArguments)</td>
+<td><p>Equivalent to CoreApplication.RequestRestartAsync, except that it is <em>not</em> async.
+<ul>
+<li>The app must be visible and foreground when it calls this API.</li>
+<li>If the restart fails, but the user subsequently launches the app manually, the app will launch normally and no restart arguments will be passed. </li>
+<li>If the app has any in-process background tasks running when it calls this API, those tasks will be cancelled in the normal way. Out-of-process background tasks will not be affected. </li>
+</ul>
+ The restarted instance will be activated with Windows.ApplicationModel.Activation.LaunchActivatedEventArgs.</p>
+ <ul>
+<li>When the app is restarted, LaunchActivatedEventArgs.PreviousExecutionState will have the value Terminated so that the app can distinguish between a resume and a restart. </li>
+</ul>
+<p>Returns a failure reason for why the restart didn’t successfully complete.</p></td>
+<td>P1</td>
+</tr>
+</tbody>
+</table>
+
+### API Sample Code
+
+#### RegisterForRestart Sample
+
+    public class App {
+
+            // App was just launched
+            protected override void OnLaunched(LaunchActivatedEventArgs args)
+            {
+                // If the application was terminated for example and has now been restarted
+                if (args != NULL)
+                {
+                    if (args.PreviousExecutionState == ApplicationExecutionState.Terminated)
+                    {
+                        Telemetry::WriteLine("Restart activated: " + args.Arguments);
+                    }
+                }
+            }
+
+            // We want to register the app for restart if termination happens only after crash
+            protected bool restartOnUpdate(){
+                bool result = AppLifecycle::RegisterForRestart("args for new instance", RestartContext::Crash);
+                Telemetry::WriteLine("RegisterForRestart: Restart Context: " + RestartContext::Crash.ToString() 
+                + ". Result: " + result ? "success" : "fail");
+
+                // Do normal app behavior
+            }
+
+            // We want to unregister for post-crash restarts
+            protected bool removeRestartOnUpdate(){
+                bool result = AppLifecycle::UnregisterForRestart();
+                Telemetry::WriteLine("UnregisterForRestart: Result: " + result ? "success" : "fail");
+            }
+    }
+
+### RequestRestartNow Sample
+
+    public class App {
+           // Let's assume this method is run when an app updates assets.
+           // The new assets have downloaded and installed, and now the app has to restart immediately
+           protected void updateInstallComplete(){
+               // code here that checks the app update has installed
+
+               WCHAR buffer\[1024\]; 
+               AppRestartFailureReason result = AppLifecycle::RequestRestartNow("args for new instance");
+
+               switch (result){
+                    case AppRestartFailureReason::RestartPending:
+                        Telemetry::WriteLine("Restart request successful.");
+                        break;
+                    case AppRestartFailureReason::NotInForeground:
+                        wcscpy_s(buffer, L"App must be in the foreground to request restart.");
+                        break;
+                    case AppRestartFailureReason::InvalidUser:
+                        wcscpy_s(buffer, L"Cannot restart for this user.");
+                        break;
+                    case AppRestartFailureReason::Other:
+                        wcscpy_s(buffer, L"Unknown failure.");
+                        break;
+               }
+           }               
+    }  
+
+## Telemetry 
+
+This section explores the telemetry needs for the Restart feature in
+four dimensions – Usage, Reliability, Performance and Failure
+Investigation. The telemetry will include the metadata that are needed
+not only for measuring quality but also for helping with investigations
+of failures. Following is the event which can be used to capture
+telemetry information:
+
+Event Name: **AppRestart**
+
+| Metadata                | Description                                                                                       | Data type |
+|-------------------------|---------------------------------------------------------------------------------------------------|-----------|
+| RestartContext          | Reason for an App to register for restart and then attempt to restart                             | Enum      |
+| AppRestartFailureReason | Reason an app restart failed. This will be collected when an app requests a restart now but fails | Enum      |
+| AppName                 | Name of the app which restarted                                                                   | String    |
+| AppType                 | UWP App or Centennial App or Win32 app                                                            | String    |
+
+## Resources
+
+| Resource                                                                                                                                                                                       | Description                                                                                   |
+|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|-----------------------------------------------------------------------------------------------|
+| [API Design Process](http://osgwiki.com/wiki/API_Design)                                                                                                                                       | API design process overview with FAQs and links to useful resources.                          |
+| [API Design Representatives](http://osgwiki.com/wiki/API_Design_Representatives)                                                                                                               | API design representatives and their areas of expertise.                                      |
+| [API Design Guidelines](http://osgwiki.com/wiki/WinRT_API_Design_Guidelines)                                                                                                                   | API design guidelines for various frameworks.                                                 |
+| [Sample Requirements](https://osgwiki.com/wiki/API_Design#Sample_Requirements)                                                                                                                 | Requirements for the samples above including when samples in specific languages are required. |
+| [Interface Definition Guidelines](https://microsoft.sharepoint.com/teams/osg_core_dep/devtools/Shared%20Documents/API%20Design/Educational%20Content/Interface%20Definition%20Guidelines.docx) | Guidelines for providing interface definitions.                                               |
+| [Code Analysis Guidelines](https://osgwiki.com/wiki/API_Design#Design_Analysis_Guidelines)                                                                                                     | Guidelines for running code analysis tools.                                                   |
+| [RtCop Bug Template](http://aka.ms/rtcopbug)                                                                                                                                                   | The bug template to use when filing RtCop bugs.                                               |

--- a/specs/AppLifecycle/Restart/restartApi.markdown
+++ b/specs/AppLifecycle/Restart/restartApi.markdown
@@ -444,15 +444,3 @@ Event Name: **AppRestart**
 | AppRestartFailureReason | Reason an app restart failed. This will be collected when an app requests a restart now but fails | Enum      |
 | AppName                 | Name of the app which restarted                                                                   | String    |
 | AppType                 | UWP App or Centennial App or Win32 app                                                            | String    |
-
-## Resources
-
-| Resource                                                                                                                                                                                       | Description                                                                                   |
-|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|-----------------------------------------------------------------------------------------------|
-| [API Design Process](http://osgwiki.com/wiki/API_Design)                                                                                                                                       | API design process overview with FAQs and links to useful resources.                          |
-| [API Design Representatives](http://osgwiki.com/wiki/API_Design_Representatives)                                                                                                               | API design representatives and their areas of expertise.                                      |
-| [API Design Guidelines](http://osgwiki.com/wiki/WinRT_API_Design_Guidelines)                                                                                                                   | API design guidelines for various frameworks.                                                 |
-| [Sample Requirements](https://osgwiki.com/wiki/API_Design#Sample_Requirements)                                                                                                                 | Requirements for the samples above including when samples in specific languages are required. |
-| [Interface Definition Guidelines](https://microsoft.sharepoint.com/teams/osg_core_dep/devtools/Shared%20Documents/API%20Design/Educational%20Content/Interface%20Definition%20Guidelines.docx) | Guidelines for providing interface definitions.                                               |
-| [Code Analysis Guidelines](https://osgwiki.com/wiki/API_Design#Design_Analysis_Guidelines)                                                                                                     | Guidelines for running code analysis tools.                                                   |
-| [RtCop Bug Template](http://aka.ms/rtcopbug)                                                                                                                                                   | The bug template to use when filing RtCop bugs.                                               |


### PR DESCRIPTION
Bringing in Restart API spec into main. This spec addresses the gaps in restart today and how we can expose new functions to manage restart across all app types.