### PR TITLE
Fix Helix tests failing to build because Microsoft.WindowsAppRuntime.Bootstrap.Net.dll is in Amd64

### DIFF
--- a/build/AzurePipelinesTemplates/WindowsAppSDK-BuildProject-Steps.yml
+++ b/build/AzurePipelinesTemplates/WindowsAppSDK-BuildProject-Steps.yml
@@ -115,7 +115,7 @@ steps:
       vsVersion: 16.0
       platform: '$(buildPlatform)'
       configuration: '$(buildConfiguration)'
-      msbuildArgs: '/restore /p:AppxSymbolPackageEnabled=false /binaryLogger:$(Build.SourcesDirectory)/${{ parameters.solutionPath }}.$(buildPlatform).$(buildConfiguration).binlog /p:WindowsAppSDKVersionBuild=$(builddate_yymm) /p:WindowsAppSDKVersionRevision=$(builddate_dd)$(buildrevision) /p:VCToolsInstallDir="$(VCToolsInstallDir)\" /p:PGOBuildMode=$(PGOBuildMode) /p:WindowsAppSDKBuildPipeline=1'
+      msbuildArgs: '/restore /p:AppxSymbolPackageEnabled=false /p:WindowsAppSDKVersionBuild=$(builddate_yymm) /p:WindowsAppSDKVersionRevision=$(builddate_dd)$(buildrevision) /p:VCToolsInstallDir="$(VCToolsInstallDir)\" /p:PGOBuildMode=$(PGOBuildMode) /p:WindowsAppSDKBuildPipeline=1'
 
   - task: CmdLine@2
     displayName: 'Install Test Certificate'

--- a/build/AzurePipelinesTemplates/WindowsAppSDK-BuildProject-Steps.yml
+++ b/build/AzurePipelinesTemplates/WindowsAppSDK-BuildProject-Steps.yml
@@ -115,7 +115,7 @@ steps:
       vsVersion: 16.0
       platform: '$(buildPlatform)'
       configuration: '$(buildConfiguration)'
-      msbuildArgs: '/restore /p:AppxSymbolPackageEnabled=false /p:WindowsAppSDKVersionBuild=$(builddate_yymm) /p:WindowsAppSDKVersionRevision=$(builddate_dd)$(buildrevision) /p:VCToolsInstallDir="$(VCToolsInstallDir)\" /p:PGOBuildMode=$(PGOBuildMode) /p:WindowsAppSDKBuildPipeline=1'
+      msbuildArgs: '/restore /p:AppxSymbolPackageEnabled=false /binaryLogger:$(Build.SourcesDirectory)/${{ parameters.solutionPath }}.$(buildPlatform).$(buildConfiguration).binlog /p:WindowsAppSDKVersionBuild=$(builddate_yymm) /p:WindowsAppSDKVersionRevision=$(builddate_dd)$(buildrevision) /p:VCToolsInstallDir="$(VCToolsInstallDir)\" /p:PGOBuildMode=$(PGOBuildMode) /p:WindowsAppSDKBuildPipeline=1'
 
   - task: CmdLine@2
     displayName: 'Install Test Certificate'

--- a/build/CopyFilesToStagingDir.ps1
+++ b/build/CopyFilesToStagingDir.ps1
@@ -115,9 +115,6 @@ PublishFile $FullBuildOutput\DynamicDependencyLifetimeManager\DynamicDependencyL
 PublishFile $FullBuildOutput\DynamicDependencyLifetimeManager.ProxyStub\DynamicDependencyLifetimeManager.ProxyStub.dll $NugetDir\runtimes\win10-$Platform\native
 PublishFile $FullBuildOutput\DynamicDependencyLifetimeManager.ProxyStub\DynamicDependencyLifetimeManager.ProxyStub.pdb $NugetDir\runtimes\win10-$Platform\native
 #
