### PR TITLE
Unpackaged Windows App SDK app doesn't run on RS5/19H1 (#1681)

### DIFF
--- a/WindowsAppRuntime.sln
+++ b/WindowsAppRuntime.sln
@@ -80,6 +80,9 @@ EndProject
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "DynamicDependencyLifetimeManager", "dev\DynamicDependencyLifetimeManager\DynamicDependencyLifetimeManager\DynamicDependencyLifetimeManager.vcxproj", "{2E5BF0D2-78FA-4B60-A341-F65A0D58BD86}"
 EndProject
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "DynamicDependencyLifetimeManager.Msix", "test\DynamicDependency\data\DynamicDependencyLifetimeManager.Msix\DynamicDependencyLifetimeManager.Msix.vcxproj", "{A7391725-4EF5-438F-8DE1-645423E46955}"
+	ProjectSection(ProjectDependencies) = postProject
+		{6539E9E1-BF36-40E5-86BC-070E99DB7B7B} = {6539E9E1-BF36-40E5-86BC-070E99DB7B7B}
+	EndProjectSection
 EndProject
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "DynamicDependencyLifetimeManager.ProxyStub", "dev\DynamicDependencyLifetimeManager\DynamicDependencyLifetimeManager.ProxyStub\DynamicDependencyLifetimeManager.ProxyStub.vcxproj", "{8C79C46D-1577-44CA-83DF-88B74C3E4586}"
 EndProject
@@ -236,6 +239,8 @@ EndProject
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "WindowsAppRuntime_MSIXInstallFromPath", "dev\WindowsAppRuntime_MSIXInstallFromPath\WindowsAppRuntime_MSIXInstallFromPath.vcxproj", "{D45D4170-E055-4926-8B03-04DAA5F02C6C}"
 EndProject
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "Framework.Widgets", "test\DynamicDependency\data\Framework.Widgets\Framework.Widgets.vcxproj", "{09DDAE21-397F-4263-8561-7F2FF28127CF}"
+EndProject
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "DynamicDependencyLifetimeManagerShadow", "dev\DynamicDependency\DynamicDependencyLifetimeManagerShadow\DynamicDependencyLifetimeManagerShadow.vcxproj", "{6539E9E1-BF36-40E5-86BC-070E99DB7B7B}"
 EndProject
 Global
 	GlobalSection(SharedMSBuildProjectFiles) = preSolution
@@ -885,6 +890,20 @@ Global
 		{09DDAE21-397F-4263-8561-7F2FF28127CF}.Release|x64.Build.0 = Release|x64
 		{09DDAE21-397F-4263-8561-7F2FF28127CF}.Release|x86.ActiveCfg = Release|Win32
 		{09DDAE21-397F-4263-8561-7F2FF28127CF}.Release|x86.Build.0 = Release|Win32
+		{6539E9E1-BF36-40E5-86BC-070E99DB7B7B}.Debug|Any CPU.ActiveCfg = Debug|Win32
+		{6539E9E1-BF36-40E5-86BC-070E99DB7B7B}.Debug|ARM64.ActiveCfg = Debug|ARM64
+		{6539E9E1-BF36-40E5-86BC-070E99DB7B7B}.Debug|ARM64.Build.0 = Debug|ARM64
+		{6539E9E1-BF36-40E5-86BC-070E99DB7B7B}.Debug|x64.ActiveCfg = Debug|x64
+		{6539E9E1-BF36-40E5-86BC-070E99DB7B7B}.Debug|x64.Build.0 = Debug|x64
+		{6539E9E1-BF36-40E5-86BC-070E99DB7B7B}.Debug|x86.ActiveCfg = Debug|Win32
+		{6539E9E1-BF36-40E5-86BC-070E99DB7B7B}.Debug|x86.Build.0 = Debug|Win32
+		{6539E9E1-BF36-40E5-86BC-070E99DB7B7B}.Release|Any CPU.ActiveCfg = Release|Win32
+		{6539E9E1-BF36-40E5-86BC-070E99DB7B7B}.Release|ARM64.ActiveCfg = Release|ARM64
+		{6539E9E1-BF36-40E5-86BC-070E99DB7B7B}.Release|ARM64.Build.0 = Release|ARM64
+		{6539E9E1-BF36-40E5-86BC-070E99DB7B7B}.Release|x64.ActiveCfg = Release|x64
+		{6539E9E1-BF36-40E5-86BC-070E99DB7B7B}.Release|x64.Build.0 = Release|x64
+		{6539E9E1-BF36-40E5-86BC-070E99DB7B7B}.Release|x86.ActiveCfg = Release|Win32
+		{6539E9E1-BF36-40E5-86BC-070E99DB7B7B}.Release|x86.Build.0 = Release|Win32
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -965,6 +984,7 @@ Global
 		{E15C3465-9D45-495D-92CE-B91EF45E8623} = {6967798A-AC07-4994-8FE9-DC9442F88E97}
 		{D45D4170-E055-4926-8B03-04DAA5F02C6C} = {448ED2E5-0B37-4D97-9E6B-8C10A507976A}
 		{09DDAE21-397F-4263-8561-7F2FF28127CF} = {0C534F12-B076-47E5-A05B-2A711233AC6F}
+		{6539E9E1-BF36-40E5-86BC-070E99DB7B7B} = {6CD01EF6-D4A4-4801-ADCF-344CF87FF942}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {4B3D7591-CFEC-4762-9A07-ABE99938FB77}

--- a/build/CopyFilesToStagingDir.ps1
+++ b/build/CopyFilesToStagingDir.ps1
@@ -52,6 +52,7 @@ PublishFile $FullBuildOutput\PushNotificationsLongRunningTask\PushNotificationsL
 #
 PublishFile $FullBuildOutput\DynamicDependencyLifetimeManager\DynamicDependencyLifetimeManager.exe $FullPublishDir\DynamicDependencyLifetimeManager\
 PublishFile $FullBuildOutput\DynamicDependencyLifetimeManager.ProxyStub\DynamicDependencyLifetimeManager.ProxyStub.dll $FullPublishDir\DynamicDependencyLifetimeManager\
+PublishFile $FullBuildOutput\DynamicDependencyLifetimeManagerShadow\DynamicDependencyLifetimeManagerShadow.exe $FullPublishDir\DynamicDependencyLifetimeManager\
 #
 PublishFile $FullBuildOutput\WindowsAppRuntime_BootstrapDLL\Microsoft.WindowsAppRuntime.Bootstrap.dll $FullPublishDir\Microsoft.WindowsAppRuntime.Bootstrap\
 PublishFile $FullBuildOutput\WindowsAppRuntime_BootstrapDLL\Microsoft.WindowsAppRuntime.Bootstrap.lib $FullPublishDir\Microsoft.WindowsAppRuntime.Bootstrap\
@@ -67,6 +68,7 @@ PublishFile $FullBuildOutput\WindowsAppRuntime_DLL\Microsoft.WindowsAppRuntime.p
 PublishFile $FullBuildOutput\DynamicDependency.DataStore\DynamicDependency.DataStore.pdb $symbolsOutputDir
 PublishFile $FullBuildOutput\PushNotificationsLongRunningTask\PushNotificationsLongRunningTask.pdb $symbolsOutputDir
 PublishFile $FullBuildOutput\DynamicDependencyLifetimeManager\DynamicDependencyLifetimeManager.pdb $symbolsOutputDir
+PublishFile $FullBuildOutput\DynamicDependencyLifetimeManagerShadow\DynamicDependencyLifetimeManagerShadow.pdb $symbolsOutputDir
 PublishFile $FullBuildOutput\WindowsAppRuntime_BootstrapDLL\Microsoft.WindowsAppRuntime.Bootstrap.pdb $symbolsOutputDir
 
 # Copy files to Full Nuget package (alphabetical by category)
@@ -109,6 +111,8 @@ PublishFile $FullBuildOutput\DynamicDependency.DataStore.ProxyStub\DynamicDepend
 # MSIX DDLM package
 PublishFile $FullBuildOutput\DynamicDependencyLifetimeManager\DynamicDependencyLifetimeManager.exe $NugetDir\runtimes\win10-$Platform\native
 PublishFile $FullBuildOutput\DynamicDependencyLifetimeManager\DynamicDependencyLifetimeManager.pdb $NugetDir\runtimes\win10-$Platform\native
