### PR TITLE
Fix x86 instancing appId generation.

### DIFF
--- a/dev/AppLifecycle/Association.cpp
+++ b/dev/AppLifecycle/Association.cpp
@@ -67,9 +67,16 @@ namespace winrt::Microsoft::Windows::AppLifecycle::implementation
 
         std::hash<std::wstring> hasher;
         auto hash = hasher(seed);
-;
+        uint64_t hash64 = static_cast<uint64_t>(hash);
+
+        // Simulate a larger hash on 32bit platforms to keep the id length consistent.
+        if constexpr (sizeof(size_t) < sizeof(uint64_t))
+        {
+            hash64 = (static_cast<uint64_t>(hash) << 32) | static_cast<uint64_t>(hash);
+        }
+
         wchar_t hashString[17]{}; // 16 + 1 characters for 64bit value represented as a string with a null terminator.
-        THROW_IF_FAILED(StringCchPrintf(hashString, _countof(hashString), L"%I64x", hash));
+        THROW_IF_FAILED(StringCchPrintf(hashString, _countof(hashString), L"%I64x", hash64));
 
         std::wstring result{ c_progIdPrefix };
         result += hashString;


### PR DESCRIPTION
Currently appIds used for association data and instancing delineation are not consistent across instances of execution for x86.  The std::hasher returns a type of size_t which is then expanded in StringCchPrintf.  The data is 32bit on x86 platforms which leads to the printf code pulling in garbage for the first half of the number.  This causes the number being different every time.

This fix keeps the appId based off of 64bit numbers, but expands the 32bit version to be 64bit and fills in the upper half with another copy of the 32bit value.

This will likely be a temporary fix though, as during investigating the root cause it was discovered that the values are not consistent between x86 and x64.  This is much more of an edge case (x86 and x64 variants of the same app, on the same machine needing to work with the same data...)  The solution for everything here would be to switch to a hasher that provides the same results for all architectures.  The most immediate need though is to get x86 functioning, and then follow-up later with a more invasive change to the algorithm used.