### PR TITLE
Add CsWin32 to C# projects

### DIFF
--- a/dev/VSIX/Directory.Build.props
+++ b/dev/VSIX/Directory.Build.props
@@ -8,6 +8,7 @@
         </RestoreSources>
         <CppWinRTVersion Condition="'$(CppWinRTVersion)' == ''">2.0.210806.1</CppWinRTVersion>
         <WindowsSDKBuildToolsVersion Condition="'$(WindowsSDKBuildToolsVersion)' == ''">10.0.22000.194</WindowsSDKBuildToolsVersion>
+        <CsWin32Version Condition="'$(CsWin32Version)' == ''">0.1.619-beta</CsWin32Version>
         <WILVersion Condition="'$(WILVersion)' == ''">1.0.211019.2</WILVersion>
         <!-- Provides a default package version in order to simplify dev inner loop testing -->
         <WindowsAppSdkVersion Condition="'$(WindowsAppSdkVersion)' == ''">1.0.0-preview1</WindowsAppSdkVersion>

--- a/dev/VSIX/Extension/Cs/Dev16/WindowsAppSDK.Cs.Extension.Dev16.csproj
+++ b/dev/VSIX/Extension/Cs/Dev16/WindowsAppSDK.Cs.Extension.Dev16.csproj
@@ -72,6 +72,10 @@
     <PackageReference Include="Microsoft.Windows.SDK.BuildTools" Version="[$(WindowsSDKBuildToolsVersion)]" GeneratePathProperty="true">
       <ExcludeAssets>All</ExcludeAssets>
     </PackageReference>
+    <PackageReference Include="Microsoft.Windows.CsWin32" Version="[$(CsWin32Version)]" GeneratePathProperty="true">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="$(ItemTemplatesDir)Desktop\CSharp\BlankWindow\WinUI.Desktop.Cs.BlankWindow.csproj">

--- a/dev/VSIX/Extension/Cs/Dev17/WindowsAppSDK.Cs.Extension.Dev17.csproj
+++ b/dev/VSIX/Extension/Cs/Dev17/WindowsAppSDK.Cs.Extension.Dev17.csproj
@@ -71,6 +71,10 @@
     <PackageReference Include="Microsoft.Windows.SDK.BuildTools" Version="[$(WindowsSDKBuildToolsVersion)]" GeneratePathProperty="true">
       <ExcludeAssets>All</ExcludeAssets>
     </PackageReference>
+    <PackageReference Include="Microsoft.Windows.CsWin32" Version="[$(CsWin32Version)]" GeneratePathProperty="true">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="$(ItemTemplatesDir)Desktop\CSharp\BlankWindow\WinUI.Desktop.Cs.BlankWindow.csproj">

--- a/dev/VSIX/Extension/Directory.Build.targets
+++ b/dev/VSIX/Extension/Directory.Build.targets
@@ -249,6 +249,9 @@
     <xsl:template match="/ns:VSTemplate/ns:WizardData/ns:packages/ns:package[@id='Microsoft.Windows.ImplementationLibrary']/@version">
         <xsl:attribute name="version">$(WILVersion)</xsl:attribute>
     </xsl:template>
+    <xsl:template match="/ns:VSTemplate/ns:WizardData/ns:packages/ns:package[@id='Microsoft.Windows.CsWin32']/@version">
+        <xsl:attribute name="version">$(CsWin32Version)</xsl:attribute>
+    </xsl:template>
 
     <!-- Update Assets section with actual Nuget package filenames -->
     <xsl:template match="/ns:VSTemplate/ns:WizardData/ns:Assets/ns:Asset[@Type='Microsoft.Windows.CppWinRT.nupkg']/@Path">
@@ -263,6 +266,9 @@
     <xsl:template match="/ns:VSTemplate/ns:WizardData/ns:Assets/ns:Asset[@Type='Microsoft.Windows.ImplementationLibrary.nupkg']/@Path">
         <xsl:attribute name="Path">Microsoft.Windows.ImplementationLibrary.$(WILVersion).nupkg</xsl:attribute>
     </xsl:template>
