### PR TITLE
Cherrypick shiproom approved fixes to release/1.0-stable

### DIFF
--- a/dev/DynamicDependency/API/MsixDynamicDependency.h
+++ b/dev/DynamicDependency/API/MsixDynamicDependency.h
@@ -8,8 +8,6 @@
 
 #include <stdint.h>
 
-#include <TerminalVelocityFeatures-DynamicDependency.h>
-
 enum class MddCreatePackageDependencyOptions : uint32_t
 {
     None = 0,


### PR DESCRIPTION
Cherry-pick's from main to release/1.0-stable

Added stdint.h to satisfy uint32_t references #1597
commit 4e5aec8

Remove obsolete TerminalVelocity include for non-existent file #1598
commit b27662c