### PR TITLE
Use WinAppSDK's own Helix queues instead of the WinUI/XAML queues

### DIFF
--- a/build/AzurePipelinesTemplates/WindowsAppSDK-RunHelixTests-Job.yml
+++ b/build/AzurePipelinesTemplates/WindowsAppSDK-RunHelixTests-Job.yml
@@ -29,10 +29,9 @@ jobs:
     winUIHelixPipelineScripts: build\Helix\packages\Microsoft.Internal.WinUI.Helix.$(winUIHelixVer)\scripts\pipeline
 
     # The target queues to run the tests on.
-    # Currently runs on queues owned by the WinUI/XAML team. This should run on queues hosted by WindowsAppSDK in the future.
     # Note: %3b is the escape sequence for ';' which is used as the delimiter
-    helixTargetQueuesOpen: 'Windows.10.Amd64.ClientRS5.Open.Xaml%3bWindows.10.Amd64.Client19h1.Open.Xaml'
-    helixTargetQueuesClosed: 'Windows.10.Amd64.ClientRS5.Xaml%3bWindows.10.Amd64.Client19h1.Xaml'
+    helixTargetQueuesOpen: 'Windows.10.Amd64.ClientRS5.Open.reunion%3bWindows.10.Amd64.Client19h1.Open.reunion%3bWindows.10.Amd64.Client20h2.Open.reunion'
+    helixTargetQueuesClosed: 'Windows.10.Amd64.ClientRS5.reunion%3bWindows.10.Amd64.Client19h1.reunion%3bWindows.10.Amd64.Client20h2.reunion'
 
     # When a test fails, it is re-run 10 times. This variable specifies how many times out of 10 it is required to pass
     rerunPassesRequiredToAvoidFailure: 8


### PR DESCRIPTION
Now that the Windows App SDK project has it's own Helix queues setup, we can switch to using them instead of borrowing from the WinUI/XAML team's queues.

This change also adds 20H2 to the set of images being used for testing as well. (Previously we couldn't test on 20H2, as there was no "open" XAML queue to use for it).
