### PR TITLE
Update GetEnvironmentVariable()-succeeeded check

### DIFF
--- a/dev/WindowsAppRuntime_BootstrapDLL/MddBootstrap.cpp
+++ b/dev/WindowsAppRuntime_BootstrapDLL/MddBootstrap.cpp
@@ -299,7 +299,7 @@ bool IsLifetimeManagerViaEnumeration()
     //     envvar=1 => AppExtension
     {
         WCHAR value[1 + 1]{};
-        if (GetEnvironmentVariableW(L"MICROSOFT_WINDOWSAPPRUNTIME_DDLM_ALGORITHM", value, ARRAYSIZE(value)) > 0)
+        if (GetEnvironmentVariableW(L"MICROSOFT_WINDOWSAPPRUNTIME_DDLM_ALGORITHM", value, ARRAYSIZE(value)) == 1)
         {
             if (*value == L'0')
             {


### PR DESCRIPTION
Update GetEnvironmentVariable()-succeeeded check to avoid undefined behavior if the function failed due to insufficient buffer

This corrects the issue @huichen123 identified @ https://github.com/microsoft/WindowsAppSDK/pull/1751#discussion_r745980956