### PR TITLE
Update Calls to GetMrtPackagingOutput to follow the Project Reference protocol.

### DIFF
--- a/dev/MRTCore/packaging/MrtCore.PriGen.targets
+++ b/dev/MRTCore/packaging/MrtCore.PriGen.targets
@@ -1223,7 +1223,7 @@
       SkipNonexistentTargets="true"
       ContinueOnError="!$(BuildingProject)"
       RemoveProperties="%(_MSBuildProjectReferenceExistent.GlobalPropertiesToRemove)$(_GlobalPropertiesToRemoveFromProjectReferences)">
-      <Output TaskParameter="TargetOutputs" ItemName="_PackagingOutputsFromOtherProjects"/>
+      <Output TaskParameter="TargetOutputs" ItemName="_PackagingOutputsFromOtherUwpProjects"/>
     </MSBuild>
 
     <ItemGroup>

--- a/dev/MRTCore/packaging/MrtCore.PriGen.targets
+++ b/dev/MRTCore/packaging/MrtCore.PriGen.targets
@@ -1196,15 +1196,16 @@
     </PropertyGroup>
 
     <MSBuild
-      Projects="@(ProjectReferenceWithConfiguration)"
+      Projects="@(_MSBuildProjectReferenceExistent)"
       Targets="GetMrtPackagingOutputs"
       BuildInParallel="$(BuildInParallel)"
-      Properties="%(ProjectReferenceWithConfiguration.SetConfiguration); %(ProjectReferenceWithConfiguration.SetPlatform)"
-      Condition="'@(ProjectReferenceWithConfiguration)' != ''
-                 and '%(ProjectReferenceWithConfiguration.BuildReference)' == 'true'
-                 and '%(ProjectReferenceWithConfiguration.ReferenceOutputAssembly)' == 'true'"
+      Properties="%(_MSBuildProjectReferenceExistent.SetConfiguration); %(_MSBuildProjectReferenceExistent.SetPlatform); %(_MSBuildProjectReferenceExistent.SetTargetFramework)"
+      Condition="'@(_MSBuildProjectReferenceExistent)' != ''
+                 and '%(_MSBuildProjectReferenceExistent.BuildReference)' == 'true'
+                 and '%(_MSBuildProjectReferenceExistent.ReferenceOutputAssembly)' == 'true'"
       SkipNonexistentTargets="true"
-      ContinueOnError="$(_ContinueOnError)">
+      ContinueOnError="!$(BuildingProject)"
+      RemoveProperties="%(_MSBuildProjectReferenceExistent.GlobalPropertiesToRemove)$(_GlobalPropertiesToRemoveFromProjectReferences)">
       <Output TaskParameter="TargetOutputs" ItemName="_PackagingOutputsFromOtherMrtCoreProjects"/>
     </MSBuild>
 
@@ -1212,16 +1213,17 @@
          project is of type UWP, it'll have GetPackagingOutputs defined. So, try calling GetPackagingOutputs. If it does not exist,
          we simply no-op - see the SkipNonexistentTargets parameter below. -->
     <MSBuild
-      Projects="@(ProjectReferenceWithConfiguration)"
+      Projects="@(_MSBuildProjectReferenceExistent)"
       Targets="GetPackagingOutputs"
       BuildInParallel="$(BuildInParallel)"
-      Properties="%(ProjectReferenceWithConfiguration.SetConfiguration); %(ProjectReferenceWithConfiguration.SetPlatform)"
-      Condition="'@(ProjectReferenceWithConfiguration)' != ''
-                 and '%(ProjectReferenceWithConfiguration.BuildReference)' == 'true'
-                 and '%(ProjectReferenceWithConfiguration.ReferenceOutputAssembly)' == 'true'"
+      Properties="%(_MSBuildProjectReferenceExistent.SetConfiguration); %(_MSBuildProjectReferenceExistent.SetPlatform); %(_MSBuildProjectReferenceExistent.SetTargetFramework)"
+      Condition="'@(_MSBuildProjectReferenceExistent)' != ''
+                 and '%(_MSBuildProjectReferenceExistent.BuildReference)' == 'true'
+                 and '%(_MSBuildProjectReferenceExistent.ReferenceOutputAssembly)' == 'true'"
       SkipNonexistentTargets="true"
-      ContinueOnError="$(_ContinueOnError)">
-      <Output TaskParameter="TargetOutputs" ItemName="_PackagingOutputsFromOtherUwpProjects"/>
+      ContinueOnError="!$(BuildingProject)"
+      RemoveProperties="%(_MSBuildProjectReferenceExistent.GlobalPropertiesToRemove)$(_GlobalPropertiesToRemoveFromProjectReferences)">
+      <Output TaskParameter="TargetOutputs" ItemName="_PackagingOutputsFromOtherProjects"/>
     </MSBuild>
 
     <ItemGroup>


### PR DESCRIPTION
This PR updates the MSBuild calls inside GetMrtPackagingOutput to closer match the MSBuild project reference protocol as documented at https://github.com/dotnet/msbuild/blob/main/documentation/ProjectReference-Protocol.md and implemented by the ResolveProjectReferences target in https://github.com/dotnet/msbuild/blob/main/src/Tasks/Microsoft.Common.CurrentVersion.targets

- Update to use _MSBuildProjectReferenceExistent, which is what ResolveProjectReferences uses.
- Add SetTargetFramework to the Properties list, so packaging output from projects that do multi-targeting is correctly resolved.
- Respects _MSBuildProjectReferenceExistent.GlobalPropertiesToRemove.