### PR TITLE
Delete linker dependency on removed lib.

### DIFF
--- a/build/NuSpecs/WindowsAppSDK-Nuget-Native.C.props
+++ b/build/NuSpecs/WindowsAppSDK-Nuget-Native.C.props
@@ -16,7 +16,6 @@
     <Link>
       <AdditionalDependencies>
         $(MSBuildThisFileDirectory)..\..\lib\win10-$(_WindowsAppSDKFoundationPlatform)\Microsoft.WindowsAppSDK.lib;
-        $(MSBuildThisFileDirectory)..\..\lib\win10-$(_WindowsAppSDKFoundationPlatform)\Microsoft.WindowsAppSDK.Insights.lib;
         %(AdditionalDependencies);
       </AdditionalDependencies>
     </Link>


### PR DESCRIPTION
This is causing build failures when building native apps, including in CI builds that build test apps.

**How verified**
Sample app built after the change (locally).