### PR TITLE
Added stdint.h to satisfy uint32_t references

### DIFF
--- a/dev/DynamicDependency/API/MsixDynamicDependency.h
+++ b/dev/DynamicDependency/API/MsixDynamicDependency.h
@@ -6,6 +6,8 @@
 
 #include <appmodel.h>
 
+#include <stdint.h>
+
 #include <TerminalVelocityFeatures-DynamicDependency.h>
 
 enum class MddCreatePackageDependencyOptions : uint32_t


### PR DESCRIPTION
`MsixDynamicDependency.h` (the Flat-C API) references `uin32_t` which is defined by `stdint.h`. Some problems don't compile as they don't happen to include stdint.h before the Dynamic Dependencies API. This ensures we compile as expected regardless what order headers are #include'd

Discovered by @AdamBraden  working on a Direct3D project

>I got errors trying to compile dynamic dependencies:
>
>Severity Code Description Project File Line Suppression State
>Error C3064 'uint32_t': must be a simple type or resolve to one D3D9ExSample E:\repos\direct3d\direct3d9ex\packages\Microsoft.WindowsAppSDK.1.0.0-20210924.20-CI\include\MsixDynamicDependency.h 12
>
>turns out the header is missing:
>
>#include <stdint.h>

https://task.ms/36531903