### PR TITLE
Protocol Activation bug fixes

### DIFF
--- a/dev/PushNotifications/GetRawNotificationEventArgs.h
+++ b/dev/PushNotifications/GetRawNotificationEventArgs.h
@@ -18,7 +18,10 @@ namespace winrt::Microsoft::Windows::PushNotifications
         {
             if (pair.Name() == L"payload")
             {
-                std::wstring payloadAsWstring{pair.Value()};
+                // Convert escaped components to its normal content
+                // from the conversion done in the LRP (see NotificationListener.cpp)
+                std::wstring payloadAsEscapedWstring{ pair.Value() };
+                std::wstring payloadAsWstring{ winrt::Windows::Foundation::Uri::UnescapeComponent(payloadAsEscapedWstring) };
                 return winrt::make<winrt::Microsoft::Windows::PushNotifications::implementation::PushNotificationReceivedEventArgs>(payloadAsWstring);
             }
         }

--- a/dev/PushNotifications/PushNotificationReceivedEventArgs.cpp
+++ b/dev/PushNotifications/PushNotificationReceivedEventArgs.cpp
@@ -132,16 +132,36 @@ namespace winrt::Microsoft::Windows::PushNotifications::implementation
         }
     }
 
-    std::string PushNotificationReceivedEventArgs::Utf16ToUtf8(_In_z_ PCWSTR utf16)
+    std::string PushNotificationReceivedEventArgs::Utf16ToUtf8(_In_ std::wstring const& utf16string)
     {
-        int size_needed = WideCharToMultiByte(CP_UTF8, 0, utf16, -1, NULL, 0, nullptr, nullptr);
+        int size_needed = WideCharToMultiByte(
+            CP_UTF8,
+            0,
+            utf16string.data(),
+            static_cast<int>(utf16string.length()),
+            nullptr,
+            0,
+            nullptr,
+            nullptr);
+
         THROW_LAST_ERROR_IF(size_needed == 0);
 
-        // size_needed minus the null character
-        std::string utf8(size_needed - 1, 0);
-        int size = WideCharToMultiByte(CP_UTF8, 0, utf16, size_needed - 1, &utf8[0], size_needed - 1, nullptr, nullptr);
+        std::string utf8string;
+        utf8string.resize(size_needed);
+
+        int size = WideCharToMultiByte(
+            CP_UTF8,
+            0,
+            utf16string.data(),
+            static_cast<int>(utf16string.length()),
+            &utf8string[0],
+            size_needed,
+            nullptr,
+            nullptr);
+
         THROW_LAST_ERROR_IF(size == 0);
-        return utf8;
+
+        return utf8string;
     }
 }
 

--- a/dev/PushNotifications/PushNotificationReceivedEventArgs.cpp
+++ b/dev/PushNotifications/PushNotificationReceivedEventArgs.cpp
@@ -15,6 +15,8 @@
 #include <PushNotificationDummyDeferral.h>
 #include "ValueMarshaling.h"
 
+#include "utils.h"
+
 namespace winrt
 {
     using namespace Windows::ApplicationModel::Background;
@@ -55,7 +57,7 @@ namespace winrt::Microsoft::Windows::PushNotifications::implementation
 
     std::vector<uint8_t> PushNotificationReceivedEventArgs::BuildPayload(std::wstring const& payload)
     {
-        std::string payloadToSimpleString = Utf16ToUtf8(payload.c_str());
+        std::string payloadToSimpleString = ConvertWideStringToUtf8String(payload);
 
         return { payloadToSimpleString.c_str(), payloadToSimpleString.c_str() + (payloadToSimpleString.length() * sizeof(uint8_t)) };
     }
@@ -130,38 +132,6 @@ namespace winrt::Microsoft::Windows::PushNotifications::implementation
         {
             m_handledUnpackaged = value;
         }
-    }
-
-    std::string PushNotificationReceivedEventArgs::Utf16ToUtf8(_In_ std::wstring const& utf16string)
-    {
-        int size_needed = WideCharToMultiByte(
-            CP_UTF8,
-            0,
-            utf16string.data(),
-            static_cast<int>(utf16string.length()),
-            nullptr,
-            0,
-            nullptr,
-            nullptr);
-
-        THROW_LAST_ERROR_IF(size_needed == 0);
-
-        std::string utf8string;
-        utf8string.resize(size_needed);
-
-        int size = WideCharToMultiByte(
-            CP_UTF8,
-            0,
-            utf16string.data(),
-            static_cast<int>(utf16string.length()),
-            &utf8string[0],
-            size_needed,
-            nullptr,
-            nullptr);
-
-        THROW_LAST_ERROR_IF(size == 0);
-
-        return utf8string;
     }
 }
 

