### PR TITLE
Correct CsWinRTWindowsMetadata

### DIFF
--- a/dev/MRTCore/mrt/Microsoft.Windows.ApplicationModel.Resources/projection/Microsoft.Windows.ApplicationModel.Resources.Projection.csproj
+++ b/dev/MRTCore/mrt/Microsoft.Windows.ApplicationModel.Resources/projection/Microsoft.Windows.ApplicationModel.Resources.Projection.csproj
@@ -17,7 +17,7 @@
 
   <PropertyGroup>
     <CSWinRTIncludes>Microsoft.Windows.ApplicationModel.Resources</CSWinRTIncludes>
-    <CSWinRTWindowsMetadata>$(CsWinRTDependencyWindowsSdkPackagePackageVersion)</CSWinRTWindowsMetadata>
+    <CSWinRTWindowsMetadata>10.0.17763.0</CSWinRTWindowsMetadata>
     <NoWarn>MSB3271</NoWarn>
   </PropertyGroup>
 

--- a/dev/MRTCore/mrt/Microsoft.Windows.ApplicationModel.Resources/projection/Microsoft.Windows.ApplicationModel.Resources.Projection.csproj
+++ b/dev/MRTCore/mrt/Microsoft.Windows.ApplicationModel.Resources/projection/Microsoft.Windows.ApplicationModel.Resources.Projection.csproj
@@ -18,7 +18,7 @@
   <PropertyGroup>
     <CSWinRTIncludes>Microsoft.Windows.ApplicationModel.Resources</CSWinRTIncludes>
     <CSWinRTWindowsMetadata>10.0.17763.0</CSWinRTWindowsMetadata>
-    <WindowsSdkPackageVersion>$(CsWinRTDependencyWindowsSdkPackagePackageVersion)</WindowsSdkPackageVersion>
+    <WindowsSdkPackageVersion>10.0.17763.$(CsWinRTDependencyWindowsSdkPackagePackageVersion)</WindowsSdkPackageVersion>
     <NoWarn>MSB3271</NoWarn>
   </PropertyGroup>
 

--- a/dev/MRTCore/mrt/Microsoft.Windows.ApplicationModel.Resources/projection/Microsoft.Windows.ApplicationModel.Resources.Projection.csproj
+++ b/dev/MRTCore/mrt/Microsoft.Windows.ApplicationModel.Resources/projection/Microsoft.Windows.ApplicationModel.Resources.Projection.csproj
@@ -18,6 +18,7 @@
   <PropertyGroup>
     <CSWinRTIncludes>Microsoft.Windows.ApplicationModel.Resources</CSWinRTIncludes>
     <CSWinRTWindowsMetadata>10.0.17763.0</CSWinRTWindowsMetadata>
+    <WindowsSdkPackageVersion>$(CsWinRTDependencyWindowsSdkPackagePackageVersion)</WindowsSdkPackageVersion>
     <NoWarn>MSB3271</NoWarn>
   </PropertyGroup>
 

--- a/dev/Projections/CS/Microsoft.Windows.AppLifecycle/Microsoft.Windows.AppLifecycle.Projection.csproj
+++ b/dev/Projections/CS/Microsoft.Windows.AppLifecycle/Microsoft.Windows.AppLifecycle.Projection.csproj
@@ -21,6 +21,7 @@
   <PropertyGroup>
     <CSWinRTIncludes>Microsoft.Windows.AppLifecycle</CSWinRTIncludes>
     <CSWinRTWindowsMetadata>10.0.17763.0</CSWinRTWindowsMetadata>
+    <WindowsSdkPackageVersion>$(CsWinRTDependencyWindowsSdkPackagePackageVersion)</WindowsSdkPackageVersion>
   </PropertyGroup>
 
   <!-- Configure the release build binary to be as required by internal API scanning tools. -->

--- a/dev/Projections/CS/Microsoft.Windows.AppLifecycle/Microsoft.Windows.AppLifecycle.Projection.csproj
+++ b/dev/Projections/CS/Microsoft.Windows.AppLifecycle/Microsoft.Windows.AppLifecycle.Projection.csproj
@@ -20,7 +20,7 @@
 
   <PropertyGroup>
     <CSWinRTIncludes>Microsoft.Windows.AppLifecycle</CSWinRTIncludes>
-    <CSWinRTWindowsMetadata>$(CsWinRTDependencyWindowsSdkPackagePackageVersion)</CSWinRTWindowsMetadata>
+    <CSWinRTWindowsMetadata>10.0.17763.0</CSWinRTWindowsMetadata>
   </PropertyGroup>
 
   <!-- Configure the release build binary to be as required by internal API scanning tools. -->

