### PR TITLE
MddBootstrapInitialize package enumeration if release Minor version >0

### DIFF
--- a/dev/WindowsAppRuntime_BootstrapDLL/MddBootstrap.cpp
+++ b/dev/WindowsAppRuntime_BootstrapDLL/MddBootstrap.cpp
@@ -500,7 +500,7 @@ void FindDDLMViaEnumeration(
     // We need to look for DDLM packages in the package family for release <major>.<minor> and <versiontag>
     // But we have no single (simple) enumeration to match that so our logic's more involved compared
     // to FindDDLMViaAppExtension():
-    // 1. Look for Framework packages with Name="microsoft.winappruntime.ddlm.<minorversion>.*[-shorttag]"
+    // 1. Look for Framework packages with Name="microsoft.winappruntime.ddlm.<minorversion>*[-shorttag]"
     // 1a. Enumerate all Framework packages registered to the user
     // 1b. Only consider packages whose Name starts with "microsoft.winappruntime.ddlm.<minorversion>."
     // 1c. If versiontag is specified, Only consider packages whose Name ends with [-shorttag]
@@ -519,7 +519,7 @@ void FindDDLMViaEnumeration(
     }
     else
     {
-        wsprintf(packageNamePrefix, L"microsoft.winappruntime.ddlm.%hu.", minorVersion);
+        wsprintf(packageNamePrefix, L"microsoft.winappruntime.ddlm.%hu", minorVersion);
     }
     const auto packageNamePrefixLength{ wcslen(packageNamePrefix) };
 


### PR DESCRIPTION
DDLM package names are `Microsoft.WinAppRuntime.DDLM.<minor><patch>.<msixminor>.<msixbuild>.<msixrevision>[-shortversiontag]`. But we only want to match down to `<minor>`. The code+spec(comment) was wrong to look for `<minor>.*` needs to be `<minor>*`

For want of a nail...