### PR TITLE
Enable SBOM generation for WindowsAppSDK

### DIFF
--- a/build/AzurePipelinesTemplates/WindowsAppSDK-BuildSolution-Steps.yml
+++ b/build/AzurePipelinesTemplates/WindowsAppSDK-BuildSolution-Steps.yml
@@ -25,6 +25,11 @@ steps:
     msbuildArgs: /binaryLogger:$(Build.SourcesDirectory)\${{ parameters.displayName }}.$(buildConfiguration).$(buildPlatform).binlog /restore ${{ parameters.additionalMsBuildArgs }}
     logProjectEvents: false
 
+- task: AzureArtifacts.manifest-generator-task.manifest-generator-task.ManifestGeneratorTask@0
+  displayName: 'SBOM Generation Task'
+  inputs:
+    BuildDropPath: '$(Build.ArtifactStagingDirectory)\mrt_raw'
+
 - task: PublishBuildArtifacts@1
   displayName: 'Publish ${{ parameters.displayName }} binlog'
   condition: always()

--- a/build/AzurePipelinesTemplates/WindowsAppSDK-BuildSolution-Steps.yml
+++ b/build/AzurePipelinesTemplates/WindowsAppSDK-BuildSolution-Steps.yml
@@ -25,11 +25,6 @@ steps:
     msbuildArgs: /binaryLogger:$(Build.SourcesDirectory)\${{ parameters.displayName }}.$(buildConfiguration).$(buildPlatform).binlog /restore ${{ parameters.additionalMsBuildArgs }}
     logProjectEvents: false
 
-- task: AzureArtifacts.manifest-generator-task.manifest-generator-task.ManifestGeneratorTask@0
-  displayName: 'SBOM Generation Task'
-  inputs:
-    BuildDropPath: '$(Build.ArtifactStagingDirectory)\mrt_raw'
-
 - task: PublishBuildArtifacts@1
   displayName: 'Publish ${{ parameters.displayName }} binlog'
   condition: always()

--- a/build/AzurePipelinesTemplates/WindowsAppSDK-PublishProjectOutput-Steps.yml
+++ b/build/AzurePipelinesTemplates/WindowsAppSDK-PublishProjectOutput-Steps.yml
@@ -9,7 +9,7 @@ steps:
   - task: AzureArtifacts.manifest-generator-task.manifest-generator-task.ManifestGeneratorTask@0
     displayName: 'SBOM Generation Task'
     inputs:
-      BuildDropPath: '$(Build.ArtifactStagingDirectory)\windowsappsdk_binaries\$(buildPlatform)\$(buildConfiguration)'
+      BuildDropPath: '$(Build.ArtifactStagingDirectory)\windowsappsdk_binaries\$(buildConfiguration)\$(buildPlatform)'
 
   - task: PublishBuildArtifacts@1
     displayName: 'Publish artifact: windowsappsdk_binaries'

--- a/build/AzurePipelinesTemplates/WindowsAppSDK-PublishProjectOutput-Steps.yml
+++ b/build/AzurePipelinesTemplates/WindowsAppSDK-PublishProjectOutput-Steps.yml
@@ -9,6 +9,11 @@ steps:
       filePath: build\CopyFilesToStagingDir.ps1
       arguments: -BuildOutputDir '$(buildOutputDir)' -OverrideDir '$(Build.SourcesDirectory)\build\override' -PublishDir '$(Build.ArtifactStagingDirectory)\${{ parameters.artifactName }}' -NugetDir '$(Build.ArtifactStagingDirectory)\FullNuget' -Platform '$(buildPlatform)' -Configuration '$(buildConfiguration)'
 
+  - task: AzureArtifacts.manifest-generator-task.manifest-generator-task.ManifestGeneratorTask@0
+    displayName: 'SBOM Generation Task'
+    inputs:
+      BuildDropPath: '$(Build.ArtifactStagingDirectory)\${{ parameters.artifactName }}'
+
   - task: PublishBuildArtifacts@1
     displayName: 'Publish artifact: ${{ parameters.artifactName }}'
     inputs:

--- a/build/AzurePipelinesTemplates/WindowsAppSDK-PublishProjectOutput-Steps.yml
+++ b/build/AzurePipelinesTemplates/WindowsAppSDK-PublishProjectOutput-Steps.yml
@@ -1,24 +1,21 @@
-parameters:
-  artifactName: 'windowsappsdk_binaries'
-
 steps:
   - task: powershell@2
     displayName: 'Copy files to staging dir'
     inputs:
       targetType: filePath
       filePath: build\CopyFilesToStagingDir.ps1
-      arguments: -BuildOutputDir '$(buildOutputDir)' -OverrideDir '$(Build.SourcesDirectory)\build\override' -PublishDir '$(Build.ArtifactStagingDirectory)\${{ parameters.artifactName }}' -NugetDir '$(Build.ArtifactStagingDirectory)\FullNuget' -Platform '$(buildPlatform)' -Configuration '$(buildConfiguration)'
+      arguments: -BuildOutputDir '$(buildOutputDir)' -OverrideDir '$(Build.SourcesDirectory)\build\override' -PublishDir '$(Build.ArtifactStagingDirectory)\windowsappsdk_binaries' -NugetDir '$(Build.ArtifactStagingDirectory)\FullNuget' -Platform '$(buildPlatform)' -Configuration '$(buildConfiguration)'
 
   - task: AzureArtifacts.manifest-generator-task.manifest-generator-task.ManifestGeneratorTask@0
     displayName: 'SBOM Generation Task'
     inputs:
-      BuildDropPath: '$(Build.ArtifactStagingDirectory)\${{ parameters.artifactName }}\sbom\$(buildPlatform)\$(buildConfiguration)'
+      BuildDropPath: '$(Build.ArtifactStagingDirectory)\windowsappsdk_binaries\$(buildPlatform)\$(buildConfiguration)'
 
   - task: PublishBuildArtifacts@1
-    displayName: 'Publish artifact: ${{ parameters.artifactName }}'
+    displayName: 'Publish artifact: windowsappsdk_binaries'
     inputs:
-      PathtoPublish: '$(Build.ArtifactStagingDirectory)\${{ parameters.artifactName }}'
-      artifactName: ${{ parameters.artifactName }}
+      PathtoPublish: '$(Build.ArtifactStagingDirectory)\windowsappsdk_binaries'
+      artifactName: windowsappsdk_binaries
 
   - task: PublishBuildArtifacts@1
     displayName: 'Publish artifact: Full Nuget (Windows App Runtime DLLs)'

--- a/build/AzurePipelinesTemplates/WindowsAppSDK-PublishProjectOutput-Steps.yml
+++ b/build/AzurePipelinesTemplates/WindowsAppSDK-PublishProjectOutput-Steps.yml
@@ -12,7 +12,7 @@ steps:
   - task: AzureArtifacts.manifest-generator-task.manifest-generator-task.ManifestGeneratorTask@0
     displayName: 'SBOM Generation Task'
     inputs:
-      BuildDropPath: '$(Build.ArtifactStagingDirectory)\${{ parameters.artifactName }}'
+      BuildDropPath: '$(Build.ArtifactStagingDirectory)\${{ parameters.artifactName }}\sbom\$(buildPlatform)\$(buildConfiguration)'
 
   - task: PublishBuildArtifacts@1
     displayName: 'Publish artifact: ${{ parameters.artifactName }}'

--- a/build/ProjectReunion-BuildFoundation.yml
+++ b/build/ProjectReunion-BuildFoundation.yml
@@ -168,7 +168,7 @@ jobs:
       channel: ${{ variables.channel }}
 
   - task: CopyFiles@2
-    displayName: 'Copy AnyCpu-built binaries'
+    displayName: 'Copy AnyCpu-built binaries to Nuget for staging'
     inputs:
       SourceFolder: '$(buildOutputDir)\$(buildConfiguration)\$(buildPlatform)\Microsoft.WindowsAppRuntime.Bootstrap.Net'
       Contents: |
@@ -176,12 +176,15 @@ jobs:
       TargetFolder: '$(Build.ArtifactStagingDirectory)\FullNuget\lib\net5.0-windows10.0.17763.0'
       flattenFolders: false
 
-  - task: powershell@2
-    displayName: 'Copy files to staging dir'
+  # This is purely for the SBOM
+  - task: CopyFiles@2
+    displayName: 'Copy AnyCpu-built binaries to windowsappsdk_binaries'
     inputs:
-      targetType: filePath
-      filePath: build\CopyFilesToStagingDir.ps1
-      arguments: -BuildOutputDir '$(buildOutputDir)' -OverrideDir '$(Build.SourcesDirectory)\build\override' -PublishDir '$(Build.ArtifactStagingDirectory)\windowsappsdk_binaries' -NugetDir '$(Build.ArtifactStagingDirectory)\FullNuget' -Platform '$(buildPlatform)' -Configuration '$(buildConfiguration)'
+      SourceFolder: '$(buildOutputDir)\$(buildConfiguration)\$(buildPlatform)\Microsoft.WindowsAppRuntime.Bootstrap.Net'
+      Contents: |
+        Microsoft.WindowsAppRuntime.Bootstrap.Net.dll
+      TargetFolder: '$(Build.ArtifactStagingDirectory)\windowsappsdk_binaries\$(buildPlatform)\$(buildConfiguration)'
+      flattenFolders: false
 
   - task: AzureArtifacts.manifest-generator-task.manifest-generator-task.ManifestGeneratorTask@0
     displayName: 'SBOM Generation Task'

--- a/build/ProjectReunion-BuildFoundation.yml
+++ b/build/ProjectReunion-BuildFoundation.yml
@@ -176,6 +176,24 @@ jobs:
       TargetFolder: '$(Build.ArtifactStagingDirectory)\FullNuget\lib\net5.0-windows10.0.17763.0'
       flattenFolders: false
 
