### PR TITLE
Validate doc links in PR/CI

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -6,9 +6,9 @@ name: docs
 on:
   # Triggers the workflow on push or pull request events but only for the main branch
   push:
-    branches: [ main, docslinks ]
+    branches: [ main ]
   pull_request:
-    branches: [ main, docslinks ]
+    branches: [ main ]
 
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,31 @@
+# This is a basic workflow to help you get started with Actions
+
+name: docs
+
+# Controls when the workflow will run
+on:
+  # Triggers the workflow on push or pull request events but only for the main branch
+  push:
+    branches: [ main, docslinks ]
+  pull_request:
+    branches: [ main, docslinks ]
+
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+# A workflow run is made up of one or more jobs that can run sequentially or in parallel
+jobs:
+  # This workflow contains a single job called "build"
+  build:
+    # The type of runner that the job will run on
+    runs-on: windows-latest
+
+    # Steps represent a sequence of tasks that will be executed as part of the job
+    steps:
+      # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
+      - uses: actions/checkout@v2
+
+      # Runs a single command using the runners shell
+      - name: Validate links in docs
+        run: npx unbroken
+        working-directory: docs

--- a/docs/Coding-Guidelines/HybridCRT.md
+++ b/docs/Coding-Guidelines/HybridCRT.md
@@ -55,9 +55,9 @@ Windows App SDK uses the hybrid CRT for all PE files.
 TL;DR Do nothing and all projects use it. If you create a new *.vcxproj delete any `<RuntimeLibrary>` tags.
 
 Windows App SDK defines the rules for Visual Studio in
-[https://github.com/microsoft/WindowsAppSDK/HybridCRT.props](https://github.com/microsoft/WindowsAppSDK/blob/main/HybridCRT.props).
+[HybridCRT.props](https://github.com/microsoft/WindowsAppSDK/blob/main/HybridCRT.props).
 This is imported by
-[Directory.Build.props](https://github.com/microsoft/WindowsAppSDK/Directory.Build.props) so all
+[Directory.Build.props](https://github.com/microsoft/WindowsAppSDK/blob/main/Directory.Build.props) so all
 projects in the directory tree get this support.
 
 If new projects are created DO NOT specify `<RuntimeLibrary>` in *.vcxproj as that's unnecessary and
@@ -115,7 +115,7 @@ The steps involved:
 
 ### Directory.Build.props
 
-[Directory.Build.props](https://github.com/microsoft/WindowsAppSDK/Directory.Build.props) in the
+[Directory.Build.props](https://github.com/microsoft/WindowsAppSDK/blob/main/Directory.Build.props) in the
 repository root imports
 [HybridCRT.props](https://github.com/microsoft/WindowsAppSDK/blob/main/HybridCRT.props) to apply to
 all projects in the repository via this statement:

--- a/docs/Coding-Guidelines/Languages-Markdown.md
+++ b/docs/Coding-Guidelines/Languages-Markdown.md
@@ -5,4 +5,4 @@ GitHub diff is line oriented. Keeping lines within the preferred limit makes cha
 review. Use a tool like Prettier to bulk-reformat files, or configure your editor's "rulers." If new
 languages become common, we will describe the coding guidelines for such languages here.
 
-**DO** validate that your links work by visiting them.
+**DO** ensure that all links in documentation are correct; click them in the markdown preview view.

--- a/docs/Coding-Guidelines/Languages-Markdown.md
+++ b/docs/Coding-Guidelines/Languages-Markdown.md
@@ -4,3 +4,5 @@
 GitHub diff is line oriented. Keeping lines within the preferred limit makes changes easier to
 review. Use a tool like Prettier to bulk-reformat files, or configure your editor's "rulers." If new
 languages become common, we will describe the coding guidelines for such languages here.
+
+**DO** validate that your links work by visiting them.


### PR DESCRIPTION
This adds link validation to our docs in CI (to prevent issues like #6312)
This change uncovered some other existing links that were invalid.

## Description
Run `unbroken` in CI
Details: https://www.npmjs.com/package/unbroken