### PR TITLE
Updating WinUI C# project templates to target .NET 6 when building in Dev17

### DIFF
--- a/dev/VSIX/Extension/Cs/Dev16/WindowsAppSDK.Cs.Extension.Dev16.csproj
+++ b/dev/VSIX/Extension/Cs/Dev16/WindowsAppSDK.Cs.Extension.Dev16.csproj
@@ -26,6 +26,8 @@
     <UICulture>en-US</UICulture>
     <!-- This MUST match VSPackage.PackageGuidString -->
     <PackageGuidString>{B14EB1D0-DD99-4930-A232-23275B4F8ED6}</PackageGuidString>
+    <!-- Dev16 templates should target .NET 5 -->
+    <DotNetVersion>net5.0</DotNetVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' " />
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' " />

--- a/dev/VSIX/Extension/Cs/Dev17/WindowsAppSDK.Cs.Extension.Dev17.csproj
+++ b/dev/VSIX/Extension/Cs/Dev17/WindowsAppSDK.Cs.Extension.Dev17.csproj
@@ -25,6 +25,8 @@
     <TargetVsixContainerName>$(AssemblyName).$(Deployment).vsix</TargetVsixContainerName>
     <!-- This MUST match VSPackage.PackageGuidString -->
     <PackageGuidString>{B0F1BA01-DE66-4EF9-9C8B-DBB99FB4DA4B}</PackageGuidString>
+    <!-- Dev17 templates should target .NET 5 -->
+    <DotNetVersion>net6.0</DotNetVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' " />
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' " />

--- a/dev/VSIX/Extension/Directory.Build.targets
+++ b/dev/VSIX/Extension/Directory.Build.targets
@@ -213,7 +213,8 @@
 
     <PropertyGroup>
       <!-- XSL transform that we want to always run against .vstemplates -->
