### PR TITLE
FI WNP_ToastNotifications_L1into WNP_ToastNotifications_L2

### DIFF
--- a/build/AzurePipelinesTemplates/WindowsAppSDK-PublishProjectOutput-Steps.yml
+++ b/build/AzurePipelinesTemplates/WindowsAppSDK-PublishProjectOutput-Steps.yml
@@ -1,19 +1,21 @@
-parameters:
-  artifactName: 'windowsappsdk_binaries'
-
 steps:
   - task: powershell@2
     displayName: 'Copy files to staging dir'
     inputs:
       targetType: filePath
       filePath: build\CopyFilesToStagingDir.ps1
-      arguments: -BuildOutputDir '$(buildOutputDir)' -OverrideDir '$(Build.SourcesDirectory)\build\override' -PublishDir '$(Build.ArtifactStagingDirectory)\${{ parameters.artifactName }}' -NugetDir '$(Build.ArtifactStagingDirectory)\FullNuget' -Platform '$(buildPlatform)' -Configuration '$(buildConfiguration)'
+      arguments: -BuildOutputDir '$(buildOutputDir)' -OverrideDir '$(Build.SourcesDirectory)\build\override' -PublishDir '$(Build.ArtifactStagingDirectory)\windowsappsdk_binaries' -NugetDir '$(Build.ArtifactStagingDirectory)\FullNuget' -Platform '$(buildPlatform)' -Configuration '$(buildConfiguration)'
+
+  - task: AzureArtifacts.manifest-generator-task.manifest-generator-task.ManifestGeneratorTask@0
+    displayName: 'SBOM Generation Task'
+    inputs:
+      BuildDropPath: '$(Build.ArtifactStagingDirectory)\windowsappsdk_binaries\$(buildConfiguration)\$(buildPlatform)'
 
   - task: PublishBuildArtifacts@1
-    displayName: 'Publish artifact: ${{ parameters.artifactName }}'
+    displayName: 'Publish artifact: windowsappsdk_binaries'
     inputs:
-      PathtoPublish: '$(Build.ArtifactStagingDirectory)\${{ parameters.artifactName }}'
-      artifactName: ${{ parameters.artifactName }}
+      PathtoPublish: '$(Build.ArtifactStagingDirectory)\windowsappsdk_binaries'
+      artifactName: windowsappsdk_binaries
 
   - task: PublishBuildArtifacts@1
     displayName: 'Publish artifact: Full Nuget (Windows App Runtime DLLs)'

--- a/build/ProjectReunion-BuildFoundation.yml
+++ b/build/ProjectReunion-BuildFoundation.yml
@@ -103,10 +103,10 @@ jobs:
     parameters:
       channel: ${{ variables.channel }}
 
-  - template: AzurePipelinesTemplates\WindowsAppSDK-PublishProjectOutput-Steps.yml
-
 # component detection must happen *within* the build task
   - task: ms.vss-governance-buildtask.governance-build-task-component-detection.ComponentGovernanceComponentDetection@0
+
+  - template: AzurePipelinesTemplates\WindowsAppSDK-PublishProjectOutput-Steps.yml
 
   - task: BinSkim@3
     inputs:
@@ -114,6 +114,7 @@ jobs:
       Function: 'analyze'
       AnalyzeTarget: '$(Build.ArtifactStagingDirectory)\*.dll;$(Build.ArtifactStagingDirectory)\*.exe'
       AnalyzeVerbose: true
+
   - task: PostAnalysis@1
     inputs:
       AllTools: false
@@ -167,13 +168,34 @@ jobs:
       channel: ${{ variables.channel }}
 
   - task: CopyFiles@2
-    displayName: 'Copy AnyCpu-built binaries'
+    displayName: 'Copy AnyCpu-built binaries to Nuget for staging'
     inputs:
       SourceFolder: '$(buildOutputDir)\$(buildConfiguration)\$(buildPlatform)\Microsoft.WindowsAppRuntime.Bootstrap.Net'
       Contents: |
         Microsoft.WindowsAppRuntime.Bootstrap.Net.dll
       TargetFolder: '$(Build.ArtifactStagingDirectory)\FullNuget\lib\net5.0-windows10.0.17763.0'
       flattenFolders: false
