### PR TITLE
(Partial Fix) Dynamic Dependencies doesn't support Elevation #567

### DIFF
--- a/tools/DevCheck.cmd
+++ b/tools/DevCheck.cmd
@@ -4,11 +4,11 @@ SETLOCAL
 IF /I "%1" == "-help" GOTO Help
 IF /I "%1" == "--help" GOTO Help
 
-powershell %~dpn0.ps1 %*
+powershell -ExecutionPolicy Unrestricted -NoLogo -NoProfile %~dpn0.ps1 %*
 GOTO TheEnd
 
 :Help
-powershell -c Get-Help %~dpn0.ps1 -full
+powershell -ExecutionPolicy Unrestricted -NoLogo -NoProfile -c Get-Help %~dpn0.ps1 -full
 
 :TheEnd
 ENDLOCAL


### PR DESCRIPTION
Dynamic Dependencies rquires PackagedCOM/WinRT activation which wasn't supported but now is as of Windows 10.0.22000.0.
[Dynamic Dependencies doesn't support Elevation #567](https://github.com/microsoft/WindowsAppSDK/issues/567) can be alleviated (I think) by updating the IsElevated check to not block if running on Windows >= 10.0.22000.0 (Win11)

This will (hopefully) unblock recent Windows releases while more comprehensive solutions are under investigation.