### PR TITLE
Update the Windows SDK version for RestartAgent

### DIFF
--- a/dev/RestartAgent/RestartAgent.vcxproj
+++ b/dev/RestartAgent/RestartAgent.vcxproj
@@ -10,7 +10,7 @@
     <ProjectGuid>{bc5e5a3e-e733-4388-8b00-f8495da7c778}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>RestartAgent</RootNamespace>
-    <WindowsTargetPlatformVersion Condition=" '$(WindowsTargetPlatformVersion)' == '' ">10.0.20348.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion Condition=" '$(WindowsTargetPlatformVersion)' == '' ">10.0</WindowsTargetPlatformVersion>
     <WindowsTargetPlatformMinVersion>10.0.17134.0</WindowsTargetPlatformMinVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />


### PR DESCRIPTION
The Windows SDK version set in the RestartAgent project should match that of other projects.