-# .NET Assemblies
-PublishFile $FullBuildOutput\Microsoft.WindowsAppRuntime.Bootstrap.Net\Microsoft.WindowsAppRuntime.Bootstrap.Net.dll $NugetDir\lib\net5.0-windows10.0.18362.0
-#
 # Native (not managed, AppLocal / no MSIX)
 PublishFile $FullBuildOutput\WindowsAppRuntime_BootstrapDLL\Microsoft.WindowsAppRuntime.Bootstrap.dll $NugetDir\runtimes\lib\native\$Platform
 PublishFile $FullBuildOutput\WindowsAppRuntime_BootstrapDLL\Microsoft.WindowsAppRuntime.Bootstrap.pdb $NugetDir\runtimes\lib\native\$Platform

--- a/build/ProjectReunion-BuildFoundation.yml
+++ b/build/ProjectReunion-BuildFoundation.yml
@@ -113,7 +113,7 @@ jobs:
   pool: $(ProjectReunionBuildPool)
   timeoutInMinutes: 120
   variables:
-    buildPlatform: 'AnyCPU'
+    buildPlatform: 'Any CPU'
     buildConfiguration: 'Release'
     normalizedConfiguration: 'fre'
     PGOBuildMode: 'Optimize'

--- a/build/ProjectReunion-BuildFoundation.yml
+++ b/build/ProjectReunion-BuildFoundation.yml
@@ -104,8 +104,8 @@ jobs:
   - template: AzurePipelinesTemplates\WindowsAppSDK-PublishProjectOutput-Steps.yml
 
 - job: BuildAnyCPU
-  # Skip the build job if we are reusing the output of a previous build.
-  # useBuildOutputFromBuildId variable is set on the Pipeline at Queue time.
+  # For now, this job just builds Microsoft.WindowsAppRuntime.Bootstrap.Net.dll in AnyCPU
+  # Can be expanded to add any other binary as needed
   condition:
     eq(variables['useBuildOutputFromBuildId'],'')
   pool: $(ProjectReunionBuildPool)

--- a/build/ProjectReunion-BuildFoundation.yml
+++ b/build/ProjectReunion-BuildFoundation.yml
@@ -104,8 +104,6 @@ jobs:
   - template: AzurePipelinesTemplates\WindowsAppSDK-PublishProjectOutput-Steps.yml
 
 - job: BuildAnyCPU
-  dependsOn:
-    - Build
   # Skip the build job if we are reusing the output of a previous build.
   # useBuildOutputFromBuildId variable is set on the Pipeline at Queue time.
   condition:
@@ -131,55 +129,11 @@ jobs:
       command: 'custom'
       arguments: 'restore ${{ parameters.WindowsAppRuntimeInsightsSourceDirectory }}\packages.config -ConfigFile ${{ parameters.WindowsAppRuntimeInsightsSourceDirectory }}\nuget.config -PackagesDirectory ${{ parameters.WindowsAppRuntimeInsightsSourceDirectory }}\packages'
 
-  # Download and extract nuget package with non-stubbed MicrosoftTelemetry.h header
-#  - task: DownloadPackage@1
-#    displayName: 'Download Microsoft.Telemetry.Inbox.Native'
-#    inputs:
-#      feed: '/3415933f-ac0d-4766-8c0a-3f4c247c25f5'                         # 0
-#      view: 'ef61a1c1-003b-4a27-bde5-beec8301021b'                          # Release
-#      definition: '2fe60c09-c66f-4275-ae2d-f015c7170c72'                    # Microsoft.Telemetry.Inbox.Native
-#      version: '10.0.18362.1-190318-1202.19h1-release.amd64fre'             # latest version
-#      downloadPath: '$(System.DefaultWorkingDirectory)'                     # download and extract to repo root
-
-  # Replace the stubbed MicrosoftTelemetry.h with the real one
-  # Delete the existing stubbed MicrosoftTelemetry.h first, to ensure that if it is no longer at the expected path that the task, and build, fails
-#  - script: |
-#     del $(System.DefaultWorkingDirectory)\dev\telemetry\MicrosoftTelemetry.h
-#     move /Y $(System.DefaultWorkingDirectory)\build\native\inc\MicrosoftTelemetry.h $(System.DefaultWorkingDirectory)\dev\telemetry\
-#    failOnStderr: true
-#    displayName: 'Replace existing stubbed MicrosoftTelemetry.h header with the real version from the nuget package'
-
-  - template: AzurePipelinesTemplates\WindowsAppSDK-BuildDevProject-Steps.yml
-
-  - template: AzurePipelinesTemplates\WindowsAppSDK-PublishProjectOutput-Steps.yml
-
-
-# component detection must happen *within* the build task
-  - task: ms.vss-governance-buildtask.governance-build-task-component-detection.ComponentGovernanceComponentDetection@0
-
-  - task: BinSkim@3
+  - task: MSBuild@1
     inputs:
