### PR TITLE
User/aeloros/fileencodefix

### DIFF
--- a/dev/AppLifecycle/ActivationRegistrationManager.cpp
+++ b/dev/AppLifecycle/ActivationRegistrationManager.cpp
@@ -15,13 +15,13 @@ namespace winrt::Microsoft::Windows::AppLifecycle::implementation
 {
     using namespace winrt::Windows::Foundation;
 
-    std::wstring GenerateCommandLine(std::wstring const& modulePath)
+    std::wstring GenerateCommandLine(std::wstring const& modulePath, std::wstring const& argumentData)
     {
         std::wstring exePath{ modulePath.empty() ? GetModulePath() : modulePath };
 
-        // Example: C:\some\path\App.exe ----ms-protocol:
-        return wil::str_printf<std::wstring>(L"%s %s%s%s", exePath.c_str(), c_argumentPrefix,
-            c_protocolArgumentString, c_argumentSuffix);
+        // Example: C:\some\path\App.exe "----ms-protocol:myscheme:some=data&some=other"
+        return wil::str_printf<std::wstring>(L"%s \"%s%s%s%s\"", exePath.c_str(), c_argumentPrefix,
+            c_protocolArgumentString, c_argumentSuffix, argumentData.c_str());
     }
 
     void ActivationRegistrationManager::RegisterForFileTypeActivation(
@@ -45,7 +45,7 @@ namespace winrt::Microsoft::Windows::AppLifecycle::implementation
             for (auto verb : supportedVerbs)
             {
                 auto args = winrt::make<FileActivatedEventArgs>(verb.c_str(), c_commandLineArgumentFormat, true).as<IInternalValueMarshalable>();
-                auto command = GenerateCommandLine(exePath.c_str()) + args->Serialize().AbsoluteUri().c_str();
+                auto command = GenerateCommandLine(exePath.c_str(), args->Serialize().AbsoluteUri().c_str());
                 RegisterVerb(progId, verb.c_str(), command);
             }
 
@@ -76,7 +76,7 @@ namespace winrt::Microsoft::Windows::AppLifecycle::implementation
 
         // Pass a value serialized version of the arguments on the command-line.
         auto args = winrt::make<StartupActivatedEventArgs>(taskId.c_str()).as<IInternalValueMarshalable>();
-        auto command = GenerateCommandLine(exePath.c_str()) + args->Serialize().AbsoluteUri().c_str();
+        auto command = GenerateCommandLine(exePath.c_str(), args->Serialize().AbsoluteUri().c_str());
 
         // Name: taskId
         // Value: commandLine
@@ -144,7 +144,7 @@ namespace winrt::Microsoft::Windows::AppLifecycle::implementation
         RegisterProgId(progId.c_str(), L"", appUserModelId.c_str(), displayName.c_str(),
             logo.c_str());
 
-        auto command = GenerateCommandLine(exePath.c_str()) + c_commandLineArgumentFormat;
+        auto command = GenerateCommandLine(exePath.c_str(), c_commandLineArgumentFormat);
         RegisterVerb(progId.c_str(), c_openVerbName, command);
 
         RegisterApplication(appId.c_str());

--- a/dev/AppLifecycle/AppInstance.cpp
+++ b/dev/AppLifecycle/AppInstance.cpp
@@ -25,41 +25,37 @@ namespace winrt::Microsoft::Windows::AppLifecycle::implementation
 
     std::tuple<std::wstring, std::wstring> ParseCommandLine(const std::wstring& commandLine)
     {
-        auto argsStart = commandLine.rfind(c_argumentPrefix);
-        if (argsStart == std::wstring::npos)
-        {
-            return { L"", L"" };
-        }
+        int argc{};
+        wil::unique_hlocal_ptr<PWSTR[]> argv{ CommandLineToArgvW(commandLine.c_str(), &argc) };
 
-        // Push past the '----' commandline argument prefix.
-        argsStart += 4;
-
-        auto argsEnd = commandLine.find_first_of(L' ', argsStart);
-
-        // Separate the argument from any behind it on the command-line.
-        std::wstring argument;
-        if (argsEnd == std::wstring::npos)
+        // Search for ----ms-protocol:
+        for (int index = 0; index < argc; index++)
         {
-            argument = commandLine.substr(argsStart);
-        }
-        else
-        {
-            if (argsStart > argsEnd)
+            std::wstring_view fullArgument = argv[index];
+            auto protocolQualifier = wil::str_printf<std::wstring>(L"%s%s%s", c_argumentPrefix, c_protocolArgumentString, c_argumentSuffix);
+
+            auto argStart = fullArgument.find(protocolQualifier);
+            if (argStart == std::wstring::npos)
             {
-                throw std::invalid_argument("commandLine");
+                continue;
             }
 
-            argument = commandLine.substr(argsStart, (argsEnd - argsStart));
+            // Push past the '----' commandline argument prefix.
+            argStart += 4;
+
+            std::wstring argument{ fullArgument.substr(argStart) };
+
+            // We explicitly use find_first_of here, so that the resulting data may contain : as a valid character.
+            auto argsDelim = argument.find_first_of(L':');
+            if (argsDelim == std::wstring::npos)
+            {
+                return { argument, L"" };
+            }
+
+            return { argument.substr(0, argsDelim), argument.substr(argsDelim + 1) };
         }
 
-        // We explicitly use find_first_of here, so that the resulting data may contain : as a valid character.
-        auto argsDelim = argument.find_first_of(L':');
-        if (argsDelim == std::wstring::npos)
-        {
-            return { argument, L"" };
-        }
-
-        return { argument.substr(0, argsDelim), argument.substr(argsDelim + 1) };
+        return { L"", L"" };
     }
 
     std::tuple<ExtendedActivationKind, winrt::Windows::Foundation::IInspectable> GetEncodedLaunchActivatedEventArgs(IProtocolActivatedEventArgs const& args)

--- a/dev/AppLifecycle/FileActivatedEventArgs.h
+++ b/dev/AppLifecycle/FileActivatedEventArgs.h
@@ -16,7 +16,7 @@ namespace winrt::Microsoft::Windows::AppLifecycle::implementation
         IInternalValueMarshalable>
     {
     public:
-        FileActivatedEventArgs(const winrt::hstring verb, const winrt::hstring file, const bool delayVerification = false)
+        FileActivatedEventArgs(const winrt::hstring verb, const winrt::hstring file, const bool supportCommandTemplates = false)
         {
             if (verb.empty())
             {
@@ -28,6 +28,7 @@ namespace winrt::Microsoft::Windows::AppLifecycle::implementation
                 throw std::invalid_argument("file");
             }
 
+            m_supportCommandTemplates = supportCommandTemplates;
             m_kind = ActivationKind::File;
             m_verb = std::move(verb);
             m_path = std::move(file);
@@ -36,7 +37,7 @@ namespace winrt::Microsoft::Windows::AppLifecycle::implementation
             // There is a scenario where we just want to create an object to serialize it.  In that situation
             // skipping verification allows for template variables to be used.  Example: %1 may be used when
             // using serialization to generate the encoded arguments for a file type association.
-            if (!delayVerification)
+            if (!m_supportCommandTemplates)
             {
                 // Currently we only support one file in the array, because the
                 // activation method forces a new process for each item in the array.
@@ -57,7 +58,21 @@ namespace winrt::Microsoft::Windows::AppLifecycle::implementation
         {
             auto uri = GenerateEncodedLaunchUri(L"App", c_fileContractId);
             uri += L"&Verb=" + winrt::Windows::Foundation::Uri::EscapeComponent(m_verb.c_str());
-            uri += L"&File=" + winrt::Windows::Foundation::Uri::EscapeComponent(m_path.c_str());
+
+            std::wstring path;
+
+            if (m_supportCommandTemplates)
+            {
+                // Don't escape command template files as they could be %1.
+                path = m_path.c_str();
+            }
+            else
+            {
+                path = winrt::Windows::Foundation::Uri::EscapeComponent(m_path.c_str());
+            }
+
+            uri += std::wstring(L"&File=") + path;
+
             return winrt::Windows::Foundation::Uri(uri);
         }
 
@@ -73,6 +88,7 @@ namespace winrt::Microsoft::Windows::AppLifecycle::implementation
         }
 
     private:
+        bool m_supportCommandTemplates;
         winrt::hstring m_verb;
         winrt::hstring m_path;
         IVector<IStorageItem> m_files;

--- a/dev/AppLifecycle/ValueMarshaling.h
+++ b/dev/AppLifecycle/ValueMarshaling.h
@@ -19,8 +19,8 @@ namespace winrt::Microsoft::Windows::AppLifecycle::implementation
 
     inline std::wstring GenerateEncodedLaunchUri(std::wstring const& appUserModelId, std::wstring const& contractId)
     {
-        // Example: ms-encodedlaunch://App/?ContractId=Windows.File&Verb=open&File=%1
-        winrt::Windows::Foundation::Uri uri{ wil::str_printf<std::wstring>(L"%s://%s?%s=%s",
+        // Example: ms-encodedlaunch:App/?ContractId=Windows.File&Verb=open&File=%1
+        winrt::Windows::Foundation::Uri uri{ wil::str_printf<std::wstring>(L"%s:%s?%s=%s",
             c_encodedLaunchSchemeName, appUserModelId.c_str(), c_contractIdKeyName, contractId.c_str()).c_str() };
         return uri.AbsoluteUri().c_str();
     }

--- a/test/AppLifecycle/FunctionalTests.cpp
+++ b/test/AppLifecycle/FunctionalTests.cpp
@@ -216,7 +216,7 @@ namespace Test::AppLifecycle
             }
             THROW_IF_WIN32_ERROR(result);
 
-            auto argsStart = command.rfind(L"----");
+            auto argsStart = command.rfind(L"\"----");
             auto exe = command.substr(0, argsStart);
             auto params = command.substr(argsStart);
             Execute(exe, params, g_deploymentDir);


### PR DESCRIPTION
Shell Verb command templates use %1 as a placeholder variable for the file being executed on (target).  This was being URI escaped to be %251 instead.  This change fixes it so that the escaping doesn't happen.  

In addition to that, it also switches parameter parsing to use CommandLineToArgvW and surrounds the protocol parameter with quotes.  This allows for LFN space support in the filenames.