+PublishFile $FullBuildOutput\DynamicDependencyLifetimeManagerShadow\DynamicDependencyLifetimeManagerShadow.exe $NugetDir\runtimes\win10-$Platform\native
+PublishFile $FullBuildOutput\DynamicDependencyLifetimeManagerShadow\DynamicDependencyLifetimeManagerShadow.pdb $NugetDir\runtimes\win10-$Platform\native
 PublishFile $FullBuildOutput\DynamicDependencyLifetimeManager.ProxyStub\DynamicDependencyLifetimeManager.ProxyStub.dll $NugetDir\runtimes\win10-$Platform\native
 PublishFile $FullBuildOutput\DynamicDependencyLifetimeManager.ProxyStub\DynamicDependencyLifetimeManager.ProxyStub.pdb $NugetDir\runtimes\win10-$Platform\native
 #

--- a/dev/Common/IsWindowsVersion.h
+++ b/dev/Common/IsWindowsVersion.h
@@ -1,0 +1,50 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+#ifndef __ISWINDOWSVERSION_H
+#define __ISWINDOWSVERSION_H
+
+#include <VersionHelpers.h>
+
+namespace WindowsVersion
+{
+VERSIONHELPERAPI IsWindowsVersionOrGreaterEx(
+    const WORD majorVersion,
+    const WORD minorVersion,
+    const WORD servicePackMajor,
+    const WORD buildNumber)
+{
+    OSVERSIONINFOEXW osvi{ sizeof(osvi) };
+    osvi.dwMajorVersion = majorVersion;
+    osvi.dwMinorVersion = minorVersion;
+    osvi.wServicePackMajor = servicePackMajor;
+    osvi.dwBuildNumber = buildNumber;
+
+    const DWORDLONG c_conditionMask{
+        VerSetConditionMask(
+            VerSetConditionMask(
+                VerSetConditionMask(
+                    VerSetConditionMask(
+                        0, VER_MAJORVERSION, VER_GREATER_EQUAL),
+                    VER_MINORVERSION, VER_GREATER_EQUAL),
+                VER_SERVICEPACKMAJOR, VER_GREATER_EQUAL),
+            VER_BUILDNUMBER, VER_GREATER_EQUAL)
+    };
+
+    return VerifyVersionInfoW(&osvi, VER_MAJORVERSION | VER_MINORVERSION | VER_SERVICEPACKMAJOR | VER_BUILDNUMBER, c_conditionMask) != FALSE;
+}
+
+VERSIONHELPERAPI IsWindows10_19H1OrGreater()
+{
+    const WORD c_win10_19h1_build{ 18362 };
+    return IsWindowsVersionOrGreaterEx(HIBYTE(_WIN32_WINNT_WIN10), LOBYTE(_WIN32_WINNT_WIN10), 0, c_win10_19h1_build);
+}
+
+VERSIONHELPERAPI IsWindows10_20H1OrGreater()
+{
+    const WORD c_win10_20h1_build{ 19041 };
+    return IsWindowsVersionOrGreaterEx(HIBYTE(_WIN32_WINNT_WIN10), LOBYTE(_WIN32_WINNT_WIN10), 0, c_win10_20h1_build);
+}
+}
+
+#endif // __ISWINDOWSVERSION_H

