### PR TITLE
Add ToastNotificationManger::Setting API

### DIFF
--- a/dev/ToastNotifications/ToastNotificationManager.cpp
+++ b/dev/ToastNotifications/ToastNotificationManager.cpp
@@ -8,7 +8,7 @@
 #include "externs.h"
 #include "ToastNotificationUtility.h"
 #include <frameworkudk/pushnotifications.h>
-
+#include <frameworkudk/toastnotifications.h>
 static winrt::event<winrt::Windows::Foundation::EventHandler<winrt::Microsoft::Windows::ToastNotifications::ToastActivatedEventArgs>> g_toastHandlers;
 
 winrt::event<winrt::Windows::Foundation::EventHandler<winrt::Microsoft::Windows::ToastNotifications::ToastActivatedEventArgs>>& GetToastHandlers()
@@ -96,7 +96,11 @@ namespace winrt::Microsoft::Windows::ToastNotifications::implementation
     }
     winrt::Microsoft::Windows::ToastNotifications::ToastNotificationSetting ToastNotificationManager::Setting()
     {
-        throw hresult_not_implemented();
+        std::wstring appId { RetrieveAppId() };
+        DWORD toastNotificationSetting{ 0 };
+        ToastNotifications_QuerySettings(appId.c_str(), 0, &toastNotificationSetting);
+
+        return static_cast<winrt::Microsoft::Windows::ToastNotifications::ToastNotificationSetting>(toastNotificationSetting);
     }
     winrt::Microsoft::Windows::ToastNotifications::ToastNotificationHistory ToastNotificationManager::History()
     {

--- a/dev/ToastNotifications/ToastNotificationManager.cpp
+++ b/dev/ToastNotifications/ToastNotificationManager.cpp
@@ -98,7 +98,7 @@ namespace winrt::Microsoft::Windows::ToastNotifications::implementation
     {
         std::wstring appId { RetrieveAppId() };
         DWORD toastNotificationSetting{ 0 };
-        ToastNotifications_QuerySettings(appId.c_str(), 0 /* ToastNotifications */, &toastNotificationSetting);
+        ToastNotifications_QuerySettings(appId.c_str(), &toastNotificationSetting);
 
         return static_cast<winrt::Microsoft::Windows::ToastNotifications::ToastNotificationSetting>(toastNotificationSetting);
     }

--- a/dev/ToastNotifications/ToastNotificationManager.cpp
+++ b/dev/ToastNotifications/ToastNotificationManager.cpp
@@ -98,7 +98,7 @@ namespace winrt::Microsoft::Windows::ToastNotifications::implementation
     {
         std::wstring appId { RetrieveAppId() };
         DWORD toastNotificationSetting{ 0 };
-        ToastNotifications_QuerySettings(appId.c_str(), 0, &toastNotificationSetting);
+        ToastNotifications_QuerySettings(appId.c_str(), 0 /* ToastNotifications */, &toastNotificationSetting);
 
         return static_cast<winrt::Microsoft::Windows::ToastNotifications::ToastNotificationSetting>(toastNotificationSetting);
     }

--- a/test/TestApps/ToastNotificationsTestApp/main.cpp
+++ b/test/TestApps/ToastNotificationsTestApp/main.cpp
@@ -186,6 +186,16 @@ bool VerifyFailedToastAssetsWithNullIconPath_Unpackaged()
     return false;
 }
 
