### PR TITLE
Pass ResourceContext to ResourceCandidate

### DIFF
--- a/dev/MRTCore/mrt/Microsoft.ApplicationModel.Resources/src/ResourceCandidate.cpp
+++ b/dev/MRTCore/mrt/Microsoft.ApplicationModel.Resources/src/ResourceCandidate.cpp
@@ -4,6 +4,7 @@
 #include "pch.h"
 #include "ResourceCandidate.h"
 #include "ResourceCandidate.g.cpp"
+#include "ResourceContext.h"
 
 namespace winrt::Microsoft::ApplicationModel::Resources::implementation
 {
@@ -21,8 +22,8 @@ ResourceCandidate::ResourceCandidate(array_view<uint8_t const> data)
     m_kind = ResourceCandidateKind::EmbeddedData;
 }
 
-ResourceCandidate::ResourceCandidate(MrmManagerHandle manager, MrmContextHandle context, MrmMapHandle map, uint32_t index, const hstring& id, ResourceCandidateKind kind, hstring data)
-    : m_resourceManagerHandle(manager), m_resourceContextHandle(context), m_resourceMapHandle(map), m_resourceIndex(index), m_resourceId(id), m_stringData(std::move(data)), m_kind(kind)
+ResourceCandidate::ResourceCandidate(MrmManagerHandle manager, Microsoft::ApplicationModel::Resources::ResourceContext context, MrmMapHandle map, uint32_t index, const hstring& id, ResourceCandidateKind kind, hstring data)
+    : m_resourceManagerHandle(manager), m_resourceContext(context), m_resourceMapHandle(map), m_resourceIndex(index), m_resourceId(id), m_stringData(std::move(data)), m_kind(kind)
 {
     if ((kind != ResourceCandidateKind::String) && (kind != ResourceCandidateKind::FilePath))
     {
@@ -30,8 +31,8 @@ ResourceCandidate::ResourceCandidate(MrmManagerHandle manager, MrmContextHandle 
     }
 }
 
-ResourceCandidate::ResourceCandidate(MrmManagerHandle manager, MrmContextHandle context, MrmMapHandle map, uint32_t index, const hstring& id, array_view<uint8_t const> data)
-    : m_resourceManagerHandle(manager), m_resourceContextHandle(context), m_resourceMapHandle(map), m_resourceIndex(index), m_resourceId(id)
+ResourceCandidate::ResourceCandidate(MrmManagerHandle manager, Microsoft::ApplicationModel::Resources::ResourceContext context, MrmMapHandle map, uint32_t index, const hstring& id, array_view<uint8_t const> data)
+    : m_resourceManagerHandle(manager), m_resourceContext(context), m_resourceMapHandle(map), m_resourceIndex(index), m_resourceId(id)
 {
     m_blobData = winrt::com_array<uint8_t>(data.begin(), data.end());
     m_kind = ResourceCandidateKind::EmbeddedData;
@@ -73,7 +74,7 @@ Windows::Foundation::Collections::IMapView<hstring, hstring> ResourceCandidate::
         {
             winrt::check_hresult(MrmLoadStringOrEmbeddedResourceWithQualifierValues(
                 m_resourceManagerHandle,
-                m_resourceContextHandle,
+                m_resourceContext.as<Resources::implementation::ResourceContext>()->GetContextHandle(),
                 m_resourceMapHandle,
                 m_resourceId.c_str(),
                 &resourceType,
@@ -87,7 +88,7 @@ Windows::Foundation::Collections::IMapView<hstring, hstring> ResourceCandidate::
         {
             winrt::check_hresult(MrmLoadStringOrEmbeddedResourceByIndexWithQualifierValues(
                 m_resourceManagerHandle,
-                m_resourceContextHandle,
+                m_resourceContext.as<Resources::implementation::ResourceContext>()->GetContextHandle(),
                 m_resourceMapHandle,
                 m_resourceIndex,
                 &resourceType,

--- a/dev/MRTCore/mrt/Microsoft.ApplicationModel.Resources/src/ResourceCandidate.h
+++ b/dev/MRTCore/mrt/Microsoft.ApplicationModel.Resources/src/ResourceCandidate.h
@@ -12,8 +12,8 @@ struct ResourceCandidate : ResourceCandidateT<ResourceCandidate>
     ResourceCandidate() = delete;
     ResourceCandidate(ResourceCandidateKind kind, hstring data);
     ResourceCandidate(array_view<uint8_t const> data);
-    ResourceCandidate(MrmManagerHandle manager, MrmContextHandle context, MrmMapHandle map, uint32_t index, const hstring& id, ResourceCandidateKind kind, hstring data);
-    ResourceCandidate(MrmManagerHandle manager, MrmContextHandle context, MrmMapHandle map, uint32_t index, const hstring& id, array_view<uint8_t const> data);
+    ResourceCandidate(MrmManagerHandle manager, Microsoft::ApplicationModel::Resources::ResourceContext context, MrmMapHandle map, uint32_t index, const hstring& id, ResourceCandidateKind kind, hstring data);
+    ResourceCandidate(MrmManagerHandle manager, Microsoft::ApplicationModel::Resources::ResourceContext context, MrmMapHandle map, uint32_t index, const hstring& id, array_view<uint8_t const> data);
 
     hstring ValueAsString();
     com_array<uint8_t> ValueAsBytes();
@@ -30,7 +30,7 @@ private:
 
     // Information required to refetch the candidate for candidate qualifier values
     MrmManagerHandle m_resourceManagerHandle = nullptr;
-    MrmContextHandle m_resourceContextHandle = nullptr;
+    Microsoft::ApplicationModel::Resources::ResourceContext m_resourceContext = nullptr;
     MrmMapHandle m_resourceMapHandle = nullptr;
     uint32_t m_resourceIndex = static_cast<uint32_t>(-1);
     hstring m_resourceId;

--- a/dev/MRTCore/mrt/Microsoft.ApplicationModel.Resources/src/ResourceMap.cpp
+++ b/dev/MRTCore/mrt/Microsoft.ApplicationModel.Resources/src/ResourceMap.cpp
@@ -96,7 +96,7 @@ Resources::ResourceCandidate ResourceMap::GetValueImpl(const Resources::Resource
         embedded_resoure_ptr resourceContainer(resourceData.data);
         return winrt::make<ResourceCandidate>(
             m_resourceManagerHandle,
-            resourceContext.as<Resources::implementation::ResourceContext>()->GetContextHandle(),
+            resourceContext,
             m_resourceMapHandle,
             static_cast<uint32_t>(-1),
             resource,
@@ -107,7 +107,7 @@ Resources::ResourceCandidate ResourceMap::GetValueImpl(const Resources::Resource
         string_resoure_ptr resourceContainer(resourceString);
         return winrt::make<ResourceCandidate>(
             m_resourceManagerHandle,
-            resourceContext.as<Resources::implementation::ResourceContext>()->GetContextHandle(),
+            resourceContext,
             m_resourceMapHandle,
             static_cast<uint32_t>(-1),
             resource,
@@ -119,7 +119,7 @@ Resources::ResourceCandidate ResourceMap::GetValueImpl(const Resources::Resource
         string_resoure_ptr resourceContainer(resourceString);
         return winrt::make<ResourceCandidate>(
             m_resourceManagerHandle,
-            resourceContext.as<Resources::implementation::ResourceContext>()->GetContextHandle(),
+            resourceContext,
             m_resourceMapHandle,
             static_cast<uint32_t>(-1),
             resource,
@@ -185,7 +185,7 @@ IKeyValuePair<hstring, Resources::ResourceCandidate> ResourceMap::GetValueByInde
         embedded_resoure_ptr resourceContainer(resourceData.data);
         Resources::ResourceCandidate candidate = winrt::make<ResourceCandidate>(
             m_resourceManagerHandle,
-            resourceContext.as<Resources::implementation::ResourceContext>()->GetContextHandle(),
+            resourceContext,
             m_resourceMapHandle,
             index,
             hstring(),
@@ -199,7 +199,7 @@ IKeyValuePair<hstring, Resources::ResourceCandidate> ResourceMap::GetValueByInde
         Resources::ResourceCandidate candidate =
             winrt::make<ResourceCandidate>(
                 m_resourceManagerHandle,
-                resourceContext.as<Resources::implementation::ResourceContext>()->GetContextHandle(),
+                resourceContext,
                 m_resourceMapHandle,
                 index,
                 hstring(),
@@ -214,7 +214,7 @@ IKeyValuePair<hstring, Resources::ResourceCandidate> ResourceMap::GetValueByInde
         Resources::ResourceCandidate candidate =
             winrt::make<ResourceCandidate>(
                 m_resourceManagerHandle,
-                resourceContext.as<Resources::implementation::ResourceContext>()->GetContextHandle(),
+                resourceContext,
                 m_resourceMapHandle,
                 index,
                 hstring(),

--- a/dev/MRTCore/mrt/Microsoft.ApplicationModel.Resources/unittests/UnitTest.cs
+++ b/dev/MRTCore/mrt/Microsoft.ApplicationModel.Resources/unittests/UnitTest.cs
@@ -108,6 +108,10 @@ namespace ManagedTest
             Assert.AreEqual(blobResourceCandidate.Kind, ResourceCandidateKind.EmbeddedData);
             blobResourceCandidate = resourceManager.MainResourceMap.TryGetValue("Files/Controls/AlbumBasicInfoControl.xbf");
             Assert.AreEqual(blobResourceCandidate.Kind, ResourceCandidateKind.EmbeddedData);
+
+            var qualifierValues = blobResourceCandidate.QualifierValues;
+            Assert.IsTrue(!qualifierValues.ContainsKey("Language"));
+            Assert.IsTrue(!qualifierValues.ContainsKey("Scale"));
         }
 
         [TestMethod]


### PR DESCRIPTION
if no ResourceContext is passed on ResourceMap::GetValue, a new context will be created and scoped to that function. Once GetValue returns, the context is deleted. To keep context alive, we pass ResourceContext to ResourceCandidate instead of the raw handle.