--- a/dev/DynamicDependency/DynamicDependencyLifetimeManagerShadow/DynamicDependencyLifetimeManagerShadow.vcxproj
+++ b/dev/DynamicDependency/DynamicDependencyLifetimeManagerShadow/DynamicDependencyLifetimeManagerShadow.vcxproj
@@ -1,0 +1,279 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="..\..\..\packages\Microsoft.SourceLink.GitHub.1.1.0-beta-20204-02\build\Microsoft.SourceLink.GitHub.props" Condition="Exists('..\..\..\packages\Microsoft.SourceLink.GitHub.1.1.0-beta-20204-02\build\Microsoft.SourceLink.GitHub.props')" />
+  <Import Project="..\..\..\packages\Microsoft.Build.Tasks.Git.1.1.0-beta-20204-02\build\Microsoft.Build.Tasks.Git.props" Condition="Exists('..\..\..\packages\Microsoft.Build.Tasks.Git.1.1.0-beta-20204-02\build\Microsoft.Build.Tasks.Git.props')" />
+  <Import Project="..\..\..\packages\Microsoft.SourceLink.Common.1.1.0-beta-21055-01\build\Microsoft.SourceLink.Common.props" Condition="Exists('..\..\..\packages\Microsoft.SourceLink.Common.1.1.0-beta-21055-01\build\Microsoft.SourceLink.Common.props')" />
+  <Import Project="..\..\WindowsAppSDK.Build.Cpp.props" />
+  <ItemGroup Label="ProjectConfigurations">
+    <ProjectConfiguration Include="Debug|ARM64">
+      <Configuration>Debug</Configuration>
+      <Platform>ARM64</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Debug|Win32">
+      <Configuration>Debug</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Debug|x64">
+      <Configuration>Debug</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|ARM64">
+      <Configuration>Release</Configuration>
+      <Platform>ARM64</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|Win32">
+      <Configuration>Release</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|x64">
+      <Configuration>Release</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+  </ItemGroup>
+  <PropertyGroup Label="Globals">
+    <VCProjectVersion>16.0</VCProjectVersion>
+    <Keyword>Win32Proj</Keyword>
+    <ProjectGuid>{6539e9e1-bf36-40e5-86bc-070e99db7b7b}</ProjectGuid>
+    <RootNamespace>DynamicDependencyLifetimeManagerShadow</RootNamespace>
+    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
+    <ProjectName>DynamicDependencyLifetimeManagerShadow</ProjectName>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>true</UseDebugLibraries>
+    <PlatformToolset>v142</PlatformToolset>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|ARM64'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>true</UseDebugLibraries>
+    <PlatformToolset>v142</PlatformToolset>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>true</UseDebugLibraries>
+    <PlatformToolset>v142</PlatformToolset>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <WholeProgramOptimization>true</WholeProgramOptimization>
+    <PlatformToolset>v142</PlatformToolset>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|ARM64'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <WholeProgramOptimization>true</WholeProgramOptimization>
+    <PlatformToolset>v142</PlatformToolset>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <WholeProgramOptimization>true</WholeProgramOptimization>
+    <PlatformToolset>v142</PlatformToolset>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
+  <ImportGroup Label="ExtensionSettings">
+  </ImportGroup>
+  <ImportGroup Label="Shared">
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Debug|ARM64'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|ARM64'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <PropertyGroup Label="UserMacros" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <LinkIncremental>true</LinkIncremental>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <LinkIncremental>false</LinkIncremental>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <LinkIncremental>true</LinkIncremental>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <LinkIncremental>false</LinkIncremental>
+  </PropertyGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <ClCompile>
+      <WarningLevel>Level4</WarningLevel>
+      <SDLCheck>true</SDLCheck>
+      <PreprocessorDefinitions>WIN32;_DEBUG;_WINDOWS;_USRDLL;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <ConformanceMode>true</ConformanceMode>
+      <PrecompiledHeader>Use</PrecompiledHeader>
+      <PrecompiledHeaderFile>pch.h</PrecompiledHeaderFile>
+      <LanguageStandard>stdcpp17</LanguageStandard>
+    </ClCompile>
+    <Link>
+      <SubSystem>Windows</SubSystem>
+      <GenerateDebugInformation>DebugFull</GenerateDebugInformation>
+      <AdditionalDependencies>onecore.lib;onecoreuap.lib;%(AdditionalDependencies)</AdditionalDependencies>
+    </Link>
+    <ProjectReference>
+      <LinkLibraryDependencies>false</LinkLibraryDependencies>
+    </ProjectReference>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|ARM64'">
+    <ClCompile>
+      <WarningLevel>Level4</WarningLevel>
+      <SDLCheck>true</SDLCheck>
+      <PreprocessorDefinitions>_DEBUG;_WINDOWS;_USRDLL;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <ConformanceMode>true</ConformanceMode>
+      <PrecompiledHeader>Use</PrecompiledHeader>
+      <PrecompiledHeaderFile>pch.h</PrecompiledHeaderFile>
+      <LanguageStandard>stdcpp17</LanguageStandard>
+    </ClCompile>
+    <Link>
+      <SubSystem>Windows</SubSystem>
+      <GenerateDebugInformation>DebugFull</GenerateDebugInformation>
+      <AdditionalDependencies>onecore.lib;onecoreuap.lib;%(AdditionalDependencies)</AdditionalDependencies>
+    </Link>
+    <ProjectReference>
+      <LinkLibraryDependencies>false</LinkLibraryDependencies>
+    </ProjectReference>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|ARM64'">
+    <ClCompile>
+      <WarningLevel>Level4</WarningLevel>
+      <FunctionLevelLinking>true</FunctionLevelLinking>
+      <IntrinsicFunctions>true</IntrinsicFunctions>
+      <SDLCheck>true</SDLCheck>
+      <PreprocessorDefinitions>NDEBUG;_WINDOWS;_USRDLL;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <ConformanceMode>true</ConformanceMode>
+      <PrecompiledHeader>Use</PrecompiledHeader>
+      <PrecompiledHeaderFile>pch.h</PrecompiledHeaderFile>
+      <LanguageStandard>stdcpp17</LanguageStandard>
+    </ClCompile>
+    <Link>
+      <SubSystem>Windows</SubSystem>
+      <EnableCOMDATFolding>true</EnableCOMDATFolding>
+      <OptimizeReferences>true</OptimizeReferences>
+      <GenerateDebugInformation>DebugFull</GenerateDebugInformation>
+      <AdditionalDependencies>onecore.lib;onecoreuap.lib;%(AdditionalDependencies)</AdditionalDependencies>
+    </Link>
+    <ProjectReference>
+      <LinkLibraryDependencies>false</LinkLibraryDependencies>
+    </ProjectReference>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <ClCompile>
+      <WarningLevel>Level4</WarningLevel>
+      <FunctionLevelLinking>true</FunctionLevelLinking>
+      <IntrinsicFunctions>true</IntrinsicFunctions>
+      <SDLCheck>true</SDLCheck>
+      <PreprocessorDefinitions>WIN32;NDEBUG;_WINDOWS;_USRDLL;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <ConformanceMode>true</ConformanceMode>
+      <PrecompiledHeader>Use</PrecompiledHeader>
+      <PrecompiledHeaderFile>pch.h</PrecompiledHeaderFile>
+      <LanguageStandard>stdcpp17</LanguageStandard>
+    </ClCompile>
+    <Link>
+      <SubSystem>Windows</SubSystem>
+      <EnableCOMDATFolding>true</EnableCOMDATFolding>
+      <OptimizeReferences>true</OptimizeReferences>
+      <GenerateDebugInformation>DebugFull</GenerateDebugInformation>
+      <AdditionalDependencies>onecore.lib;onecoreuap.lib;%(AdditionalDependencies)</AdditionalDependencies>
+    </Link>
+    <ProjectReference>
+      <LinkLibraryDependencies>false</LinkLibraryDependencies>
+    </ProjectReference>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <ClCompile>
+      <WarningLevel>Level4</WarningLevel>
+      <SDLCheck>true</SDLCheck>
+      <PreprocessorDefinitions>_DEBUG;_WINDOWS;_USRDLL;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <ConformanceMode>true</ConformanceMode>
+      <PrecompiledHeader>Use</PrecompiledHeader>
+      <PrecompiledHeaderFile>pch.h</PrecompiledHeaderFile>
+      <LanguageStandard>stdcpp17</LanguageStandard>
+    </ClCompile>
+    <Link>
+      <SubSystem>Windows</SubSystem>
+      <GenerateDebugInformation>DebugFull</GenerateDebugInformation>
+      <AdditionalDependencies>onecore.lib;onecoreuap.lib;%(AdditionalDependencies)</AdditionalDependencies>
+    </Link>
+    <ProjectReference>
+      <LinkLibraryDependencies>false</LinkLibraryDependencies>
+    </ProjectReference>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <ClCompile>
+      <WarningLevel>Level4</WarningLevel>
+      <FunctionLevelLinking>true</FunctionLevelLinking>
+      <IntrinsicFunctions>true</IntrinsicFunctions>
+      <SDLCheck>true</SDLCheck>
+      <PreprocessorDefinitions>NDEBUG;_WINDOWS;_USRDLL;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <ConformanceMode>true</ConformanceMode>
+      <PrecompiledHeader>Use</PrecompiledHeader>
+      <PrecompiledHeaderFile>pch.h</PrecompiledHeaderFile>
+      <LanguageStandard>stdcpp17</LanguageStandard>
+    </ClCompile>
+    <Link>
+      <SubSystem>Windows</SubSystem>
+      <EnableCOMDATFolding>true</EnableCOMDATFolding>
+      <OptimizeReferences>true</OptimizeReferences>
+      <GenerateDebugInformation>DebugFull</GenerateDebugInformation>
+      <AdditionalDependencies>onecore.lib;onecoreuap.lib;%(AdditionalDependencies)</AdditionalDependencies>
+    </Link>
+    <ProjectReference>
+      <LinkLibraryDependencies>false</LinkLibraryDependencies>
+    </ProjectReference>
+  </ItemDefinitionGroup>
+  <ItemGroup>
+    <ClInclude Include="pch.h" />
+  </ItemGroup>
+  <ItemGroup>
+    <ClCompile Include="pch.cpp">
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">Create</PrecompiledHeader>
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">Create</PrecompiledHeader>
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|ARM64'">Create</PrecompiledHeader>
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Release|ARM64'">Create</PrecompiledHeader>
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">Create</PrecompiledHeader>
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Release|x64'">Create</PrecompiledHeader>
+    </ClCompile>
+    <ClCompile Include="winmain.cpp" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="packages.config" />
+  </ItemGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
+  <ImportGroup Label="ExtensionTargets">
+    <Import Project="..\..\..\packages\Microsoft.Windows.ImplementationLibrary.1.0.210803.1\build\native\Microsoft.Windows.ImplementationLibrary.targets" Condition="Exists('..\..\..\packages\Microsoft.Windows.ImplementationLibrary.1.0.210803.1\build\native\Microsoft.Windows.ImplementationLibrary.targets')" />
+    <Import Project="..\..\..\packages\Microsoft.SourceLink.Common.1.1.0-beta-21055-01\build\Microsoft.SourceLink.Common.targets" Condition="Exists('..\..\..\packages\Microsoft.SourceLink.Common.1.1.0-beta-21055-01\build\Microsoft.SourceLink.Common.targets')" />
+    <Import Project="..\..\..\packages\Microsoft.Build.Tasks.Git.1.1.0-beta-20204-02\build\Microsoft.Build.Tasks.Git.targets" Condition="Exists('..\..\..\packages\Microsoft.Build.Tasks.Git.1.1.0-beta-20204-02\build\Microsoft.Build.Tasks.Git.targets')" />
+    <Import Project="..\..\..\packages\Microsoft.SourceLink.GitHub.1.1.0-beta-20204-02\build\Microsoft.SourceLink.GitHub.targets" Condition="Exists('..\..\..\packages\Microsoft.SourceLink.GitHub.1.1.0-beta-20204-02\build\Microsoft.SourceLink.GitHub.targets')" />
+  </ImportGroup>
+  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
+    <PropertyGroup>
+      <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
+    </PropertyGroup>
+    <Error Condition="!Exists('..\..\..\packages\Microsoft.Windows.ImplementationLibrary.1.0.210803.1\build\native\Microsoft.Windows.ImplementationLibrary.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\packages\Microsoft.Windows.ImplementationLibrary.1.0.210803.1\build\native\Microsoft.Windows.ImplementationLibrary.targets'))" />
+    <Error Condition="!Exists('..\..\..\packages\Microsoft.SourceLink.Common.1.1.0-beta-21055-01\build\Microsoft.SourceLink.Common.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\packages\Microsoft.SourceLink.Common.1.1.0-beta-21055-01\build\Microsoft.SourceLink.Common.props'))" />
+    <Error Condition="!Exists('..\..\..\packages\Microsoft.SourceLink.Common.1.1.0-beta-21055-01\build\Microsoft.SourceLink.Common.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\packages\Microsoft.SourceLink.Common.1.1.0-beta-21055-01\build\Microsoft.SourceLink.Common.targets'))" />
+    <Error Condition="!Exists('..\..\..\packages\Microsoft.Build.Tasks.Git.1.1.0-beta-20204-02\build\Microsoft.Build.Tasks.Git.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\packages\Microsoft.Build.Tasks.Git.1.1.0-beta-20204-02\build\Microsoft.Build.Tasks.Git.props'))" />
+    <Error Condition="!Exists('..\..\..\packages\Microsoft.Build.Tasks.Git.1.1.0-beta-20204-02\build\Microsoft.Build.Tasks.Git.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\packages\Microsoft.Build.Tasks.Git.1.1.0-beta-20204-02\build\Microsoft.Build.Tasks.Git.targets'))" />
+    <Error Condition="!Exists('..\..\..\packages\Microsoft.SourceLink.GitHub.1.1.0-beta-20204-02\build\Microsoft.SourceLink.GitHub.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\packages\Microsoft.SourceLink.GitHub.1.1.0-beta-20204-02\build\Microsoft.SourceLink.GitHub.props'))" />
+    <Error Condition="!Exists('..\..\..\packages\Microsoft.SourceLink.GitHub.1.1.0-beta-20204-02\build\Microsoft.SourceLink.GitHub.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\packages\Microsoft.SourceLink.GitHub.1.1.0-beta-20204-02\build\Microsoft.SourceLink.GitHub.targets'))" />
+  </Target>
+</Project>