-      InputType: 'Basic'
-      Function: 'analyze'
-      AnalyzeTarget: '$(Build.ArtifactStagingDirectory)\*.dll;$(Build.ArtifactStagingDirectory)\*.exe'
-      AnalyzeVerbose: true
-  - task: PostAnalysis@1
-    inputs:
-      AllTools: false
-      APIScan: false
-      BinSkim: true
-      BinSkimBreakOn: 'Error'
-      CodesignValidation: false
-      CredScan: false
-      FortifySCA: false
-      FxCop: false
-      ModernCop: false
-      PoliCheck: false
-      RoslynAnalyzers: false
-      SDLNativeRules: false
-      Semmle: false
-      TSLint: false
-      ToolLogsNotFoundAction: 'Standard'
+      solution: 'dev\Bootstrap\CS\Microsoft.WindowsAppRuntime.Bootstrap.Net\Microsoft.WindowsAppRuntime.Bootstrap.Net.csproj'
+      msbuildVersion: 'latest' # Optional. Options: latest, 16.0, 15.0, 14.0, 12.0, 4.0
+      msbuildArchitecture: 'Any CPU' # Optional. Options: x86, x64
 
 - job: BuildMRT
   pool: $(ProjectReunionBuildPool)

--- a/build/ProjectReunion-BuildFoundation.yml
+++ b/build/ProjectReunion-BuildFoundation.yml
@@ -128,12 +128,14 @@ jobs:
     inputs:
       command: 'custom'
       arguments: 'restore ${{ parameters.WindowsAppRuntimeInsightsSourceDirectory }}\packages.config -ConfigFile ${{ parameters.WindowsAppRuntimeInsightsSourceDirectory }}\nuget.config -PackagesDirectory ${{ parameters.WindowsAppRuntimeInsightsSourceDirectory }}\packages'
+  
+  - template: WindowsAppSDK-BuildProject-Steps.yml
+    parameters:
+      solutionPath: 'dev\Bootstrap\CS\Microsoft.WindowsAppRuntime.Bootstrap.Net\Microsoft.WindowsAppRuntime.Bootstrap.Net.csproj'
+      nugetConfigPath: nuget.config
+      buildOutputDir: $(buildOutputDir)
+      publishDir: $(publishDir)
 
-  - task: MSBuild@1
-    inputs:
-      solution: 'dev\Bootstrap\CS\Microsoft.WindowsAppRuntime.Bootstrap.Net\Microsoft.WindowsAppRuntime.Bootstrap.Net.csproj'
-      msbuildVersion: 'latest' # Optional. Options: latest, 16.0, 15.0, 14.0, 12.0, 4.0
-      msbuildArchitecture: 'Any CPU' # Optional. Options: x86, x64
 
 - job: BuildMRT
   pool: $(ProjectReunionBuildPool)

--- a/build/ProjectReunion-BuildFoundation.yml
+++ b/build/ProjectReunion-BuildFoundation.yml
@@ -139,7 +139,7 @@ jobs:
   - task: CopyFiles@2
     displayName: 'Copy bootstrap.net.dll'
     inputs:
-      SourceFolder: '$(buildOutputDir)\$(Configuration)\$(Platform)\Microsoft.WindowsAppRuntime.Bootstrap.Net'
+      SourceFolder: '$(buildOutputDir)\$(buildConfiguration)\$(buildPlatform)\Microsoft.WindowsAppRuntime.Bootstrap.Net'
       Contents: |
         Microsoft.WindowsAppRuntime.Bootstrap.Net.dll
       TargetFolder: '$(Build.ArtifactStagingDirectory)\FullNuget\lib\net5.0-windows10.0.18362.0'

