### PR TITLE
User/aeloros/wait_crash_gacp

### DIFF
--- a/dev/AppLifecycle/AppInstance.cpp
+++ b/dev/AppLifecycle/AppInstance.cpp
@@ -124,25 +124,23 @@ namespace winrt::Microsoft::Windows::AppLifecycle::implementation
             m_instanceHandle.reset(OpenProcess(SYNCHRONIZE, FALSE, processId));
 
             // Create a monitor thread to handle cleaning up this instance if the backing process terminates.
-            auto onInstanceTerminated = [weak_this]
+            auto onInstanceTerminated = [](_In_ void* context, _In_ BOOLEAN /*reason*/) -> void
             {
-                auto strong_this{ weak_this.get() };
-                if (strong_this)
-                {
-                    strong_this->OnInstanceTerminated();
-                }
+                uint32_t processId{ static_cast<uint32_t>(reinterpret_cast<size_t>(context)) };
+                GetCurrent().as<AppInstance>()->RemoveInstance(processId);
             };
 
-            m_terminationWatcher.create(m_instanceHandle.get(), onInstanceTerminated);
+            THROW_IF_WIN32_BOOL_FALSE(RegisterWaitForSingleObject(&m_terminationWatcherWaitHandle, m_instanceHandle.get(), onInstanceTerminated,
+                reinterpret_cast<void*>(static_cast<size_t>(m_processId)), INFINITE, WT_EXECUTEONLYONCE));
         }
 
         m_redirectionArgs.Init(m_processName + L"_RedirectionQueue");
     }
 
-    void AppInstance::OnInstanceTerminated()
+    void AppInstance::RemoveInstance(uint32_t processId)
     {
         auto releaseOnExit = m_dataMutex.acquire();
-        m_instances.Remove(m_processId);
+        m_instances.Remove(processId);
     }
 
     GUID AppInstance::DequeueRedirectionRequestId()

--- a/test/TestApps/ManualTestApp/ManualTestApp.rc
+++ b/test/TestApps/ManualTestApp/ManualTestApp.rc
@@ -1,0 +1,76 @@
+// Microsoft Visual C++ generated resource script.
+//
+#include "resource.h"
+
+#define APSTUDIO_READONLY_SYMBOLS
+/////////////////////////////////////////////////////////////////////////////
+//
+// Generated from the TEXTINCLUDE 2 resource.
+//
+#include "winres.h"
+
+/////////////////////////////////////////////////////////////////////////////
+#undef APSTUDIO_READONLY_SYMBOLS
+
+/////////////////////////////////////////////////////////////////////////////
+// English (United States) resources
+
+#if !defined(AFX_RESOURCE_DLL) || defined(AFX_TARG_ENU)
+LANGUAGE LANG_ENGLISH, SUBLANG_ENGLISH_US
+#pragma code_page(1252)
+
+#ifdef APSTUDIO_INVOKED
+/////////////////////////////////////////////////////////////////////////////
+//
+// TEXTINCLUDE
+//
+
+1 TEXTINCLUDE 
+BEGIN
+    "resource.h\0"
+END
+
+2 TEXTINCLUDE 
+BEGIN
+    "#include ""winres.h""\r\n"
+    "\0"
+END
+
+3 TEXTINCLUDE 
+BEGIN
+    "\r\n"
+    "\0"
+END
+
+#endif    // APSTUDIO_INVOKED
+
+
+/////////////////////////////////////////////////////////////////////////////
+//
+// Menu
+//
+
+IDM_FILE_MENU MENU
+BEGIN
+    POPUP "&File"
+    BEGIN
+        MENUITEM "&GetInstances",               IDM_FILE_GETINSTANCES
+        MENUITEM "E&xit",                       IDM_FILE_EXIT
+    END
+END
+
+#endif    // English (United States) resources
+/////////////////////////////////////////////////////////////////////////////
+
+
+
+#ifndef APSTUDIO_INVOKED
+/////////////////////////////////////////////////////////////////////////////
+//
+// Generated from the TEXTINCLUDE 3 resource.
+//
+
+
+/////////////////////////////////////////////////////////////////////////////
+#endif    // not APSTUDIO_INVOKED
+

--- a/test/TestApps/ManualTestApp/ManualTestApp.vcxproj
+++ b/test/TestApps/ManualTestApp/ManualTestApp.vcxproj
@@ -320,6 +320,7 @@
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="pch.h" />
+    <ClInclude Include="resource.h" />
   </ItemGroup>
   <ItemGroup>
     <None Include="packages.config" />
@@ -334,6 +335,9 @@
     <ProjectReference Include="..\..\..\dev\WindowsAppRuntime_BootstrapDLL\WindowsAppRuntime_BootstrapDLL.vcxproj">
       <Project>{f76b776e-86f5-48c5-8fc7-d2795ecc9746}</Project>
     </ProjectReference>
