### PR TITLE
Unconditionally restore vsext to Dev16 VSIX

### DIFF
--- a/dev/VSIX/Extension/Cpp/Dev16/WindowsAppSDK.Cpp.Extension.Dev16.csproj
+++ b/dev/VSIX/Extension/Cpp/Dev16/WindowsAppSDK.Cpp.Extension.Dev16.csproj
@@ -48,7 +48,7 @@
     <Content Include="$(RepoRoot)LICENSE">
       <IncludeInVSIX>true</IncludeInVSIX>
     </Content>
-    <Content Condition="'$(Deployment)'=='Standalone'" Include="ExtensionPack.vsext">
+    <Content Include="ExtensionPack.vsext">
       <IncludeInVSIX>true</IncludeInVSIX>
     </Content>
   </ItemGroup>

--- a/dev/VSIX/Extension/Cs/Dev16/WindowsAppSDK.Cs.Extension.Dev16.csproj
+++ b/dev/VSIX/Extension/Cs/Dev16/WindowsAppSDK.Cs.Extension.Dev16.csproj
@@ -48,7 +48,7 @@
     <Content Include="$(RepoRoot)LICENSE">
       <IncludeInVSIX>true</IncludeInVSIX>
     </Content>
-    <Content Condition="'$(Deployment)'=='Standalone'" Include="ExtensionPack.vsext">
+    <Content Include="ExtensionPack.vsext">
       <IncludeInVSIX>true</IncludeInVSIX>
     </Content>
   </ItemGroup>


### PR DESCRIPTION
#1482 removed the MSIX vsext from the Component extension, but this was mistakenly done for the Dev16 extension. The Dev16 extension doesn't have a component-specific build with a different filename, so it builds twice, with the Component clobbering the Standalone.

This reverts the part of #1482 that touched the Dev16 projects.

Long-term, we should tidy up this part of the build so we do less work (i.e. don't build Dev16 twice).