### PR TITLE
Add Licensing API

### DIFF
--- a/build/CopyFilesToStagingDir.ps1
+++ b/build/CopyFilesToStagingDir.ps1
@@ -57,6 +57,7 @@ PublishFile $FullBuildOutput\DynamicDependencyLifetimeManagerShadow\DynamicDepen
 PublishFile $FullBuildOutput\WindowsAppRuntime_BootstrapDLL\Microsoft.WindowsAppRuntime.Bootstrap.dll $FullPublishDir\Microsoft.WindowsAppRuntime.Bootstrap\
 PublishFile $FullBuildOutput\WindowsAppRuntime_BootstrapDLL\Microsoft.WindowsAppRuntime.Bootstrap.lib $FullPublishDir\Microsoft.WindowsAppRuntime.Bootstrap\
 PublishFile $FullBuildOutput\WindowsAppRuntime_BootstrapDLL\MddBootstrap.h $FullPublishDir\Microsoft.WindowsAppRuntime.Bootstrap\
+PublishFile $FullBuildOutput\WindowsAppRuntime_BootstrapDLL\WindowsAppRuntime-Licensing.h $FullPublishDir\Microsoft.WindowsAppRuntime.Bootstrap\
 PublishFile $FullBuildOutput\Microsoft.WindowsAppRuntime.Bootstrap.Net\Microsoft.WindowsAppRuntime.Bootstrap.Net.dll $FullPublishDir\Microsoft.WindowsAppRuntime.Bootstrap\
 PublishFile $FullBuildOutput\Microsoft.WindowsAppRuntime.Bootstrap.Net\Microsoft.WindowsAppRuntime.Bootstrap.Net.pdb $FullPublishDir\Microsoft.WindowsAppRuntime.Bootstrap\
 
@@ -88,6 +89,7 @@ PublishFile $OverrideDir\DynamicDependency-Override.json $NugetDir\runtimes\win1
 #
 # Includes (*.h)
 PublishFile $FullBuildOutput\WindowsAppRuntime_BootstrapDLL\MddBootstrap.h $NugetDir\include
+PublishFile $FullBuildOutput\WindowsAppRuntime_BootstrapDLL\WindowsAppRuntime-Licensing.h $NugetDir\include
 PublishFile $FullBuildOutput\WindowsAppRuntime_DLL\MsixDynamicDependency.h $NugetDir\include
 PublishFile $FullBuildOutput\WindowsAppRuntime_DLL\wil_msixdynamicdependency.h $NugetDir\include
 PublishFile $FullBuildOutput\WindowsAppRuntime_DLL\WindowsAppRuntimeInsights.h $NugetDir\include\

--- a/dev/Licensing/MsixLicensing.cpp
+++ b/dev/Licensing/MsixLicensing.cpp
@@ -6,11 +6,92 @@
 
 #include <WindowsAppRuntime-License.h>
 
-STDAPI MsixInstallLicenses() noexcept try
+STDAPI MsixInstallLicenses(
+    UINT32 majorMinorVersion,
+    PCWSTR versionTag) noexcept try
 {
-    //TODO
-    // FOREACH file IN pkgdir\MSIX\*_license.xml
-    //  InstallLicenseFile(file)
-    return S_OK;
+    // Licenses are only needed for Stable releases (versionTag=null or "")
+    if (versionTag && (versionTag[0] != L'\0'))
+    {
+        return S_OK;
+    }
+
+    const UINT16 majorVersion{ HIWORD(majorMinorVersion) };
+    const UINT16 minorVersion{ LOWORD(majorMinorVersion) };
+    WCHAR packageFamilyName[PACKAGE_FAMILY_NAME_MAX_LENGTH + 1]{};
+    wsprintf(packageFamilyName, L"Microsoft.WindowsAppRuntime.%hu.%hu_8wekyb3d8bbwe", majorVersion, minorVersion);
+
+    // Find a framework package in the family (any will do)
+    winrt::Windows::Management::Deployment::PackageManager packageManager;
+    winrt::hstring currentUser;
+    const auto c_packageTypes{ winrt::Windows::Management::Deployment::PackageTypes::Framework };
+    for (auto package : packageManager.FindPackagesForUserWithPackageTypes(currentUser, packageFamilyName, c_packageTypes))
+    {
+        // Install the license(s)
+        const auto packageId{ package.Id() };
+        const auto packageFullName{ packageId.FullName() };
+        RETURN_IF_FAILED(MsixInstallLicensesInPackage(packageFullName.c_str()));
+        return S_OK;
+    }
+
+    // No framework package found in the family
+    RETURN_HR_MSG(HRESULT_FROM_WIN32(ERROR_NOT_FOUND), "PackageFamilyName:%ls", packageFamilyName);
 }
 CATCH_RETURN();