+    <xsl:template match="/ns:VSTemplate/ns:WizardData/ns:Assets/ns:Asset[@Type='Microsoft.Windows.CsWin32.nupkg']/@Path">
+        <xsl:attribute name="Path">Microsoft.Windows.CsWin32.$(CsWin32Version).nupkg</xsl:attribute>
+    </xsl:template>
 
     <!-- Update custom parameters passed into subtemplates -->
     <xsl:template match="/ns:VSTemplate/ns:TemplateContent/ns:CustomParameters/ns:CustomParameter[@Name='$CppWinRTVersion$']/@Value">
@@ -276,6 +282,9 @@
     </xsl:template>
     <xsl:template match="/ns:VSTemplate/ns:TemplateContent/ns:CustomParameters/ns:CustomParameter[@Name='$WILVersion$']/@Value">
         <xsl:attribute name="Value">$(WILVersion)</xsl:attribute>
+    </xsl:template>
+    <xsl:template match="/ns:VSTemplate/ns:TemplateContent/ns:CustomParameters/ns:CustomParameter[@Name='$CsWin32Version$']/@Value">
+        <xsl:attribute name="Value">$(CsWin32Version)</xsl:attribute>
     </xsl:template>
     <xsl:template match="/ns:VSTemplate/ns:TemplateContent/ns:CustomParameters/ns:CustomParameter[@Name='$DotNetVersion$']/@Value">
         <xsl:attribute name="Value">$(DotNetVersion)</xsl:attribute>

--- a/dev/VSIX/ProjectTemplates/Desktop/CSharp/ClassLibrary/ProjectTemplate.csproj
+++ b/dev/VSIX/ProjectTemplates/Desktop/CSharp/ClassLibrary/ProjectTemplate.csproj
@@ -8,7 +8,15 @@
   </PropertyGroup>
 
   <ItemGroup>
-      <PackageReference Include="Microsoft.WindowsAppSDK" Version="$WindowsAppSDKNupkgVersion$" />
-      <PackageReference Include="Microsoft.Windows.SDK.BuildTools" Version="$WindowsSDKBuildToolsNupkgVersion$" />
+    <None Include="NativeMethods.txt" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.WindowsAppSDK" Version="$WindowsAppSDKNupkgVersion$" />
+    <PackageReference Include="Microsoft.Windows.SDK.BuildTools" Version="$WindowsSDKBuildToolsNupkgVersion$" />
+    <PackageReference Include="Microsoft.Windows.CsWin32" Version="$CsWin32Version$">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
   </ItemGroup>
 </Project>

--- a/dev/VSIX/ProjectTemplates/Desktop/CSharp/ClassLibrary/WinUI.Desktop.Cs.ClassLibrary.csproj
+++ b/dev/VSIX/ProjectTemplates/Desktop/CSharp/ClassLibrary/WinUI.Desktop.Cs.ClassLibrary.csproj
@@ -68,6 +68,7 @@
   </ItemGroup>
   <ItemGroup>
     <None Include="Class1.cs" />
+    <None Include="NativeMethods.txt" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Import Project="$(VSToolsPath)\VSSDK\Microsoft.VsSDK.targets" Condition="'$(VSToolsPath)' != ''" />

--- a/dev/VSIX/ProjectTemplates/Desktop/CSharp/ClassLibrary/WinUI.Desktop.Cs.ClassLibrary.vstemplate
+++ b/dev/VSIX/ProjectTemplates/Desktop/CSharp/ClassLibrary/WinUI.Desktop.Cs.ClassLibrary.vstemplate
@@ -30,9 +30,11 @@
       <CustomParameter Name="$WindowsAppSDKNupkgVersion$" Value="FIXME-Verify-Directory.Build.Targets-XmlPoke-Queries" />
       <CustomParameter Name="$WindowsSDKBuildToolsNupkgVersion$" Value="FIXME-Verify-Directory.Build.Targets-XmlPoke-Queries" />
       <CustomParameter Name="$DotNetVersion$" Value="FIXME-Verify-Directory.Build.Targets-XmlPoke-Queries"/>
+      <CustomParameter Name="$CsWin32Version$" Value="FIXME-Verify-Directory.Build.Targets-XmlPoke-Queries" />
     </CustomParameters>
     <Project File="ProjectTemplate.csproj" ReplaceParameters="true">
       <ProjectItem ReplaceParameters="true" OpenInEditor="true">Class1.cs</ProjectItem>
