### PR TITLE
Rename preview VSIX to experimental (#1178)

### DIFF
--- a/dev/VSIX/Directory.Build.targets
+++ b/dev/VSIX/Directory.Build.targets
@@ -72,12 +72,12 @@
                 <ExperimentalDisplayName>[Experimental] $(_tempVsTemplateDisplayName)</ExperimentalDisplayName>
 
                 <OriginalTemplateId>$(_tempVsTemplateId)</OriginalTemplateId>
-                <ExperimentalTemplateId>$(_tempVsTemplateId).Preview</ExperimentalTemplateId>
+                <ExperimentalTemplateId>$(_tempVsTemplateId).Experimental</ExperimentalTemplateId>
 
                 <OriginalNugetRepositoryId>$(_tempVsTemplateNugetRepositoryId)</OriginalNugetRepositoryId>
                 <!-- 'ExperimentalNugetRepositoryId' needs to match the value set by the XmlPoke query for
                 "/ns:PackageManifest/ns:Metadata/ns:Identity/@Id" in Extension\WindowsAppSDK.Extension.csproj -->
-                <ExperimentalNugetRepositoryId>$(_tempVsTemplateNugetRepositoryId).Preview</ExperimentalNugetRepositoryId>
+                <ExperimentalNugetRepositoryId>$(_tempVsTemplateNugetRepositoryId).Experimental</ExperimentalNugetRepositoryId>
             </AllVSTemplates>
         </ItemGroup>
 

--- a/dev/VSIX/Extension/WindowsAppSDK.Extension.csproj
+++ b/dev/VSIX/Extension/WindowsAppSDK.Extension.csproj
@@ -10,7 +10,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>WindowsAppSDK.Extension</RootNamespace>
     <AssemblyName Condition="'$(EnableExperimentalVSIXFeatures)'!='true'">WindowsAppSDK.Extension</AssemblyName>
-    <AssemblyName Condition="'$(EnableExperimentalVSIXFeatures)'=='true'">WindowsAppSDK.Extension.Preview</AssemblyName>
+    <AssemblyName Condition="'$(EnableExperimentalVSIXFeatures)'=='true'">WindowsAppSDK.Extension.Experimental</AssemblyName>
     <TargetFramework>net472</TargetFramework>
     <!-- This project may not have any C# source files, so suppress that compiler warning. -->
     <NoWarn>2008</NoWarn>
@@ -263,7 +263,7 @@
     <!--
       Add a timestamp as part 4 of the version for uniqueness, and to ensure newer builds are newer
       versions. Note that the timestamp is also included in release builds. This avoids version
-      sequencing issues between public previews and release versions that might otherwise have the same
+      sequencing issues between experimental and stable/preview versions that might otherwise have the same
       version number, since VSIX does not support preview tags or other mechanisms to distinguish.
     -->
     <TimeSpan>$([System.Math]::Floor($([System.DateTime]::UtcNow.Subtract($([System.DateTime]::Parse('2020-01-01T00:00Z'))).TotalSeconds)))</TimeSpan>
@@ -292,8 +292,14 @@
       Namespaces="&lt;Namespace Prefix='ns' Uri='http://schemas.microsoft.com/developer/vsx-schema/2011' /&gt;">
       <Output TaskParameter="Result" PropertyName="_OriginalVsixTags" />
     </XmlPeek>
+    <XmlPeek
+      XmlInputPath="$(VsixManifestSource)"
+      Query="/ns:PackageManifest/ns:Metadata/ns:Preview/text()"
+      Namespaces="&lt;Namespace Prefix='ns' Uri='http://schemas.microsoft.com/developer/vsx-schema/2011' /&gt;">
+      <Output TaskParameter="Result" PropertyName="_OriginalVsixPreview" />
+    </XmlPeek>
 
-    <!-- Update the .vsixmanifest to reflect preview status if necessary -->
+    <!-- Update the .vsixmanifest to reflect experimental status if necessary -->
 
     <!-- The value set here for the Id needs to match that set for 'ExperimentalNugetRepositoryId' in
     ..\Directory.Build.targets -->
@@ -307,13 +313,19 @@
       Condition="'$(EnableExperimentalVSIXFeatures)'=='true'"
       XmlInputPath="$(VsixManifestSource)"
       Query="/ns:PackageManifest/ns:Metadata/ns:DisplayName"
-      Value="$(_OriginalVsixName) (Preview)"
+      Value="$(_OriginalVsixName) (Experimental)"
       Namespaces="&lt;Namespace Prefix='ns' Uri='http://schemas.microsoft.com/developer/vsx-schema/2011' /&gt;" />
     <XmlPoke
       Condition="'$(EnableExperimentalVSIXFeatures)'=='true'"
       XmlInputPath="$(VsixManifestSource)"
       Query="/ns:PackageManifest/ns:Metadata/ns:Tags"
       Value="$(_OriginalVsixTags), UWP"
+      Namespaces="&lt;Namespace Prefix='ns' Uri='http://schemas.microsoft.com/developer/vsx-schema/2011' /&gt;" />
+    <XmlPoke
+      Condition="'$(EnableExperimentalVSIXFeatures)'=='true'"
+      XmlInputPath="$(VsixManifestSource)"
+      Query="/ns:PackageManifest/ns:Metadata/ns:Preview"
+      Value="true"
       Namespaces="&lt;Namespace Prefix='ns' Uri='http://schemas.microsoft.com/developer/vsx-schema/2011' /&gt;" />
   </Target>
   <Target Name="AfterBuild">
@@ -338,6 +350,11 @@
       XmlInputPath="$(VsixManifestSource)"
       Query="/ns:PackageManifest/ns:Metadata/ns:Tags"
       Value="$(_OriginalVsixTags)"
+      Namespaces="&lt;Namespace Prefix='ns' Uri='http://schemas.microsoft.com/developer/vsx-schema/2011' /&gt;" />
+    <XmlPoke
+      XmlInputPath="$(VsixManifestSource)"
+      Query="/ns:PackageManifest/ns:Metadata/ns:Preview"
+      Value="$(_OriginalVsixPreview)"
       Namespaces="&lt;Namespace Prefix='ns' Uri='http://schemas.microsoft.com/developer/vsx-schema/2011' /&gt;" />
   </Target>
 </Project>

--- a/dev/VSIX/Extension/source.extension.vsixmanifest
+++ b/dev/VSIX/Extension/source.extension.vsixmanifest
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <PackageManifest Version="2.0.0" xmlns="http://schemas.microsoft.com/developer/vsx-schema/2011" xmlns:d="http://schemas.microsoft.com/developer/vsx-schema-design/2011">
   <Metadata>
-    <Identity Id="Microsoft.WindowsAppSDK" Version="|%CurrentProject%;GetVSIXVersion|" Language="en-US" Publisher="Microsoft" />
+    <Identity Id="Microsoft.ProjectReunion" Version="|%CurrentProject%;GetVSIXVersion|" Language="en-US" Publisher="Microsoft" />
     <DisplayName>Windows App SDK</DisplayName>
     <Description xml:space="preserve">The Microsoft Windows App SDK Visual Studio extension adds project and item templates to support building Windows apps and components.</Description>
     <MoreInfo>https://github.com/microsoft/WindowsAppSDK/</MoreInfo>


### PR DESCRIPTION
* Rename preview VSIX to experimental

Set "Preview" metadata label to "true"

* Restore original Microsoft.ProjectReunion and Microsoft.ProjectReunion.Preview VSIX identity