+
+STDAPI MsixInstallLicensesInPackage(PCWSTR frameworkPackageFullName) noexcept try
+{
+    // Get the package's path
+    //
+    // NOTE: Use GetStagedPackagePathByFullName as don't care if the package is registered.
+    //
+    // NOTE: Don't use GetStagedPackagePathByFullName2 as we want the *install* location
+    //       (not e.g. modifiable location). Plus Get...2() is new in 20H1 (too new for us)
+    //       where Get...() exists down to Win81. In this case simplest is bestest.
+    wil::unique_cotaskmem_string packagePathBufferDynamic;
+    uint32_t packagePathLength{};
+    const auto rc{ GetStagedPackagePathByFullName(frameworkPackageFullName, &packagePathLength, nullptr) };
+    if (rc != ERROR_INSUFFICIENT_BUFFER)
+    {
+        RETURN_HR_MSG(HRESULT_FROM_WIN32(rc), "PackageFullName:%ls", frameworkPackageFullName);
+    }
+    auto packagePath{ wil::make_cotaskmem_string(nullptr, packagePathLength) };
+    RETURN_IF_WIN32_ERROR(GetStagedPackagePathByFullName(frameworkPackageFullName, &packagePathLength, packagePath.get()));
+
+    // Build path for licenses
+    std::filesystem::path licensePath{ packagePath.get() };
+    const auto c_packageRelativeLicensePath{ L"MSIX" };
+    licensePath /= c_packageRelativeLicensePath;
+    auto licenseFilespec{ licensePath };
+    licenseFilespec /= L"*_license.xml";
+
+    // Deploy the licenses (if any)
+    ::Microsoft::Windows::ApplicationModel::Licensing::Installer licenseInstaller;
+    WIN32_FIND_DATA findFileData{};
+    wil::unique_hfind hfind{ FindFirstFileW(licenseFilespec.c_str(), &findFileData) };
+    if (!hfind)
+    {
+        const auto lastError{ GetLastError() };
+        RETURN_HR_IF_MSG(HRESULT_FROM_WIN32(lastError), (lastError != ERROR_FILE_NOT_FOUND) && (lastError != ERROR_PATH_NOT_FOUND),
+                         "FindFirstFile:%ls", licenseFilespec.c_str());
+        return S_OK;
+    }
+    for (;;)
+    {
+        // Install the license file
+        auto licenseFilename{ licensePath };
+        licenseFilename /= findFileData.cFileName;
+        RETURN_IF_FAILED_MSG(licenseInstaller.InstallLicenseFile(licenseFilename.c_str()),
+                             "LicenseFile:%ls", licenseFilename.c_str());
+
+        // Next! (if any)
+        if (!FindNextFileW(hfind.get(), &findFileData))
+        {
+            const auto lastError{ GetLastError() };
+            RETURN_HR_IF(HRESULT_FROM_WIN32(lastError), lastError != ERROR_NO_MORE_FILES);
+            break;
+        }
+    }
+    return S_OK;
+}
+CATCH_RETURN()

--- a/dev/Licensing/MsixLicensing.h
+++ b/dev/Licensing/MsixLicensing.h
@@ -3,6 +3,11 @@
 #ifndef __MSIXLICENSING_H
 #define __MSIXLICENSING_H
 
-STDAPI MsixInstallLicenses() noexcept;
+STDAPI MsixInstallLicenses(
+    UINT32 majorMinorVersion,
+    PCWSTR versionTag) noexcept;
+
+STDAPI MsixInstallLicensesInPackage(
+    PCWSTR frameworkPackageFullName) noexcept;
 
 #endif // __MSIXLICENSING_H