+      <ProjectItem ReplaceParameters="false">NativeMethods.txt</ProjectItem>
     </Project>
   </TemplateContent>
 </VSTemplate>

--- a/dev/VSIX/ProjectTemplates/Desktop/CSharp/PackagedApp/BlankApp/App.xaml.cs
+++ b/dev/VSIX/ProjectTemplates/Desktop/CSharp/PackagedApp/BlankApp/App.xaml.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Runtime.InteropServices;
 using System.Runtime.InteropServices.WindowsRuntime;
 using Windows.ApplicationModel;
 using Windows.ApplicationModel.Activation;
@@ -15,6 +16,10 @@ using Microsoft.UI.Xaml.Input;
 using Microsoft.UI.Xaml.Media;
 using Microsoft.UI.Xaml.Navigation;
 using Microsoft.UI.Xaml.Shapes;
+using static Windows.Win32.PInvoke;
+using Windows.Win32.Foundation;
+using Windows.Win32.UI.WindowsAndMessaging;
+using WinRT;
 
 // To learn more about WinUI, the WinUI project structure,
 // and more about our project templates, see: http://aka.ms/winui-project-info.
@@ -26,6 +31,9 @@ namespace $safeprojectname$
     /// </summary>
     public partial class App : Application
     {
+        private Window m_window;
+        private HWND m_hwnd;
+
         /// <summary>
         /// Initializes the singleton application object.  This is the first line of authored code
         /// executed, and as such is the logical equivalent of main() or WinMain().
@@ -43,9 +51,41 @@ namespace $safeprojectname$
         protected override void OnLaunched(Microsoft.UI.Xaml.LaunchActivatedEventArgs args)
         {
             m_window = new MainWindow();
+
+            var windowNative = m_window.As<IWindowNative>();
+            m_hwnd = new HWND(windowNative.WindowHandle);
+
             m_window.Activate();
+
+            SetWindowSize(m_hwnd, 800, 600);
         }
 
-        private Window m_window;
+        /// <summary>
+        /// Uses Win32 interop to set the window size
+        /// </summary>
+        /// <param name="hwnd">Window handle</param>
+        /// <param name="width">Window width</param>
+        /// <param name="height">Window height</param>
+        private static void SetWindowSize(HWND hwnd, int width, int height)
+        {
+            var dpi = GetDpiForWindow(hwnd);
+            float scalingFactor = (float)dpi / 96f;
+            width = (int)(width * scalingFactor);
+            height = (int)(height * scalingFactor);
+
+            SetWindowPos(
+                hwnd, 
+                HWND_TOP,
+                0, 0, width, height,
+                SET_WINDOW_POS_FLAGS.SWP_NOMOVE);
+        }
+
+        [ComImport]
+        [InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
+        [Guid("EECDBF0E-BAE9-4CB6-A68E-9598E1CB57BB")]
+        internal interface IWindowNative
+        {
+            IntPtr WindowHandle { get; }
+        }
     }
 }

--- a/dev/VSIX/ProjectTemplates/Desktop/CSharp/PackagedApp/BlankApp/App.xaml.cs
+++ b/dev/VSIX/ProjectTemplates/Desktop/CSharp/PackagedApp/BlankApp/App.xaml.cs
@@ -52,8 +52,7 @@ namespace $safeprojectname$
         {
             m_window = new MainWindow();
 
-            var windowNative = m_window.As<IWindowNative>();
-            m_hwnd = new HWND(windowNative.WindowHandle);
+            m_hwnd = (HWND)WinRT.Interop.WindowNative.GetWindowHandle(m_window);
 
             m_window.Activate();
 
@@ -78,14 +77,6 @@ namespace $safeprojectname$
                 HWND_TOP,
                 0, 0, width, height,
                 SET_WINDOW_POS_FLAGS.SWP_NOMOVE);
-        }
-
-        [ComImport]
-        [InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
-        [Guid("EECDBF0E-BAE9-4CB6-A68E-9598E1CB57BB")]
-        internal interface IWindowNative
-        {
-            IntPtr WindowHandle { get; }
         }
     }
 }