--- a/build/ProjectReunion-BuildFoundation.yml
+++ b/build/ProjectReunion-BuildFoundation.yml
@@ -137,20 +137,13 @@ jobs:
       publishDir: $(publishDir)
 
   - task: CopyFiles@2
-    displayName: 'copy projection binaries and symbols for signing'
-    condition: and(succeeded(), eq(variables['buildPlatform'], 'x86'))
+    displayName: 'Copy bootstrap.net.dll'
     inputs:
       SourceFolder: '$(buildOutputDir)\$(Configuration)\$(Platform)\Microsoft.WindowsAppRuntime.Bootstrap.Net'
       Contents: |
         Microsoft.WindowsAppRuntime.Bootstrap.Net.dll
       TargetFolder: '$(Build.ArtifactStagingDirectory)\FullNuget\lib\net5.0-windows10.0.18362.0'
       flattenFolders: false
-
-  - task: PublishBuildArtifacts@1
-    displayName: 'Publish artifact: $(artifactName)'
-    inputs:
-      PathtoPublish: '$(Build.ArtifactStagingDirectory)\$(artifactName)'
-      artifactName: $(artifactName)
 
   - task: PublishBuildArtifacts@1
     displayName: 'Publish artifact: Full Nuget (Windows App Runtime DLLs)'

--- a/build/ProjectReunion-BuildFoundation.yml
+++ b/build/ProjectReunion-BuildFoundation.yml
@@ -129,7 +129,7 @@ jobs:
       command: 'custom'
       arguments: 'restore ${{ parameters.WindowsAppRuntimeInsightsSourceDirectory }}\packages.config -ConfigFile ${{ parameters.WindowsAppRuntimeInsightsSourceDirectory }}\nuget.config -PackagesDirectory ${{ parameters.WindowsAppRuntimeInsightsSourceDirectory }}\packages'
   
-  - template: WindowsAppSDK-BuildProject-Steps.yml
+  - template: AzurePipelinesTemplates\WindowsAppSDK-BuildProject-Steps.yml
     parameters:
       solutionPath: 'dev\Bootstrap\CS\Microsoft.WindowsAppRuntime.Bootstrap.Net\Microsoft.WindowsAppRuntime.Bootstrap.Net.csproj'
       nugetConfigPath: nuget.config

--- a/build/ProjectReunion-BuildFoundation.yml
+++ b/build/ProjectReunion-BuildFoundation.yml
@@ -111,7 +111,7 @@ jobs:
   pool: $(ProjectReunionBuildPool)
   timeoutInMinutes: 120
   variables:
-    buildPlatform: 'Any CPU'
+    buildPlatform: 'anycpu'
     buildConfiguration: 'Release'
     normalizedConfiguration: 'fre'
     PGOBuildMode: 'Optimize'

--- a/build/ProjectReunion-BuildFoundation.yml
+++ b/build/ProjectReunion-BuildFoundation.yml
@@ -117,7 +117,7 @@ jobs:
     PGOBuildMode: 'Optimize'
     buildOutputDir : $(Build.SourcesDirectory)\BuildOutput
     publishDir : $(Build.ArtifactStagingDirectory)
-
+    artifactName: 'windowsappsdk_binaries'
   steps:
   - task: NuGetAuthenticate@0
     inputs:
@@ -136,6 +136,27 @@ jobs:
       buildOutputDir: $(buildOutputDir)
       publishDir: $(publishDir)
 
+  - task: CopyFiles@2
+    displayName: 'copy projection binaries and symbols for signing'
+    condition: and(succeeded(), eq(variables['buildPlatform'], 'x86'))
+    inputs:
+      SourceFolder: '$(buildOutputDir)\$(Configuration)\$(Platform)\Microsoft.WindowsAppRuntime.Bootstrap.Net'
+      Contents: |
+        Microsoft.WindowsAppRuntime.Bootstrap.Net.dll
+      TargetFolder: '$(Build.ArtifactStagingDirectory)\FullNuget\lib\net5.0-windows10.0.18362.0'
+      flattenFolders: false
+
+  - task: PublishBuildArtifacts@1
+    displayName: 'Publish artifact: ${{ parameters.artifactName }}'
+    inputs:
+      PathtoPublish: '$(Build.ArtifactStagingDirectory)\${{ parameters.artifactName }}'
+      artifactName: ${{ parameters.artifactName }}
+
+  - task: PublishBuildArtifacts@1
+    displayName: 'Publish artifact: Full Nuget (Windows App Runtime DLLs)'
+    inputs:
+      PathtoPublish: '$(Build.ArtifactStagingDirectory)\FullNuget'
+      artifactName: FullNuget
 
 - job: BuildMRT
   pool: $(ProjectReunionBuildPool)