--- a/dev/WindowsAppRuntime_BootstrapDLL/WindowsAppRuntime-Licensing.cpp
+++ b/dev/WindowsAppRuntime_BootstrapDLL/WindowsAppRuntime-Licensing.cpp
@@ -6,9 +6,125 @@
 
 #include <msixlicensing.h>
 
-STDAPI WindowsAppRuntime_InstallLicenses() noexcept try
+static std::filesystem::path GetPathForPackage(
+    PCWSTR packageFullName)
 {
-    RETURN_IF_FAILED(MsixInstallLicenses());
+    // Get the package's path
+    //
+    // NOTE: Use GetStagedPackagePathByFullName as don't care if the package is registered.
+    //
+    // NOTE: Don't use GetStagedPackagePathByFullName2 as we want the *install* location
+    //       (not e.g. modifiable location). Plus Get...2() is new in 20H1 (too new for us)
+    //       where Get...() exists down to Win81. In this case simplest is bestest.
+    wil::unique_cotaskmem_string packagePathBufferDynamic;
+    uint32_t packagePathLength{};
+    const auto rc{ GetStagedPackagePathByFullName(packageFullName, &packagePathLength, nullptr) };
+    if (rc != ERROR_INSUFFICIENT_BUFFER)
+    {
+        THROW_HR_MSG(HRESULT_FROM_WIN32(rc), "PackageFullName:%ls", packageFullName);
+    }
+    auto packagePath{ wil::make_cotaskmem_string(nullptr, packagePathLength) };
+    THROW_IF_WIN32_ERROR(GetStagedPackagePathByFullName(packageFullName, &packagePathLength, packagePath.get()));
+    std::filesystem::path path{ packagePath.get() };
+    return path;
+}
+
+static HMODULE LoadMsixLicensingApisAtPath(
+    const std::filesystem::path& path)
+{
+    auto windowsAppRuntimeDllFilename{ path };
+    windowsAppRuntimeDllFilename /= L"Microsoft.WindowsAppRuntime.dll";
+    auto windowsAppRuntimeDll(LoadLibraryEx(windowsAppRuntimeDllFilename.c_str(), nullptr, LOAD_WITH_ALTERED_SEARCH_PATH ));
+    if (!windowsAppRuntimeDll)
+    {
+        const auto lastError{ GetLastError() };
+        THROW_WIN32_MSG(lastError, "Error in LoadLibrary: %d (0x%X) loading %ls", lastError, lastError, windowsAppRuntimeDllFilename.c_str());
+    }
+    return windowsAppRuntimeDll;
+}
+
+static HMODULE LoadMsixLicensingApisInPackage(
+    PCWSTR packageFullName)
+{
+    auto path{ GetPathForPackage(packageFullName) };
+    return LoadMsixLicensingApisAtPath(path);
+}
+
+static HMODULE LoadMsixLicensingApisInRelease(
+    UINT32 majorMinorVersion,
+    PCWSTR versionTag)
+{
+    // Licenses are only needed for Stable releases (versionTag=null or "")
+    if (versionTag && (versionTag[0] != L'\0'))
+    {
+        // Nothing to do!
+        return nullptr;
+    }
+
+    // Find a package in the family
+    const UINT16 majorVersion{ HIWORD(majorMinorVersion) };
+    const UINT16 minorVersion{ LOWORD(majorMinorVersion) };
+    WCHAR packageFamilyName[PACKAGE_FAMILY_NAME_MAX_LENGTH + 1]{};
+    wsprintf(packageFamilyName, L"Microsoft.WindowsAppRuntime.%hu.%hu_8wekyb3d8bbwe", majorVersion, minorVersion);
+
+    // Find a framework package in the family (any will do)
+    winrt::Windows::Management::Deployment::PackageManager packageManager;
+    winrt::hstring currentUser;
+    const auto c_packageTypes{ winrt::Windows::Management::Deployment::PackageTypes::Framework };
+    for (auto package : packageManager.FindPackagesForUserWithPackageTypes(currentUser, packageFamilyName, c_packageTypes))
+    {
+        // Load the Licensing APIs' implementation
+        const auto packageId{ package.Id() };
+        const auto packageFullName{ packageId.FullName() };
+        return LoadMsixLicensingApisInPackage(packageFullName.c_str());
+    }
+
+    // No framework package found in the family
+    THROW_HR_MSG(HRESULT_FROM_WIN32(ERROR_NOT_FOUND), "PackageFamilyName:%ls", packageFamilyName);
+}
+
+STDAPI WindowsAppRuntime_InstallLicenses(
+    UINT32 majorMinorVersion,
+    PCWSTR versionTag) noexcept try
+{
+    // Explicitly load the DLL before using it
+    // NOTE: It doesn't need to be Register'd for the caller
+    //       but it must be at least Stage'd for this to work.
+    //
+    // NOTE: Yes, this is a rather unusual usage. It's a very specific way
+    //       that's safe for this specific case. Be very careful if/when
+    //       changing this logic. And DON'T consider this license <heh>
+    //       to use packages without being registered (and the usual
+    //       unpackaged-processes-need-DynamicDependencies rules).
+    //       This is the exception that proves the rule.
+    wil::unique_hmodule windowsAppRuntimeDll{ LoadMsixLicensingApisInRelease(majorMinorVersion, versionTag) };
+    if (windowsAppRuntimeDll)
+    {
+        RETURN_IF_FAILED(MsixInstallLicenses(majorMinorVersion, versionTag));
+    }
     return S_OK;
 }
 CATCH_RETURN();
