### PR TITLE
The vsext install gremlins have returned, so disable it again.

### DIFF
--- a/dev/VSIX/Extension/Cpp/Dev16/WindowsAppSDK.Cpp.Extension.Dev16.csproj
+++ b/dev/VSIX/Extension/Cpp/Dev16/WindowsAppSDK.Cpp.Extension.Dev16.csproj
@@ -48,10 +48,10 @@
     <Content Include="$(RepoRoot)LICENSE">
       <IncludeInVSIX>true</IncludeInVSIX>
     </Content>
-    <Content Include="ExtensionPack.vsext">
+<!--     <Content Include="ExtensionPack.vsext">
       <IncludeInVSIX>true</IncludeInVSIX>
     </Content>
-  </ItemGroup>
+ -->  </ItemGroup>
   <ItemGroup>
     <Reference Include="System" />
   </ItemGroup>

--- a/dev/VSIX/Extension/Cpp/Dev17/WindowsAppSDK.Cpp.Extension.Dev17.csproj
+++ b/dev/VSIX/Extension/Cpp/Dev17/WindowsAppSDK.Cpp.Extension.Dev17.csproj
@@ -49,10 +49,10 @@
     <Content Include="$(RepoRoot)LICENSE">
       <IncludeInVSIX>true</IncludeInVSIX>
     </Content>
-    <Content Include="ExtensionPack.vsext">
+<!--     <Content Include="ExtensionPack.vsext">
       <IncludeInVSIX>true</IncludeInVSIX>
     </Content>
-  </ItemGroup>
+ -->  </ItemGroup>
   <ItemGroup>
     <Reference Include="System" />
   </ItemGroup>

--- a/dev/VSIX/Extension/Cs/Dev16/WindowsAppSDK.Cs.Extension.Dev16.csproj
+++ b/dev/VSIX/Extension/Cs/Dev16/WindowsAppSDK.Cs.Extension.Dev16.csproj
@@ -47,10 +47,10 @@
     <Content Include="$(RepoRoot)LICENSE">
       <IncludeInVSIX>true</IncludeInVSIX>
     </Content>
-    <Content Include="ExtensionPack.vsext">
+<!--     <Content Include="ExtensionPack.vsext">
       <IncludeInVSIX>true</IncludeInVSIX>
     </Content>
-  </ItemGroup>
+ -->  </ItemGroup>
   <ItemGroup>
     <Reference Include="System" />
   </ItemGroup>

--- a/dev/VSIX/Extension/Cs/Dev17/WindowsAppSDK.Cs.Extension.Dev17.csproj
+++ b/dev/VSIX/Extension/Cs/Dev17/WindowsAppSDK.Cs.Extension.Dev17.csproj
@@ -48,10 +48,10 @@
     <Content Include="$(RepoRoot)LICENSE">
       <IncludeInVSIX>true</IncludeInVSIX>
     </Content>
-    <Content Include="ExtensionPack.vsext">
+<!--     <Content Include="ExtensionPack.vsext">
       <IncludeInVSIX>true</IncludeInVSIX>
     </Content>
-  </ItemGroup>
+ -->  </ItemGroup>
   <ItemGroup>
     <Reference Include="System" />
   </ItemGroup>


### PR DESCRIPTION
For some reason the gremlins plaguing the automatic installation of the single-project MSIX extension via a VS Extension Pack (vsext) have returned.

Disabling this part for now, and we'll need to communicate to users to install that extension separately.