### PR TITLE
Enable APIscan-friendly build options

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -51,6 +51,9 @@
   <!-- Build with the hybrid CRT (Universal CRT + Static VS CRT (for what little the Universal CRT doesn't cover) -->
   <Import Project="$(MSBuildThisFileDirectory)HybridCRT.props" />
 
+  <!-- Build with APIscan-friendly compiler+linker options -->
+  <Import Project="$(MSBuildThisFileDirectory)ApiScan.Cpp.props" />
+
   <!-- Load the test certificate's password (so we do it once for reuse across projects) -->
   <PropertyGroup Condition="'$(RepoTestCertificatePFX)' == ''">
     <RepoTestCertificatePFX>$(RepoRoot)\.user\winappsdk.certificate.test.pfx</RepoTestCertificatePFX>

--- a/dev/MRTCore/mrt/Core/src/MRM.vcxproj
+++ b/dev/MRTCore/mrt/Core/src/MRM.vcxproj
@@ -4,7 +4,6 @@
   <Import Project="..\..\packages\Microsoft.Build.Tasks.Git.1.1.0-beta-20204-02\build\Microsoft.Build.Tasks.Git.props" Condition="Exists('..\..\packages\Microsoft.Build.Tasks.Git.1.1.0-beta-20204-02\build\Microsoft.Build.Tasks.Git.props')" />
   <Import Project="..\..\packages\Microsoft.SourceLink.Common.1.1.0-beta-21055-01\build\Microsoft.SourceLink.Common.props" Condition="Exists('..\..\packages\Microsoft.SourceLink.Common.1.1.0-beta-21055-01\build\Microsoft.SourceLink.Common.props')" />
   <Import Project="..\..\..\..\WindowsAppSDK.Build.Cpp.props" />
-  <Import Project="..\..\..\..\..\ApiScan.Cpp.props" />
   <PropertyGroup Label="DevEnvironmentScenario">
     <ConsumeWinRT>false</ConsumeWinRT>
     <UseModernCompliantVclibs>true</UseModernCompliantVclibs>

--- a/dev/MRTCore/mrt/Microsoft.Windows.ApplicationModel.Resources/src/Microsoft.Windows.ApplicationModel.Resources.vcxproj
+++ b/dev/MRTCore/mrt/Microsoft.Windows.ApplicationModel.Resources/src/Microsoft.Windows.ApplicationModel.Resources.vcxproj
@@ -5,7 +5,6 @@
   <Import Project="..\..\packages\Microsoft.SourceLink.Common.1.1.0-beta-21055-01\build\Microsoft.SourceLink.Common.props" Condition="Exists('..\..\packages\Microsoft.SourceLink.Common.1.1.0-beta-21055-01\build\Microsoft.SourceLink.Common.props')" />
   <Import Project="..\..\packages\Microsoft.Windows.CppWinRT.2.0.210913.7\build\native\Microsoft.Windows.CppWinRT.props" Condition="Exists('..\..\packages\Microsoft.Windows.CppWinRT.2.0.210913.7\build\native\Microsoft.Windows.CppWinRT.props')" />
   <Import Project="..\..\..\..\WindowsAppSDK.Build.Cpp.props" />
-  <Import Project="..\..\..\..\..\ApiScan.Cpp.props" />
   <PropertyGroup Label="Globals">
     <CppWinRTOptimized>true</CppWinRTOptimized>
     <CppWinRTRootNamespaceAutoMerge>true</CppWinRTRootNamespaceAutoMerge>


### PR DESCRIPTION
Enable build options so Release binaries are APIscan-friendly.

https://task.ms/37934927

All product projects had the right settings except `/DEBUGTYPE:FIXUP`.

`ApiScan.Cpp.props` sets `/Zi /Gf /Gy` and `/DEBUG /OPT:REF /OPT:ICF /INCREMENTAL:NO /DEBUGTYPE:CV,FIXUP` (albeit via english-y named XML Elements) but only a couple of MRT projects imported that. This change moves the import to `Directory.Build.props` so all projects get the necessary options for Release builds.

Needed compiler options => `/Zi /Gf /Gy`

* `/Zi` - Debug Information Format = Program Database (PDB)
* `/Gf` - Enable string pooling = Yes. Also enabled if `/O1` (optimize for size) or `/O2` (optimize for speed) are set
* `/Gy` - Enable Function-Level Linking = Yes

Needed linker options => `/DEBUG /DEBUGTYPE:CV,FIXUP /OPT:REF /OPT:ICF /INCREMENTAL:NO`

* `/DEBUG` - Generate Debug Info
* `/OPT:REF` - References = Yes
* `/OPT:ICF` - Enable COMDAT Folding = Yes
* `/INCREMENTAL:NO` - Enable Incremental Linking = No

`/DEBUG:FULL` also works. Generates more info than Vulcan requires but not a problem.

`/profile` linker option also works . Though I've yet to see a project set that (ever, not just in WinAppSDK).

If `/DEBUGTYPE` is set Vulcan needs CV + FIXUP. If `/DEBUG` is specified and `/DEBUGTYPE` isn't then `/DEBUGTYPE` defaults to `CV`.

I reviewed Release settings for..

* RestartAgent
* DynamicDependencyLifetimeManagerShadow
* DynamicDependency.DataStore
* DynamicDependency.DataStore.ProxyStub
* DynamicDependencyLifetimeManager
* DynamicDependencyLifetimeManager.ProxyStub
* PushNotiticationsLongRunningTask
* PushNotiticationsLongRunningTask.ProxyStub
* PushNotiticationsLongRunningTask.StartupTask
* WindowsAppRuntime_DLL
* WindowsAppRuntime_Bootstrap
* dev/mrtcore/MRM
* dev/mrtcore/mrmex
* dev/mrtcore/mrmmin
* installer/WindowsAppRuntimeInstall

(i.e. all the product projects. No test projects)

They all use the same key settings: `/Zi`, `/Gy`, `/DEBUG:FULL`, `/OPT:ICF`, `/OPT:REF`, `/INCREMENTAL:NO`.

`/GF` is good, though not consistent. MRM sets `/Gf` (only one to explicitly do so). No other explicitly sets `/Gf` but do set `/O2` which implies `/Gf`.

No project set `/DEBUGTYPE` but since they set `/DEBUG` they get the default of `/DEBUGTYPE:CV`. (These are typical settings for Release configurations in VS templates).

Only option missing: `/DEBUGTYPE:FIXUP`.

VS project settings has no GUI property to set /DEBUGTYPE directly. You can only point/click set it indirectly via the `Generate Debug Info` option and that combobox of choices only offers No, /DEBUG, /DEBUG:FASTLINK, /DEBUG:FULL and inherit from parent. You'd have to enable this via the raw `Command Line` option, or via msbuild props/targets. Like, say, ApiScan.Cpp.props... ;-)