### PR TITLE
[Cherry-pick] Power Notifications Un-register Fix

### DIFF
--- a/dev/PowerNotifications/PowerNotifications.h
+++ b/dev/PowerNotifications/PowerNotifications.h
@@ -253,7 +253,8 @@ namespace winrt::Microsoft::Windows::System::Power
                 auto& eventObj{ fn.event() };
                 std::scoped_lock<std::mutex> lock(m_mutex);
                 eventObj.remove(token);
-                if (RegisteredForEvents(eventObj))
+                // If that was the last registration, remove the OS registration
+                if (!RegisteredForEvents(eventObj))
                 {
                     fn.unregisterListener();
                 }


### PR DESCRIPTION
Cherry-pick of https://github.com/microsoft/WindowsAppSDK/pull/1561
The existing code caused the unregister code to not be called. The code checked for existing registrations after removing the last one, instead of checking for no existing registrations.
The fix changes the test for existing events on the event object and if there aren't any, proceeds with un-registering from the FrameworkUDK code.