--- a/dev/DynamicDependency/DynamicDependencyLifetimeManagerShadow/DynamicDependencyLifetimeManagerShadow.vcxproj.filters
+++ b/dev/DynamicDependency/DynamicDependencyLifetimeManagerShadow/DynamicDependencyLifetimeManagerShadow.vcxproj.filters
@@ -1,0 +1,33 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup>
+    <Filter Include="Source Files">
+      <UniqueIdentifier>{4FC737F1-C7A5-4376-A066-2A32D752A2FF}</UniqueIdentifier>
+      <Extensions>cpp;c;cc;cxx;c++;cppm;ixx;def;odl;idl;hpj;bat;asm;asmx</Extensions>
+    </Filter>
+    <Filter Include="Header Files">
+      <UniqueIdentifier>{93995380-89BD-4b04-88EB-625FBE52EBFB}</UniqueIdentifier>
+      <Extensions>h;hh;hpp;hxx;h++;hm;inl;inc;ipp;xsd</Extensions>
+    </Filter>
+    <Filter Include="Resource Files">
+      <UniqueIdentifier>{67DA6AB6-F800-4c08-8B7A-83BB121AAD01}</UniqueIdentifier>
+      <Extensions>rc;ico;cur;bmp;dlg;rc2;rct;bin;rgs;gif;jpg;jpeg;jpe;resx;tiff;tif;png;wav;mfcribbon-ms</Extensions>
+    </Filter>
+  </ItemGroup>
+  <ItemGroup>
+    <ClCompile Include="pch.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="winmain.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+  </ItemGroup>
+  <ItemGroup>
+    <ClInclude Include="pch.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="packages.config" />
+  </ItemGroup>
+</Project>

--- a/dev/DynamicDependency/DynamicDependencyLifetimeManagerShadow/packages.config
+++ b/dev/DynamicDependency/DynamicDependencyLifetimeManagerShadow/packages.config
@@ -1,0 +1,6 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="Microsoft.Build.Tasks.Git" version="1.1.0-beta-20204-02" targetFramework="native" developmentDependency="true" />
+  <package id="Microsoft.SourceLink.Common" version="1.1.0-beta-21055-01" targetFramework="native" developmentDependency="true" />
+  <package id="Microsoft.SourceLink.GitHub" version="1.1.0-beta-20204-02" targetFramework="native" developmentDependency="true" />
+</packages>

--- a/dev/DynamicDependency/DynamicDependencyLifetimeManagerShadow/pch.cpp
+++ b/dev/DynamicDependency/DynamicDependencyLifetimeManagerShadow/pch.cpp
@@ -1,0 +1,4 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+#include "pch.h"

--- a/dev/DynamicDependency/DynamicDependencyLifetimeManagerShadow/pch.h
+++ b/dev/DynamicDependency/DynamicDependencyLifetimeManagerShadow/pch.h
@@ -1,0 +1,14 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+#pragma once
+
+#include <unknwn.h>
+#include <appmodel.h>
+
+#include <thread>
+#include <mutex>
+
+#include <wil/token_helpers.h>
+#include <wil/resource.h>
+#include <wil/result_macros.h>

--- a/dev/DynamicDependency/DynamicDependencyLifetimeManagerShadow/winmain.cpp
+++ b/dev/DynamicDependency/DynamicDependencyLifetimeManagerShadow/winmain.cpp
@@ -1,0 +1,62 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+#include "pch.h"
+
+const HRESULT WINDOWSAPPSDK_DDLM_SHUTDOWN{ MAKE_HRESULT(SEVERITY_SUCCESS, FACILITY_ITF, 0x8000) };
+const HRESULT WINDOWSAPPSDK_DDLM_CALLER_TERMINATED{ MAKE_HRESULT(SEVERITY_SUCCESS, FACILITY_ITF, 0x8001) };
+const HRESULT WINDOWSAPPSDK_DDLM_CALLER_NOT_FOUND{ MAKE_HRESULT(SEVERITY_SUCCESS, FACILITY_ITF, 0x8002) };
+
+int WINAPI WinMain(HINSTANCE /*hInstance*/, HINSTANCE /*hPrevInstance*/, PSTR /*lpCmdLine*/, int /*nCmdShow*/)
+{
+    // Usage: This.Exe <eventname>
+    // where
+    //     eventname = event name signaling we should quit. Syntax: "<processid>;<packagefullname>;<uniqueid>"
+
+    // Parse the command line
+    const auto commandLine{ GetCommandLineW() };
+    RETURN_HR_IF_NULL(E_INVALIDARG, commandLine);
+    int argc{};
+    PWSTR* argv{ CommandLineToArgvW(commandLine, &argc) };
+    RETURN_HR_IF_NULL(E_INVALIDARG, argv);
+    wil::unique_hlocal argvBuffer{ argv };
+    RETURN_HR_IF(E_INVALIDARG, argc < 2);
+    PCWSTR eventName{ argv[1] };
+    PWSTR endPtr{};
+    uint32_t callerProcessId{ wcstoul(eventName, &endPtr, 10) };
+    // We'll never have ProcessId=0
+    RETURN_HR_IF_MSG(E_INVALIDARG, (callerProcessId == 0) || (endPtr == nullptr) || (*endPtr != L';'), "CommandLine=%ls", eventName);
+
+    // Open the named event created by the process calling the Bootstrap API (the process that caused us to run)
+    // If we can't it's because the process has terminated (or already called MddBootstrapShutdown())
+    // so we have nothing to do and we're out.
+    wil::unique_event_nothrow endOfTheLine;
+    RETURN_HR_IF_MSG(WINDOWSAPPSDK_DDLM_CALLER_NOT_FOUND, !endOfTheLine.try_open(eventName), "DDLM EventName=%ls", eventName);
+
+    // Open a handle to the calling process so we can watch for its termination
+    // (in case the process terminates without calling MddBootstrapShutdown())
+    wil::unique_handle callerProcessHandle{ OpenProcess(SYNCHRONIZE, FALSE, callerProcessId) };
+    RETURN_LAST_ERROR_IF_NULL(callerProcessHandle);
+
+    // Wait for our calling process to tell us to quit OR our calling process terminates.
+    // Either way, we've served our purpose and should quit.
+    HANDLE waitForHandles[]{ endOfTheLine.get(), callerProcessHandle.get() };
+    auto rc{ WaitForMultipleObjects(static_cast<DWORD>(ARRAYSIZE(waitForHandles)), waitForHandles, FALSE, INFINITE) };
+    if (rc == WAIT_OBJECT_0)
+    {
+        (void) LOG_HR_MSG(WINDOWSAPPSDK_DDLM_SHUTDOWN, "DDLM.Shutdown: %ls", eventName);
+    }
+    else if (rc == WAIT_OBJECT_0 + 1)
+    {
+        (void) LOG_HR_MSG(WINDOWSAPPSDK_DDLM_CALLER_TERMINATED, "DDLM.CallerTerminated: %ls", eventName);
+    }
+    else if (rc == WAIT_FAILED)
+    {
+        RETURN_LAST_ERROR_MSG("DDLM.Wait: %ls", eventName);
+    }
+    else
+    {
+        RETURN_HR_MSG(E_UNEXPECTED, "DDLM.Wait.Unexpected: %ls", eventName);
+    }
+    return 0;
+}

