### PR TITLE
Fix inline PowerShell to support multiple traceloggingconfig.h files from different WIL versions.

### DIFF
--- a/build/AzurePipelinesTemplates/WindowsAppSDK-BuildProject-Steps.yml
+++ b/build/AzurePipelinesTemplates/WindowsAppSDK-BuildProject-Steps.yml
@@ -112,7 +112,8 @@ steps:
 
           if (($destinationPaths -ne $null)) {
             foreach ($destPath in $destinationPaths) {
-              Write-Host 'SourcePath:' $srcPath.FullName $destPath.FullName
+              Write-Host 'SourcePath:' $srcPath.FullName
+              Write-Host 'DestinationPath:' $destPath.FullName
               Copy-Item -Force $srcPath.FullName $destPath.FullName
             }
           }

--- a/build/AzurePipelinesTemplates/WindowsAppSDK-BuildProject-Steps.yml
+++ b/build/AzurePipelinesTemplates/WindowsAppSDK-BuildProject-Steps.yml
@@ -108,11 +108,13 @@ steps:
         $srcPath = Get-Childitem -Path 'dev\WindowsAppRuntime_Insights\packages' -File 'MicrosoftTelemetry.h' -Recurse
         
         if (($srcPath -ne $null)){
-          $destinationPath = Get-Childitem -Path 'packages' -File 'Traceloggingconfig.h' -Recurse
+          $destinationPaths = Get-Childitem -Path 'packages' -File 'Traceloggingconfig.h' -Recurse
 
-          if (($destinationPath -ne $null)){
-            Write-Host 'SourcePath:' $srcPath.FullName $destinationPath.FullName
-            Copy-Item -Force $srcPath.FullName $destinationPath.FullName
+          if (($destinationPaths -ne $null)) {
+            foreach ($destPath in $destinationPaths) {
+              Write-Host 'SourcePath:' $srcPath.FullName $destPath.FullName
+              Copy-Item -Force $srcPath.FullName $destPath.FullName
+            }
           }
         }
 


### PR DESCRIPTION
If there are multiple `traceloggingconfig.h` files from different package versions of WIL, then the script fails as it only expects there to be one `traceloggingconfig.h` file.

Instead, replace all of the files with the one from `microsofttelemetry.h`