### PR TITLE
Revert "Update the Windows SDK version for RestartAgent"

### DIFF
--- a/dev/RestartAgent/RestartAgent.vcxproj
+++ b/dev/RestartAgent/RestartAgent.vcxproj
@@ -10,7 +10,7 @@
     <ProjectGuid>{bc5e5a3e-e733-4388-8b00-f8495da7c778}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>RestartAgent</RootNamespace>
-    <WindowsTargetPlatformVersion Condition=" '$(WindowsTargetPlatformVersion)' == '' ">10.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion Condition=" '$(WindowsTargetPlatformVersion)' == '' ">10.0.20348.0</WindowsTargetPlatformVersion>
     <WindowsTargetPlatformMinVersion>10.0.17134.0</WindowsTargetPlatformMinVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />


### PR DESCRIPTION
Reverts microsoft/WindowsAppSDK#2043

I'm reverting this PR as it seems that it is causing the nightly build to fail. I am not sure I fully understand why that it the case as the other projects for the WindowsAppSDK seem to be happy with 10.0 (latest installed verion)

I find it strange that this project is specifically targeting v10.0.20348.0 but I assume that we're relying on a bug fix that wasn't present before. Then the question becomes why is WindowsTargetPlatformMinVersion set to 10.0.17134.0.

