### PR TITLE
fail fast fix

### DIFF
--- a/dev/WindowsAppRuntime_BootstrapDLL/MddBootstrapAutoInitializer.cpp
+++ b/dev/WindowsAppRuntime_BootstrapDLL/MddBootstrapAutoInitializer.cpp
@@ -5,6 +5,7 @@
 #include <stdint.h>
 #include <MddBootstrap.h>
 #include <WindowsAppSDK-VersionInfo.h>
+#include <intrin.h>
 
 namespace Microsoft::Windows::ApplicationModel::DynamicDependency::Bootstrap
 {
@@ -22,13 +23,11 @@ namespace Microsoft::Windows::ApplicationModel::DynamicDependency::Bootstrap
 
         static void Initialize()
         {
-            const UINT32 c_majorMinorVersion{ WINDOWSAPPSDK_RELEASE_MAJORMINOR };
-            PCWSTR c_versionTag{ WINDOWSAPPSDK_RELEASE_VERSION_TAG_W };
-            const PACKAGE_VERSION c_minVersion{ WINDOWSAPPSDK_RUNTIME_VERSION_UINT64 };
-            const HRESULT hr{ ::MddBootstrapInitialize(c_majorMinorVersion, c_versionTag, c_minVersion) };
+            const PACKAGE_VERSION c_minVersion{WINDOWSAPPSDK_RUNTIME_VERSION_UINT64};
+            const HRESULT hr{::MddBootstrapInitialize(WINDOWSAPPSDK_RELEASE_MAJORMINOR, WINDOWSAPPSDK_RELEASE_VERSION_TAG_W, c_minVersion)};
             if (FAILED(hr))
             {
-                exit(hr);
+                __fastfail(hr);
             }
         }
     };


### PR DESCRIPTION
This change helps solve this problem : https://github.com/microsoft/WindowsAppSDK/issues/1683. By using failfast instead of exit, there will not be a compile time error. 