-      <_UnconditionalVsTemplateXslt><![CDATA[
+      <_UnconditionalVsTemplateXslt>
+            <![CDATA[
 <xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:ns="http://schemas.microsoft.com/developer/vstemplate/2005">
     <!-- Identity template to copy everything by default -->
     <xsl:template match="@*|node()">
@@ -266,6 +267,9 @@
     </xsl:template>
     <xsl:template match="/ns:VSTemplate/ns:TemplateContent/ns:CustomParameters/ns:CustomParameter[@Name='$WindowsSDKBuildToolsNupkgVersion$']/@Value">
         <xsl:attribute name="Value">$(WindowsSDKBuildToolsVersion)</xsl:attribute>
+    </xsl:template>
+    <xsl:template match="/ns:VSTemplate/ns:TemplateContent/ns:CustomParameters/ns:CustomParameter[@Name='$DotNetVersion$']/@Value">
+        <xsl:attribute name="Value">$(DotNetVersion)</xsl:attribute>
     </xsl:template>
 </xsl:stylesheet>
       ]]></_UnconditionalVsTemplateXslt>

--- a/dev/VSIX/ProjectTemplates/Desktop/CSharp/ClassLibrary/ProjectTemplate.csproj
+++ b/dev/VSIX/ProjectTemplates/Desktop/CSharp/ClassLibrary/ProjectTemplate.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net5.0-windows10.0.19041.0</TargetFramework>
+    <TargetFramework>$DotNetVersion$-windows10.0.19041.0</TargetFramework>
     <TargetPlatformMinVersion>10.0.17763.0</TargetPlatformMinVersion>
     <RootNamespace>$safeprojectname$</RootNamespace>
     <RuntimeIdentifiers>win10-x86;win10-x64;win10-arm64</RuntimeIdentifiers>

--- a/dev/VSIX/ProjectTemplates/Desktop/CSharp/ClassLibrary/WinUI.Desktop.Cs.ClassLibrary.vstemplate
+++ b/dev/VSIX/ProjectTemplates/Desktop/CSharp/ClassLibrary/WinUI.Desktop.Cs.ClassLibrary.vstemplate
@@ -29,6 +29,7 @@
     <CustomParameters>
       <CustomParameter Name="$WindowsAppSDKNupkgVersion$" Value="FIXME-Verify-Directory.Build.Targets-XmlPoke-Queries" />
       <CustomParameter Name="$WindowsSDKBuildToolsNupkgVersion$" Value="FIXME-Verify-Directory.Build.Targets-XmlPoke-Queries" />
+      <CustomParameter Name="$DotNetVersion$" Value="FIXME-Verify-Directory.Build.Targets-XmlPoke-Queries"/>
     </CustomParameters>
     <Project File="ProjectTemplate.csproj" ReplaceParameters="true">
       <ProjectItem ReplaceParameters="true" OpenInEditor="true">Class1.cs</ProjectItem>

--- a/dev/VSIX/ProjectTemplates/Desktop/CSharp/PackagedApp/BlankApp/ProjectTemplate.csproj
+++ b/dev/VSIX/ProjectTemplates/Desktop/CSharp/PackagedApp/BlankApp/ProjectTemplate.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
-    <TargetFramework>net5.0-windows10.0.19041.0</TargetFramework>
+    <TargetFramework>$ext_DotNetVersion$-windows10.0.19041.0</TargetFramework>
     <TargetPlatformMinVersion>10.0.17763.0</TargetPlatformMinVersion>
     <RootNamespace>$safeprojectname$</RootNamespace>
     <ApplicationManifest>app.manifest</ApplicationManifest>

--- a/dev/VSIX/ProjectTemplates/Desktop/CSharp/PackagedApp/WapProj/WapProjTemplate.wapproj
+++ b/dev/VSIX/ProjectTemplates/Desktop/CSharp/PackagedApp/WapProj/WapProjTemplate.wapproj
@@ -43,7 +43,7 @@
     <ProjectGuid>$guid1$</ProjectGuid>
     <TargetPlatformVersion>$targetplatformversion$</TargetPlatformVersion>
     <TargetPlatformMinVersion>$targetplatformminversion$</TargetPlatformMinVersion>
-    <AssetTargetFallback>net5.0-windows$(TargetPlatformVersion);$(AssetTargetFallback)</AssetTargetFallback>
+    <AssetTargetFallback>$ext_DotNetVersion$-windows$(TargetPlatformVersion);$(AssetTargetFallback)</AssetTargetFallback>
     <DefaultLanguage>$currentuiculturename$</DefaultLanguage>
     $if$($includeKeyFile$==true)
     <PackageCertificateKeyFile>$projectname$_TemporaryKey.pfx</PackageCertificateKeyFile>

--- a/dev/VSIX/ProjectTemplates/Desktop/CSharp/PackagedApp/WinUI.Desktop.Cs.PackagedApp.vstemplate
+++ b/dev/VSIX/ProjectTemplates/Desktop/CSharp/PackagedApp/WinUI.Desktop.Cs.PackagedApp.vstemplate
@@ -29,6 +29,7 @@
     <CustomParameters>
       <CustomParameter Name="$WindowsAppSDKNupkgVersion$" Value="FIXME-Verify-Directory.Build.Targets-XmlPoke-Queries" />
       <CustomParameter Name="$WindowsSDKBuildToolsNupkgVersion$" Value="FIXME-Verify-Directory.Build.Targets-XmlPoke-Queries" />
+      <CustomParameter Name="$DotNetVersion$" Value="FIXME-Verify-Directory.Build.Targets-XmlPoke-Queries"/>
     </CustomParameters>
     <ProjectCollection>
       <ProjectTemplateLink ProjectName="$projectname$ (Package)" CopyParameters="true">WapProj\WinUI.Desktop.Cs.WapProj.vstemplate</ProjectTemplateLink>

--- a/dev/VSIX/ProjectTemplates/Desktop/CSharp/SingleProjectPackagedApp/ProjectTemplate.csproj
+++ b/dev/VSIX/ProjectTemplates/Desktop/CSharp/SingleProjectPackagedApp/ProjectTemplate.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
-    <TargetFramework>net5.0-windows10.0.19041.0</TargetFramework>
+    <TargetFramework>$DotNetVersion$-windows10.0.19041.0</TargetFramework>
     <TargetPlatformMinVersion>10.0.17763.0</TargetPlatformMinVersion>
     <RootNamespace>$safeprojectname$</RootNamespace>
     <ApplicationManifest>app.manifest</ApplicationManifest>

--- a/dev/VSIX/ProjectTemplates/Desktop/CSharp/SingleProjectPackagedApp/WinUI.Desktop.Cs.SingleProjectPackagedApp.vstemplate
+++ b/dev/VSIX/ProjectTemplates/Desktop/CSharp/SingleProjectPackagedApp/WinUI.Desktop.Cs.SingleProjectPackagedApp.vstemplate
@@ -29,6 +29,7 @@
     <CustomParameters>
       <CustomParameter Name="$WindowsAppSDKNupkgVersion$" Value="FIXME-Verify-Directory.Build.Targets-XmlPoke-Queries" />
       <CustomParameter Name="$WindowsSDKBuildToolsNupkgVersion$" Value="FIXME-Verify-Directory.Build.Targets-XmlPoke-Queries" />
+      <CustomParameter Name="$DotNetVersion$" Value="FIXME-Verify-Directory.Build.Targets-XmlPoke-Queries"/>
     </CustomParameters>
     <Project File="ProjectTemplate.csproj" ReplaceParameters="true">
       <ProjectItem ReplaceParameters="true" TargetFileName="launchSettings.json">Properties\launchSettings.json</ProjectItem>


### PR DESCRIPTION
~~This pull request updates the WinUI C# project templates to target .NET 6 when the project is built in Dev17.  This is controlled by changing two MSBuild properties, `TargetFramework` and `AssetTargetFallback`, to reference a `net6.0` target framework moniker instead of `net5.0`.~~

~~Because the Dev16 and Dev17 VSIXs package the same project templates, we cannot change the emitted template based on whether the VSIX is for Dev16 or Dev17.  Instead, the .NET version determination is made at the created project's build-time, based on `VisualStudioVersion`.  If `VisualStudioVersion` is at least `17.0` (indicating we're building in Dev17 or later), the project uses the .NET 6 TFM - otherwise it uses the .NET 5 TFM.~~

_Note: the above description was for the initial implementation, which was replaced in favor of a [new approach](https://github.com/microsoft/WindowsAppSDK/pull/1581#issuecomment-941790045).  Leaving the original description above so the subsequent discussion makes sense._

This pull request updates new projects created via the VS2022 WinUI C# project templates to target .NET 6 instead of .NET 5, as VS2022 only ships with .NET 6 and the new project experience in VS2022 would be broken unless the developer had also installed .NET 5.  New projects created using the VS2019 WinUI C# project templates will continue to target .NET 5.

This is implemented by having the standalone C# VSIXs for VS2019 (`WindowsAppSDK.Cs.Extension.Dev16.csproj`) and VS2022 (`WindowsAppSDK.Cs.Extension.Dev17.csproj`) inject a custom parameter into the C# project templates .vsmanifests, similar to how the .vsmanifests are updated with the `Microsoft.WindowsAppSDK` NuGet package version they should reference.