--- a/dev/Projections/CS/Microsoft.Windows.AppLifecycle/Microsoft.Windows.AppLifecycle.Projection.csproj
+++ b/dev/Projections/CS/Microsoft.Windows.AppLifecycle/Microsoft.Windows.AppLifecycle.Projection.csproj
@@ -21,7 +21,7 @@
   <PropertyGroup>
     <CSWinRTIncludes>Microsoft.Windows.AppLifecycle</CSWinRTIncludes>
     <CSWinRTWindowsMetadata>10.0.17763.0</CSWinRTWindowsMetadata>
-    <WindowsSdkPackageVersion>$(CsWinRTDependencyWindowsSdkPackagePackageVersion)</WindowsSdkPackageVersion>
+    <WindowsSdkPackageVersion>10.0.17763.$(CsWinRTDependencyWindowsSdkPackagePackageVersion)</WindowsSdkPackageVersion>
   </PropertyGroup>
 
   <!-- Configure the release build binary to be as required by internal API scanning tools. -->

--- a/dev/Projections/CS/Microsoft.Windows.ApplicationModel.DynamicDependency/Microsoft.Windows.ApplicationModel.DynamicDependency.Projection.csproj
+++ b/dev/Projections/CS/Microsoft.Windows.ApplicationModel.DynamicDependency/Microsoft.Windows.ApplicationModel.DynamicDependency.Projection.csproj
@@ -20,7 +20,7 @@
 
   <PropertyGroup>
     <CSWinRTIncludes>Microsoft.Windows.ApplicationModel.DynamicDependency</CSWinRTIncludes>
-    <CSWinRTWindowsMetadata>$(CsWinRTDependencyWindowsSdkPackagePackageVersion)</CSWinRTWindowsMetadata>
+    <CSWinRTWindowsMetadata>10.0.17763.0</CSWinRTWindowsMetadata>
   </PropertyGroup>
 
   <!-- Configure the release build binary to be as required by internal API scanning tools. -->

--- a/dev/Projections/CS/Microsoft.Windows.ApplicationModel.DynamicDependency/Microsoft.Windows.ApplicationModel.DynamicDependency.Projection.csproj
+++ b/dev/Projections/CS/Microsoft.Windows.ApplicationModel.DynamicDependency/Microsoft.Windows.ApplicationModel.DynamicDependency.Projection.csproj
@@ -21,7 +21,7 @@
   <PropertyGroup>
     <CSWinRTIncludes>Microsoft.Windows.ApplicationModel.DynamicDependency</CSWinRTIncludes>
     <CSWinRTWindowsMetadata>10.0.17763.0</CSWinRTWindowsMetadata>
-    <WindowsSdkPackageVersion>$(CsWinRTDependencyWindowsSdkPackagePackageVersion)</WindowsSdkPackageVersion>
+    <WindowsSdkPackageVersion>10.0.17763.$(CsWinRTDependencyWindowsSdkPackagePackageVersion)</WindowsSdkPackageVersion>
   </PropertyGroup>
 
   <!-- Configure the release build binary to be as required by internal API scanning tools. -->

--- a/dev/Projections/CS/Microsoft.Windows.ApplicationModel.DynamicDependency/Microsoft.Windows.ApplicationModel.DynamicDependency.Projection.csproj
+++ b/dev/Projections/CS/Microsoft.Windows.ApplicationModel.DynamicDependency/Microsoft.Windows.ApplicationModel.DynamicDependency.Projection.csproj
@@ -21,6 +21,7 @@
   <PropertyGroup>
     <CSWinRTIncludes>Microsoft.Windows.ApplicationModel.DynamicDependency</CSWinRTIncludes>
     <CSWinRTWindowsMetadata>10.0.17763.0</CSWinRTWindowsMetadata>
+    <WindowsSdkPackageVersion>$(CsWinRTDependencyWindowsSdkPackagePackageVersion)</WindowsSdkPackageVersion>
   </PropertyGroup>
 
   <!-- Configure the release build binary to be as required by internal API scanning tools. -->

--- a/dev/Projections/CS/Microsoft.Windows.ApplicationModel.WindowsAppRuntime/Microsoft.Windows.ApplicationModel.WindowsAppRuntime.Projection.csproj
+++ b/dev/Projections/CS/Microsoft.Windows.ApplicationModel.WindowsAppRuntime/Microsoft.Windows.ApplicationModel.WindowsAppRuntime.Projection.csproj
@@ -20,7 +20,7 @@
 
   <PropertyGroup>
     <CSWinRTIncludes>Microsoft.Windows.ApplicationModel.WindowsAppRuntime</CSWinRTIncludes>
