### PR TITLE
Fix instancing mutex name generation to support multiple keys per app.

### DIFF
--- a/dev/AppLifecycle/AppInstance.cpp
+++ b/dev/AppLifecycle/AppInstance.cpp
@@ -398,7 +398,8 @@ namespace winrt::Microsoft::Windows::AppLifecycle::implementation
 
     bool AppInstance::TrySetKey(std::wstring const& key)
     {
-        std::wstring mutexName = m_moduleName + L"_Mutex";
+        auto escapedKey = std::regex_replace(key, std::wregex(L"\\\\"), L"_");
+        std::wstring mutexName = wil::str_printf<std::wstring>(L"%s_%s_Mutex", m_moduleName.c_str(), escapedKey.c_str());
 
         // We keep the mutex as a live member to ensure all other instances continue
         // to get an 'open' instead of a 'create' due to it already existing.

--- a/dev/WindowsAppRuntime_DLL/pch.h
+++ b/dev/WindowsAppRuntime_DLL/pch.h
@@ -18,7 +18,7 @@
 #include <mutex>
 #include <list>
 #include <stdexcept>
-
+#include <regex>
 #include <filesystem>
 
 #include <wil/cppwinrt.h>


### PR DESCRIPTION
The mutex used to synchronize key names was not properly including the key name in it.  This changes it so that the provided key is part of the unique named mutex, and that it is properly escaped to remove the backslash character.