--- a/dev/PushNotifications/PushNotificationReceivedEventArgs.h
+++ b/dev/PushNotifications/PushNotificationReceivedEventArgs.h
@@ -24,7 +24,7 @@ namespace winrt::Microsoft::Windows::PushNotifications::implementation
         void Handled(bool value);
 
     private:
-        std::string Utf16ToUtf8(_In_z_ PCWSTR utf16);
+        std::string Utf16ToUtf8(_In_ std::wstring const& utf16string);
 
         const winrt::Windows::Storage::Streams::IBuffer m_rawNotification{};
 

--- a/dev/PushNotifications/PushNotificationReceivedEventArgs.h
+++ b/dev/PushNotifications/PushNotificationReceivedEventArgs.h
@@ -24,8 +24,6 @@ namespace winrt::Microsoft::Windows::PushNotifications::implementation
         void Handled(bool value);
 
     private:
-        std::string Utf16ToUtf8(_In_ std::wstring const& utf16string);
-
         const winrt::Windows::Storage::Streams::IBuffer m_rawNotification{};
 
         std::vector<uint8_t> BuildPayload(winrt::Windows::Storage::Streams::IBuffer const& buffer);

--- a/dev/PushNotifications/PushNotifications.vcxitems
+++ b/dev/PushNotifications/PushNotifications.vcxitems
@@ -36,5 +36,6 @@
     <ClInclude Include="$(MSBuildThisFileDirectory)PushNotificationRegistrationToken.h" />
     <ClInclude Include="$(MSBuildThisFileDirectory)PushNotificationDummyDeferral.h" />
     <ClInclude Include="$(MSBuildThisFileDirectory)PushNotificationTelemetry.h" />
+    <ClInclude Include="$(MSBuildThisFileDirectory)utils.h" />
   </ItemGroup>
 </Project>

--- a/dev/PushNotifications/PushNotificationsLongRunningTask/NotificationListener.cpp
+++ b/dev/PushNotifications/PushNotificationsLongRunningTask/NotificationListener.cpp
@@ -21,28 +21,26 @@ STDMETHODIMP_(HRESULT __stdcall) NotificationListener::OnRawNotificationReceived
 
     if (!m_foregroundSinkManager->InvokeForegroundHandlers(m_appId, payloadArray, payloadLength))
     {
-        std::string commandLine = "----WindowsAppSDKPushServer:-Payload:\"";
+        // Command line format: ----WindowsAppSDKPushServer:-Payload:"<payloadAsEscapedUriFormat>"
+        std::wstring commandLine = L"----WindowsAppSDKPushServer:-Payload:\"";
 
         // Escape special characters to follow command line standards for any app activation type in AppLifecycle
         // (See AppInstance.cpp and Serialize() from other activation types)
         std::wstring payloadAsWideString = GetPayloadAsWideString(payloadLength, payload);
-        auto escapedUri = winrt::Windows::Foundation::Uri::EscapeComponent(payloadAsWideString.c_str());
-        const std::string payloadAsEscapedUriFormat = ConvertWideStringToUtf8String(escapedUri.c_str());
+        auto payloadAsEscapedUriFormat = winrt::Windows::Foundation::Uri::EscapeComponent(payloadAsWideString.c_str());
 
         commandLine.append(payloadAsEscapedUriFormat);
-        commandLine.append("\"");
+        commandLine.append(L"\"");
 
-        const std::string processNameAsUtf8String = ConvertWideStringToUtf8String(m_processName);
-
-        SHELLEXECUTEINFOA shellExecuteInfo{};
-        shellExecuteInfo.cbSize = sizeof(SHELLEXECUTEINFOA);
+        SHELLEXECUTEINFO shellExecuteInfo{};
+        shellExecuteInfo.cbSize = sizeof(SHELLEXECUTEINFO);
         shellExecuteInfo.fMask = SEE_MASK_NOCLOSEPROCESS | SEE_MASK_DOENVSUBST;
-        shellExecuteInfo.lpFile = processNameAsUtf8String.c_str();
+        shellExecuteInfo.lpFile = m_processName.c_str();
         shellExecuteInfo.lpParameters = commandLine.c_str();
 
         shellExecuteInfo.nShow = SW_NORMAL;
 
-        if (!ShellExecuteExA(&shellExecuteInfo))
+        if (!ShellExecuteEx(&shellExecuteInfo))
         {
             THROW_IF_WIN32_ERROR(GetLastError());
         }
@@ -52,25 +50,26 @@ STDMETHODIMP_(HRESULT __stdcall) NotificationListener::OnRawNotificationReceived
 }
 CATCH_RETURN()
 
