### PR TITLE
Fix bootstrap dll binplacement issues

### DIFF
--- a/build/NuSpecs/Microsoft.WindowsAppSDK.Foundation.props
+++ b/build/NuSpecs/Microsoft.WindowsAppSDK.Foundation.props
@@ -6,6 +6,8 @@
         If true, this is the WindowsAppSdk deployment of Foundation, versus the internal deployment for test only.
         This property is defined by deployment-specific props imports, and should not be overridden by clients.-->
     <WindowsAppSdkFoundation>true</WindowsAppSdkFoundation>
+    <_WindowsAppSDKFoundationPlatform Condition="'$(Platform)' == 'Win32'">x86</_WindowsAppSDKFoundationPlatform>
+    <_WindowsAppSDKFoundationPlatform Condition="'$(Platform)' != 'Win32'">$(Platform)</_WindowsAppSDKFoundationPlatform>
   </PropertyGroup>
 
   <!--
@@ -13,5 +15,9 @@
     property cannot be defined beforehand.
   -->
   <Import Project="$(MSBuildThisFileDirectory)MrtCore.props" />
+
+  <ItemGroup Condition="'$(AppxPackage)' != 'true'">
+    <ReferenceCopyLocalPaths Include="$(MSBuildThisFileDirectory)..\runtimes\lib\native\$(_WindowsAppSDKFoundationPlatform)\Microsoft.WindowsAppRuntime.Bootstrap.dll"/>
+  </ItemGroup>
 
 </Project>

--- a/build/NuSpecs/WindowsAppSDK-Nuget-Native.C.props
+++ b/build/NuSpecs/WindowsAppSDK-Nuget-Native.C.props
@@ -1,11 +1,6 @@
 ﻿<!-- Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT License. See LICENSE in the project root for license information. -->
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 
-  <PropertyGroup>
-    <_WindowsAppSDKFoundationPlatform Condition="'$(Platform)' == 'Win32'">x86</_WindowsAppSDKFoundationPlatform>
-    <_WindowsAppSDKFoundationPlatform Condition="'$(Platform)' != 'Win32'">$(Platform)</_WindowsAppSDKFoundationPlatform>
-  </PropertyGroup>
-
   <ItemDefinitionGroup>
     <ClCompile>
       <AdditionalIncludeDirectories>$(MSBuildThisFileDirectory)..\..\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
@@ -28,9 +23,6 @@
         %(AdditionalDependencies);
       </AdditionalDependencies>
     </Link>
-    <PostBuildEvent>
-      <Command>xcopy /y "$(MSBuildThisFileDirectory)..\..\runtimes\lib\native\$(_WindowsAppSDKFoundationPlatform)\Microsoft.WindowsAppRuntime.Bootstrap.dll" "$(OutDir)"</Command>
-    </PostBuildEvent>
   </ItemDefinitionGroup>
 
 </Project>


### PR DESCRIPTION
Always binplace bootstrap dll for unpackaged, not just native, and use ReferenceCopyLocalPaths instead of post build step