--- a/build/ProjectReunion-BuildFoundation.yml
+++ b/build/ProjectReunion-BuildFoundation.yml
@@ -164,7 +164,7 @@ jobs:
       publishDir: $(publishDir)
 
   - task: CopyFiles@2
-    displayName: 'Copy bootstrap.net.dll'
+    displayName: 'Copy AnyCpu-built binaries'
     inputs:
       SourceFolder: '$(buildOutputDir)\$(buildConfiguration)\$(buildPlatform)\Microsoft.WindowsAppRuntime.Bootstrap.Net'
       Contents: |

--- a/build/ProjectReunion-BuildFoundation.yml
+++ b/build/ProjectReunion-BuildFoundation.yml
@@ -147,10 +147,10 @@ jobs:
       flattenFolders: false
 
   - task: PublishBuildArtifacts@1
-    displayName: 'Publish artifact: ${{ parameters.artifactName }}'
+    displayName: 'Publish artifact: $(artifactName)'
     inputs:
-      PathtoPublish: '$(Build.ArtifactStagingDirectory)\${{ parameters.artifactName }}'
-      artifactName: ${{ parameters.artifactName }}
+      PathtoPublish: '$(Build.ArtifactStagingDirectory)\$(artifactName)'
+      artifactName: $(artifactName)
 
   - task: PublishBuildArtifacts@1
     displayName: 'Publish artifact: Full Nuget (Windows App Runtime DLLs)'

--- a/build/ProjectReunion-BuildFoundation.yml
+++ b/build/ProjectReunion-BuildFoundation.yml
@@ -103,6 +103,57 @@ jobs:
 
   - template: AzurePipelinesTemplates\WindowsAppSDK-PublishProjectOutput-Steps.yml
 
+- job: BuildAnyCPU
+  dependsOn:
+    - Build
+  # Skip the build job if we are reusing the output of a previous build.
+  # useBuildOutputFromBuildId variable is set on the Pipeline at Queue time.
+  condition:
+    eq(variables['useBuildOutputFromBuildId'],'')
+  pool: $(ProjectReunionBuildPool)
+  timeoutInMinutes: 120
+  variables:
+    buildPlatform: 'AnyCPU'
+    buildConfiguration: 'Release'
+    normalizedConfiguration: 'fre'
+    PGOBuildMode: 'Optimize'
+    buildOutputDir : $(Build.SourcesDirectory)\BuildOutput
+    publishDir : $(Build.ArtifactStagingDirectory)
+
+  steps:
+  - task: NuGetAuthenticate@0
+    inputs:
+      nuGetServiceConnections: 'TelemetryInternal'
+
+  - task: 333b11bd-d341-40d9-afcf-b32d5ce6f23b@2
+    displayName: 'NuGet restore of packages'
+    inputs:
+      command: 'custom'
+      arguments: 'restore ${{ parameters.WindowsAppRuntimeInsightsSourceDirectory }}\packages.config -ConfigFile ${{ parameters.WindowsAppRuntimeInsightsSourceDirectory }}\nuget.config -PackagesDirectory ${{ parameters.WindowsAppRuntimeInsightsSourceDirectory }}\packages'
+
+  # Download and extract nuget package with non-stubbed MicrosoftTelemetry.h header
+#  - task: DownloadPackage@1
+#    displayName: 'Download Microsoft.Telemetry.Inbox.Native'
+#    inputs:
+#      feed: '/3415933f-ac0d-4766-8c0a-3f4c247c25f5'                         # 0
+#      view: 'ef61a1c1-003b-4a27-bde5-beec8301021b'                          # Release
+#      definition: '2fe60c09-c66f-4275-ae2d-f015c7170c72'                    # Microsoft.Telemetry.Inbox.Native
+#      version: '10.0.18362.1-190318-1202.19h1-release.amd64fre'             # latest version
+#      downloadPath: '$(System.DefaultWorkingDirectory)'                     # download and extract to repo root
+
+  # Replace the stubbed MicrosoftTelemetry.h with the real one
+  # Delete the existing stubbed MicrosoftTelemetry.h first, to ensure that if it is no longer at the expected path that the task, and build, fails
+#  - script: |
+#     del $(System.DefaultWorkingDirectory)\dev\telemetry\MicrosoftTelemetry.h
+#     move /Y $(System.DefaultWorkingDirectory)\build\native\inc\MicrosoftTelemetry.h $(System.DefaultWorkingDirectory)\dev\telemetry\
+#    failOnStderr: true
+#    displayName: 'Replace existing stubbed MicrosoftTelemetry.h header with the real version from the nuget package'
+
+  - template: AzurePipelinesTemplates\WindowsAppSDK-BuildDevProject-Steps.yml
+
+  - template: AzurePipelinesTemplates\WindowsAppSDK-PublishProjectOutput-Steps.yml
+
+
 # component detection must happen *within* the build task
   - task: ms.vss-governance-buildtask.governance-build-task-component-detection.ComponentGovernanceComponentDetection@0
 