--- a/dev/UndockedRegFreeWinRT/urfw.cpp
+++ b/dev/UndockedRegFreeWinRT/urfw.cpp
@@ -66,32 +66,6 @@ enum class ActivationLocation
     CrossApartmentMTA
 };
 
-VERSIONHELPERAPI IsWindowsVersionOrGreaterEx(WORD wMajorVersion, WORD wMinorVersion, WORD wServicePackMajor, WORD wBuildNumber)
-{
-    OSVERSIONINFOEXW osvi = { sizeof(osvi) };
-    DWORDLONG const dwlConditionMask =
-        VerSetConditionMask(
-            VerSetConditionMask(
-                VerSetConditionMask(
-                    VerSetConditionMask(
-                        0, VER_MAJORVERSION, VER_GREATER_EQUAL),
-                    VER_MINORVERSION, VER_GREATER_EQUAL),
-                VER_SERVICEPACKMAJOR, VER_GREATER_EQUAL),
-            VER_BUILDNUMBER, VER_GREATER_EQUAL);
-
-    osvi.dwMajorVersion = wMajorVersion;
-    osvi.dwMinorVersion = wMinorVersion;
-    osvi.wServicePackMajor = wServicePackMajor;
-    osvi.dwBuildNumber = wBuildNumber;
-
-    return VerifyVersionInfoW(&osvi, VER_MAJORVERSION | VER_MINORVERSION | VER_SERVICEPACKMAJOR | VER_BUILDNUMBER, dwlConditionMask) != FALSE;
-}
-
-VERSIONHELPERAPI IsWindows1019H1OrGreater()
-{
-    return IsWindowsVersionOrGreaterEx(HIBYTE(_WIN32_WINNT_WIN10), LOBYTE(_WIN32_WINNT_WIN10), 0, WIN1019H1_BLDNUM);
-}
-
 VOID CALLBACK EnsureMTAInitializedCallBack
 (
     PTP_CALLBACK_INSTANCE /*instance*/,

--- a/dev/WindowsAppRuntime_BootstrapDLL/MddBootstrap.cpp
+++ b/dev/WindowsAppRuntime_BootstrapDLL/MddBootstrap.cpp
@@ -10,16 +10,45 @@
 
 #include "IDynamicDependencyLifetimeManager.h"
 
+#include <filesystem>
+
 wil::unique_cotaskmem_ptr<BYTE[]> GetFrameworkPackageInfoForPackage(PCWSTR packageFullName, const PACKAGE_INFO*& frameworkPackageInfo);
 DLL_DIRECTORY_COOKIE AddFrameworkToPath(PCWSTR path);
 void RemoveFrameworkFromPath(PCWSTR frameworkPath);
-CLSID FindDDLM(
+bool IsLifetimeManagerViaEnumeration();
+void CreateLifetimeManager(
+    UINT32 majorMinorVersion,
+    PCWSTR versionTag,
+    PACKAGE_VERSION minVersion,
+    wil::com_ptr_nothrow<IDynamicDependencyLifetimeManager>& lifetimeManager,
+    wil::unique_event& endTheLifetimeManagerEvent,
+    wil::unique_cotaskmem_string& ddlmPackageFullName);
+void CreateLifetimeManagerViaAppExtension(
+    UINT32 majorMinorVersion,
+    PCWSTR versionTag,
+    PACKAGE_VERSION minVersion,
+    wil::com_ptr_nothrow<IDynamicDependencyLifetimeManager>& lifetimeManager,
+    wil::unique_cotaskmem_string& ddlmPackageFullName);
+void CreateLifetimeManagerViaEnumeration(
+    UINT32 majorMinorVersion,
+    PCWSTR versionTag,
+    PACKAGE_VERSION minVersion,
+    wil::unique_event& endTheLifetimeManagerEvent,
+    wil::unique_cotaskmem_string& ddlmPackageFullName);
+CLSID FindDDLMViaAppExtension(
     UINT32 majorMinorVersion,
     PCWSTR versionTag,
     PACKAGE_VERSION minVersion);
+void FindDDLMViaEnumeration(
+    UINT32 majorMinorVersion,
+    PCWSTR versionTag,
+    PACKAGE_VERSION minVersion,
+    std::wstring& ddlmPackageFamilyName,
+    std::wstring& ddlmPackageFullName);
 CLSID GetClsid(const winrt::Windows::ApplicationModel::AppExtensions::AppExtension& appExtension);
 
 IDynamicDependencyLifetimeManager* g_lifetimeManager{};
+wil::unique_event g_endTheLifetimeManagerEvent;
 wil::unique_hmodule g_windowsAppRuntimeDll;
 wil::unique_process_heap_string g_packageDependencyId;
 MDD_PACKAGEDEPENDENCY_CONTEXT g_packageDependencyContext{};
@@ -53,14 +82,10 @@ STDAPI MddBootstrapInitialize(
     FAIL_FAST_HR_IF(HRESULT_FROM_WIN32(ERROR_ALREADY_INITIALIZED), g_packageDependencyId != nullptr);
     FAIL_FAST_HR_IF(HRESULT_FROM_WIN32(ERROR_ALREADY_INITIALIZED), g_packageDependencyContext != nullptr);
 
-    const auto appDynamicDependencyLifetimeManagerClsid{ FindDDLM(majorMinorVersion, versionTag, minVersion) };
-
-    wil::com_ptr_nothrow<IDynamicDependencyLifetimeManager> lifetimeManager(wil::CoCreateInstance<IDynamicDependencyLifetimeManager>(appDynamicDependencyLifetimeManagerClsid, CLSCTX_LOCAL_SERVER));
-
-    THROW_IF_FAILED(lifetimeManager->Initialize());
-
     wil::unique_cotaskmem_string packageFullName;
-    THROW_IF_FAILED(lifetimeManager->GetPackageFullName(&packageFullName));
+    wil::com_ptr_nothrow<IDynamicDependencyLifetimeManager> lifetimeManager;
+    wil::unique_event endTheLifetimeManagerEvent;
+    CreateLifetimeManager(majorMinorVersion, versionTag, minVersion, lifetimeManager, endTheLifetimeManagerEvent, packageFullName);
 
     const PACKAGE_INFO* frameworkPackageInfo{};
     auto packageInfoBuffer{ GetFrameworkPackageInfoForPackage(packageFullName.get(), frameworkPackageInfo) };
@@ -91,6 +116,7 @@ STDAPI MddBootstrapInitialize(
     dllDirectoryCookie.reset();
 
     g_lifetimeManager = lifetimeManager.detach();
+    g_endTheLifetimeManagerEvent = std::move(endTheLifetimeManagerEvent);
     g_windowsAppRuntimeDll = std::move(windowsAppRuntimeDll);
     g_packageDependencyId = std::move(packageDependencyId);
     g_packageDependencyContext = packageDependencyContext;
@@ -110,13 +136,18 @@ STDAPI_(void) MddBootstrapShutdown() noexcept
 
     g_windowsAppRuntimeDll.reset();
 
+    if (g_endTheLifetimeManagerEvent)
+    {
+        g_endTheLifetimeManagerEvent.SetEvent();
+        g_endTheLifetimeManagerEvent.reset();
+    }
+
     if (g_lifetimeManager)
     {
         (void)LOG_IF_FAILED(g_lifetimeManager->Shutdown());
         g_lifetimeManager->Release();
         g_lifetimeManager = nullptr;
     }
-
 }
 
 STDAPI MddBootstrapTestInitialize(
@@ -250,7 +281,105 @@ void RemoveFrameworkFromPath(PCWSTR frameworkPath)
     }
 }
 
-CLSID FindDDLM(
+bool IsLifetimeManagerViaEnumeration()
+{
+    // AppExtension enumerates appextensions on <=19H1 only if the caller declares a matching AppExtensionHost.
+    // To workaround on older systems we'll fallback to a more complex but functionally equivalent solution.
+    if (!WindowsVersion::IsWindows10_20H1OrGreater())
+    {
+        // Windows version < 20H1. Enumeration is required
+        return true;
+    }
+
+    // Enable the Enumeration-style LifetimeManager if the environment variable
+    // MICROSOFT_WINDOWSAPPRUNTIME_DDLM_ENUMERATION is defined (for testing scenarios)
+    if (GetEnvironmentVariableW(L"MICROSOFT_WINDOWSAPPRUNTIME_DDLM_ENUMERATION", nullptr, 0) > 0)
+    {
+        return true;
+    }
+
+    // Use the AppExtension-style LifetimeManager
+    return false;
+}
+
+void CreateLifetimeManager(
+    UINT32 majorMinorVersion,
+    PCWSTR versionTag,
+    PACKAGE_VERSION minVersion,
+    wil::com_ptr_nothrow<IDynamicDependencyLifetimeManager>& lifetimeManager,
+    wil::unique_event& endTheLifetimeManagerEvent,
+    wil::unique_cotaskmem_string& ddlmPackageFullName)
+{
+    if (IsLifetimeManagerViaEnumeration())
+    {
+        CreateLifetimeManagerViaEnumeration(majorMinorVersion, versionTag, minVersion, endTheLifetimeManagerEvent, ddlmPackageFullName);
+    }
+    else
+    {
+        CreateLifetimeManagerViaAppExtension(majorMinorVersion, versionTag, minVersion, lifetimeManager, ddlmPackageFullName);
+    }
+}
+
+void CreateLifetimeManagerViaAppExtension(
+    UINT32 majorMinorVersion,
+    PCWSTR versionTag,
+    PACKAGE_VERSION minVersion,
+    wil::com_ptr_nothrow<IDynamicDependencyLifetimeManager>& lifetimeManager,
+    wil::unique_cotaskmem_string& ddlmPackageFullName)
+{
+    const auto appDynamicDependencyLifetimeManagerClsid{ FindDDLMViaAppExtension(majorMinorVersion, versionTag, minVersion) };
+
+    wil::com_ptr_nothrow<IDynamicDependencyLifetimeManager> dynamicDependencyLifetimeManager{
+        wil::CoCreateInstance<IDynamicDependencyLifetimeManager>(appDynamicDependencyLifetimeManagerClsid, CLSCTX_LOCAL_SERVER)
+    };
+
+    THROW_IF_FAILED(dynamicDependencyLifetimeManager->Initialize());
+
+    wil::unique_cotaskmem_string packageFullName;
+    THROW_IF_FAILED(dynamicDependencyLifetimeManager->GetPackageFullName(&packageFullName));
+
+    lifetimeManager = std::move(dynamicDependencyLifetimeManager);
+    ddlmPackageFullName = std::move(packageFullName);
+}
+
+void CreateLifetimeManagerViaEnumeration(
+    UINT32 majorMinorVersion,
+    PCWSTR versionTag,
+    PACKAGE_VERSION minVersion,
+    wil::unique_event& endTheLifetimeManagerEvent,
+    wil::unique_cotaskmem_string& ddlmPackageFullName)
+{
+    std::wstring packageFamilyName;
+    std::wstring packageFullName;
+    FindDDLMViaEnumeration(majorMinorVersion, versionTag, minVersion, packageFamilyName, packageFullName);
+
+    // Create the named event used later to signal to the lifetime manager it's time to quit
+    // The named event has the syntax: "<processid>;<packagefullname>;<uniqueid>"
+    GUID uniqueId{};
+    THROW_IF_FAILED(CoCreateGuid(&uniqueId));
+    const auto c_uniqueIdAsString{ winrt::to_hstring(uniqueId) };
+    auto eventName{ wil::str_printf<wil::unique_cotaskmem_string>(L"%u;%s;%s", GetCurrentProcessId(), packageFullName.c_str(), c_uniqueIdAsString.c_str()) };
+    wil::unique_event event;
+    event.create(wil::EventOptions::ManualReset, eventName.get());
+
+    WCHAR lifetimeManagerApplicationUserModelId[APPLICATION_USER_MODEL_ID_MAX_LENGTH]{};
+    uint32_t lifetimeManagerApplicationUserModelIdLength{ static_cast<uint32_t>(ARRAYSIZE(lifetimeManagerApplicationUserModelId)) };
+    PCWSTR c_packageRelativeApplicationId{ L"DDLM" };
+    THROW_IF_WIN32_ERROR(FormatApplicationUserModelId(packageFamilyName.c_str(), c_packageRelativeApplicationId, &lifetimeManagerApplicationUserModelIdLength, lifetimeManagerApplicationUserModelId));
+
+    wil::com_ptr_nothrow<IApplicationActivationManager> aam{
+        wil::CoCreateInstance<IApplicationActivationManager>(CLSID_ApplicationActivationManager, CLSCTX_INPROC_SERVER)
+    };
+    auto arguments{ eventName.get() };
+    ACTIVATEOPTIONS c_options{ AO_NOERRORUI | AO_NOSPLASHSCREEN };
+    DWORD processId{};
+    THROW_IF_FAILED(aam->ActivateApplication(lifetimeManagerApplicationUserModelId, arguments, c_options, &processId));
+
+    endTheLifetimeManagerEvent = std::move(event);
+    ddlmPackageFullName = wil::make_cotaskmem_string(packageFullName.c_str());
+}
+
+CLSID FindDDLMViaAppExtension(
     UINT32 majorMinorVersion,
     PCWSTR versionTag,
     PACKAGE_VERSION minVersion)
@@ -336,8 +465,186 @@ CLSID FindDDLM(
         }
     }
     THROW_HR_IF_MSG(HRESULT_FROM_WIN32(ERROR_NO_MATCH), !foundAny, "AppExtension.Name=%ls, Major=%hu, Minor=%hu, Tag=%ls, MinVersion=%hu.%hu.%hu.%hu",
-                    appExtensionName, majorVersion, minorVersion, (!versionTag ? L"" : versionTag), minVersion.Major, minVersion.Minor, minVersion.Build, minVersion.Revision);
+                    appExtensionName, majorVersion, minorVersion, (!versionTag ? L"" : versionTag),
+                    minVersion.Major, minVersion.Minor, minVersion.Build, minVersion.Revision);
     return bestFitClsid;
+}
+
+void FindDDLMViaEnumeration(
+    UINT32 majorMinorVersion,
+    PCWSTR versionTag,
+    PACKAGE_VERSION minVersion,
+    std::wstring& ddlmPackageFamilyName,
+    std::wstring& ddlmPackageFullName)
+{
+    // Find the best fit
+    bool foundAny{};
+    PACKAGE_VERSION bestFitVersion{};
+    winrt::hstring bestFitPackageFamilyName{};
+    winrt::hstring bestFitPackageFullName{};
+
+    // We need to look for DDLM packages in the package family for release <major>.<minor> and <versiontag>
+    // But we have no single (simple) enumeration to match that so our logic's more involved compared
+    // to FindDDLMViaAppExtension():
+    // 1. Look for Framework packages with Name="microsoft.winappruntime.ddlm.<minorversion>.*[-shorttag]"
+    // 1a. Enumerate all Framework packages registered to the user
+    // 1b. Only consider packages whose Name starts with "microsoft.winappruntime.ddlm.<minorversion>."
+    // 1c. If versiontag is specified, Only consider packages whose Name ends with [-shorttag]
+    // 1d. Only consider packages whose PublisherID = "8wekyb3d8bbwe"
+    // 2. Check if the package is in the <majorversion>.<minorversion> release
+    // 2a. Check if the package's Description starts with "Microsoft Windows App Runtime DDLM <majorversion>.<minorversion> "
+    // 3. Check if the architecture matches
+    // 4. Check if the package meets the specified minVerrsion
+
+    const UINT16 majorVersion{ HIWORD(majorMinorVersion) };
+    const UINT16 minorVersion{ LOWORD(majorMinorVersion) };
+    WCHAR packageNamePrefix[PACKAGE_NAME_MAX_LENGTH + 1]{};
+    if (!g_test_ddlmPackageNamePrefix.empty())
+    {
+        FAIL_FAST_IF_FAILED(StringCchCopyW(packageNamePrefix, ARRAYSIZE(packageNamePrefix), g_test_ddlmPackageNamePrefix.c_str()));
+    }
+    else
+    {
+        wsprintf(packageNamePrefix, L"microsoft.winappruntime.ddlm.%hu.", minorVersion);
+    }
+    const auto packageNamePrefixLength{ wcslen(packageNamePrefix) };
+
+    WCHAR packageNameSuffix[10]{};
+    size_t packageNameSuffixLength{};
+    const auto versionShortTag{ AppModel::Identity::GetVersionShortTagFromVersionTag(versionTag) };
+    if (!versionShortTag.empty())
+    {
+        packageNameSuffix[0] = L'-';
+        FAIL_FAST_IF_FAILED(StringCchCopyW(packageNameSuffix + 1, ARRAYSIZE(packageNameSuffix) - 1, versionShortTag.c_str()));
+        packageNameSuffixLength = wcslen(packageNameSuffix);
+    }
+
+    PCWSTR expectedPublisherId{ L"8wekyb3d8bbwe" };
+    if (!g_test_ddlmPackagePublisherId.empty())
+    {
+        expectedPublisherId = g_test_ddlmPackagePublisherId.c_str();
+    }
+
+    winrt::Windows::Management::Deployment::PackageManager packageManager;
+    winrt::hstring currentUser;
+    const auto c_packageTypes{ winrt::Windows::Management::Deployment::PackageTypes::Main };
+    for (auto package : packageManager.FindPackagesForUserWithPackageTypes(currentUser, c_packageTypes))
+    {
+        // Check the package identity against the package identity test qualifiers (if any)
+        const auto packageId{ package.Id() };
+        const auto packageName{ packageId.Name() };
+        const auto packageNameLength{ packageName.size() };
+        if (packageNameLength < packageNamePrefixLength + packageNameSuffixLength)
+        {
+            // The package's Name can't match the expected prefix and/or suffix. Skip it
+            continue;
+        }
+        if (CompareStringOrdinal(packageName.c_str(), static_cast<int>(packageNamePrefixLength), packageNamePrefix, static_cast<int>(packageNamePrefixLength), TRUE) != CSTR_EQUAL)
+        {
+                // The package's Name prefix doesn't match the expected value. Skip it
+                continue;
+        }
+        if (packageNameSuffixLength > 0)
+        {
+            const auto offsetToSuffix{ packageNameLength - packageNameSuffixLength };
+            if (CompareStringOrdinal(packageName.c_str() + offsetToSuffix, static_cast<int>(packageNameSuffixLength), packageNameSuffix, static_cast<int>(packageNameSuffixLength), TRUE) != CSTR_EQUAL)
+            {
+                    // The package's Name suffix doesn't match the expected value. Skip it
+                    continue;
+            }
+        }
+        if (CompareStringOrdinal(packageId.PublisherId().c_str(), -1, expectedPublisherId, -1, TRUE) != CSTR_EQUAL)
+        {
+            // The package's PublisherId doesn't match the expected value. Skip it
+            continue;
+        }
+
+        // Is this DDLM in the major.minor release?
+        //
+        // NOTE: Package.InstalledLocation.Path can be expensive as it has to create
+        //       a StorageFolder just to get the path as a string. We'd like to use
+        //       Package.EffectivePath but that didn't exist until 20H1 and we need
+        //       to work down to RS5. So instead we'll use GetPackagePathByFullName()
+        //       as that exists since Win81 (and can be significantly faster than
+        //       Package.InstalledLocation).
+        const auto packageFullName{ packageId.FullName() };
+        wil::unique_cotaskmem_string packagePathBufferDynamic;
+        uint32_t packagePathLength{};
+        const auto rc{ GetPackagePathByFullName(packageFullName.c_str(), &packagePathLength, nullptr) };
+        if (rc != ERROR_INSUFFICIENT_BUFFER)
+        {
+            THROW_HR_MSG(HRESULT_FROM_WIN32(rc), "Enumeration: %ls", packageFullName.c_str());
+        }
+        auto packagePath{ wil::make_cotaskmem_string_nothrow(nullptr, packagePathLength) };
+        THROW_IF_WIN32_ERROR(GetPackagePathByFullName(packageFullName.c_str(), &packagePathLength, packagePath.get()));
+        auto fileSpec{ std::filesystem::path(packagePath.get()) };
+        fileSpec /= L"Microsoft.WindowsAppRuntime.Release!*";
+        //
+        WIN32_FIND_DATA findFileData{};
+        wil::unique_hfind hfind{ FindFirstFile(fileSpec.c_str(), &findFileData) };
+        if (!hfind)
+        {
+            // The package's release version couldn't be determined. Skip it
+            (void)LOG_LAST_ERROR_MSG("Enumeration: FindFirst(%ls)", fileSpec.c_str());
+            continue;
+        }
+        uint16_t releaseMajorVersion{};
+        uint16_t releaseMinorVersion{};
+        if (swscanf_s(findFileData.cFileName, L"Microsoft.WindowsAppRuntime.Release!%hu.%hu", &releaseMajorVersion, &releaseMinorVersion) != 2)
+        {
+            // These aren't the droids you're looking for...
+            (void)LOG_LAST_ERROR_MSG("Enumeration: FindFirst(%ls) found %ls", fileSpec.c_str(), findFileData.cFileName);
+            continue;
+        }
+        if ((releaseMajorVersion != majorVersion) || (releaseMinorVersion != minorVersion))
+        {
+            // The package's minor release version doesn't match the expected value. Skip it
+            continue;
+        }
+
+        // Does the version meet the minVersion criteria?
+        auto packageVersion{ packageId.Version() };
+        PACKAGE_VERSION version{};
+        version.Major = packageVersion.Major;
+        version.Minor = packageVersion.Minor;
+        version.Build = packageVersion.Build;
+        version.Revision = packageVersion.Revision;
+        if (version.Version < minVersion.Version)
+        {
+            continue;
+        }
+
+        // Does the architecture match?
+        const auto architecture{ packageId.Architecture() };
+        if (architecture != AppModel::Identity::GetCurrentArchitecture())
+        {
+            continue;
+        }
+
+        // Do we have a package under consideration?
+        if (!foundAny)
+        {
+            bestFitVersion = version;
+            bestFitPackageFamilyName = packageId.FamilyName();
+            bestFitPackageFullName = packageId.FullName();
+            foundAny = true;
+            continue;
+        }
+
+        // Do we already have a higher version under consideration?
+        if (bestFitVersion.Version < version.Version)
+        {
+            bestFitVersion = version;
+            bestFitPackageFamilyName = packageId.FamilyName();
+            bestFitPackageFullName = packageId.FullName();
+            continue;
+        }
+    }
+    THROW_HR_IF_MSG(HRESULT_FROM_WIN32(ERROR_NO_MATCH), !foundAny, "Enumeration: Major=%hu, Minor=%hu, Tag=%ls, MinVersion=%hu.%hu.%hu.%hu",
+                    majorVersion, minorVersion, (!versionTag ? L"" : versionTag),
+                    minVersion.Major, minVersion.Minor, minVersion.Build, minVersion.Revision);
+    ddlmPackageFamilyName = bestFitPackageFamilyName.c_str();
+    ddlmPackageFullName = bestFitPackageFullName.c_str();
 }
 
 CLSID GetClsid(const winrt::Windows::ApplicationModel::AppExtensions::AppExtension& appExtension)