+
+STDAPI WindowsAppRuntime_InstallLicensesInPackage(
+    PCWSTR frameworkPackageFullName) noexcept try
+{
+    // Explicitly load the DLL before using it
+    // NOTE: It doesn't need to be Register'd for the caller
+    //       but it must be at least Stage'd for this to work.
+    //
+    // NOTE: Yes, this is a rather unusual usage. It's a very specific way
+    //       that's safe for this specific case. Be very careful if/when
+    //       changing this logic. And DON'T consider this license <heh>
+    //       to use packages without being registered (and the usual
+    //       unpackaged-processes-need-DynamicDependencies rules).
+    //       This is the exception that proves the rule.
+    wil::unique_hmodule windowsAppRuntimeDll{ LoadMsixLicensingApisInPackage(frameworkPackageFullName) };
+    if (windowsAppRuntimeDll)
+    {
+        RETURN_IF_FAILED(MsixInstallLicensesInPackage(frameworkPackageFullName));
+    }
+    return S_OK;
+}
+CATCH_RETURN();
+

--- a/dev/WindowsAppRuntime_BootstrapDLL/WindowsAppRuntime-Licensing.h
+++ b/dev/WindowsAppRuntime_BootstrapDLL/WindowsAppRuntime-Licensing.h
@@ -3,10 +3,27 @@
 #ifndef __WINDOWSAPPRUNTIME_LICENSING_H
 #define __WINDOWSAPPRUNTIME_LICENSING_H
 
+/// Install licenses (if any) for a Windows App Runtime release.
+///
+/// This finds the Windows App Runtime's framework package and installs the contained licenses (if any).
+///
+/// @note Appropriate licenses MUST be installed for MddBootstrapInitialize() to succeed.
+///
+/// @param majorMinorVersion the major and minor version to use, e..g 0x00010002 for Major.Minor=1.2
+/// @param versionTag the version pre-release identifier, or NULL if none.
 STDAPI WindowsAppRuntime_InstallLicenses(
     UINT32 majorMinorVersion,
     PCWSTR versionTag) noexcept;
 
+/// Install licenses (if any) in a Windows App Runtime's framework package.
+///
+/// This installs the licenses (if any) in the specified Windows App Runtime framework package.
+///
+/// @note Appropriate licenses MUST be installed for MddBootstrapInitialize() to succeed.
+///
+/// @note This is primarily for testing purposes. Developers are encouraged to use WindowsAppRuntime_InstallLicenses().
+///
+/// @param frameworkPackageFullName path to Windows App Runtime's framework package.
 STDAPI WindowsAppRuntime_InstallLicensesInPackage(
     PCWSTR frameworkPackageFullName) noexcept;
 