--- a/build/ProjectReunion-BuildFoundation.yml
+++ b/build/ProjectReunion-BuildFoundation.yml
@@ -103,6 +103,33 @@ jobs:
 
   - template: AzurePipelinesTemplates\WindowsAppSDK-PublishProjectOutput-Steps.yml
 
+# component detection must happen *within* the build task
+  - task: ms.vss-governance-buildtask.governance-build-task-component-detection.ComponentGovernanceComponentDetection@0
+
+  - task: BinSkim@3
+    inputs:
+      InputType: 'Basic'
+      Function: 'analyze'
+      AnalyzeTarget: '$(Build.ArtifactStagingDirectory)\*.dll;$(Build.ArtifactStagingDirectory)\*.exe'
+      AnalyzeVerbose: true
+  - task: PostAnalysis@1
+    inputs:
+      AllTools: false
+      APIScan: false
+      BinSkim: true
+      BinSkimBreakOn: 'Error'
+      CodesignValidation: false
+      CredScan: false
+      FortifySCA: false
+      FxCop: false
+      ModernCop: false
+      PoliCheck: false
+      RoslynAnalyzers: false
+      SDLNativeRules: false
+      Semmle: false
+      TSLint: false
+      ToolLogsNotFoundAction: 'Standard'
+
 - job: BuildAnyCPU
   # For now, this job just builds Microsoft.WindowsAppRuntime.Bootstrap.Net.dll in AnyCPU
   # Can be expanded to add any other binary as needed

--- a/dev/Bootstrap/CS/Microsoft.WindowsAppRuntime.Bootstrap.Net/Microsoft.WindowsAppRuntime.Bootstrap.Net.csproj
+++ b/dev/Bootstrap/CS/Microsoft.WindowsAppRuntime.Bootstrap.Net/Microsoft.WindowsAppRuntime.Bootstrap.Net.csproj
@@ -4,7 +4,7 @@
     <TargetFramework>net5.0</TargetFramework>
     <TargetFramework>net5.0-windows10.0.19041.0</TargetFramework>
     <TargetPlatformMinVersion>10.0.17763.0</TargetPlatformMinVersion>
-    <Platforms>x86;x64;arm64</Platforms>
+    <Platforms>x86;x64;arm64;AnyCPU</Platforms>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">


### PR DESCRIPTION
Fix x86 and arm64 Helix tests failing to build because Microsoft.WindowsAppRuntime.Bootstrap.Net.dll is in Amd64.

There was a race condition in the build where there are three jobs for amd64, x86, arm64 that builds Foundation and which ever job copied this dll to the net5.0-windows10.0.18362.0 folder is the one that gets included in the final WindowsAppSDK. 
This PR fixes this issue and allows the tests in x86 and arm64 to compile against the binary.  