### PR TITLE
Copy Bootstrap .NET dll. Don't copy Bootstrap DLL if OutputType=Library

### DIFF
--- a/build/NuSpecs/Microsoft.WindowsAppSDK.Bootstrap.targets
+++ b/build/NuSpecs/Microsoft.WindowsAppSDK.Bootstrap.targets
@@ -5,10 +5,13 @@
   <PropertyGroup>
     <_WindowsAppSDKFoundationPlatform Condition="'$(Platform)' == 'Win32'">x86</_WindowsAppSDKFoundationPlatform>
     <_WindowsAppSDKFoundationPlatform Condition="'$(Platform)' != 'Win32'">$(Platform)</_WindowsAppSDKFoundationPlatform>
+    <_WindowsAppSDKBootstrapPlatform Condition="'$(_WindowsAppSDKFoundationPlatform)' == 'AnyCPU'">x86</_WindowsAppSDKBootstrapPlatform>
+    <_WindowsAppSDKBootstrapPlatform Condition="'$(_WindowsAppSDKFoundationPlatform)' != 'AnyCPU'">$(_WindowsAppSDKFoundationPlatform)</_WindowsAppSDKBootstrapPlatform>
   </PropertyGroup>
 
-  <Target Name="BinPlaceBootstrapDll" Condition="'$(AppxPackage)' != 'true'" AfterTargets="Build">
-    <Copy SourceFiles="$(MSBuildThisFileDirectory)..\runtimes\lib\native\$(_WindowsAppSDKFoundationPlatform)\Microsoft.WindowsAppRuntime.Bootstrap.dll" DestinationFolder="$(OutDir)" OverwriteReadOnlyFiles="true" ContinueOnError="false"/>
+  <Target Name="BinPlaceBootstrapDll" Condition="'$(AppxPackage)' != 'true' and '$(OutputType)' != 'Library'" AfterTargets="Build">
+    <Copy SourceFiles="$(MSBuildThisFileDirectory)..\runtimes\lib\native\$(_WindowsAppSDKBootstrapPlatform)\Microsoft.WindowsAppRuntime.Bootstrap.dll" DestinationFolder="$(OutDir)" OverwriteReadOnlyFiles="true" ContinueOnError="false"/>
+    <Copy SourceFiles="$(MSBuildThisFileDirectory)..\runtimes\lib\native\$(_WindowsAppSDKBootstrapPlatform)\Microsoft.WindowsAppRuntime.Bootstrap.Net.dll" DestinationFolder="$(OutDir)" OverwriteReadOnlyFiles="true" ContinueOnError="false"/>
   </Target>
 
 </Project>


### PR DESCRIPTION
This corrects 2 problems:

1. Microsoft.WindowsAppSDK.Bootstrap.targets copied the Bootstrap dll from `...\runtimes\lib\**cpu**\...` and handled it when `**cpu**` = `Win32` but not when it's `AnyCPU`. Either should grab the `x86` dll
2. Microsoft.WindowsAppRuntime.Bootstrap.Net.dll wasn't getting copied for .NET projects

I tested with various permutations of C++ and C# projects.  This doesn't affect C++ projects (were doing the right thing before, this doesn't _negatively_ impact them). OTOH C# projects now build successfully with content as expected.

This addresses [AnyCPU Class libraries are broken again #1217](https://github.com/microsoft/WindowsAppSDK/issues/1217#)

[Bug 33477857](https://task.ms/33477857)