-    <CSWinRTWindowsMetadata>$(CsWinRTDependencyWindowsSdkPackagePackageVersion)</CSWinRTWindowsMetadata>
+    <CSWinRTWindowsMetadata>10.0.17763.0</CSWinRTWindowsMetadata>
   </PropertyGroup>
 
   <!-- Configure the release build binary to be as required by internal API scanning tools. -->

--- a/dev/Projections/CS/Microsoft.Windows.ApplicationModel.WindowsAppRuntime/Microsoft.Windows.ApplicationModel.WindowsAppRuntime.Projection.csproj
+++ b/dev/Projections/CS/Microsoft.Windows.ApplicationModel.WindowsAppRuntime/Microsoft.Windows.ApplicationModel.WindowsAppRuntime.Projection.csproj
@@ -21,7 +21,7 @@
   <PropertyGroup>
     <CSWinRTIncludes>Microsoft.Windows.ApplicationModel.WindowsAppRuntime</CSWinRTIncludes>
     <CSWinRTWindowsMetadata>10.0.17763.0</CSWinRTWindowsMetadata>
-    <WindowsSdkPackageVersion>$(CsWinRTDependencyWindowsSdkPackagePackageVersion)</WindowsSdkPackageVersion>
+    <WindowsSdkPackageVersion>10.0.17763.$(CsWinRTDependencyWindowsSdkPackagePackageVersion)</WindowsSdkPackageVersion>
   </PropertyGroup>
 
   <!-- Configure the release build binary to be as required by internal API scanning tools. -->

--- a/dev/Projections/CS/Microsoft.Windows.ApplicationModel.WindowsAppRuntime/Microsoft.Windows.ApplicationModel.WindowsAppRuntime.Projection.csproj
+++ b/dev/Projections/CS/Microsoft.Windows.ApplicationModel.WindowsAppRuntime/Microsoft.Windows.ApplicationModel.WindowsAppRuntime.Projection.csproj
@@ -21,6 +21,7 @@
   <PropertyGroup>
     <CSWinRTIncludes>Microsoft.Windows.ApplicationModel.WindowsAppRuntime</CSWinRTIncludes>
     <CSWinRTWindowsMetadata>10.0.17763.0</CSWinRTWindowsMetadata>
+    <WindowsSdkPackageVersion>$(CsWinRTDependencyWindowsSdkPackagePackageVersion)</WindowsSdkPackageVersion>
   </PropertyGroup>
 
   <!-- Configure the release build binary to be as required by internal API scanning tools. -->

--- a/dev/Projections/CS/Microsoft.Windows.PushNotifications.Projection/Microsoft.Windows.PushNotifications.Projection.csproj
+++ b/dev/Projections/CS/Microsoft.Windows.PushNotifications.Projection/Microsoft.Windows.PushNotifications.Projection.csproj
@@ -21,7 +21,7 @@
   <PropertyGroup>
     <CSWinRTIncludes>Microsoft.Windows.PushNotifications</CSWinRTIncludes>
     <CSWinRTWindowsMetadata>10.0.17763.0</CSWinRTWindowsMetadata>
-    <WindowsSdkPackageVersion>$(CsWinRTDependencyWindowsSdkPackagePackageVersion)</WindowsSdkPackageVersion>
+    <WindowsSdkPackageVersion>10.0.17763.$(CsWinRTDependencyWindowsSdkPackagePackageVersion)</WindowsSdkPackageVersion>
   </PropertyGroup>
 
   <!-- Configure the release build binary to be as required by internal API scanning tools. -->

--- a/dev/Projections/CS/Microsoft.Windows.PushNotifications.Projection/Microsoft.Windows.PushNotifications.Projection.csproj
+++ b/dev/Projections/CS/Microsoft.Windows.PushNotifications.Projection/Microsoft.Windows.PushNotifications.Projection.csproj
@@ -21,6 +21,7 @@
   <PropertyGroup>
     <CSWinRTIncludes>Microsoft.Windows.PushNotifications</CSWinRTIncludes>
     <CSWinRTWindowsMetadata>10.0.17763.0</CSWinRTWindowsMetadata>
