### PR TITLE
Pipeline to call TouchDownBuild

### DIFF
--- a/build/WindowsAppSDK-CallTouchDownBuild.yml
+++ b/build/WindowsAppSDK-CallTouchDownBuild.yml
@@ -2,8 +2,7 @@
 name: $(BuildDefinitionName)_$(date:yyMM).$(date:dd)$(rev:rrr)
 jobs:
 - job: Localization
-  pool:
-    vmImage: 'windows-2019'
+  pool: 'ProjectReunionESPool'
   steps:
   - task: TouchdownBuildTask@1
     inputs:

--- a/build/WindowsAppSDK-CallTouchDownBuild.yml
+++ b/build/WindowsAppSDK-CallTouchDownBuild.yml
@@ -5,6 +5,8 @@ jobs:
   pool: 'ProjectReunionESPool'
   steps:
   - script: |
+      Write-Host $(GitEmail)
+      Write-Host $(GitUserName)
       git config --global user.email $(GitEmail)
       git config --global user.name $(GitUserName)
 

--- a/build/WindowsAppSDK-CallTouchDownBuild.yml
+++ b/build/WindowsAppSDK-CallTouchDownBuild.yml
@@ -4,6 +4,10 @@ jobs:
 - job: Localization
   pool: 'ProjectReunionESPool'
   steps:
+  - script: |
+      git config --global user.email $(GitEmail)
+      git config --global user.name $(GitUserName)
+
   - task: TouchdownBuildTask@1
     inputs:
       environment: 'PRODEXT'

--- a/build/WindowsAppSDK-CallTouchDownBuild.yml
+++ b/build/WindowsAppSDK-CallTouchDownBuild.yml
@@ -23,3 +23,6 @@ jobs:
       appendRelativeDir: true
       cultureMappingType: 'None'
       gitAction: 'None'
+
+  - script: |
+      git push

--- a/build/WindowsAppSDK-CallTouchDownBuild.yml
+++ b/build/WindowsAppSDK-CallTouchDownBuild.yml
@@ -5,8 +5,6 @@ jobs:
   pool: 'ProjectReunionESPool'
   steps:
   - script: |
-      Write-Host $(GitEmail)
-      Write-Host $(GitUserName)
       git config --global user.email $(GitEmail)
       git config --global user.name $(GitUserName)
 

--- a/build/WindowsAppSDK-CallTouchDownBuild.yml
+++ b/build/WindowsAppSDK-CallTouchDownBuild.yml
@@ -1,0 +1,22 @@
+# see https://docs.microsoft.com/azure/devops/pipelines/process/phases for info on yaml ADO jobs
+name: $(BuildDefinitionName)_$(date:yyMM).$(date:dd)$(rev:rrr)
+jobs:
+- job: Localization
+  pool:
+    vmImage: 'windows-2019'
+  steps:
+  - task: TouchdownBuildTask@1
+    inputs:
+      environment: 'PRODEXT'
+      teamId: '36910'
+      authType: 'OAuth'
+      authId: $(TdBuildAuthID)
+      authKey: $(TdBuildToken)
+      localizationTarget: false
+      isPreview: false
+      resourceFilePath: |
+        dev\VSIX\Extension\Cpp\Common\VSPackage.resx
+        dev\VSIX\Extension\Cs\Common\VSPackage.resx
+      appendRelativeDir: true
+      cultureMappingType: 'None'
+      gitAction: 'COMMIT'

--- a/build/WindowsAppSDK-CallTouchDownBuild.yml
+++ b/build/WindowsAppSDK-CallTouchDownBuild.yml
@@ -24,4 +24,4 @@ jobs:
         dev\VSIX\Extension\Cs\Common\VSPackage.resx
       appendRelativeDir: true
       cultureMappingType: 'None'
-      gitAction: 'COMMIT'
+      gitAction: 'None'


### PR DESCRIPTION
Pipeline to call TouchDownBuild

GitAction is currently set to "None"
This will bring localized resources to the current branch. 