### PR TITLE
 Adding WIL dependency in WindowsAppSDK transport package.

### DIFF
--- a/build/NuSpecs/Microsoft.WindowsAppSDK.Foundation.nuspec
+++ b/build/NuSpecs/Microsoft.WindowsAppSDK.Foundation.nuspec
@@ -11,5 +11,9 @@
          <projectUrl>https://aka.ms/windowsappsdk</projectUrl>
          <copyright>© Microsoft Corporation. All rights reserved.</copyright>
          <tags>Microsoft Resources Native Windows WindowsAppSDK</tags>
+
+         <dependencies>
+             <dependency id="Microsoft.Windows.ImplementationLibrary" version="[1.0.210803,)" />
+         </dependencies>
      </metadata>
 </package>


### PR DESCRIPTION
 The insights library depends on WIL package. This change introduces the dependency on the appropriate version of WIL.