### PR TITLE
feat: Added global:: to MddBootstrapAutoInitializer.

### DIFF
--- a/dev/WindowsAppRuntime_BootstrapDLL/MddBootstrapAutoInitializer.cs
+++ b/dev/WindowsAppRuntime_BootstrapDLL/MddBootstrapAutoInitializer.cs
@@ -1,23 +1,19 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
-using System.Runtime.CompilerServices;
-using Microsoft.WindowsAppSDK;
-using Microsoft.WindowsAppSDK.Runtime;
-
 namespace Microsoft.Windows.ApplicationModel.DynamicDependency.BootstrapCS
 {
     class AutoInitialize
     {
-        [ModuleInitializer]
+        [global::System.Runtime.CompilerServices.ModuleInitializer]
         internal static void AccessWindowsAppSDK()
         {
-            uint majorMinorVersion = Release.MajorMinor;
-            string versionTag = Release.VersionTag;
-            var minVersion = new PackageVersion(Version.UInt64);
+            uint majorMinorVersion = global::Microsoft.WindowsAppSDK.Release.MajorMinor;
+            string versionTag = global::Microsoft.WindowsAppSDK.Release.VersionTag;
+            var minVersion = new PackageVersion(global::Microsoft.WindowsAppSDK.Runtime.Version.UInt64);
             try
             {
-                Bootstrap.Initialize(majorMinorVersion, versionTag, minVersion);
+                global::Microsoft.Windows.ApplicationModel.DynamicDependency.Bootstrap.Initialize(majorMinorVersion, versionTag, minVersion);
             }
             catch (global::System.Exception e)
             {


### PR DESCRIPTION
to support `ImplicitUsings` and fix a bug with the intersection of `Microsoft.WindowsAppSDK.Runtime.Version` with `System.Version`.

Fixes #1686 