### PR TITLE
Explicitly control PackageVersion field layout

### DIFF
--- a/dev/Bootstrap/CS/Microsoft.WindowsAppRuntime.Bootstrap.Net/Bootstrap.cs
+++ b/dev/Bootstrap/CS/Microsoft.WindowsAppRuntime.Bootstrap.Net/Bootstrap.cs
@@ -12,10 +12,11 @@ namespace Microsoft.Windows.ApplicationModel.DynamicDependency
     [StructLayout(LayoutKind.Sequential)]
     public struct PackageVersion
     {
-        public ushort Major;
-        public ushort Minor;
-        public ushort Build;
+        // NOTE: MUST match memory layout of PACKAGE_VERSION in appmodel.h
         public ushort Revision;
+        public ushort Build;
+        public ushort Minor;
+        public ushort Major;
 
         // Create an instance with the value `major.0.0.0`.
         public PackageVersion(ushort major) :


### PR DESCRIPTION
The Bootstrapper's C# PackageVersion didn't specify a structure layout so C# could reorder fields. Add `[StructLayout(LayoutKind.Sequential)]` to explicitly control memory layout

https://task.ms/36680317