### PR TITLE
Exclude "CsWinRT.Dependency*" in version.details.xml from converting to package.config

### DIFF
--- a/build/ProjectReunion-BuildFoundation.yml
+++ b/build/ProjectReunion-BuildFoundation.yml
@@ -150,6 +150,14 @@ jobs:
     publishDir : $(Build.ArtifactStagingDirectory)
     artifactName: 'windowsappsdk_binaries'
   steps:
+  - task: powershell@2
+    displayName: 'Create test pfx to sign MSIX test packages (DevCheck)'
+    inputs:
+      targetType: filePath
+      filePath: tools\DevCheck.ps1
+      arguments: -NoInteractive -Offline -Verbose -CertPassword 'BuildPipeline' -CheckTestPfx -Clean
+      workingDirectory: '$(Build.SourcesDirectory)'
+
   - task: NuGetAuthenticate@0
     inputs:
       nuGetServiceConnections: 'TelemetryInternal'

--- a/build/scripts/ConvertVersionDetailsToPackageConfig.ps1
+++ b/build/scripts/ConvertVersionDetailsToPackageConfig.ps1
@@ -27,9 +27,13 @@ foreach ($dependency in $buildConfig.Dependencies.ProductDependencies.Dependency
         Write-Host "##vso[task.setvariable variable=AppLicensingInternalPackageVersion;]$ver"
     }
 
-    $packagesText += '	<package id="' + $name + '" version="' + $ver + '" targetFramework="native" />
+    $excluded = $name.StartsWith("CsWinRT.Dependency.")
+    if (-not $excluded)
+    {
+        $packagesText += '	<package id="' + $name + '" version="' + $ver + '" targetFramework="native" />
 '
     }
+}
 $packagesText +=
 @"
 </packages>


### PR DESCRIPTION
Exclude "CsWinRT.Dependency*" in version.details.xml from converting to package.config.

These are not real packages.

Also call devcheck.ps1 in the any CPU stage