### PR TITLE
Ensure order of WARfwk install to avoid a Deployment issue

### DIFF
--- a/installer/dev/packages.h
+++ b/installer/dev/packages.h
@@ -36,34 +36,34 @@ namespace WindowsAppRuntimeInstaller {
         WAR_FRAMEWORK_X86_LISTENTRY
     #endif
 
-    #if defined(WAR_MAIN_X86_LISTENTRY)
-        WAR_MAIN_X86_LISTENTRY
+    #if defined(WAR_MAIN_ARM64_LISTENTRY)
+        WAR_MAIN_ARM64_LISTENTRY
     #endif
     #if defined(WAR_MAIN_X64_LISTENTRY)
         WAR_MAIN_X64_LISTENTRY
     #endif
-    #if defined(WAR_MAIN_ARM64_LISTENTRY)
-        WAR_MAIN_ARM64_LISTENTRY
+    #if defined(WAR_MAIN_X86_LISTENTRY)
+        WAR_MAIN_X86_LISTENTRY
     #endif
 
-    #if defined(WAR_SINGLETON_X86_LISTENTRY)
-        WAR_SINGLETON_X86_LISTENTRY
+    #if defined(WAR_SINGLETON_ARM64_LISTENTRY)
+        WAR_SINGLETON_ARM64_LISTENTRY
     #endif
     #if defined(WAR_SINGLETON_X64_LISTENTRY)
         WAR_SINGLETON_X64_LISTENTRY
     #endif
-    #if defined(WAR_SINGLETON_ARM64_LISTENTRY)
-        WAR_SINGLETON_ARM64_LISTENTRY
+    #if defined(WAR_SINGLETON_X86_LISTENTRY)
+        WAR_SINGLETON_X86_LISTENTRY
     #endif
 
-    #if defined(WAR_DDLM_X86_LISTENTRY)
-        WAR_DDLM_X86_LISTENTRY
+    #if defined(WAR_DDLM_ARM64_LISTENTRY)
+        WAR_DDLM_ARM64_LISTENTRY
     #endif
     #if defined(WAR_DDLM_X64_LISTENTRY)
         WAR_DDLM_X64_LISTENTRY
     #endif
-    #if defined(WAR_DDLM_ARM64_LISTENTRY)
-        WAR_DDLM_ARM64_LISTENTRY
+    #if defined(WAR_DDLM_X86_LISTENTRY)
+        WAR_DDLM_X86_LISTENTRY
     #endif
     };
 }

--- a/installer/dev/packages.h
+++ b/installer/dev/packages.h
@@ -26,15 +26,16 @@ namespace WindowsAppRuntimeInstaller {
 
     static ResourcePackageInfo c_packages[] =
     {
-    #if defined(WAR_FRAMEWORK_X86_LISTENTRY)
-        WAR_FRAMEWORK_X86_LISTENTRY
+    #if defined(WAR_FRAMEWORK_ARM64_LISTENTRY)
+        WAR_FRAMEWORK_ARM64_LISTENTRY
     #endif
     #if defined(WAR_FRAMEWORK_X64_LISTENTRY)
         WAR_FRAMEWORK_X64_LISTENTRY
     #endif
-    #if defined(WAR_FRAMEWORK_ARM64_LISTENTRY)
-        WAR_FRAMEWORK_ARM64_LISTENTRY
+    #if defined(WAR_FRAMEWORK_X86_LISTENTRY)
+        WAR_FRAMEWORK_X86_LISTENTRY
     #endif
+
     #if defined(WAR_MAIN_X86_LISTENTRY)
         WAR_MAIN_X86_LISTENTRY
     #endif
@@ -44,6 +45,7 @@ namespace WindowsAppRuntimeInstaller {
     #if defined(WAR_MAIN_ARM64_LISTENTRY)
         WAR_MAIN_ARM64_LISTENTRY
     #endif
+
     #if defined(WAR_SINGLETON_X86_LISTENTRY)
         WAR_SINGLETON_X86_LISTENTRY
     #endif
@@ -53,6 +55,7 @@ namespace WindowsAppRuntimeInstaller {
     #if defined(WAR_SINGLETON_ARM64_LISTENTRY)
         WAR_SINGLETON_ARM64_LISTENTRY
     #endif
+
     #if defined(WAR_DDLM_X86_LISTENTRY)
         WAR_DDLM_X86_LISTENTRY
     #endif


### PR DESCRIPTION
Ensure order of WARfwk is arm64 > x64 > x86 to avoid a bug in appxsvc erroneously using e.g. x86 on an x64 machine if there's only WARfwk x86 and not x64

The installer has an ordered list to process packages - [fwk, main, singleton, ddlm] - and for each ordered as [x86, x64, arm64]. If you installed x86 first the appxsvc would then try to load the Environment dll and fail on x64(+arm64) systems due to a bug ("I see no x64 packages in this family but I do see an x86, I'll load that..."). This was purely if there's no native-arch-matching package in the family; long as WARfwk-x64 is on the machine the Environment dll would be loaded by the x64 appxsvc process, even if there's a newer version of other architectures (like I said, a bug).

But to workaround that in the short-term we can reorder the installer's list of packages so 'the most applicable supported architecture' for a system is always processed before any other package in the family is considered, i.e. order the packages [arm64, x64, x86] and e.g. Deployment on an arm64 system will find the arm64 package before x64|x86, and likewise on an x64 system will find the x64 package before x86.

This bug is unique to Win11/Cobalt builds with new plumbing used by the Environment dll. It's not an issue on older systems, and soon to be a non-issue even on Win11/Cobalt once that's fixed.