--- a/dev/WindowsAppRuntime_BootstrapDLL/framework.h
+++ b/dev/WindowsAppRuntime_BootstrapDLL/framework.h
@@ -5,6 +5,7 @@
 
 #include <unknwn.h>
 #include <appmodel.h>
+#include <shobjidl.h>
 
 #include <thread>
 #include <mutex>
@@ -21,8 +22,10 @@
 
 #include <winrt/Windows.ApplicationModel.h>
 #include <winrt/Windows.ApplicationModel.AppExtensions.h>
+#include <winrt/Windows.Management.Deployment.h>
 
 #include <appmodel.identity.h>
 #include <security.integritylevel.h>
+#include <iswindowsversion.h>
 
 #include "wil_msixdynamicdependency.h"

--- a/test/DynamicDependency/data/DynamicDependencyLifetimeManager.Msix/Makefile.mak
+++ b/test/DynamicDependency/data/DynamicDependencyLifetimeManager.Msix/Makefile.mak
@@ -46,13 +46,24 @@ TARGET_PROXYSTUB_FILE=$(TARGET_PROXYSTUB_DIR)\$(TARGET_PROXYSTUB).dll
 !MESSAGE $(TARGET_PROXYSTUB_FILE)
 !ENDIF
 
+DDLM_SHADOW=DynamicDependencyLifetimeManagerShadow
+DDLM_SHADOW_EXE=$(DDLM_SHADOW)
+DDLM_SHADOW_EXE_DIR=$(OutDir)$(DDLM_SHADOW_EXE)
+DDLM_SHADOW_EXE_FILE=$(DDLM_SHADOW_EXE_DIR)\$(DDLM_SHADOW_EXE).exe
+DDLM_SHADOW_EXE_PDB=$(DDLM_SHADOW_EXE_DIR)\$(DDLM_SHADOW_EXE).pdb
+
+VERSIONINFO_DIR=$(ProjectDir)
+VERSIONINFO_FILE=$(VERSIONINFO_DIR)Microsoft.WindowsAppRuntime.Release!4.1.0
+
 TargetDir=$(OutDir)$(TargetName)
 WorkDir=$(TargetDir)\msix
 OutMsix=$(TargetDir)\$(TargetName)
 
 !IFDEF VERBOSE
