### PR TITLE
Fix paths of bootstrap DLL after recent change.

### DIFF
--- a/build/NuSpecs/Microsoft.WindowsAppSDK.Bootstrap.targets
+++ b/build/NuSpecs/Microsoft.WindowsAppSDK.Bootstrap.targets
@@ -8,7 +8,7 @@
   </PropertyGroup>
 
   <Target Name="BinPlaceBootstrapDll" Condition="'$(AppxPackage)' != 'true'" AfterTargets="Build">
-    <Copy SourceFiles="$(MSBuildThisFileDirectory)..\runtimes\lib\native\$(_WindowsAppSDKFoundationPlatform)\Microsoft.WindowsAppSDK.Bootstrap.dll" DestinationFolder="$(OutDir)" OverwriteReadOnlyFiles="true" ContinueOnError="false"/>
+    <Copy SourceFiles="$(MSBuildThisFileDirectory)..\runtimes\win-$(_WindowsAppSDKFoundationPlatform)\native\Microsoft.WindowsAppSDK.Bootstrap.dll" DestinationFolder="$(OutDir)" OverwriteReadOnlyFiles="true" ContinueOnError="false"/>
   </Target>
 
 </Project>

--- a/build/NuSpecs/WindowsAppSDK-Nuget-Native.C.props
+++ b/build/NuSpecs/WindowsAppSDK-Nuget-Native.C.props
@@ -29,7 +29,7 @@
       </AdditionalDependencies>
     </Link>
     <PostBuildEvent>
-      <Command>xcopy /y "$(MSBuildThisFileDirectory)..\..\runtimes\lib\native\$(_WindowsAppSDKFoundationPlatform)\Microsoft.WindowsAppSDK.Bootstrap.dll" "$(OutDir)"</Command>
+      <Command>xcopy /y "$(MSBuildThisFileDirectory)..\..\runtimes\win-$(_WindowsAppSDKFoundationPlatform)\native\Microsoft.WindowsAppSDK.Bootstrap.dll" "$(OutDir)"</Command>
     </PostBuildEvent>
   </ItemDefinitionGroup>
 


### PR DESCRIPTION
This is causing CI build failures (when building native test apps).

Recent change that changed the path: https://github.com/microsoft/WindowsAppSDK/pull/1282