--- a/dev/VSIX/ProjectTemplates/Desktop/CSharp/PackagedApp/BlankApp/NativeMethods.txt
+++ b/dev/VSIX/ProjectTemplates/Desktop/CSharp/PackagedApp/BlankApp/NativeMethods.txt
@@ -1,0 +1,4 @@
+GetDpiForWindow
+SetWindowPos
+HWND_TOP
+SET_WINDOW_POS_FLAGS

--- a/dev/VSIX/ProjectTemplates/Desktop/CSharp/PackagedApp/BlankApp/ProjectTemplate.csproj
+++ b/dev/VSIX/ProjectTemplates/Desktop/CSharp/PackagedApp/BlankApp/ProjectTemplate.csproj
@@ -11,8 +11,16 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <None Include="NativeMethods.txt" />
+  </ItemGroup>
+	
+  <ItemGroup>
     <PackageReference Include="Microsoft.WindowsAppSDK" Version="$ext_WindowsAppSDKNupkgVersion$" />
     <PackageReference Include="Microsoft.Windows.SDK.BuildTools" Version="$ext_WindowsSDKBuildToolsNupkgVersion$" />
+    <PackageReference Include="Microsoft.Windows.CsWin32" Version="$ext_CsWin32Version$">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
     <Manifest Include="$(ApplicationManifest)" />
   </ItemGroup>
 </Project>

--- a/dev/VSIX/ProjectTemplates/Desktop/CSharp/PackagedApp/BlankApp/WinUI.Desktop.Cs.BlankApp.vstemplate
+++ b/dev/VSIX/ProjectTemplates/Desktop/CSharp/PackagedApp/BlankApp/WinUI.Desktop.Cs.BlankApp.vstemplate
@@ -36,6 +36,7 @@
       <ProjectItem ReplaceParameters="true" TargetFileName="App.xaml.cs">App.xaml.cs</ProjectItem>
       <ProjectItem ReplaceParameters="true" TargetFileName="MainWindow.xaml">MainWindow.xaml</ProjectItem>
       <ProjectItem ReplaceParameters="true" TargetFileName="MainWindow.xaml.cs">MainWindow.xaml.cs</ProjectItem>
+      <ProjectItem ReplaceParameters="false" TargetFileName="NativeMethods.txt">NativeMethods.txt</ProjectItem>
     </Project>
   </TemplateContent>
 </VSTemplate>

--- a/dev/VSIX/ProjectTemplates/Desktop/CSharp/PackagedApp/WinUI.Desktop.Cs.PackagedApp.csproj
+++ b/dev/VSIX/ProjectTemplates/Desktop/CSharp/PackagedApp/WinUI.Desktop.Cs.PackagedApp.csproj
@@ -67,6 +67,7 @@
     <None Include="BlankApp\Properties\PublishProfiles\WinX64.pubxml" />
     <None Include="BlankApp\Properties\PublishProfiles\WinX86.pubxml" />
     <None Include="BlankApp\ProjectTemplate.csproj" />
+    <None Include="BlankApp\NativeMethods.txt" />
     <None Include="WapProj\WapProjTemplate.wapproj" />
   </ItemGroup>
 </Project>

--- a/dev/VSIX/ProjectTemplates/Desktop/CSharp/PackagedApp/WinUI.Desktop.Cs.PackagedApp.vstemplate
+++ b/dev/VSIX/ProjectTemplates/Desktop/CSharp/PackagedApp/WinUI.Desktop.Cs.PackagedApp.vstemplate
@@ -30,6 +30,7 @@
       <CustomParameter Name="$WindowsAppSDKNupkgVersion$" Value="FIXME-Verify-Directory.Build.Targets-XmlPoke-Queries" />
       <CustomParameter Name="$WindowsSDKBuildToolsNupkgVersion$" Value="FIXME-Verify-Directory.Build.Targets-XmlPoke-Queries" />
       <CustomParameter Name="$DotNetVersion$" Value="FIXME-Verify-Directory.Build.Targets-XmlPoke-Queries"/>
+      <CustomParameter Name="$CsWin32Version$" Value="FIXME-Verify-Directory.Build.Targets-XmlPoke-Queries" />
     </CustomParameters>
     <ProjectCollection>
       <ProjectTemplateLink ProjectName="$projectname$ (Package)" CopyParameters="true">WapProj\WinUI.Desktop.Cs.WapProj.vstemplate</ProjectTemplateLink>