-!MESSAGE Workdir           =$(WorkDir)
-!MESSAGE OutMsix           =$(OutMsix)
+!MESSAGE Workdir              =$(WorkDir)
+!MESSAGE OutMsix              =$(OutMsix)
+!MESSAGE DDLM_SHADOW_EXE_FILE =$(DDLM_SHADOW_EXE_FILE)
+!MESSAGE DDLM_SHADOW_EXE_PDB  =$(DDLM_SHADOW_EXE_PDB)
 !ENDIF
 
 MAKE_APPXMANIFEST_FROM_TEMPLATE=$(SolutionDir)tools\MakeAppxManifestFromTemplate.cmd
@@ -67,6 +78,9 @@ $(OutMsix): $(ProjectDir)appxmanifest.xml
     @copy /Y $(ProjectDir)Assets\* $(WorkDir)\Assets\* >NUL
     @copy /Y $(TARGET_EXE_FILE) $(WorkDir) >NUL
     @copy /Y $(TARGET_PROXYSTUB_FILE) $(WorkDir) >NUL
+    @copy /Y $(DDLM_SHADOW_EXE_FILE) $(WorkDir) >NUL
+    @copy /Y $(DDLM_SHADOW_EXE_PDB) $(WorkDir) >NUL
+    @copy /Y $(VERSIONINFO_FILE) $(WorkDir) >NUL
     @makeappx.exe pack $(MAKEAPPX_OPTS) /o /h SHA256 /d $(WorkDir) /p $(OutMsix)
     @signtool.exe sign /a $(SIGNTOOL_OPTS) /fd SHA256 /f $(SolutionDir)temp\MSTest.pfx $(OutMsix)
 

