### PR TITLE
Reunion VSIX: Update title of "Blank App, Packaged with WAP" project type

### DIFF
--- a/dev/VSIX/Extension/Cpp/Common/VSPackage.resx
+++ b/dev/VSIX/Extension/Cpp/Common/VSPackage.resx
@@ -186,10 +186,10 @@
     <value>A user control for apps based on the Windows UI Library (WinUI 3).</value>
   </data>
   <data name="1025" xml:space="preserve">
-    <value>Blank App, Packaged with Windows Packaging Project (WinUI 3 in Desktop)</value>
+    <value>Blank App, Packaged with Windows Application Packaging Project (WinUI 3 in Desktop)</value>
   </data>
   <data name="1026" xml:space="preserve">
-    <value>[Experimental] Blank App, Packaged with Windows Packaging Project (WinUI 3 in Desktop)</value>
+    <value>[Experimental] Blank App, Packaged with Windows Application Packaging Project (WinUI 3 in Desktop)</value>
   </data>
   <data name="1027" xml:space="preserve">
     <value>A project template for creating a Desktop app based on the Windows UI Library (WinUI 3). A Windows Application Packaging (WAP) project is included to create a MSIX package for side-loading or distribution via the Microsoft Store.</value>

--- a/dev/VSIX/Extension/Cs/Common/VSPackage.resx
+++ b/dev/VSIX/Extension/Cs/Common/VSPackage.resx
@@ -195,10 +195,10 @@
     <value>A project for creating a managed class library (.dll) for Desktop apps based on the Windows UI Library (WinUI 3).</value>
   </data>
   <data name="1029" xml:space="preserve">
-    <value>Blank App, Packaged with Windows Packaging Project (WinUI 3 in Desktop)</value>
+    <value>Blank App, Packaged with Windows Application Packaging Project (WinUI 3 in Desktop)</value>
   </data>
   <data name="1030" xml:space="preserve">
-    <value>[Experimental] Blank App, Packaged with Windows Packaging Project (WinUI 3 in Desktop)</value>
+    <value>[Experimental] Blank App, Packaged with Windows Application Packaging Project (WinUI 3 in Desktop)</value>
   </data>
   <data name="1031" xml:space="preserve">
     <value>A project template for creating a Desktop app based on the Windows UI Library (WinUI 3). A Windows Application Packaging (WAP) project is included to create a MSIX package for side-loading or distribution via the Microsoft Store.</value>


### PR DESCRIPTION
Update the Visual Studio template title to "Blank App, Packaged with Windows Packaging Project (WinUI 3 in Desktop)" to avoid using "WAP".  (Tracked by an internal bug.)

This is the associated localization change: 

TDBuild - updating localized resource files. · microsoft/WindowsAppSDK@a03cec3 (github.com)