### PR TITLE
Fixing WNP_LRP tests 

### DIFF
--- a/dev/PushNotifications/PushNotificationManager.cpp
+++ b/dev/PushNotifications/PushNotificationManager.cpp
@@ -409,7 +409,7 @@ namespace winrt::Microsoft::Windows::PushNotifications::implementation
 
             if (WI_IsFlagSet(activators, PushNotificationRegistrationActivators::ProtocolActivator))
             {
-                THROW_HR_IF(HRESULT_FROM_WIN32(ERROR_NOT_FOUND), s_protocolRegistration);
+                THROW_HR_IF(HRESULT_FROM_WIN32(ERROR_NOT_FOUND), !s_protocolRegistration);
                 auto coInitialize = wil::CoInitializeEx();
 
                 wil::com_ptr<INotificationsLongRunningPlatform> notificationPlatform{

--- a/dev/PushNotifications/PushNotificationManager.cpp
+++ b/dev/PushNotifications/PushNotificationManager.cpp
@@ -254,6 +254,11 @@ namespace winrt::Microsoft::Windows::PushNotifications::implementation
 
             if (isProtocolActivatorSet)
             {
+                {
+                    auto lock = s_activatorInfoLock.lock_exclusive();
+                    THROW_HR_IF(E_INVALIDARG, s_protocolRegistration);
+                }
+
                 auto coInitialize = wil::CoInitializeEx();
 
                 wil::com_ptr<INotificationsLongRunningPlatform> notificationPlatform{

--- a/dev/PushNotifications/PushNotificationManager.cpp
+++ b/dev/PushNotifications/PushNotificationManager.cpp
@@ -255,7 +255,7 @@ namespace winrt::Microsoft::Windows::PushNotifications::implementation
             if (isProtocolActivatorSet)
             {
                 {
-                    auto lock = s_activatorInfoLock.lock_exclusive();
+                    auto lock = s_activatorInfoLock.lock_shared();
                     THROW_HR_IF(E_INVALIDARG, s_protocolRegistration);
                 }
 
@@ -282,7 +282,7 @@ namespace winrt::Microsoft::Windows::PushNotifications::implementation
                 THROW_HR_IF(E_INVALIDARG, taskClsid == GUID_NULL);
 
                 {
-                    auto lock = s_activatorInfoLock.lock_exclusive();
+                    auto lock = s_activatorInfoLock.lock_shared();
                     THROW_HR_IF(E_INVALIDARG, s_pushTriggerRegistration);
                 }
 
@@ -351,7 +351,7 @@ namespace winrt::Microsoft::Windows::PushNotifications::implementation
                 THROW_HR_IF(E_INVALIDARG, taskClsid == GUID_NULL);
 
                 {
-                    auto lock = s_activatorInfoLock.lock_exclusive();
+                    auto lock = s_activatorInfoLock.lock_shared();
                     THROW_HR_IF_MSG(E_INVALIDARG, s_comActivatorRegistration, "ComActivator already registered.");
                 }
 

--- a/dev/PushNotifications/PushNotificationsLongRunningTask/NotificationListenerManager.cpp
+++ b/dev/PushNotifications/PushNotificationsLongRunningTask/NotificationListenerManager.cpp
@@ -24,6 +24,7 @@ void NotificationListenerManager::AddListener(std::wstring appId, std::wstring p
     {
         ComPtr<INotificationListener> listener;
         THROW_IF_FAILED(MakeAndInitialize<NotificationListener>(&listener, m_foregroundSinkManager, appId, processName));
+        THROW_IF_FAILED(PushNotifications_RegisterFullTrustApplication(appId.c_str(), GUID_NULL));
         THROW_IF_FAILED(PushNotifications_RegisterNotificationSinkForFullTrustApplication(appId.c_str(), listener.Get()));
 
         AgileRef agileListener;

--- a/test/PushNotificationTests/APITests.cpp
+++ b/test/PushNotificationTests/APITests.cpp
@@ -277,11 +277,6 @@ namespace Test::PushNotifications
             RunTest(L"RegisterActivatorNullClsid", testWaitTime());
         }
 
-        TEST_METHOD(RegisterActivatorNullClsid_Unpackaged)
-        {
-            RunTestUnpackaged(L"RegisterActivatorNullClsid", testWaitTime());
-        }
-
         TEST_METHOD(MultipleRegisterActivatorTest)
         {
             RunTest(L"MultipleRegisterActivatorTest", testWaitTime());

--- a/test/PushNotificationTests/APITests.cpp
+++ b/test/PushNotificationTests/APITests.cpp
@@ -262,6 +262,11 @@ namespace Test::PushNotifications
             RunTest(L"ActivatorTest", testWaitTime());
         }
 
+        TEST_METHOD(ActivatorTest_Unpackaged)
+        {
+            RunTestUnpackaged(L"ActivatorTest", channelTestWaitTime());
+        }
+
         TEST_METHOD(RegisterActivatorNullDetails)
         {
             RunTest(L"RegisterActivatorNullDetails", testWaitTime());
@@ -275,6 +280,11 @@ namespace Test::PushNotifications
         TEST_METHOD(RegisterActivatorNullClsid)
         {
             RunTest(L"RegisterActivatorNullClsid", testWaitTime());
+        }
+
+        TEST_METHOD(RegisterActivatorNullClsid_Unpackaged)
+        {
+            RunTestUnpackaged(L"RegisterActivatorNullClsid", testWaitTime());
         }
 
         TEST_METHOD(MultipleRegisterActivatorTest)

--- a/test/TestApps/PushNotificationsTestApp/main.cpp
+++ b/test/TestApps/PushNotificationsTestApp/main.cpp
@@ -195,7 +195,8 @@ bool MultipleRegisterActivatorTest()
         }
         else
         {
-
+            PushNotificationActivationInfo info(PushNotificationRegistrationActivators::ProtocolActivator);
+            PushNotificationManager::RegisterActivator(info);
         }
     }
     catch (...)
@@ -305,7 +306,6 @@ std::string unitTestNameFromLaunchArguments(const ILaunchActivatedEventArgs& lau
 
 int main() try
 {
-    Sleep(20000);
     bool testResult = false;
     auto scope_exit = wil::scope_exit([&] {
         PushNotificationManager::UnregisterAllActivators();

--- a/test/TestApps/PushNotificationsTestApp/main.cpp
+++ b/test/TestApps/PushNotificationsTestApp/main.cpp
@@ -165,7 +165,7 @@ bool RegisterActivatorNullClsid()
         {
             PushNotificationActivationInfo info(
                 PushNotificationRegistrationActivators::PushTrigger | PushNotificationRegistrationActivators::ComActivator,
-                winrt::guid()); // Null guid
+                winrt::guid());
 
             PushNotificationManager::RegisterActivator(info);
         }
@@ -181,7 +181,7 @@ bool RegisterActivatorNullClsid()
         {
             PushNotificationActivationInfo info(
                 PushNotificationRegistrationActivators::ProtocolActivator,
-                winrt::guid()); // Null guid
+                winrt::guid());
 
             PushNotificationManager::RegisterActivator(info);
         }


### PR DESCRIPTION
Removed PushNotificationTokens from TestApp and fixed Register/Unregister Activator across tests. Also, added RegisterFullTrustApplication in RegisterLongRunningActivator.