### PR TITLE
remove MRTCore .net sdk version

### DIFF
--- a/dev/MRTCore/global.json
+++ b/dev/MRTCore/global.json
@@ -1,7 +1,4 @@
 {
-    "sdk": {
-        "version": "5.0.302"
-    },
     "msbuild-sdks": {
         "Microsoft.Build.NoTargets" : "1.0.88"
     }


### PR DESCRIPTION
Remove the specific .net sdk version requirement for MRTCore. 5.0.302+ is probably installed for most of the people (if not all). It would be annoying you have to keep a version of 5.0.302 to build MRTCore locally, and I don't have enough space on C drive :). Build pipeline will do a version check based on .\build\versions.props. 