### PR TITLE
Fix signing pattern to capture all winmd and dll in the transport package

### DIFF
--- a/build/ProjectReunion-BuildFoundation.yml
+++ b/build/ProjectReunion-BuildFoundation.yml
@@ -196,6 +196,7 @@ jobs:
     signingPattern: |
         **/*.winmd
         **/*.dll
+        **/*.exe
   dependsOn:
     - Build
     - PublishMRT

--- a/build/ProjectReunion-BuildFoundation.yml
+++ b/build/ProjectReunion-BuildFoundation.yml
@@ -194,9 +194,8 @@ jobs:
 - job: SignBinariesAndPublishSymbols
   variables:
     signingPattern: |
-        lib\uap10.0\*.winmd
-        lib\net5.0-windows\*.dll
-        runtimes\*\*\*.dll
+        **/*.winmd
+        **/*.dll
   dependsOn:
     - Build
     - PublishMRT


### PR DESCRIPTION
Fix signing pattern to capture all winmd and dll in the transport package