### PR TITLE
Update the "Microsoft.Internal.WinUI.Helix" package version to 0.5.4

### DIFF
--- a/build/AzurePipelinesTemplates/WindowsAppSDK-RunHelixTests-Job.yml
+++ b/build/AzurePipelinesTemplates/WindowsAppSDK-RunHelixTests-Job.yml
@@ -25,7 +25,7 @@ jobs:
     # This version number should be kept in sync with the value in these files:
     #   build\Helix\packages.config
     #   test\WindowsAppSDK.Helix.TestCommon\WindowsAppSDK.Helix.TestCommon.csproj
-    winUIHelixVer: 0.5.2
+    winUIHelixVer: 0.5.4
     winUIHelixPipelineScripts: build\Helix\packages\Microsoft.Internal.WinUI.Helix.$(winUIHelixVer)\scripts\pipeline
 
     # The target queues to run the tests on.

--- a/build/AzurePipelinesTemplates/WindowsAppSDK-RunHelixTests-Job.yml
+++ b/build/AzurePipelinesTemplates/WindowsAppSDK-RunHelixTests-Job.yml
@@ -17,7 +17,7 @@ jobs:
   condition: ${{ parameters.condition }}
   pool:
     vmImage: 'windows-2019'
-  timeoutInMinutes: 120
+  timeoutInMinutes: 80
   strategy:
     maxParallel: ${{ parameters.maxParallel }}
     matrix: ${{ parameters.matrix }}
@@ -157,6 +157,7 @@ jobs:
   - task: DotNetCoreCLI@2
     displayName: 'Run tests in Helix (open queues)'
     condition: and(succeeded(),eq(variables['System.CollectionUri'],'https://dev.azure.com/ms/'))
+    timeoutInMinutes: 45
     env:
       SYSTEM_ACCESSTOKEN: $(System.AccessToken)
     inputs:
@@ -168,6 +169,7 @@ jobs:
   - task: DotNetCoreCLI@2
     displayName: 'Run tests in Helix (closed queues)'
     condition: and(succeeded(),ne(variables['System.CollectionUri'],'https://dev.azure.com/ms/'))
+    timeoutInMinutes: 45
     env:
       SYSTEM_ACCESSTOKEN: $(System.AccessToken)
       HelixAccessToken: $(HelixApiAccessToken)
@@ -181,6 +183,7 @@ jobs:
   - task: powershell@2
     displayName: 'UpdateUnreliableTests.ps1'
     condition: succeededOrFailed()
+    timeoutInMinutes: 15
     env:
       SYSTEM_ACCESSTOKEN: $(System.AccessToken)
       HelixAccessToken: $(HelixApiAccessToken)
@@ -193,6 +196,7 @@ jobs:
   - task: powershell@2
     displayName: 'OutputTestResults.ps1'
     condition: succeededOrFailed()
+    timeoutInMinutes: 15
     env:
       SYSTEM_ACCESSTOKEN: $(System.AccessToken)
       HelixAccessToken: $(HelixApiAccessToken)
@@ -206,6 +210,7 @@ jobs:
   - task: powershell@2
     displayName: 'ProcessHelixFiles.ps1'
     condition: succeededOrFailed()
+    timeoutInMinutes: 15
     env:
       SYSTEM_ACCESSTOKEN: $(System.AccessToken)
       HelixAccessToken: $(HelixApiAccessToken)

--- a/build/Helix/packages.config
+++ b/build/Helix/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.Internal.WinUI.Helix" version="0.5.2" targetFramework="native" />
+  <package id="Microsoft.Internal.WinUI.Helix" version="0.5.4" targetFramework="native" />
 </packages>

--- a/test/WindowsAppSDK.Helix.TestCommon/WindowsAppSDK.Helix.TestCommon.csproj
+++ b/test/WindowsAppSDK.Helix.TestCommon/WindowsAppSDK.Helix.TestCommon.csproj
@@ -11,7 +11,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.7.0" />
     <PackageReference Include="Microsoft.Taef" Version="10.58.210222006-develop" />
-    <PackageReference Include="Microsoft.Internal.WinUI.Helix" Version="0.5.2" GeneratePathProperty="true" />
+    <PackageReference Include="Microsoft.Internal.WinUI.Helix" Version="0.5.4" GeneratePathProperty="true" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
This updates the "`Microsoft.Internal.WinUI.Helix`" package version to `0.5.4` to pick up the fix for the re-try logic when the Helix infra fails, causing endless timing out.

From my PR in the WinUI repo:

> We recently ran into an issue in `WindowsAppSDK` where the `ProcessHelixFiles.ps1` script was taking over ~2 hours to run (due to Helix infrastructure being down) as it never timed out / hit the maximum number of retries.
> Looking at the logs, the retry logic was never hitting the max attempts of 10 times to obtain the results from Helix.
> It turns out that these variables need to be explicitly referred to in the "global" scope, otherwise the individual functions end up redeclaring the same variable. (We want there to be a maximum number of retries overall for all functions.)