--- a/dev/VSIX/ProjectTemplates/Desktop/CSharp/SingleProjectPackagedApp/App.xaml.cs
+++ b/dev/VSIX/ProjectTemplates/Desktop/CSharp/SingleProjectPackagedApp/App.xaml.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Runtime.InteropServices;
 using System.Runtime.InteropServices.WindowsRuntime;
 using Windows.ApplicationModel;
 using Windows.ApplicationModel.Activation;
@@ -15,6 +16,10 @@ using Microsoft.UI.Xaml.Input;
 using Microsoft.UI.Xaml.Media;
 using Microsoft.UI.Xaml.Navigation;
 using Microsoft.UI.Xaml.Shapes;
+using static Windows.Win32.PInvoke;
+using Windows.Win32.Foundation;
+using Windows.Win32.UI.WindowsAndMessaging;
+using WinRT;
 
 // To learn more about WinUI, the WinUI project structure,
 // and more about our project templates, see: http://aka.ms/winui-project-info.
@@ -26,6 +31,9 @@ namespace $safeprojectname$
     /// </summary>
     public partial class App : Application
     {
+        private Window m_window;
+        private HWND m_hwnd;
+
         /// <summary>
         /// Initializes the singleton application object.  This is the first line of authored code
         /// executed, and as such is the logical equivalent of main() or WinMain().
@@ -43,9 +51,41 @@ namespace $safeprojectname$
         protected override void OnLaunched(Microsoft.UI.Xaml.LaunchActivatedEventArgs args)
         {
             m_window = new MainWindow();
+
+            var windowNative = m_window.As<IWindowNative>();
+            m_hwnd = new HWND(windowNative.WindowHandle);
+
             m_window.Activate();
+
+            SetWindowSize(m_hwnd, 800, 600);
         }
 
-        private Window m_window;
+        /// <summary>
+        /// Uses Win32 interop to set the window size
+        /// </summary>
+        /// <param name="hwnd">Window handle</param>
+        /// <param name="width">Window width</param>
+        /// <param name="height">Window height</param>
+        private static void SetWindowSize(HWND hwnd, int width, int height)
+        {
+            var dpi = GetDpiForWindow(hwnd);
+            float scalingFactor = (float)dpi / 96f;
+            width = (int)(width * scalingFactor);
+            height = (int)(height * scalingFactor);
+
+            SetWindowPos(
+                hwnd, 
+                HWND_TOP,
+                0, 0, width, height,
+                SET_WINDOW_POS_FLAGS.SWP_NOMOVE);
+        }
+
+        [ComImport]
+        [InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
+        [Guid("EECDBF0E-BAE9-4CB6-A68E-9598E1CB57BB")]
+        internal interface IWindowNative
+        {
+            IntPtr WindowHandle { get; }
+        }
     }
 }

--- a/dev/VSIX/ProjectTemplates/Desktop/CSharp/SingleProjectPackagedApp/App.xaml.cs
+++ b/dev/VSIX/ProjectTemplates/Desktop/CSharp/SingleProjectPackagedApp/App.xaml.cs
@@ -52,8 +52,7 @@ namespace $safeprojectname$
         {
             m_window = new MainWindow();
 
-            var windowNative = m_window.As<IWindowNative>();
-            m_hwnd = new HWND(windowNative.WindowHandle);
+            m_hwnd = (HWND)WinRT.Interop.WindowNative.GetWindowHandle(m_window);
 
             m_window.Activate();
 
@@ -78,14 +77,6 @@ namespace $safeprojectname$
                 HWND_TOP,
                 0, 0, width, height,
                 SET_WINDOW_POS_FLAGS.SWP_NOMOVE);
-        }
-
-        [ComImport]
-        [InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
-        [Guid("EECDBF0E-BAE9-4CB6-A68E-9598E1CB57BB")]
-        internal interface IWindowNative
-        {
-            IntPtr WindowHandle { get; }
         }
     }
 }

--- a/dev/VSIX/ProjectTemplates/Desktop/CSharp/SingleProjectPackagedApp/NativeMethods.txt
+++ b/dev/VSIX/ProjectTemplates/Desktop/CSharp/SingleProjectPackagedApp/NativeMethods.txt
@@ -1,0 +1,4 @@
+GetDpiForWindow
+SetWindowPos
+HWND_TOP
+SET_WINDOW_POS_FLAGS