+bool VerifyToastSettingEnabled_Unpackaged()
+{
+    return winrt::ToastNotificationManager::Default().Setting() == winrt::ToastNotificationSetting::Enabled;
+}
+
+bool VerifyToastSettingEnabled()
+{
+    return winrt::ToastNotificationManager::Default().Setting() == winrt::ToastNotificationSetting::Enabled;
+}
+
 std::string unitTestNameFromLaunchArguments(const winrt::ILaunchActivatedEventArgs& launchArgs)
 {
     std::string unitTestName = to_string(launchArgs.Arguments());
@@ -211,6 +221,8 @@ std::map<std::string, bool(*)()> const& GetSwitchMapping()
         { "VerifyFailedToastAssetsWithEmptyDisplayName_Unpackaged", &VerifyFailedToastAssetsWithEmptyDisplayName_Unpackaged },
         { "VerifyFailedToastAssetsWithEmptyIconPath_Unpackaged", &VerifyFailedToastAssetsWithEmptyIconPath_Unpackaged },
         { "VerifyFailedToastAssetsWithNullIconPath_Unpackaged", &VerifyFailedToastAssetsWithNullIconPath_Unpackaged },
+        { "VerifyToastSettingEnabled_Unpackaged", &VerifyToastSettingEnabled_Unpackaged },
+        { "VerifyToastSettingEnabled", &VerifyToastSettingEnabled },
     };
     return switchMapping;
 }

--- a/test/TestApps/ToastNotificationsTestApp/main.cpp
+++ b/test/TestApps/ToastNotificationsTestApp/main.cpp
@@ -186,11 +186,6 @@ bool VerifyFailedToastAssetsWithNullIconPath_Unpackaged()
     return false;
 }
 
-bool VerifyToastSettingEnabled_Unpackaged()
-{
-    return winrt::ToastNotificationManager::Default().Setting() == winrt::ToastNotificationSetting::Enabled;
-}
-
 bool VerifyToastSettingEnabled()
 {
     return winrt::ToastNotificationManager::Default().Setting() == winrt::ToastNotificationSetting::Enabled;
@@ -221,7 +216,6 @@ std::map<std::string, bool(*)()> const& GetSwitchMapping()
         { "VerifyFailedToastAssetsWithEmptyDisplayName_Unpackaged", &VerifyFailedToastAssetsWithEmptyDisplayName_Unpackaged },
         { "VerifyFailedToastAssetsWithEmptyIconPath_Unpackaged", &VerifyFailedToastAssetsWithEmptyIconPath_Unpackaged },
         { "VerifyFailedToastAssetsWithNullIconPath_Unpackaged", &VerifyFailedToastAssetsWithNullIconPath_Unpackaged },
-        { "VerifyToastSettingEnabled_Unpackaged", &VerifyToastSettingEnabled_Unpackaged },
         { "VerifyToastSettingEnabled", &VerifyToastSettingEnabled },
     };
     return switchMapping;

--- a/test/ToastNotificationTests/APITests.cpp
+++ b/test/ToastNotificationTests/APITests.cpp
@@ -215,7 +215,7 @@ namespace Test::ToastNotifications
 
         TEST_METHOD(VerifyToastSettingEnabled_Unpackaged)
         {
-            RunTestUnpackaged(L"VerifyToastSettingEnabled_Unpackaged", testWaitTime());
+            RunTestUnpackaged(L"VerifyToastSettingEnabled", testWaitTime());
         }
 
         TEST_METHOD(VerifyToastSettingEnabled)

--- a/test/ToastNotificationTests/APITests.cpp
+++ b/test/ToastNotificationTests/APITests.cpp
@@ -212,5 +212,15 @@ namespace Test::ToastNotifications
         {
             RunTestUnpackaged(L"VerifyFailedToastAssetsWithEmptyIconPath_Unpackaged", testWaitTime());
         }
+
+        TEST_METHOD(VerifyToastSettingEnabled_Unpackaged)
+        {
+            RunTestUnpackaged(L"VerifyToastSettingEnabled_Unpackaged", testWaitTime());
+        }
+
+        TEST_METHOD(VerifyToastSettingEnabled)
+        {
+            RunTest(L"VerifyToastSettingEnabled", testWaitTime());
+        }
     };
 }


### PR DESCRIPTION
- Implements the ToastNotificationManager::Setting API
- Includes unit tests checking for the enabled scenario for unpackaged/packaged applications
