### PR TITLE
Move the native Bootstrap dll to play nice(r) with VS

### DIFF
--- a/build/CopyFilesToStagingDir.ps1
+++ b/build/CopyFilesToStagingDir.ps1
@@ -116,8 +116,8 @@ PublishFile $FullBuildOutput\DynamicDependencyLifetimeManager.ProxyStub\DynamicD
 PublishFile $FullBuildOutput\DynamicDependencyLifetimeManager.ProxyStub\DynamicDependencyLifetimeManager.ProxyStub.pdb $NugetDir\runtimes\win10-$Platform\native
 #
 # Native (not managed, AppLocal / no MSIX)
-PublishFile $FullBuildOutput\WindowsAppRuntime_BootstrapDLL\Microsoft.WindowsAppRuntime.Bootstrap.dll $NugetDir\runtimes\lib\native\$Platform
-PublishFile $FullBuildOutput\WindowsAppRuntime_BootstrapDLL\Microsoft.WindowsAppRuntime.Bootstrap.pdb $NugetDir\runtimes\lib\native\$Platform
+PublishFile $FullBuildOutput\WindowsAppRuntime_BootstrapDLL\Microsoft.WindowsAppRuntime.Bootstrap.dll $NugetDir\runtimes\win10-$(Platform)\native
+PublishFile $FullBuildOutput\WindowsAppRuntime_BootstrapDLL\Microsoft.WindowsAppRuntime.Bootstrap.pdb $NugetDir\runtimes\win10-$(Platform)\native
 #
 # Tools
 PublishFile $FullBuildOutput\WindowsAppRuntime_MSIXInstallFromPath\WindowsAppRuntime_MSIXInstallFromPath.exe $NugetDir\tools\$Platform

--- a/build/NuSpecs/Microsoft.WindowsAppSDK.Bootstrap.targets
+++ b/build/NuSpecs/Microsoft.WindowsAppSDK.Bootstrap.targets
@@ -10,7 +10,7 @@
   </PropertyGroup>
 
   <Target Name="BinPlaceBootstrapDll" Condition="'$(AppxPackage)' != 'true' and '$(OutputType)' != 'Library'" AfterTargets="Build">
-    <Copy SourceFiles="$(MSBuildThisFileDirectory)..\runtimes\lib\native\$(_WindowsAppSDKBootstrapPlatform)\Microsoft.WindowsAppRuntime.Bootstrap.dll" DestinationFolder="$(OutDir)" OverwriteReadOnlyFiles="true" ContinueOnError="false"/>
+    <Copy SourceFiles="$(MSBuildThisFileDirectory)..\runtimes\win10-$(_WindowsAppSDKBootstrapPlatform)\native\Microsoft.WindowsAppRuntime.Bootstrap.dll" DestinationFolder="$(OutDir)" OverwriteReadOnlyFiles="true" ContinueOnError="false"/>
   </Target>
 
 </Project>


### PR DESCRIPTION
Move the native bootstrap DLL to

**runtimes\win10-$(Platform)\native**\Microsoft.WindowsAppRuntime.Bootstrap.dll

and change build\nuspecs\Microsoft.WindowsAppSDK.Bootstrap.targets

```
<Copy SourceFiles="$(MSBuildThisFileDirectory)..\runtimes\lib\native\$(_WindowsAppSDKBootstrapPlatform)\Microsoft.WindowsAppRuntime.Bootstrap.dll" DestinationFolder="$(OutDir)" OverwriteReadOnlyFiles="true" ContinueOnError="false"/>
```

to

```
<Copy SourceFiles="$(MSBuildThisFileDirectory)..\runtimes\win10-$(_WindowsAppSDKBootstrapPlatform)\native\$(_WindowsAppSDKBootstrapPlatform)\Microsoft.WindowsAppRuntime.Bootstrap.dll" DestinationFolder="$(OutDir)" OverwriteReadOnlyFiles="true" ContinueOnError="false"/>
```

i.e. `runtimes\lib\native\$(_WindowsAppSDKBootstrapPlatform)` to `runtimes\win10-$(_WindowsAppSDKBootstrapPlatform)\native`