+    <WindowsSdkPackageVersion>$(CsWinRTDependencyWindowsSdkPackagePackageVersion)</WindowsSdkPackageVersion>
   </PropertyGroup>
 
   <!-- Configure the release build binary to be as required by internal API scanning tools. -->

--- a/dev/Projections/CS/Microsoft.Windows.PushNotifications.Projection/Microsoft.Windows.PushNotifications.Projection.csproj
+++ b/dev/Projections/CS/Microsoft.Windows.PushNotifications.Projection/Microsoft.Windows.PushNotifications.Projection.csproj
@@ -20,7 +20,7 @@
 
   <PropertyGroup>
     <CSWinRTIncludes>Microsoft.Windows.PushNotifications</CSWinRTIncludes>
-    <CSWinRTWindowsMetadata>$(CsWinRTDependencyWindowsSdkPackagePackageVersion)</CSWinRTWindowsMetadata>
+    <CSWinRTWindowsMetadata>10.0.17763.0</CSWinRTWindowsMetadata>
   </PropertyGroup>
 
   <!-- Configure the release build binary to be as required by internal API scanning tools. -->

--- a/dev/Projections/CS/Microsoft.Windows.System.Power/Microsoft.Windows.System.Power.Projection.csproj
+++ b/dev/Projections/CS/Microsoft.Windows.System.Power/Microsoft.Windows.System.Power.Projection.csproj
@@ -21,7 +21,7 @@
   <PropertyGroup>
     <CSWinRTIncludes>Microsoft.Windows.System.Power</CSWinRTIncludes>
     <CSWinRTWindowsMetadata>10.0.17763.0</CSWinRTWindowsMetadata>
-    <WindowsSdkPackageVersion>$(CsWinRTDependencyWindowsSdkPackagePackageVersion)</WindowsSdkPackageVersion>
+    <WindowsSdkPackageVersion>10.0.17763.$(CsWinRTDependencyWindowsSdkPackagePackageVersion)</WindowsSdkPackageVersion>
   </PropertyGroup>
 
   <!-- Configure the release build binary to be as required by internal API scanning tools. -->

--- a/dev/Projections/CS/Microsoft.Windows.System.Power/Microsoft.Windows.System.Power.Projection.csproj
+++ b/dev/Projections/CS/Microsoft.Windows.System.Power/Microsoft.Windows.System.Power.Projection.csproj
@@ -21,6 +21,7 @@
   <PropertyGroup>
     <CSWinRTIncludes>Microsoft.Windows.System.Power</CSWinRTIncludes>
     <CSWinRTWindowsMetadata>10.0.17763.0</CSWinRTWindowsMetadata>
+    <WindowsSdkPackageVersion>$(CsWinRTDependencyWindowsSdkPackagePackageVersion)</WindowsSdkPackageVersion>
   </PropertyGroup>
 
   <!-- Configure the release build binary to be as required by internal API scanning tools. -->

--- a/dev/Projections/CS/Microsoft.Windows.System.Power/Microsoft.Windows.System.Power.Projection.csproj
+++ b/dev/Projections/CS/Microsoft.Windows.System.Power/Microsoft.Windows.System.Power.Projection.csproj
@@ -20,7 +20,7 @@
 
   <PropertyGroup>
     <CSWinRTIncludes>Microsoft.Windows.System.Power</CSWinRTIncludes>
-    <CSWinRTWindowsMetadata>$(CsWinRTDependencyWindowsSdkPackagePackageVersion)</CSWinRTWindowsMetadata>
+    <CSWinRTWindowsMetadata>10.0.17763.0</CSWinRTWindowsMetadata>
   </PropertyGroup>
 
   <!-- Configure the release build binary to be as required by internal API scanning tools. -->

--- a/dev/Projections/CS/Microsoft.Windows.System/Microsoft.Windows.System.Projection.csproj
+++ b/dev/Projections/CS/Microsoft.Windows.System/Microsoft.Windows.System.Projection.csproj
@@ -21,6 +21,7 @@
   <PropertyGroup>
     <CSWinRTIncludes>Microsoft.Windows.System</CSWinRTIncludes>
     <CSWinRTWindowsMetadata>10.0.17763.0</CSWinRTWindowsMetadata>
+    <WindowsSdkPackageVersion>$(CsWinRTDependencyWindowsSdkPackagePackageVersion)</WindowsSdkPackageVersion>
   </PropertyGroup>
 
   <!-- Configure the release build binary to be as required by internal API scanning tools. -->

