### PR TITLE
set rollForward value to latestMajor

### DIFF
--- a/dev/MRTCore/global.json
+++ b/dev/MRTCore/global.json
@@ -1,6 +1,7 @@
 {
     "sdk": {
-        "version": "5.0.302"
+        "version": "5.0.302",
+        "rollForward": "latestMajor"
     },
     "msbuild-sdks": {
         "Microsoft.Build.NoTargets" : "1.0.88"


### PR DESCRIPTION
the default rollForward value is latestPatch. Now the version on my machine is 5.0.400, and it fails to match 5.0.302. Change the value to latestMajor so that it builds as long as the version is greater or equal to 5.0.302.