### PR TITLE
Reduce Microsoft.Windows.ApplicationModel.Resources.dll binary size by 70KB by disabling RTTI.

### DIFF
--- a/dev/MRTCore/mrt/Microsoft.Windows.ApplicationModel.Resources/src/Microsoft.Windows.ApplicationModel.Resources.vcxproj
+++ b/dev/MRTCore/mrt/Microsoft.Windows.ApplicationModel.Resources/src/Microsoft.Windows.ApplicationModel.Resources.vcxproj
@@ -98,6 +98,8 @@
       </DisableSpecificWarnings>
       <PreprocessorDefinitions>_WINRT_DLL;WIN32_LEAN_AND_MEAN;WINRT_LEAN_AND_MEAN;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <AdditionalUsingDirectories>$(WindowsSDK_WindowsMetadata);$(AdditionalUsingDirectories)</AdditionalUsingDirectories>
+      <!-- MRT Core doesn't use RTTI. -->
+      <RuntimeTypeInfo>false</RuntimeTypeInfo>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>


### PR DESCRIPTION
MRT Core doesn't use [RTTI](https://en.wikipedia.org/wiki/Run-time_type_information), but the `*.vcxproj` file that is used for building `Microsoft.Windows.ApplicationModel.Resources.dll` doesn't explicitly disable it -- and it is enabled by default. We can turn it off, which saves ~70 KB.

| File    | Size Before     | Size After     |
|---------|----------------:|---------------:|
| Microsoft.Windows.ApplicationModel.Resources.dll | 178,688 | 107,520 |

**Delta** = **-71,168 bytes (69.5 KB)**

Note: I already disabled it for `MRM.dll` in the PR here: https://github.com/microsoft/WindowsAppSDK/pull/904, which saved 37 KB.

