### PR TITLE
Notify the Shell when association data changes.

### DIFF
--- a/dev/AppLifecycle/ActivationRegistrationManager.cpp
+++ b/dev/AppLifecycle/ActivationRegistrationManager.cpp
@@ -63,6 +63,9 @@ namespace winrt::Microsoft::Windows::AppLifecycle::implementation
 
             RegisterAssociationHandler(appId, fileType.c_str(), type);
         }
+
+        // Notify Shell that an association has changed.
+        NotifyShellAssocChanged();
     }
 
     void ActivationRegistrationManager::RegisterForProtocolActivation(hstring const& schemeName,
@@ -73,6 +76,9 @@ namespace winrt::Microsoft::Windows::AppLifecycle::implementation
 
         RegisterForProtocolActivationInternal(schemeName.c_str(), L"", logo.c_str(),
             displayName.c_str(), exePath.c_str());
+
+        // Notify Shell that an association has changed.
+        NotifyShellAssocChanged();
     }
 
     void ActivationRegistrationManager::RegisterForStartupActivation(hstring const& taskId,
@@ -112,6 +118,9 @@ namespace winrt::Microsoft::Windows::AppLifecycle::implementation
             UnregisterAssociationHandler(appId, fileType.c_str(), type);
             UnregisterProgId(progId);
         }
+
+        // Notify Shell that an association has changed.
+        NotifyShellAssocChanged();
     }
 
     void ActivationRegistrationManager::UnregisterForProtocolActivation(hstring const& schemeName,
@@ -125,6 +134,9 @@ namespace winrt::Microsoft::Windows::AppLifecycle::implementation
         auto progId = ComputeProgId(appId, type);
         UnregisterAssociationHandler(appId, schemeName.c_str(), type);
         UnregisterProgId(progId);
+
+        // Notify Shell that an association has changed.
+        NotifyShellAssocChanged();
     }
 
     void ActivationRegistrationManager::UnregisterForStartupActivation(hstring const& taskId)

--- a/dev/AppLifecycle/Association.cpp
+++ b/dev/AppLifecycle/Association.cpp
@@ -461,4 +461,9 @@ namespace winrt::Microsoft::Windows::AppLifecycle::implementation
             }
         }
     }
+
+    void NotifyShellAssocChanged()
+    {
+        SHChangeNotify(SHCNE_ASSOCCHANGED, SHCNF_IDLIST, 0, 0);
+    }
 }

--- a/dev/AppLifecycle/Association.cpp
+++ b/dev/AppLifecycle/Association.cpp
@@ -464,6 +464,6 @@ namespace winrt::Microsoft::Windows::AppLifecycle::implementation
 
     void NotifyShellAssocChanged()
     {
-        SHChangeNotify(SHCNE_ASSOCCHANGED, SHCNF_IDLIST, 0, 0);
+        SHChangeNotify(SHCNE_ASSOCCHANGED, SHCNF_IDLIST, nullptr, nullptr);
     }
 }

--- a/dev/AppLifecycle/Association.h
+++ b/dev/AppLifecycle/Association.h
@@ -64,4 +64,5 @@ namespace winrt::Microsoft::Windows::AppLifecycle::implementation
         AssociationType type);
     void UnregisterAssociationHandler(const std::wstring& handlerAppId, const std::wstring& association,
         AssociationType type);
+    void NotifyShellAssocChanged();
 }

--- a/dev/WindowsAppRuntime_DLL/pch.h
+++ b/dev/WindowsAppRuntime_DLL/pch.h
@@ -5,6 +5,7 @@
 #include <Windows.h>
 #include <assert.h>
 #include <unknwn.h>
+#include <ShlObj_core.h>
 #include <ShObjIdl_core.h>
 #include <shlguid.h>
 #include <shlwapi.h>


### PR DESCRIPTION
When changes happen to associations, the shell must be notified.  If it is not, then it may take a long time to show updated icons or other resources from the registration change.  This updates the AppLifecycle APIs to automatically notify the shell every time a registration happens.