### PR TITLE
VSIX titles/descriptions mention templates and VS versions

### DIFF
--- a/dev/VSIX/Extension/Cpp/Dev16/source.extension.vsixmanifest
+++ b/dev/VSIX/Extension/Cpp/Dev16/source.extension.vsixmanifest
@@ -2,8 +2,8 @@
 <PackageManifest Version="2.0.0" xmlns="http://schemas.microsoft.com/developer/vsx-schema/2011" xmlns:d="http://schemas.microsoft.com/developer/vsx-schema-design/2011">
   <Metadata>
     <Identity Id="Microsoft.WindowsAppSDK.Cpp" Version="|%CurrentProject%;GetVSIXVersion|" Language="en-US" Publisher="Microsoft" />
-    <DisplayName>Windows App SDK (C++)</DisplayName>
-    <Description xml:space="preserve">The Microsoft Windows App SDK Visual Studio extension adds C++ project and item templates to support building Windows apps and components.</Description>
+    <DisplayName>Windows App SDK C++ VS 2019 Templates</DisplayName>
+    <Description xml:space="preserve">The Microsoft Windows App SDK Visual Studio extension adds C++ project and item templates to support building Windows apps and components in VS 2019.</Description>
     <MoreInfo>https://github.com/microsoft/WindowsAppSDK/</MoreInfo>
     <License>LICENSE</License>
     <GettingStartedGuide>https://github.com/microsoft/WindowsAppSDK/</GettingStartedGuide>

--- a/dev/VSIX/Extension/Cpp/Dev17/Component/source.extension.vsixmanifest
+++ b/dev/VSIX/Extension/Cpp/Dev17/Component/source.extension.vsixmanifest
@@ -2,8 +2,8 @@
 <PackageManifest Version="2.0.0" xmlns="http://schemas.microsoft.com/developer/vsx-schema/2011" xmlns:d="http://schemas.microsoft.com/developer/vsx-schema-design/2011">
   <Metadata>
     <Identity Id="Microsoft.WindowsAppSDK.Cpp.Dev17" Version="|%CurrentProject%;GetVSIXVersion|" Language="en-US" Publisher="Microsoft" />
-    <DisplayName>Windows App SDK (C++)</DisplayName>
-    <Description xml:space="preserve">The Microsoft Windows App SDK Visual Studio extension adds C++ project and item templates to support building Windows apps and components.</Description>
+    <DisplayName>Windows App SDK C++ VS 2022 Templates</DisplayName>
+    <Description xml:space="preserve">The Microsoft Windows App SDK Visual Studio extension adds C++ project and item templates to support building Windows apps and components in VS 2022.</Description>
     <MoreInfo>https://github.com/microsoft/WindowsAppSDK/</MoreInfo>
     <License>LICENSE</License>
     <GettingStartedGuide>https://github.com/microsoft/WindowsAppSDK/</GettingStartedGuide>

--- a/dev/VSIX/Extension/Cpp/Dev17/Standalone/source.extension.vsixmanifest
+++ b/dev/VSIX/Extension/Cpp/Dev17/Standalone/source.extension.vsixmanifest
@@ -2,8 +2,8 @@
 <PackageManifest Version="2.0.0" xmlns="http://schemas.microsoft.com/developer/vsx-schema/2011" xmlns:d="http://schemas.microsoft.com/developer/vsx-schema-design/2011">
   <Metadata>
     <Identity Id="Microsoft.WindowsAppSDK.Cpp.Dev17" Version="|%CurrentProject%;GetVSIXVersion|" Language="en-US" Publisher="Microsoft" />
-    <DisplayName>Windows App SDK (C++)</DisplayName>
-    <Description xml:space="preserve">The Microsoft Windows App SDK Visual Studio extension adds C++ project and item templates to support building Windows apps and components.</Description>
+    <DisplayName>Windows App SDK C++ VS 2022 Templates</DisplayName>
+    <Description xml:space="preserve">The Microsoft Windows App SDK Visual Studio extension adds C++ project and item templates to support building Windows apps and components in VS 2022.</Description>
     <MoreInfo>https://github.com/microsoft/WindowsAppSDK/</MoreInfo>
     <License>LICENSE</License>
     <GettingStartedGuide>https://github.com/microsoft/WindowsAppSDK/</GettingStartedGuide>

