### PR TITLE
IsLifetimeManagerViaEnumeration() always returned true

### DIFF
--- a/dev/Common/IsWindowsVersion.h
+++ b/dev/Common/IsWindowsVersion.h
@@ -12,7 +12,7 @@ inline bool IsExportPresent(
     PCWSTR filename,
     PCSTR functionName)
 {
-    wil::unique_hmodule dll{ LoadLibraryExW(filename, nullptr, LOAD_WITH_ALTERED_SEARCH_PATH) };
+    wil::unique_hmodule dll{ LoadLibraryExW(filename, nullptr, 0) };
     if (dll)
     {
         auto function{ GetProcAddress(dll.get(), functionName) };

--- a/dev/WindowsAppRuntime_BootstrapDLL/MddBootstrap.cpp
+++ b/dev/WindowsAppRuntime_BootstrapDLL/MddBootstrap.cpp
@@ -292,11 +292,24 @@ bool IsLifetimeManagerViaEnumeration()
         return true;
     }
 
-    // Enable the Enumeration-style LifetimeManager if the environment variable
-    // MICROSOFT_WINDOWSAPPRUNTIME_DDLM_ENUMERATION is defined (for testing scenarios)
-    if (GetEnvironmentVariableW(L"MICROSOFT_WINDOWSAPPRUNTIME_DDLM_ENUMERATION", nullptr, 0) > 0)
+    // Select the LifetimeManager implementation if the environment variable
+    // MICROSOFT_WINDOWSAPPRUNTIME_DDLM_ALGORITHM is defined (for testing scenarios)
+    // where:
+    //     envvar=0 => Enumeration
+    //     envvar=1 => AppExtension
     {
-        return true;
+        WCHAR value[1 + 1]{};
+        if (GetEnvironmentVariableW(L"MICROSOFT_WINDOWSAPPRUNTIME_DDLM_ALGORITHM", value, ARRAYSIZE(value)) > 0)
+        {
+            if (*value == L'0')
+            {
+                return true;
+            }
+            else if (*value == L'1')
+            {
+                return false;
+            }
+        }
     }
 
     // Use the AppExtension-style LifetimeManager


### PR DESCRIPTION
https://task.ms/36938053

Rewrite IsWindows10_*OrGreater() to workaround GetVersionEx() lying to the caller (us) if the process' exe wasn't 'built for the OS' (PE Header indicating it's built for 20H1+ or (somehow) same via a SxS manifest). This caused IsLifetimeManagerViaEnumeration() to always evaluate to using the Enumeration algorithm even on newer platforms where we wanted the AppExtension algorithm.

Also changed the testing environment variable to MICROSOFT_WINDOWSAPPRUNTIME_DDLM_ALGORITHM=0|1 (Enumeration|AppExtension).

Changes tested via test collateral as well as walking through the relevant code in the debugger bit fiddling results to ensure ultimately 100 branch coverage.