### PR TITLE
Logging the error in loading resources instead of throwing.

### DIFF
--- a/dev/WindowsAppSDK_Insights/WindowsAppRuntimeInsights.h
+++ b/dev/WindowsAppSDK_Insights/WindowsAppRuntimeInsights.h
@@ -41,7 +41,11 @@
 
             if(module)
             {
-                LOG_IF_WIN32_BOOL_FALSE_MSG(::LoadStringA(module.get(), id, resourceValue, ARRAYSIZE(resourceValue)), "Failed to load resource string. id: %d", id);
+                if(0 == ::LoadStringA(module.get(), id, resourceValue, ARRAYSIZE(resourceValue)))
+                {
+                    DWORD error{ GetLastError() };
+                    LOG_HR_IF_MSG(HRESULT_FROM_WIN32(error), ERROR_SUCCESS != error, "Failed to load resource string. id: %d", id);
+                }
             }
             return resourceValue;
         }


### PR DESCRIPTION
Logging the error in loading resources instead of throwing. This is useful for developers running the unit tests etc. without installing the WindowsAppSDK on their machine.