--- a/dev/Projections/CS/Microsoft.Windows.System/Microsoft.Windows.System.Projection.csproj
+++ b/dev/Projections/CS/Microsoft.Windows.System/Microsoft.Windows.System.Projection.csproj
@@ -20,7 +20,7 @@
 
   <PropertyGroup>
     <CSWinRTIncludes>Microsoft.Windows.System</CSWinRTIncludes>
-    <CSWinRTWindowsMetadata>$(CsWinRTDependencyWindowsSdkPackagePackageVersion)</CSWinRTWindowsMetadata>
+    <CSWinRTWindowsMetadata>10.0.17763.0</CSWinRTWindowsMetadata>
   </PropertyGroup>
 
   <!-- Configure the release build binary to be as required by internal API scanning tools. -->

--- a/dev/Projections/CS/Microsoft.Windows.System/Microsoft.Windows.System.Projection.csproj
+++ b/dev/Projections/CS/Microsoft.Windows.System/Microsoft.Windows.System.Projection.csproj
@@ -21,7 +21,7 @@
   <PropertyGroup>
     <CSWinRTIncludes>Microsoft.Windows.System</CSWinRTIncludes>
     <CSWinRTWindowsMetadata>10.0.17763.0</CSWinRTWindowsMetadata>
-    <WindowsSdkPackageVersion>$(CsWinRTDependencyWindowsSdkPackagePackageVersion)</WindowsSdkPackageVersion>
+    <WindowsSdkPackageVersion>10.0.17763.$(CsWinRTDependencyWindowsSdkPackagePackageVersion)</WindowsSdkPackageVersion>
   </PropertyGroup>
 
   <!-- Configure the release build binary to be as required by internal API scanning tools. -->

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -4,7 +4,7 @@
     <MicrosoftWindowsCsWinRTPackageVersion>1.4.1</MicrosoftWindowsCsWinRTPackageVersion>
     <CsWinRTDependencyDotNetCoreSdkPackageVersion>5.0.404</CsWinRTDependencyDotNetCoreSdkPackageVersion>
     <CsWinRTDependencyDotNetCoreRuntimePackageVersion>5.0.13</CsWinRTDependencyDotNetCoreRuntimePackageVersion>
-    <CsWinRTDependencyWindowsSdkPackagePackageVersion>10.0.18362.0</CsWinRTDependencyWindowsSdkPackagePackageVersion>
+    <CsWinRTDependencyWindowsSdkPackagePackageVersion>0</CsWinRTDependencyWindowsSdkPackagePackageVersion>
     <!-- TODO: Fix DownloadDotNetCoreSdk.ps1 script so we don't need this property -->
     <CsWinRTDependencyDotNetCoreSdkLkgPackageVersion>$(CsWinRTDependencyDotNetCoreSdkPackageVersion)</CsWinRTDependencyDotNetCoreSdkLkgPackageVersion>
   </PropertyGroup>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -4,7 +4,7 @@
     <MicrosoftWindowsCsWinRTPackageVersion>1.4.1</MicrosoftWindowsCsWinRTPackageVersion>
     <CsWinRTDependencyDotNetCoreSdkPackageVersion>5.0.404</CsWinRTDependencyDotNetCoreSdkPackageVersion>
     <CsWinRTDependencyDotNetCoreRuntimePackageVersion>5.0.13</CsWinRTDependencyDotNetCoreRuntimePackageVersion>
-    <CsWinRTDependencyWindowsSdkPackagePackageVersion>0</CsWinRTDependencyWindowsSdkPackagePackageVersion>
+    <CsWinRTDependencyWindowsSdkPackagePackageVersion>22</CsWinRTDependencyWindowsSdkPackagePackageVersion>
     <!-- TODO: Fix DownloadDotNetCoreSdk.ps1 script so we don't need this property -->
     <CsWinRTDependencyDotNetCoreSdkLkgPackageVersion>$(CsWinRTDependencyDotNetCoreSdkPackageVersion)</CsWinRTDependencyDotNetCoreSdkLkgPackageVersion>
   </PropertyGroup>


### PR DESCRIPTION
There was a mistake with [this PR](https://github.com/microsoft/WindowsAppSDK/pull/1916) that used the CsWinRTDependencyWindowsSdkPackagePackageVersion for the Windows metadata used by CsWinRT.

Instead, it should be used for WindowsSdkPackageVersion. 

Further, CsWinRTDependencyWindowsSdkPackagePackageVersion should include just the patch version, as the Windows version can vary. This means instead of taking "10.0.18362.23-preview" from Maestro, just take "23-preview". 