### PR TITLE
use MetaDataGetDispenser

### DIFF
--- a/dev/UndockedRegFreeWinRT/catalog.cpp
+++ b/dev/UndockedRegFreeWinRT/catalog.cpp
@@ -405,6 +405,9 @@ HRESULT WinRTGetMetadataFile(
     // will create an instance of the metadata reader to dispense metadata files.
     if (metaDataDispenser == nullptr)
     {
+        // Avoid using CoCreateInstance here, which will trigger a Feature-On-Demand (FOD) 
+        // installation request of .NET Framework 3.5 if it's not already installed. In the
+        // mean time, Windows App SDK runtime doesn't need .NET Framework 3.5.
         RETURN_IF_FAILED(MetaDataGetDispenser(CLSID_CorMetaDataDispenser,
             IID_IMetaDataDispenser,
             &spMetaDataDispenser));


### PR DESCRIPTION
CoCreateInstance(CLSID_CorMetaDataDispenser) will trigger a runtime check, and request a FOD installation of .net framework 3.5 if it's not installed. The net result is when you launch an unpackaged WinUI3 app on machine without .net framework 3.5 installed, it will pop up a window asking you to install. You can choose skip without any harm. Then next time you will be greeted with this again. Replacing CoCreateInstance with MetaDataGetDispenser eliminates this annoyance.