-const std::string NotificationListener::ConvertWideStringToUtf8String(std::wstring const& wideString)
-{
-    int size_needed = WideCharToMultiByte(CP_UTF8, 0, wideString.c_str(), -1, NULL, 0, nullptr, nullptr);
-    THROW_LAST_ERROR_IF(size_needed == 0);
-
-    // size_needed minus the null character
-    std::string utf8(size_needed - 1, 0);
-    int size = WideCharToMultiByte(CP_UTF8, 0, wideString.c_str(), size_needed - 1, &utf8[0], size_needed - 1, nullptr, nullptr);
-    THROW_LAST_ERROR_IF(size == 0);
-    return utf8;
-}
-
 const std::wstring NotificationListener::GetPayloadAsWideString(unsigned int payloadLength, byte* payload)
 {
-    int size_needed = MultiByteToWideChar(CP_UTF8, 0, reinterpret_cast<LPCSTR>(payload), payloadLength, nullptr, 0);
+    int size_needed = MultiByteToWideChar(
+        CP_UTF8,
+        0,
+        reinterpret_cast<PCSTR>(payload),
+        payloadLength,
+        nullptr,
+        0);
     THROW_LAST_ERROR_IF(size_needed == 0);
 
     std::wstring payloadAsWideString(size_needed, 0);
-    size_needed = MultiByteToWideChar(CP_UTF8, 0, reinterpret_cast<LPCSTR>(payload), payloadLength, &payloadAsWideString[0], size_needed);
+    size_needed = MultiByteToWideChar(
+        CP_UTF8,
+        0,
+        reinterpret_cast<PCSTR>(payload),
+        payloadLength,
+        &payloadAsWideString[0],
+        size_needed);
     THROW_LAST_ERROR_IF(size_needed == 0);
+
     return payloadAsWideString;
 }

--- a/dev/PushNotifications/PushNotificationsLongRunningTask/NotificationListener.h
+++ b/dev/PushNotifications/PushNotificationsLongRunningTask/NotificationListener.h
@@ -10,7 +10,6 @@ public:
     STDMETHOD(OnRawNotificationReceived)(unsigned int payloadLength, _In_ byte* payload, _In_ HSTRING correlationVector) noexcept;
 
 private:
-    const std::string ConvertWideStringToUtf8String(std::wstring const& wideString);
     const std::wstring GetPayloadAsWideString(unsigned int payloadLength, byte* payload);
 
     std::shared_ptr<ForegroundSinkManager> m_foregroundSinkManager;

--- a/dev/PushNotifications/PushNotificationsLongRunningTask/NotificationListener.h
+++ b/dev/PushNotifications/PushNotificationsLongRunningTask/NotificationListener.h
@@ -10,7 +10,8 @@ public:
     STDMETHOD(OnRawNotificationReceived)(unsigned int payloadLength, _In_ byte* payload, _In_ HSTRING correlationVector) noexcept;
 
 private:
-    const std::string ConvertProcessNameToUtf8String();
+    const std::string ConvertWideStringToUtf8String(std::wstring const& wideString);
+    const std::wstring GetPayloadAsWideString(unsigned int payloadLength, byte* payload);
 
     std::shared_ptr<ForegroundSinkManager> m_foregroundSinkManager;
 