+  </ItemGroup>
+  <ItemGroup>
+    <ResourceCompile Include="ManualTestApp.rc" />
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">

--- a/test/TestApps/ManualTestApp/main.cpp
+++ b/test/TestApps/ManualTestApp/main.cpp
@@ -9,6 +9,7 @@ using namespace winrt;
 using namespace winrt::Windows::Storage;
 using namespace winrt::Windows::Storage::Streams;
 using namespace winrt::Windows::Foundation;
+using namespace winrt::Windows::Foundation::Collections;
 using namespace winrt::Windows::ApplicationModel::Activation;
 using namespace winrt::Microsoft::Windows::AppLifecycle;
 
@@ -16,6 +17,7 @@ using namespace std::chrono;
 
 HWND g_window = NULL;
 wchar_t g_windowClass[] = L"TestWndClass"; // the main window class name
+IVector<AppInstance> g_instances;
 
 ATOM _RegisterClass(HINSTANCE hInstance);
 BOOL InitInstance(HINSTANCE, int);
@@ -97,6 +99,7 @@ int main()
 
     THROW_IF_FAILED(BootstrapInitialize());
 
+    bool isSingleInstanced = false;
     std::wstring key{ L"derp.txt" };
     AppInstance::Activated_revoker token;
 
@@ -105,6 +108,7 @@ int main()
     {
         auto fileArgs = args.Data().as<winrt::Windows::ApplicationModel::Activation::FileActivatedEventArgs>();
         key = fileArgs.Files().GetAt(0).Path();
+        isSingleInstanced = true;
     }
 
     if (args.Kind() == ExtendedActivationKind::Launch)
@@ -124,7 +128,7 @@ int main()
     }
 
     AppInstance keyInstance = AppInstance::FindOrRegisterForKey(key.c_str());
-    if (!keyInstance.IsCurrent())
+    if (isSingleInstanced && !keyInstance.IsCurrent())
     {
         keyInstance.RedirectActivationToAsync(args).get();
     }
@@ -163,6 +167,11 @@ int main()
     return 0;
 }
 
+void RunGetInstancesTest()
+{
+    g_instances = AppInstance::GetInstances();
+}
+
 ATOM _RegisterClass(HINSTANCE hInstance)
 {
     WNDCLASSEX wcex = {};
@@ -176,6 +185,7 @@ ATOM _RegisterClass(HINSTANCE hInstance)
     wcex.hInstance = hInstance;
     wcex.hCursor = LoadCursor(NULL, IDC_ARROW);
     wcex.lpszClassName = g_windowClass;
+    wcex.lpszMenuName = MAKEINTRESOURCE(IDM_FILE_MENU);
 
     return RegisterClassEx(&wcex);
 }
@@ -202,6 +212,19 @@ LRESULT CALLBACK WndProc(HWND hWnd, UINT message, WPARAM wParam, LPARAM lParam)
 
     switch (message)
     {
+    case WM_COMMAND:
+        switch (LOWORD(wParam))
+        {
+        case IDM_FILE_EXIT:
+            PostQuitMessage(0);
+            break;
+
+        case IDM_FILE_GETINSTANCES:
+            RunGetInstancesTest();
+            break;
+        }
+        break;
+
     case WM_PAINT:
         hdc = BeginPaint(hWnd, &ps);
         EndPaint(hWnd, &ps);

--- a/test/TestApps/ManualTestApp/pch.h
+++ b/test/TestApps/ManualTestApp/pch.h
@@ -15,3 +15,5 @@
 #include <winrt/Windows.Storage.h>
 #include <winrt/Windows.Storage.Streams.h>
 #include <winrt/Microsoft.Windows.AppLifecycle.h>
+
+#include "resource.h"

--- a/test/TestApps/ManualTestApp/resource.h
+++ b/test/TestApps/ManualTestApp/resource.h
@@ -1,0 +1,18 @@
+﻿//{{NO_DEPENDENCIES}}
+// Microsoft Visual C++ generated include file.
+// Used by ManualTestApp.rc
+//
+#define IDM_FILE_MENU                   101
+#define IDM_FILE_GETINSTANCES           40001
+#define IDM_FILE_EXIT                   40002
+
+// Next default values for new objects
+// 
+#ifdef APSTUDIO_INVOKED
+#ifndef APSTUDIO_READONLY_SYMBOLS
+#define _APS_NEXT_RESOURCE_VALUE        102
+#define _APS_NEXT_COMMAND_VALUE         40006
+#define _APS_NEXT_CONTROL_VALUE         1001
+#define _APS_NEXT_SYMED_VALUE           101
+#endif
+#endif


### PR DESCRIPTION
* Convert to using RegisterWaitForSingleObject since unique_event_watcher doesn't support non-event waitable kernel objects.

* Updated test to exercise multiinstancing management.