--- a/dev/VSIX/Extension/Cs/Dev16/source.extension.vsixmanifest
+++ b/dev/VSIX/Extension/Cs/Dev16/source.extension.vsixmanifest
@@ -2,8 +2,8 @@
 <PackageManifest Version="2.0.0" xmlns="http://schemas.microsoft.com/developer/vsx-schema/2011" xmlns:d="http://schemas.microsoft.com/developer/vsx-schema-design/2011">
   <Metadata>
     <Identity Id="Microsoft.WindowsAppSDK.Cs" Version="|%CurrentProject%;GetVSIXVersion|" Language="en-US" Publisher="Microsoft" />
-    <DisplayName>Windows App SDK (C#)</DisplayName>
-    <Description xml:space="preserve">The Microsoft Windows App SDK Visual Studio extension adds C# project and item templates to support building Windows apps and components.</Description>
+    <DisplayName>Windows App SDK C# VS 2019 Templates</DisplayName>
+    <Description xml:space="preserve">The Microsoft Windows App SDK Visual Studio extension adds C# project and item templates to support building Windows apps and components in VS 2019.</Description>
     <MoreInfo>https://github.com/microsoft/WindowsAppSDK/</MoreInfo>
     <License>LICENSE</License>
     <GettingStartedGuide>https://github.com/microsoft/WindowsAppSDK/</GettingStartedGuide>

--- a/dev/VSIX/Extension/Cs/Dev17/Component/source.extension.vsixmanifest
+++ b/dev/VSIX/Extension/Cs/Dev17/Component/source.extension.vsixmanifest
@@ -2,8 +2,8 @@
 <PackageManifest Version="2.0.0" xmlns="http://schemas.microsoft.com/developer/vsx-schema/2011" xmlns:d="http://schemas.microsoft.com/developer/vsx-schema-design/2011">
   <Metadata>
     <Identity Id="Microsoft.WindowsAppSDK.Cs.Dev17" Version="|%CurrentProject%;GetVSIXVersion|" Language="en-US" Publisher="Microsoft" />
-    <DisplayName>Windows App SDK (C#)</DisplayName>
-    <Description xml:space="preserve">The Microsoft Windows App SDK Visual Studio extension adds C# project and item templates to support building Windows apps and components.</Description>
+    <DisplayName>Windows App SDK C# VS 2022 Templates</DisplayName>
+    <Description xml:space="preserve">The Microsoft Windows App SDK Visual Studio extension adds C# project and item templates to support building Windows apps and components in VS 2022.</Description>
     <MoreInfo>https://github.com/microsoft/WindowsAppSDK/</MoreInfo>
     <License>LICENSE</License>
     <GettingStartedGuide>https://github.com/microsoft/WindowsAppSDK/</GettingStartedGuide>

--- a/dev/VSIX/Extension/Cs/Dev17/Standalone/source.extension.vsixmanifest
+++ b/dev/VSIX/Extension/Cs/Dev17/Standalone/source.extension.vsixmanifest
@@ -2,8 +2,8 @@
 <PackageManifest Version="2.0.0" xmlns="http://schemas.microsoft.com/developer/vsx-schema/2011" xmlns:d="http://schemas.microsoft.com/developer/vsx-schema-design/2011">
   <Metadata>
     <Identity Id="Microsoft.WindowsAppSDK.Cs.Dev17" Version="|%CurrentProject%;GetVSIXVersion|" Language="en-US" Publisher="Microsoft" />
-    <DisplayName>Windows App SDK (C#)</DisplayName>
-    <Description xml:space="preserve">The Microsoft Windows App SDK Visual Studio extension adds C# project and item templates to support building Windows apps and components.</Description>
+    <DisplayName>Windows App SDK C# VS 2022 Templates</DisplayName>
+    <Description xml:space="preserve">The Microsoft Windows App SDK Visual Studio extension adds C# project and item templates to support building Windows apps and components in VS 2022.</Description>
     <MoreInfo>https://github.com/microsoft/WindowsAppSDK/</MoreInfo>
     <License>LICENSE</License>
     <GettingStartedGuide>https://github.com/microsoft/WindowsAppSDK/</GettingStartedGuide>


### PR DESCRIPTION
This updates the titles and descriptions of our VSIXs to clarify that they hold templates for C++/C#, and which version of Visual Studio they target.