--- a/test/DynamicDependency/data/DynamicDependencyLifetimeManager.Msix/Microsoft.WindowsAppRuntime.Release!4.1.0
+++ b/test/DynamicDependency/data/DynamicDependencyLifetimeManager.Msix/Microsoft.WindowsAppRuntime.Release!4.1.0
@@ -1,0 +1,1 @@
+Windows App SDK release = 4.1.0

--- a/test/DynamicDependency/data/DynamicDependencyLifetimeManager.Msix/appxmanifest.xml
+++ b/test/DynamicDependency/data/DynamicDependencyLifetimeManager.Msix/appxmanifest.xml
@@ -31,7 +31,7 @@
   </Resources>
 
   <Applications>
-    <Application Id="App"
+    <Application Id="DDLMCOMServer"
       Executable="DynamicDependencyLifetimeManager.exe"
       EntryPoint="Windows.FullTrustApplication">
       <uap:VisualElements
@@ -39,7 +39,8 @@
         Square150x150Logo="Assets\Square150x150Logo.png"
         Square44x44Logo="Assets\Square44x44Logo.png"
         Description="Microsoft Windows App Runtime DynamicDependency LifetimeManager"
-        BackgroundColor="transparent">
+        BackgroundColor="transparent"
+        AppListEntry="none">
         <uap:DefaultTile Wide310x150Logo="Assets\Wide310x150Logo.png"/>
         <uap:SplashScreen Image="Assets\SplashScreen.png" uap5:Optional="true"/>
       </uap:VisualElements>
@@ -68,6 +69,20 @@
           </com:ComInterface>
         </com:Extension>
       </Extensions>
+    </Application>
+    <Application Id="DDLM"
+      Executable="DynamicDependencyLifetimeManagerShadow.exe"
+      EntryPoint="Windows.FullTrustApplication">
+      <uap:VisualElements
+        DisplayName="Microsoft Windows App Runtime DynamicDependency LifetimeManager"
+        Square150x150Logo="Assets\Square150x150Logo.png"
+        Square44x44Logo="Assets\Square44x44Logo.png"
+        Description="Microsoft Windows App Runtime DynamicDependency LifetimeManager"
+        BackgroundColor="transparent"
+        AppListEntry="none">
+        <uap:DefaultTile Wide310x150Logo="Assets\Wide310x150Logo.png"/>
+        <uap:SplashScreen Image="Assets\SplashScreen.png" uap5:Optional="true"/>
+      </uap:VisualElements>
     </Application>
   </Applications>
 


### PR DESCRIPTION
https://task.ms/36777674

cherry-pick commit d7b2e035171f622975140e970c6cdc8b24eddff4 from main

Non-AppExtension implementation for <=19H1

Altered Bootstrap to workaround AppExtension issue on RS5+19H1:

1) Bootstrap enumerates potential DDLMs via PackageManager.FindsPackagesByPackageType(framework) instead of AppExtension.OpenCatalog(ddlm)

2) Bootstrap uses a DesktopBridge application process instead of a PackagedCOM OOP Server to indicate WinAppSDK Framework package-in-use

3) the package-in-use process quits when it's told to (because MddBootstrapShutdown was called) or the caller process terminated (w/o calling MddBootstrapShutdown) instead of last COM reference to the PackagedCOM OOP Server was Release'd.

We now get N 'shadow' processes (1 per Bootstrap-calling process) instead of 1 process (1 PackagedCOM OOP Server for all Bootstrap-calling processes), but the DDLMShadow process is small and cheap. Single-instancing DDLMShadow.exe is an exercise for the future (assuming it's not obsolete and dropped).

Added/relies-on a 'release marker' file in the DDLM package to identify the major.minor release (required as otherwise few options to determine the major, none of them cheap).