+
+  # This is purely for the SBOM
+  - task: CopyFiles@2
+    displayName: 'Copy AnyCpu-built binaries to windowsappsdk_binaries'
+    inputs:
+      SourceFolder: '$(buildOutputDir)\$(buildConfiguration)\$(buildPlatform)\Microsoft.WindowsAppRuntime.Bootstrap.Net'
+      Contents: |
+        Microsoft.WindowsAppRuntime.Bootstrap.Net.dll
+      TargetFolder: '$(Build.ArtifactStagingDirectory)\windowsappsdk_binaries\$(buildPlatform)\$(buildConfiguration)'
+      flattenFolders: false
+
+  - task: AzureArtifacts.manifest-generator-task.manifest-generator-task.ManifestGeneratorTask@0
+    displayName: 'SBOM Generation Task'
+    inputs:
+      BuildDropPath: '$(Build.ArtifactStagingDirectory)\windowsappsdk_binaries\$(buildPlatform)\$(buildConfiguration)'
+
+  - task: PublishBuildArtifacts@1
+    displayName: 'Publish artifact: windowsappsdk_binaries'
+    inputs:
+      PathtoPublish: '$(Build.ArtifactStagingDirectory)\windowsappsdk_binaries'
+      artifactName: windowsappsdk_binaries
 
   - task: PublishBuildArtifacts@1
     displayName: 'Publish artifact: Full Nuget (Windows App Runtime DLLs)'

--- a/build/build-mrt.yml
+++ b/build/build-mrt.yml
@@ -233,6 +233,11 @@ steps:
     TargetFolder: '$(Build.ArtifactStagingDirectory)\mrt_raw\lib\anycpu'
     flattenFolders: true
 
+- task: AzureArtifacts.manifest-generator-task.manifest-generator-task.ManifestGeneratorTask@0
+  displayName: 'SBOM Generation Task'
+  inputs:
+    BuildDropPath: '$(Build.ArtifactStagingDirectory)\mrt_raw\lib\$(buildPlatform)'
+
 - task: PublishBuildArtifacts@1
   displayName: 'Publish Artifact: Binaries'
   inputs:

--- a/dev/VSIX/Extension/Cpp/Common/it-IT/VSPackage.it-IT.resx
+++ b/dev/VSIX/Extension/Cpp/Common/it-IT/VSPackage.it-IT.resx
@@ -183,7 +183,7 @@
     <value>[Esperimento] Controllo utente (WinUI 3)</value>
   </data>
   <data name="1023" xml:space="preserve">
-    <value>Un controllo utente per le app basato sulla libreria dell'interfaccia utente di Windows (WinUI 3).</value>
+    <value>Un controllo utente per le app basato sulla Libreria dell'interfaccia utente di Windows (WinUI 3).</value>
   </data>
   <data name="1025" xml:space="preserve">
     <value>App vuota, in pacchetto con Progetto di creazione pacchetti per applicazioni Windows (WinUI 3 in desktop)</value>

--- a/dev/VSIX/Extension/Cpp/Common/ko-KR/VSPackage.ko-KR.resx
+++ b/dev/VSIX/Extension/Cpp/Common/ko-KR/VSPackage.ko-KR.resx
@@ -177,13 +177,13 @@
     <value>Windows UI 라이브러리(WinUI 3)를 기반으로 하는 앱용 사용자 지정 컨트롤입니다.</value>
   </data>
   <data name="1021" xml:space="preserve">
-    <value>사용자 컨트롤(WinUI 3)</value>
+    <value>사용자 정의 컨트롤(WinUI 3)</value>
   </data>
   <data name="1022" xml:space="preserve">
-    <value>[실험적] 사용자 컨트롤(WinUI 3)</value>
+    <value>[실험적] 사용자 정의 컨트롤(WinUI 3)</value>
   </data>
   <data name="1023" xml:space="preserve">
-    <value>Windows UI 라이브러리(WinUI 3)를 기반으로 하는 앱용 사용자 컨트롤입니다.</value>
+    <value>Windows UI 라이브러리(WinUI 3)를 기반으로 하는 앱용 사용자 정의 컨트롤입니다.</value>
   </data>
   <data name="1025" xml:space="preserve">
     <value>빈 앱, Windows 애플리케이션 패키징 프로젝트가 포함된 패키지(데스크톱의 WinUI 3)</value>

--- a/dev/VSIX/Extension/Cpp/Common/pt-BR/VSPackage.pt-BR.resx
+++ b/dev/VSIX/Extension/Cpp/Common/pt-BR/VSPackage.pt-BR.resx
@@ -177,7 +177,7 @@
     <value>Um controle personalizado para aplicativos baseado na Biblioteca de Interface do Usuário do Windows (WinUI 3).</value>
   </data>
   <data name="1021" xml:space="preserve">
-    <value>Controle do Usuário (WinUI 3)</value>
+    <value>Controle de Usuário (WinUI 3)</value>
   </data>
   <data name="1022" xml:space="preserve">
     <value>[Experimental] Controle de Usuário (WinUI 3)</value>

--- a/dev/VSIX/Extension/Cs/Common/it-IT/VSPackage.it-IT.resx
+++ b/dev/VSIX/Extension/Cs/Common/it-IT/VSPackage.it-IT.resx
@@ -183,7 +183,7 @@
     <value>[Esperimento] Controllo utente (WinUI 3)</value>
   </data>
   <data name="1023" xml:space="preserve">
