### PR TITLE
Remove Experimental-ness from Deployment API

### DIFF
--- a/dev/Common/TerminalVelocityFeatures-DeploymentAPI.xml
+++ b/dev/Common/TerminalVelocityFeatures-DeploymentAPI.xml
@@ -12,9 +12,5 @@
         <name>Feature_DeploymentAPI</name>
         <description>DeploymentAPI for the WindowsAppRuntime</description>
         <state>AlwaysEnabled</state>
-        <alwaysDisabledChannelTokens>
-            <channelToken>Preview</channelToken>
-            <channelToken>Stable</channelToken>
-        </alwaysDisabledChannelTokens>
     </feature>
 </features>

--- a/dev/Deployment/Deployment.idl
+++ b/dev/Deployment/Deployment.idl
@@ -4,7 +4,6 @@
 namespace Microsoft.Windows.ApplicationModel.WindowsAppRuntime
 {
     /// Represents the current Deployment status of the WindowsAppRuntime
-    [experimental]
     enum DeploymentStatus
     {
         Unknown = 0,
@@ -14,7 +13,6 @@ namespace Microsoft.Windows.ApplicationModel.WindowsAppRuntime
     };
 
     /// Represents the a result of a Deployment Manager method.
-    [experimental]
     runtimeclass DeploymentResult
     {
         DeploymentResult(DeploymentStatus status, HRESULT extendedError);
@@ -27,7 +25,6 @@ namespace Microsoft.Windows.ApplicationModel.WindowsAppRuntime
     };
 
     /// Used to query deployment information for WindowsAppRuntime
-    [experimental]
     static runtimeclass DeploymentManager
     {
         /// Returns the current deployment status of the current package's Windows App Runtime.

--- a/dev/Deployment/DeploymentManager.cpp
+++ b/dev/Deployment/DeploymentManager.cpp
@@ -13,21 +13,18 @@ namespace winrt::Microsoft::Windows::ApplicationModel::WindowsAppRuntime::implem
 
     winrt::Microsoft::Windows::ApplicationModel::WindowsAppRuntime::DeploymentResult DeploymentManager::GetStatus()
     {
-        THROW_HR_IF(E_NOTIMPL, !::Microsoft::Windows::ApplicationModel::WindowsAppRuntime::Feature_DeploymentAPI::IsEnabled());
         FAIL_FAST_HR_IF(HRESULT_FROM_WIN32(APPMODEL_ERROR_NO_PACKAGE), !AppModel::Identity::IsPackagedProcess());
         return GetStatus(GetCurrentFrameworkPackageFullName());
     }
 
     winrt::Microsoft::Windows::ApplicationModel::WindowsAppRuntime::DeploymentResult DeploymentManager::Initialize()
     {
-        THROW_HR_IF(E_NOTIMPL, !::Microsoft::Windows::ApplicationModel::WindowsAppRuntime::Feature_DeploymentAPI::IsEnabled());
         FAIL_FAST_HR_IF(HRESULT_FROM_WIN32(APPMODEL_ERROR_NO_PACKAGE), !AppModel::Identity::IsPackagedProcess());
         return Initialize(GetCurrentFrameworkPackageFullName());
     }
 
     winrt::Microsoft::Windows::ApplicationModel::WindowsAppRuntime::DeploymentResult DeploymentManager::GetStatus(hstring const& packageFullName)
     {
-        THROW_HR_IF(E_NOTIMPL, !::Microsoft::Windows::ApplicationModel::WindowsAppRuntime::Feature_DeploymentAPI::IsEnabled());
         std::wstring frameworkPackageFullName{ packageFullName };
         auto frameworkPackageInfo{ GetPackageInfoForPackage(frameworkPackageFullName) };
 
@@ -81,7 +78,6 @@ namespace winrt::Microsoft::Windows::ApplicationModel::WindowsAppRuntime::implem
 
     winrt::Microsoft::Windows::ApplicationModel::WindowsAppRuntime::DeploymentResult DeploymentManager::Initialize(hstring const& packageFullName)
     {
-        THROW_HR_IF(E_NOTIMPL, !::Microsoft::Windows::ApplicationModel::WindowsAppRuntime::Feature_DeploymentAPI::IsEnabled());
         auto getStatusResult{ DeploymentManager::GetStatus(packageFullName) };
         if (getStatusResult.Status() == DeploymentStatus::Ok)
         {

--- a/test/Deployment/APITests.cpp
+++ b/test/Deployment/APITests.cpp
@@ -31,12 +31,6 @@ namespace Test::Deployment
 
         TEST_CLASS_SETUP(ClassInit)
         {
-            if (!::Microsoft::Windows::ApplicationModel::WindowsAppRuntime::Feature_DeploymentAPI::IsEnabled())
-            {
-                Log::Result(TestResults::Skipped, L"Deployment API Features are not enabled.");
-                return true;
-            }
-
             ClassUninit();
             TP::AddPackage_DeploymentWindowsAppRuntimeFramework();
             TP::AddPackage_WindowsAppRuntimeFramework();


### PR DESCRIPTION
Removes [experimental] attributes from the WindowsAppRuntime deployment API and sets the feature to being always available.