### PR TITLE
Fix parameter names for AssetsName and AssetsVersions

### DIFF
--- a/build/ProjectReunion-BuildFoundation.yml
+++ b/build/ProjectReunion-BuildFoundation.yml
@@ -487,6 +487,6 @@ jobs:
     - ${{ if or(eq(variables['Build.Reason'], 'Schedule'), eq(parameters.publishToMaestro, 'true')) }}:
       - template: ..\eng\common\AzurePipelinesTemplates\Maestro-PublishBuildToMaestro-Steps.yml
         parameters:
-          AssetName: 'Microsoft.WindowsAppSDK.Foundation.TransportPackage'
-          AssetVersion: $(WindowsAppSDKPackageVersion)
+          AssetsName: 'Microsoft.WindowsAppSDK.Foundation.TransportPackage'
+          AssetsVersion: $(WindowsAppSDKPackageVersion)
           TriggerSubscription: true

--- a/build/ProjectReunion-BuildFoundation.yml
+++ b/build/ProjectReunion-BuildFoundation.yml
@@ -487,6 +487,6 @@ jobs:
     - ${{ if or(eq(variables['Build.Reason'], 'Schedule'), eq(parameters.publishToMaestro, 'true')) }}:
       - template: ..\eng\common\AzurePipelinesTemplates\Maestro-PublishBuildToMaestro-Steps.yml
         parameters:
-          AssetsName: 'Microsoft.WindowsAppSDK.Foundation.TransportPackage'
-          AssetsVersion: $(WindowsAppSDKPackageVersion)
+          AssetNames: 'Microsoft.WindowsAppSDK.Foundation.TransportPackage'
+          AssetVersions: $(WindowsAppSDKPackageVersion)
           TriggerSubscription: true


### PR DESCRIPTION
Fix parameter names for AssetsName and AssetsVersions. 

I noticed Foundation builds were not publishing correctly. 