### PR TITLE
Implement GetRuntimeClassName correctly to support C#/WinRT downcasting of RCW

### DIFF
--- a/dev/AppLifecycle/LaunchActivatedEventArgs.h
+++ b/dev/AppLifecycle/LaunchActivatedEventArgs.h
@@ -19,6 +19,11 @@ namespace winrt::Microsoft::Windows::AppLifecycle::implementation
         {
             m_kind = ActivationKind::Launch;
         }
+        
+        winrt::hstring GetRuntimeClassName() const noexcept override
+        {
+            return winrt::hstring(L"Windows::ApplicationModel::Activation.LaunchActivatedEventArgs"sv);
+        }
 
         static winrt::Windows::Foundation::IInspectable Deserialize(winrt::Windows::Foundation::Uri const& uri)
         {


### PR DESCRIPTION
Without this change, C#/WinRT cannot project the interface correctly.  
See also:
https://github.com/microsoft/CsWinRT/issues/966