--- a/dev/PushNotifications/PushNotificationsLongRunningTask/NotificationListener.h
+++ b/dev/PushNotifications/PushNotificationsLongRunningTask/NotificationListener.h
@@ -10,8 +10,6 @@ public:
     STDMETHOD(OnRawNotificationReceived)(unsigned int payloadLength, _In_ byte* payload, _In_ HSTRING correlationVector) noexcept;
 
 private:
-    const std::wstring GetPayloadAsWideString(unsigned int payloadLength, byte* payload);
-
     std::shared_ptr<ForegroundSinkManager> m_foregroundSinkManager;
 
     std::wstring m_appId;

--- a/dev/PushNotifications/PushNotificationsLongRunningTask/PushNotificationsLongRunningTask.vcxproj
+++ b/dev/PushNotifications/PushNotificationsLongRunningTask/PushNotificationsLongRunningTask.vcxproj
@@ -239,6 +239,7 @@
     <ClInclude Include="platformfactory.h" />
     <ClInclude Include="PlatformLifetimeManager.h" />
     <ClInclude Include="NotificationListenerManager.h" />
+    <ClInclude Include="utils.h" />
   </ItemGroup>
   <ItemGroup>
     <None Include="packages.config" />

--- a/dev/PushNotifications/PushNotificationsLongRunningTask/PushNotificationsLongRunningTask.vcxproj.filters
+++ b/dev/PushNotifications/PushNotificationsLongRunningTask/PushNotificationsLongRunningTask.vcxproj.filters
@@ -36,6 +36,9 @@
     <ClInclude Include="PlatformLifetimeManager.h">
       <Filter>Header Files</Filter>
     </ClInclude>
+    <ClInclude Include="utils.h">
+      <Filter>Source Files</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="pch.cpp">

--- a/dev/PushNotifications/PushNotificationsLongRunningTask/utils.h
+++ b/dev/PushNotifications/PushNotificationsLongRunningTask/utils.h
@@ -1,0 +1,27 @@
+﻿#pragma once
+
+#include "pch.h"
+
+const std::wstring ConvertByteArrayToWideString(unsigned int payloadLength, byte* payload)
+{
+    int size = MultiByteToWideChar(
+        CP_UTF8,
+        0,
+        reinterpret_cast<PCSTR>(payload),
+        payloadLength,
+        nullptr,
+        0);
+    THROW_LAST_ERROR_IF(size == 0);
+
+    std::wstring payloadAsWideString(size, 0);
+    size = MultiByteToWideChar(
+        CP_UTF8,
+        0,
+        reinterpret_cast<PCSTR>(payload),
+        payloadLength,
+        &payloadAsWideString[0],
+        size);
+    THROW_LAST_ERROR_IF(size == 0);
+
+    return payloadAsWideString;
+}

--- a/dev/PushNotifications/utils.h
+++ b/dev/PushNotifications/utils.h
@@ -1,0 +1,38 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+#pragma once
+
+#include "pch.h"
+
+std::string ConvertWideStringToUtf8String(_In_ std::wstring const& utf16string)
+{
+    int size = WideCharToMultiByte(
+        CP_UTF8,
+        0,
+        utf16string.data(),
+        static_cast<int>(utf16string.length()),
+        nullptr,
+        0,
+        nullptr,
+        nullptr);
+
+    THROW_LAST_ERROR_IF(size == 0);
+
+    std::string utf8string;
+    utf8string.resize(size);
+
+    size = WideCharToMultiByte(
+        CP_UTF8,
+        0,
+        utf16string.data(),
+        static_cast<int>(utf16string.length()),
+        &utf8string[0],
+        size,
+        nullptr,
+        nullptr);
+
+    THROW_LAST_ERROR_IF(size == 0);
+
+    return utf8string;
+}


### PR DESCRIPTION
This PR fixes a couple of issues:

1. **Truncated payloads delivered to the app**: the Push payload is now processed correctly to comply with AppLifecycle command line expectations (i.e. truncation happened at the first space character - other activation types are already escaping such characters, now we do it too. Then, the payload is unescaped at GetRawNotificationEventArgs.h).
2. **Payloads with special characters crashed the app**: Special characters weren't playing okay with wstring->string conversion at PushNotificationReceivedEventArgs, because WideCharToMultiByte was erroring out with ERROR_INSUFFICIENT_BUFFER.