--- a/dev/WindowsAppRuntime_BootstrapDLL/WindowsAppRuntime-Licensing.h
+++ b/dev/WindowsAppRuntime_BootstrapDLL/WindowsAppRuntime-Licensing.h
@@ -3,6 +3,11 @@
 #ifndef __WINDOWSAPPRUNTIME_LICENSING_H
 #define __WINDOWSAPPRUNTIME_LICENSING_H
 
-STDAPI WindowsAppRuntime_InstallLicenses() noexcept;
+STDAPI WindowsAppRuntime_InstallLicenses(
+    UINT32 majorMinorVersion,
+    PCWSTR versionTag) noexcept;
+
+STDAPI WindowsAppRuntime_InstallLicensesInPackage(
+    PCWSTR frameworkPackageFullName) noexcept;
 
 #endif // __WINDOWSAPPRUNTIME_LICENSING_H

--- a/dev/WindowsAppRuntime_BootstrapDLL/WindowsAppRuntime.Bootstrap.def
+++ b/dev/WindowsAppRuntime_BootstrapDLL/WindowsAppRuntime.Bootstrap.def
@@ -5,3 +5,6 @@ EXPORTS
     MddBootstrapInitialize
     MddBootstrapShutdown
     MddBootstrapTestInitialize
+
+    WindowsAppRuntime_InstallLicenses
+    WindowsAppRuntime_InstallLicensesInPackage

--- a/dev/WindowsAppRuntime_BootstrapDLL/WindowsAppRuntime_BootstrapDLL.vcxproj
+++ b/dev/WindowsAppRuntime_BootstrapDLL/WindowsAppRuntime_BootstrapDLL.vcxproj
@@ -465,6 +465,7 @@
     <PublicHeaders Include="$(MSBuildThisFileDirectory)MddBootstrapTest.h" />
     <PublicHeaders Include="$(MSBuildThisFileDirectory)MddBootstrapAutoInitializer.cs" />
     <PublicHeaders Include="$(MSBuildThisFileDirectory)MddBootstrapAutoInitializer.cpp" />
+    <PublicHeaders Include="$(MSBuildThisFileDirectory)WindowsAppRuntime-Licensing.h" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\DynamicDependencyLifetimeManager\IDynamicDependencyLifetimeManager\IDynamicDependencyLifetimeManager.vcxproj">

--- a/dev/WindowsAppRuntime_BootstrapDLL/framework.h
+++ b/dev/WindowsAppRuntime_BootstrapDLL/framework.h
@@ -9,6 +9,7 @@
 
 #include <thread>
 #include <mutex>
+#include <filesystem>
 
 #include <wil/cppwinrt.h>
 #include <wil/token_helpers.h>

--- a/dev/WindowsAppRuntime_DLL/WindowsAppRuntime.def
+++ b/dev/WindowsAppRuntime_DLL/WindowsAppRuntime.def
@@ -17,3 +17,4 @@ EXPORTS
     MddGetGenerationId
 
     MsixInstallLicenses
+    MsixInstallLicensesInPackage


### PR DESCRIPTION
Add an API to install our licenses.

Those who directly install the WindowsAppSDK packages (i.e. don't run WindowsAppRuntimeInstaller.exe and don't use the Deployment API) need to install the *.msix packages AND their licenses.

Easiest way to do that is to

```
#include <WindowsAppRuntime-Licensing.h>
...
const uint32_t c_majorMinorVersion{ WINDOWSAPPSDK_RELEASE_MAJORMINOR };
PCWSTR c_versionTag{ WINDOWSAPPSDK_RELEASE_VERSION_TAG_W };
const auto hr{ WindowsAppRuntime_InstallLicenses(c_majorMinorVersion, c_versionTag) };
if (FAILED(hr))
{
    ...error...
}
```

NOTE: There's also `WindowsAppRuntime_InstallLicensesInPackage()` but that's primarily for testing.

See `WindowsAppRuntime-Licensing.h` for more details.