-    <value>Un controllo utente per le app basato sulla libreria dell'interfaccia utente di Windows (WinUI 3).</value>
+    <value>Un controllo utente per le app basato sulla Libreria dell'interfaccia utente di Windows (WinUI 3).</value>
   </data>
   <data name="1025" xml:space="preserve">
     <value>Libreria di classi (WinUI 3 su desktop)</value>

--- a/dev/VSIX/Extension/Cs/Common/ko-KR/VSPackage.ko-KR.resx
+++ b/dev/VSIX/Extension/Cs/Common/ko-KR/VSPackage.ko-KR.resx
@@ -177,13 +177,13 @@
     <value>Windows UI 라이브러리(WinUI 3)를 기반으로 하는 앱용 사용자 지정 컨트롤입니다.</value>
   </data>
   <data name="1021" xml:space="preserve">
-    <value>사용자 컨트롤(WinUI 3)</value>
+    <value>사용자 정의 컨트롤(WinUI 3)</value>
   </data>
   <data name="1022" xml:space="preserve">
-    <value>[실험적] 사용자 컨트롤(WinUI 3)</value>
+    <value>[실험적] 사용자 정의 컨트롤(WinUI 3)</value>
   </data>
   <data name="1023" xml:space="preserve">
-    <value>Windows UI 라이브러리(WinUI 3)를 기반으로 하는 앱용 사용자 컨트롤입니다.</value>
+    <value>Windows UI 라이브러리(WinUI 3)를 기반으로 하는 앱용 사용자 정의 컨트롤입니다.</value>
   </data>
   <data name="1025" xml:space="preserve">
     <value>클래스 라이브러리(데스크톱의 WinUI 3)</value>

--- a/dev/VSIX/Extension/Cs/Common/pt-BR/VSPackage.pt-BR.resx
+++ b/dev/VSIX/Extension/Cs/Common/pt-BR/VSPackage.pt-BR.resx
@@ -177,7 +177,7 @@
     <value>Um controle personalizado para aplicativos baseado na Biblioteca de Interface do Usuário do Windows (WinUI 3).</value>
   </data>
   <data name="1021" xml:space="preserve">
-    <value>Controle do Usuário (WinUI 3)</value>
+    <value>Controle de Usuário (WinUI 3)</value>
   </data>
   <data name="1022" xml:space="preserve">
     <value>[Experimental] Controle de Usuário (WinUI 3)</value>

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -23,9 +23,9 @@
     </Dependency>
   </ProductDependencies>
   <ToolsetDependencies>
-    <Dependency Name="Microsoft.WinAppSDK.EngCommon" Version="1.0.0-20220110.0-CI">
+    <Dependency Name="Microsoft.WinAppSDK.EngCommon" Version="1.0.0-20220114.0-CI">
       <Uri>https://dev.azure.com/microsoft/ProjectReunion/_git/ProjectReunionInternal</Uri>
-      <Sha>bc05e6cd828aed47148cb75597685d8cd59ae39d</Sha>
+      <Sha>61330e0ea3df267a2fe535aaf9541cf65b7a05e8</Sha>
     </Dependency>
   </ToolsetDependencies>
 </Dependencies>

--- a/eng/common/AzurePipelinesTemplates/WindowsAppSDK-IntegrationTest-Steps.yml
+++ b/eng/common/AzurePipelinesTemplates/WindowsAppSDK-IntegrationTest-Steps.yml
@@ -86,3 +86,10 @@ steps:
         -YamlStep "none"
         -RunTestMachineSetup
         -Name "${{ parameters.TestSelection }}"
+
+  - task: PublishBuildArtifacts@1
+    displayName: 'Publish test results'
+    condition: succeededOrFailed()
+    inputs:
+      PathtoPublish: $(Build.SourcesDirectory)\PipelineTestOutput
+      artifactName: TestResults-WindowsAppSDKIntegration

--- a/global.json
+++ b/global.json
@@ -3,6 +3,6 @@
     "dotnet": "6.0.101"
   },
   "msbuild-sdks": {
-    "Microsoft.WinAppSDK.EngCommon": "1.0.0-20220110.0-CI"
+    "Microsoft.WinAppSDK.EngCommon": "1.0.0-20220114.0-CI"
   }
 }


### PR DESCRIPTION
Forward Integration from feature/WNP_ToastNotifications_L1 to WNP_ToastNotifications_L2.

Conflicts in the following files:
* dev/ToastNotifications/ToastActivationCallback.h
* dev/ToastNotifications/ToastNotificationManager.cpp
* dev/ToastNotifications/ToastNotificationUtility.h
* test/TestApps/ToastNotificationsTestApp/main.cpp
* test/TestApps/ToastNotificationsTestAppPackage/Package.appxmanifest
* test/ToastNotificationTests/APITests.cpp

Conflicts were resolved by keeping the changes in the L2 branch and rejecting incoming changes from L1. (git checkout --ours)

The result is identical to https://github.com/microsoft/WindowsAppSDK/pull/1993, which makes sense since we're simply cascading changes from main into our L1, then into our L2.