--- a/dev/VSIX/ProjectTemplates/Desktop/CSharp/SingleProjectPackagedApp/ProjectTemplate.csproj
+++ b/dev/VSIX/ProjectTemplates/Desktop/CSharp/SingleProjectPackagedApp/ProjectTemplate.csproj
@@ -23,8 +23,16 @@
   </ItemGroup>
 
   <ItemGroup>
+    <None Include="NativeMethods.txt" />
+  </ItemGroup>
+
+  <ItemGroup>
     <PackageReference Include="Microsoft.WindowsAppSDK" Version="$WindowsAppSDKNupkgVersion$" />
     <PackageReference Include="Microsoft.Windows.SDK.BuildTools" Version="$WindowsSDKBuildToolsNupkgVersion$" />
+    <PackageReference Include="Microsoft.Windows.CsWin32" Version="$CsWin32Version$">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
     <Manifest Include="$(ApplicationManifest)" />
   </ItemGroup>
 

--- a/dev/VSIX/ProjectTemplates/Desktop/CSharp/SingleProjectPackagedApp/WinUI.Desktop.Cs.SingleProjectPackagedApp.csproj
+++ b/dev/VSIX/ProjectTemplates/Desktop/CSharp/SingleProjectPackagedApp/WinUI.Desktop.Cs.SingleProjectPackagedApp.csproj
@@ -70,6 +70,7 @@
     </Content>
     <Content Include="App.xaml.cs" />
     <Content Include="MainWindow.xaml.cs" />
+    <Content Include="NativeMethods.txt" />
     <Content Include="Assets\LockScreenLogo.scale-200.png" />
     <Content Include="Assets\SplashScreen.scale-200.png" />
     <Content Include="Assets\Square150x150Logo.scale-200.png" />

--- a/dev/VSIX/ProjectTemplates/Desktop/CSharp/SingleProjectPackagedApp/WinUI.Desktop.Cs.SingleProjectPackagedApp.vstemplate
+++ b/dev/VSIX/ProjectTemplates/Desktop/CSharp/SingleProjectPackagedApp/WinUI.Desktop.Cs.SingleProjectPackagedApp.vstemplate
@@ -29,6 +29,7 @@
     <CustomParameters>
       <CustomParameter Name="$WindowsAppSDKNupkgVersion$" Value="FIXME-Verify-Directory.Build.Targets-XmlPoke-Queries" />
       <CustomParameter Name="$WindowsSDKBuildToolsNupkgVersion$" Value="FIXME-Verify-Directory.Build.Targets-XmlPoke-Queries" />
+      <CustomParameter Name="$CsWin32Version$" Value="FIXME-Verify-Directory.Build.Targets-XmlPoke-Queries" />
       <CustomParameter Name="$DotNetVersion$" Value="FIXME-Verify-Directory.Build.Targets-XmlPoke-Queries"/>
     </CustomParameters>
     <Project File="ProjectTemplate.csproj" ReplaceParameters="true">
@@ -42,6 +43,7 @@
       <ProjectItem ReplaceParameters="true" TargetFileName="MainWindow.xaml">MainWindow.xaml</ProjectItem>
       <ProjectItem ReplaceParameters="true" TargetFileName="MainWindow.xaml.cs">MainWindow.xaml.cs</ProjectItem>
       <ProjectItem ReplaceParameters="true" TargetFileName="Package.appxmanifest">Package-managed.appxmanifest</ProjectItem>
+      <ProjectItem ReplaceParameters="false" TargetFileName="NativeMethods.txt">NativeMethods.txt</ProjectItem>
       <Folder Name="Assets" TargetFolderName="Assets">
         <ProjectItem ReplaceParameters="false" TargetFileName="SplashScreen.scale-200.png">SplashScreen.scale-200.png</ProjectItem>
         <ProjectItem ReplaceParameters="false" TargetFileName="LockScreenLogo.scale-200.png">LockScreenLogo.scale-200.png</ProjectItem>


### PR DESCRIPTION
This adds the CsWin32 package to the C# templates. It also adds some code that uses Win32 interop via CsWin32 to the C# WinUI projects that allows them to set the window size. I built this using our internal pipeline and tested it on VS 2022 to make sure it worked correctly.