+  - task: powershell@2
+    displayName: 'Copy files to staging dir'
+    inputs:
+      targetType: filePath
+      filePath: build\CopyFilesToStagingDir.ps1
+      arguments: -BuildOutputDir '$(buildOutputDir)' -OverrideDir '$(Build.SourcesDirectory)\build\override' -PublishDir '$(Build.ArtifactStagingDirectory)\windowsappsdk_binaries' -NugetDir '$(Build.ArtifactStagingDirectory)\FullNuget' -Platform '$(buildPlatform)' -Configuration '$(buildConfiguration)'
+
+  - task: AzureArtifacts.manifest-generator-task.manifest-generator-task.ManifestGeneratorTask@0
+    displayName: 'SBOM Generation Task'
+    inputs:
+      BuildDropPath: '$(Build.ArtifactStagingDirectory)\windowsappsdk_binaries\$(buildPlatform)\$(buildConfiguration)'
+
+  - task: PublishBuildArtifacts@1
+    displayName: 'Publish artifact: windowsappsdk_binaries'
+    inputs:
+      PathtoPublish: '$(Build.ArtifactStagingDirectory)\windowsappsdk_binaries'
+      artifactName: windowsappsdk_binaries
+
   - task: PublishBuildArtifacts@1
     displayName: 'Publish artifact: Full Nuget (Windows App Runtime DLLs)'
     inputs:

--- a/build/ProjectReunion-BuildFoundation.yml
+++ b/build/ProjectReunion-BuildFoundation.yml
@@ -103,10 +103,10 @@ jobs:
     parameters:
       channel: ${{ variables.channel }}
 
-  - template: AzurePipelinesTemplates\WindowsAppSDK-PublishProjectOutput-Steps.yml
-
 # component detection must happen *within* the build task
   - task: ms.vss-governance-buildtask.governance-build-task-component-detection.ComponentGovernanceComponentDetection@0
+
+  - template: AzurePipelinesTemplates\WindowsAppSDK-PublishProjectOutput-Steps.yml
 
   - task: BinSkim@3
     inputs:
@@ -114,6 +114,7 @@ jobs:
       Function: 'analyze'
       AnalyzeTarget: '$(Build.ArtifactStagingDirectory)\*.dll;$(Build.ArtifactStagingDirectory)\*.exe'
       AnalyzeVerbose: true
+
   - task: PostAnalysis@1
     inputs:
       AllTools: false

--- a/build/build-mrt.yml
+++ b/build/build-mrt.yml
@@ -233,6 +233,11 @@ steps:
     TargetFolder: '$(Build.ArtifactStagingDirectory)\mrt_raw\lib\anycpu'
     flattenFolders: true
 
+- task: AzureArtifacts.manifest-generator-task.manifest-generator-task.ManifestGeneratorTask@0
+  displayName: 'SBOM Generation Task'
+  inputs:
+    BuildDropPath: '$(Build.ArtifactStagingDirectory)\mrt_raw'
+
 - task: PublishBuildArtifacts@1
   displayName: 'Publish Artifact: Binaries'
   inputs:

--- a/build/build-mrt.yml
+++ b/build/build-mrt.yml
@@ -236,7 +236,7 @@ steps:
 - task: AzureArtifacts.manifest-generator-task.manifest-generator-task.ManifestGeneratorTask@0
   displayName: 'SBOM Generation Task'
   inputs:
-    BuildDropPath: '$(Build.ArtifactStagingDirectory)\mrt_raw\lib\$(buildConfiguration)'
+    BuildDropPath: '$(Build.ArtifactStagingDirectory)\mrt_raw\lib\$(buildPlatform)'
 
 - task: PublishBuildArtifacts@1
   displayName: 'Publish Artifact: Binaries'

--- a/build/build-mrt.yml
+++ b/build/build-mrt.yml
@@ -236,7 +236,7 @@ steps:
 - task: AzureArtifacts.manifest-generator-task.manifest-generator-task.ManifestGeneratorTask@0
   displayName: 'SBOM Generation Task'
   inputs:
-    BuildDropPath: '$(Build.ArtifactStagingDirectory)\mrt_raw\sbom\$(buildPlatform)\$(buildConfiguration)'
+    BuildDropPath: '$(Build.ArtifactStagingDirectory)\mrt_raw\lib\$(buildConfiguration)'
 
 - task: PublishBuildArtifacts@1
   displayName: 'Publish Artifact: Binaries'

--- a/build/build-mrt.yml
+++ b/build/build-mrt.yml
@@ -236,7 +236,7 @@ steps:
 - task: AzureArtifacts.manifest-generator-task.manifest-generator-task.ManifestGeneratorTask@0
   displayName: 'SBOM Generation Task'
   inputs:
-    BuildDropPath: '$(Build.ArtifactStagingDirectory)\mrt_raw'
+    BuildDropPath: '$(Build.ArtifactStagingDirectory)\mrt_raw\sbom\$(buildPlatform)\$(buildConfiguration)'
 
 - task: PublishBuildArtifacts@1
   displayName: 'Publish Artifact: Binaries'


### PR DESCRIPTION
SBOM generation is enabled in each platform and configuration of the MRT and the main Foundation build. 
The json from the generations will be placed in mrtcore_binaries and windowsappsdk_binaries build artifacts for each platform and configuration.  

