### PR TITLE
DynamicDependencies: support elevation

### DIFF
--- a/dev/AccessControl/Microsoft.Windows.Security.AccessControl.cpp
+++ b/dev/AccessControl/Microsoft.Windows.Security.AccessControl.cpp
@@ -26,7 +26,7 @@ namespace winrt::Microsoft::Windows::Security::AccessControl::implementation
 
         winrt::check_hresult(
             GetSecurityDescriptorForAppContainerNames(
-                rawAccessRequests.size(), rawAccessRequests.data(), sid.get(), principalAccessMask, &sd, sdLength));
+                static_cast<uint32_t>(rawAccessRequests.size()), rawAccessRequests.data(), sid.get(), principalAccessMask, &sd, sdLength));
         return sd;
     }
 

--- a/dev/Common/AppModel.PackageGraph.h
+++ b/dev/Common/AppModel.PackageGraph.h
@@ -1,0 +1,36 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+#ifndef __APPMODEL_PACKAGEGRAPH_H
+#define __APPMODEL_PACKAGEGRAPH_H
+
+#include <appmodel.h>
+
+namespace AppModel::PackageGraph
+{
+inline HRESULT GetCurrentPackageGraph(
+    const UINT32 flags,
+    uint32_t& packageInfoCount,
+    const PACKAGE_INFO*& packageInfo,
+    wil::unique_cotaskmem_ptr<BYTE[]>& buffer)
+{
+   packageInfoCount = 0;
+    packageInfo = nullptr;
+
+    uint32_t bufferLength{};
+    LONG rc{ ::GetCurrentPackageInfo(flags, &bufferLength, nullptr, &packageInfoCount) };
+    if ((rc == APPMODEL_ERROR_NO_PACKAGE) || (packageInfoCount == 0))
+   {
+        // No packages. We�re done
+        return S_OK;
+    }
+    RETURN_HR_IF(HRESULT_FROM_WIN32(rc), rc != ERROR_INSUFFICIENT_BUFFER);
+
+    buffer = wil::make_unique_cotaskmem<BYTE[]>(bufferLength);
+    RETURN_IF_WIN32_ERROR(::GetCurrentPackageInfo(flags, &bufferLength, buffer.get(), &packageInfoCount));
+    packageInfo = reinterpret_cast<PACKAGE_INFO*>(buffer.get());
+    return S_OK;
+}
+}
+
+#endif // __APPMODEL_PACKAGEGRAPH_H

--- a/dev/DynamicDependency/API/DataStore.cpp
+++ b/dev/DynamicDependency/API/DataStore.cpp
@@ -154,6 +154,9 @@ std::filesystem::path MddCore::DataStore::GetDataStorePathForSystem()
 
 std::filesystem::path MddCore::DataStore::GetDataStorePathForUser()
 {
+    // AppContainer processes MUST use the PackagedCOM data store.
+    // MediumIL can go either way so we'll favor ApplicationDataManager as the more efficient option.
+    // Elevated CANNOT use PackagedCOM so MUST use AppliccationDataManager.
     if (wil::get_token_is_app_container())
     {
         return GetDataStorePathForUserViaCOMDataStore();

--- a/dev/DynamicDependency/API/DataStore.cpp
+++ b/dev/DynamicDependency/API/DataStore.cpp
@@ -154,6 +154,18 @@ std::filesystem::path MddCore::DataStore::GetDataStorePathForSystem()
 
 std::filesystem::path MddCore::DataStore::GetDataStorePathForUser()
 {
+    if (wil::get_token_is_app_container())
+    {
+        return GetDataStorePathForUserViaCOMDataStore();
+    }
+    else
+    {
+        return GetDataStorePathForUserViaApplicationDataManager();
+    }
+}
+
+std::filesystem::path MddCore::DataStore::GetDataStorePathForUserViaCOMDataStore()
+{
     wil::com_ptr<IDynamicDependencyDataStore> dataStore{ wil::CoCreateInstance<DynamicDependencyDataStore, IDynamicDependencyDataStore>(CLSCTX_LOCAL_SERVER) };
 
     wil::com_ptr<IUnknown> applicationData_iunknown;
@@ -162,4 +174,56 @@ std::filesystem::path MddCore::DataStore::GetDataStorePathForUser()
     auto applicationData{ winrt::convert_from_abi<winrt::Windows::Storage::ApplicationData>(applicationData_iunknown.get()) };
 
     return std::filesystem::path(applicationData.LocalFolder().Path().c_str());
+}
+
+std::filesystem::path MddCore::DataStore::GetDataStorePathForUserViaApplicationDataManager()
+{
+    static winrt::hstring mainPackageFamilyName{ GetWindowsAppRuntimeMainPackageFamilyName().c_str() };
+    auto applicationData{ winrt::Windows::Management::Core::ApplicationDataManager::CreateForPackageFamily(mainPackageFamilyName) };
+
+    return std::filesystem::path(applicationData.LocalFolder().Path().c_str());
+}
+
+std::wstring MddCore::DataStore::GetWindowsAppRuntimeMainPackageFamilyName()
+{
+    const UINT32 flags{ PACKAGE_FILTER_HEAD | PACKAGE_FILTER_DIRECT | PACKAGE_FILTER_STATIC | PACKAGE_FILTER_DYNAMIC | PACKAGE_INFORMATION_BASIC };
+    uint32_t packageInfosCount{};
+    const PACKAGE_INFO* packageInfos{};
+    wil::unique_cotaskmem_ptr<BYTE[]> buffer;
+    THROW_IF_FAILED(::AppModel::PackageGraph::GetCurrentPackageGraph(flags, packageInfosCount, packageInfos, buffer));
+    for (uint32_t index=0; index < packageInfosCount; ++index)
+    {
+        // Check the PublisherId
+        const auto& packageInfo{ packageInfos[index] };
+        const auto& packageId{ packageInfo.packageId };
+        const auto packagePublisherId{ packageId.publisherId };
+        PCWSTR c_windowsAppRuntimePublisherId{ L"8wekyb3d8bbwe" };
+        if (CompareStringOrdinal(packagePublisherId, -1, c_windowsAppRuntimePublisherId, -1, TRUE) != CSTR_EQUAL)
+        {
+            continue;
+        }
+
+        // Framework package's name in the package graph is Microsoft.WindowsAppRuntime.Main.<major>.<minor>
+        const auto packageName{ packageId.name };
+        const auto packageNameLength{ wcslen(packageName) };
+        PCWSTR c_windowsAppRuntimeNamePrefix{ L"Microsoft.WindowsAppRuntime." };
+        const auto c_windowsAppRuntimeNamePrefixLength{ ARRAYSIZE(L"Microsoft.WindowsAppRuntime.") - 1 };
+        if (packageNameLength < c_windowsAppRuntimeNamePrefixLength)
+        {
+            continue;
+        }
+        if (CompareStringOrdinal(packageName, c_windowsAppRuntimeNamePrefixLength, c_windowsAppRuntimeNamePrefix, c_windowsAppRuntimeNamePrefixLength, TRUE) != CSTR_EQUAL)
+        {
+            continue;
+        }
+        PCWSTR packageNameSuffix{ packageName + packageNameLength };
+
+        // Gotcha!
+        WCHAR mainPackageFamilyName[PACKAGE_FAMILY_NAME_MAX_LENGTH + 1]{};
+        wsprintf(mainPackageFamilyName, L"MicrosoftCorporationII.WindowsAppRuntime.Main.1.0_8wekyb3d8bbwe", packageNameSuffix);
+        return std::wstring(mainPackageFamilyName);
+    }
+
+    // Didn't find the Windows App SDK framework package in the package graph. Can't determine the package identity!
+    THROW_HR(MDD_E_WINDOWSAPPRUNTIME_NOT_IN_PACKAGE_GRAPH);
 }

--- a/dev/DynamicDependency/API/DataStore.h
+++ b/dev/DynamicDependency/API/DataStore.h
@@ -34,5 +34,9 @@ namespace MddCore
         static std::filesystem::path GetDataStorePathForSystem();
 
         static std::filesystem::path GetDataStorePathForUser();
+        static std::filesystem::path GetDataStorePathForUserViaCOMDataStore();
+        static std::filesystem::path GetDataStorePathForUserViaApplicationDataManager();
+
+        static std::wstring GetWindowsAppRuntimeMainPackageFamilyName();
     };
 }

--- a/dev/DynamicDependency/API/MsixDynamicDependency.cpp
+++ b/dev/DynamicDependency/API/MsixDynamicDependency.cpp
@@ -9,17 +9,6 @@
 #include "PackageDependencyManager.h"
 #include "PackageGraphManager.h"
 
-namespace MddCore
-{
-// Temporary check to prevent accidental misuse and false bug reports until we address Issue #567 https://github.com/microsoft/WindowsAppSDK/issues/567
-HRESULT FailIfElevated()
-{
-    RETURN_HR_IF_MSG(HRESULT_FROM_WIN32(ERROR_NOT_SUPPORTED), Security::IntegrityLevel::IsElevated() || Security::IntegrityLevel::IsElevated(GetCurrentProcessToken()),
-                     "DynamicDependencies doesn't support elevation. See Issue #567 https://github.com/microsoft/WindowsAppSDK/issues/567");
-    return S_OK;
-}
-}
-
 STDAPI MddTryCreatePackageDependency(
     PSID user,
     _In_ PCWSTR packageFamilyName,
@@ -30,9 +19,6 @@ STDAPI MddTryCreatePackageDependency(
     MddCreatePackageDependencyOptions options,
     _Outptr_result_maybenull_ PWSTR* packageDependencyId) noexcept try
 {
-    // Dynamic Dependencies doesn't support elevation. See Issue #567 https://github.com/microsoft/WindowsAppSDK/issues/567
-    THROW_IF_FAILED(MddCore::FailIfElevated());
-
     *packageDependencyId = nullptr;
 
     // Dynamic Dependencies requires a non-packaged process
@@ -46,9 +32,6 @@ CATCH_RETURN();
 STDAPI_(void) MddDeletePackageDependency(
     _In_ PCWSTR packageDependencyId) noexcept try
 {
-    // Dynamic Dependencies doesn't support elevation. See Issue #567 https://github.com/microsoft/WindowsAppSDK/issues/567
-    THROW_IF_FAILED(MddCore::FailIfElevated());
-
     // Dynamic Dependencies requires a non-packaged process
     THROW_HR_IF(HRESULT_FROM_WIN32(ERROR_NOT_SUPPORTED), AppModel::Identity::IsPackagedProcess());
 
@@ -63,9 +46,6 @@ STDAPI MddAddPackageDependency(
     _Out_ MDD_PACKAGEDEPENDENCY_CONTEXT* packageDependencyContext,
     _Outptr_opt_result_maybenull_ PWSTR* packageFullName) noexcept try
 {
-    // Dynamic Dependencies doesn't support elevation. See Issue #567 https://github.com/microsoft/WindowsAppSDK/issues/567
-    THROW_IF_FAILED(MddCore::FailIfElevated());
-
     *packageDependencyContext = nullptr;
     if (packageFullName)
     {
@@ -83,9 +63,6 @@ CATCH_RETURN();
 STDAPI_(void) MddRemovePackageDependency(
     _In_ MDD_PACKAGEDEPENDENCY_CONTEXT packageDependencyContext) noexcept try
 {
-    // Dynamic Dependencies doesn't support elevation. See Issue #567 https://github.com/microsoft/WindowsAppSDK/issues/567
-    THROW_IF_FAILED(MddCore::FailIfElevated());
-
     // Dynamic Dependencies requires a non-packaged process
     LOG_HR_IF(HRESULT_FROM_WIN32(ERROR_NOT_SUPPORTED), AppModel::Identity::IsPackagedProcess());
 
@@ -97,9 +74,6 @@ STDAPI MddGetResolvedPackageFullNameForPackageDependency(
     _In_ PCWSTR packageDependencyId,
     _Outptr_result_maybenull_ PWSTR* packageFullName) noexcept try
 {
-    // Dynamic Dependencies doesn't support elevation. See Issue #567 https://github.com/microsoft/WindowsAppSDK/issues/567
-    THROW_IF_FAILED(MddCore::FailIfElevated());
-
     *packageFullName = nullptr;
 
     // Dynamic Dependencies requires a non-packaged process
@@ -119,9 +93,6 @@ STDAPI MddGetIdForPackageDependencyContext(
     _In_ MDD_PACKAGEDEPENDENCY_CONTEXT packageDependencyContext,
     _Outptr_result_maybenull_ PWSTR* packageDependencyId) noexcept try
 {
-    // Dynamic Dependencies doesn't support elevation. See Issue #567 https://github.com/microsoft/WindowsAppSDK/issues/567
-    THROW_IF_FAILED(MddCore::FailIfElevated());
-
     *packageDependencyId = nullptr;
 
     // Dynamic Dependencies requires a non-packaged process

--- a/dev/DynamicDependency/API/MsixDynamicDependency.h
+++ b/dev/DynamicDependency/API/MsixDynamicDependency.h
@@ -8,6 +8,9 @@
 
 #include <stdint.h>
 
+/// MSIX Dynamic Dependency HRESULT: Windows App Runtime is not in the package graph.
+#define MDD_E_WINDOWSAPPRUNTIME_NOT_IN_PACKAGE_GRAPH    _HRESULT_TYPEDEF_(0x80040001L)
+
 enum class MddCreatePackageDependencyOptions : uint32_t
 {
     None = 0,

--- a/dev/DynamicDependency/API/pch.h
+++ b/dev/DynamicDependency/API/pch.h
@@ -33,10 +33,12 @@
 #include <winrt/Windows.ApplicationModel.h>
 #include <winrt/Windows.ApplicationModel.AppExtensions.h>
 #include <winrt/Windows.Data.Json.h>
+#include <winrt/Windows.Management.Core.h>
 #include <winrt/Windows.Management.Deployment.h>
 #include <winrt/Windows.Storage.h>
 #include <winrt/Windows.System.h>
 
 #include <appmodel.identity.h>
+#include <appmodel.packagegraph.h>
 #include <microsoft.utf8.h>
 #include <security.integritylevel.h>

--- a/dev/DynamicDependency/DynamicDependencyLifetimeManagerShadow/winmain.cpp
+++ b/dev/DynamicDependency/DynamicDependencyLifetimeManagerShadow/winmain.cpp
@@ -3,8 +3,8 @@
 
 #include "pch.h"
 
-const HRESULT WINDOWSAPPSDK_DDLM_SHUTDOWN{ MAKE_HRESULT(SEVERITY_SUCCESS, FACILITY_ITF, 0x8000) };
-const HRESULT WINDOWSAPPSDK_DDLM_CALLER_TERMINATED{ MAKE_HRESULT(SEVERITY_SUCCESS, FACILITY_ITF, 0x8001) };
+const HRESULT WINDOWSAPPSDK_DDLM_SHUTDOWN{ MAKE_HRESULT(SEVERITY_ERROR, FACILITY_ITF, 0x8000) };
+const HRESULT WINDOWSAPPSDK_DDLM_CALLER_TERMINATED{ MAKE_HRESULT(SEVERITY_ERROR, FACILITY_ITF, 0x8001) };
 const HRESULT WINDOWSAPPSDK_DDLM_CALLER_NOT_FOUND{ MAKE_HRESULT(SEVERITY_SUCCESS, FACILITY_ITF, 0x8002) };
 
 int WINAPI WinMain(HINSTANCE /*hInstance*/, HINSTANCE /*hPrevInstance*/, PSTR /*lpCmdLine*/, int /*nCmdShow*/)
@@ -44,10 +44,12 @@ int WINAPI WinMain(HINSTANCE /*hInstance*/, HINSTANCE /*hPrevInstance*/, PSTR /*
     auto rc{ WaitForMultipleObjects(ARRAYSIZE(waitForHandles), waitForHandles, FALSE, INFINITE) };
     if (rc == WAIT_OBJECT_0)
     {
+        //TODO:Replace with Telemetry
         (void) LOG_HR_MSG(WINDOWSAPPSDK_DDLM_SHUTDOWN, "DDLM.Shutdown: %ls", eventName);
     }
     else if (rc == WAIT_OBJECT_0 + 1)
     {
+        //TODO:Replace with Telemetry
         (void) LOG_HR_MSG(WINDOWSAPPSDK_DDLM_CALLER_TERMINATED, "DDLM.CallerTerminated: %ls", eventName);
     }
     else if (rc == WAIT_FAILED)

--- a/dev/WindowsAppRuntime_DLL/pch.h
+++ b/dev/WindowsAppRuntime_DLL/pch.h
@@ -40,6 +40,7 @@
 #include <winrt/Windows.ApplicationModel.AppExtensions.h>
 #include <winrt/Windows.Data.Json.h>
 #include <winrt/Windows.Data.Xml.Dom.h>
+#include <winrt/Windows.Management.Core.h>
 #include <winrt/Windows.Management.Deployment.h>
 #include <winrt/Windows.Storage.h>
 #include <winrt/Windows.Storage.Streams.h>
@@ -48,6 +49,7 @@
 #include <MsixDynamicDependency.h>
 
 #include <appmodel.identity.h>
+#include <appmodel.packagegraph.h>
 #include <microsoft.utf8.h>
 #include <security.integritylevel.h>
 

--- a/test/DynamicDependency/Test_Win32/TestMddBootstrap.cpp
+++ b/test/DynamicDependency/Test_Win32/TestMddBootstrap.cpp
@@ -233,4 +233,62 @@ namespace Test::DynamicDependency
             }
         }
     };
+
+    class BootstrapTests_Elevated : BootstrapTests
+    {
+    public:
+        BEGIN_TEST_CLASS(BootstrapTests_Elevated)
+            TEST_CLASS_PROPERTY(L"IsolationLevel", L"Method")
+            TEST_CLASS_PROPERTY(L"ThreadingModel", L"MTA")
+            //TEST_CLASS_PROPERTY(L"RunFixtureAs:Class", L"RestrictedUser")
+            TEST_CLASS_PROPERTY(L"RunAs", L"ElevatedUser")
+        END_TEST_CLASS()
+
+        TEST_CLASS_SETUP(Setup_Elevated)
+        {
+            return Setup();
+        }
+
+        TEST_CLASS_CLEANUP(Cleanup_Elevated)
+        {
+            return Cleanup();
+        }
+
+        TEST_METHOD(Initialize_DDLMNotFound_Elevated)
+        {
+            Initialize_DDLMNotFound();
+        }
+
+        TEST_METHOD(Initialize_DDLMMinVersionNoMatch_Elevated)
+        {
+            Initialize_DDLMMinVersionNoMatch();
+        }
+
+        TEST_METHOD(Initialize_Elevated)
+        {
+            Initialize();
+        }
+
+        TEST_METHOD(ShutdownWithoutInitialize_Elevated)
+        {
+            ShutdownWithoutInitialize();
+        }
+
+        TEST_METHOD(GetCurrentPackageInfo_NotPackaged_InvalidParameter_Elevated)
+        {
+            GetCurrentPackageInfo_NotPackaged_InvalidParameter();
+        }
+
+        TEST_METHOD(GetCurrentPackageInfo_NotPackaged_Elevated)
+        {
+            GetCurrentPackageInfo_NotPackaged();
+        }
+
+#if defined(TODO_EnableAfterConvertingToTAEF)
+        TEST_METHOD(GetCurrentPackageInfo_Packaged_Elevated)
+        {
+            GetCurrentPackageInfo_Packaged();
+        }
+#endif
+    };
 }

--- a/test/DynamicDependency/Test_Win32/TestMddBootstrap.cpp
+++ b/test/DynamicDependency/Test_Win32/TestMddBootstrap.cpp
@@ -78,7 +78,9 @@ namespace Test::DynamicDependency
             // Major.Minor version, MinVersion=0 to find any framework package for this major.minor version
             const UINT32 c_Version_MajorMinor{ Test::Packages::DynamicDependencyLifetimeManager::c_Version_MajorMinor };
             const PACKAGE_VERSION minVersion{};
-            VERIFY_ARE_EQUAL(HRESULT_FROM_WIN32(ERROR_NOT_SUPPORTED), MddBootstrapInitialize(c_Version_MajorMinor, nullptr, minVersion));
+            VERIFY_SUCCEEDED(MddBootstrapInitialize(c_Version_MajorMinor, nullptr, minVersion));
+
+            MddBootstrapShutdown();
         }
     };
 

--- a/test/DynamicDependency/Test_Win32/Test_GetCurrentPackageInfo.cpp
+++ b/test/DynamicDependency/Test_Win32/Test_GetCurrentPackageInfo.cpp
@@ -372,6 +372,37 @@ namespace Test::DynamicDependency
     private:
         static wil::unique_hmodule m_dll;
     };
+
+    class GetCurrentPackageInfoTests_Elevated : GetCurrentPackageInfoTests
+    {
+    public:
+        BEGIN_TEST_CLASS(GetCurrentPackageInfoTests_Elevated)
+            TEST_CLASS_PROPERTY(L"IsolationLevel", L"Class")
+            TEST_CLASS_PROPERTY(L"ThreadingModel", L"MTA")
+            //TEST_CLASS_PROPERTY(L"RunFixtureAs:Class", L"RestrictedUser")
+            TEST_CLASS_PROPERTY(L"RunAs", L"ElevatedUser")
+        END_TEST_CLASS()
+
+        TEST_CLASS_SETUP(Setup_Elevated)
+        {
+            return Setup();
+        }
+
+        TEST_CLASS_CLEANUP(Cleanup_Elevated)
+        {
+            return Cleanup();
+        }
+
+        TEST_METHOD(Unpackaged_PackageGraph0_Elevated)
+        {
+            Unpackaged_PackageGraph0();
+        }
+
+        TEST_METHOD(Unpackaged_PackageGraph1_Elevated)
+        {
+            Unpackaged_PackageGraph1();
+        }
+    };
 }
 
 wil::unique_hmodule Test::DynamicDependency::GetCurrentPackageInfoTests::m_dll;

--- a/test/DynamicDependency/Test_Win32/Test_LifetimeManagement.cpp
+++ b/test/DynamicDependency/Test_Win32/Test_LifetimeManagement.cpp
@@ -118,6 +118,42 @@ namespace Test::DynamicDependency
     private:
         static wil::unique_hmodule m_bootstrapDll;
     };
+
+    class LifetimeManagementTests_Elevated : LifetimeManagementTests
+    {
+    public:
+        BEGIN_TEST_CLASS(LifetimeManagementTests_Elevated)
+            TEST_CLASS_PROPERTY(L"IsolationLevel", L"Method")
+            TEST_CLASS_PROPERTY(L"ThreadingModel", L"MTA")
+            //TEST_CLASS_PROPERTY(L"RunFixtureAs:Class", L"RestrictedUser")
+            TEST_CLASS_PROPERTY(L"RunAs", L"ElevatedUser")
+        END_TEST_CLASS()
+
+        TEST_CLASS_SETUP(Setup_Elevated)
+        {
+            return Setup();
+        }
+
+        TEST_CLASS_CLEANUP(Cleanup_Elevated)
+        {
+            return Cleanup();
+        }
+
+        TEST_METHOD(GC_Found0_Elevated)
+        {
+            GC_Found0();
+        }
+
+        TEST_METHOD(GC_Found1_Elevated)
+        {
+            GC_Found1();
+        }
+
+        TEST_METHOD(GC_Found2_Elevated)
+        {
+            GC_Found2();
+        }
+    };
 }
 
 wil::unique_hmodule Test::DynamicDependency::LifetimeManagementTests::m_bootstrapDll;

--- a/test/DynamicDependency/Test_Win32/Test_Win32.h
+++ b/test/DynamicDependency/Test_Win32/Test_Win32.h
@@ -230,4 +230,113 @@ namespace Test::DynamicDependency
     private:
         static wil::unique_hmodule m_bootstrapDll;
     };
+
+	class Test_Win32_Elevated : Test_Win32
+	{
+	public:
+        BEGIN_TEST_CLASS(Test_Win32_Elevated)
+            //TEST_CLASS_PROPERTY(L"IsolationLevel", L"Method")
+            TEST_CLASS_PROPERTY(L"ThreadingModel", L"MTA")
+            //TEST_CLASS_PROPERTY(L"RunFixtureAs:Class", L"RestrictedUser")
+            TEST_CLASS_PROPERTY(L"RunAs", L"ElevatedUser")
+        END_TEST_CLASS()
+
+        TEST_CLASS_SETUP(Setup_Elevated)
+        {
+            return Setup();
+        }
+        TEST_CLASS_CLEANUP(Cleanup_Elevated)
+        {
+            return Cleanup();
+        }
+
+        TEST_METHOD(Create_Delete_Elevated)
+        {
+            Create_Delete();
+        }
+
+        TEST_METHOD(Delete_Null_Elevated)
+        {
+            Delete_Null();
+        }
+        TEST_METHOD(Delete_NotFound_Elevated)
+        {
+            Delete_NotFound();
+        }
+
+        TEST_METHOD(FullLifecycle_ProcessLifetime_Framework_WindowsAppRuntime_Elevated)
+        {
+            FullLifecycle_ProcessLifetime_Framework_WindowsAppRuntime();
+        }
+        TEST_METHOD(FullLifecycle_ProcessLifetime_Frameworks_WindowsAppRuntime_MathAdd_Elevated)
+        {
+            FullLifecycle_ProcessLifetime_Frameworks_WindowsAppRuntime_MathAdd();
+        }
+        TEST_METHOD(FullLifecycle_FilePathLifetime_Frameworks_WindowsAppRuntime_MathAdd_Elevated)
+        {
+            FullLifecycle_FilePathLifetime_Frameworks_WindowsAppRuntime_MathAdd();
+        }
+        TEST_METHOD(FullLifecycle_RegistryLifetime_Frameworks_WindowsAppRuntime_MathAdd_Elevated)
+        {
+            FullLifecycle_RegistryLifetime_Frameworks_WindowsAppRuntime_MathAdd();
+        }
+
+        TEST_METHOD(Add_Rank_A0_B10_Elevated)
+        {
+            Add_Rank_A0_B10();
+        }
+        TEST_METHOD(Add_Rank_B0prepend_A0_Elevated)
+        {
+            Add_Rank_B0prepend_A0();
+        }
+        TEST_METHOD(Add_Rank_Bneg10_A0_Elevated)
+        {
+            Add_Rank_Bneg10_A0();
+        }
+
+        TEST_METHOD(Create_FilePathLifetime_NoExist_Elevated)
+        {
+            Create_FilePathLifetime_NoExist();
+        }
+        TEST_METHOD(Create_RegistryLifetime_NoExist_Elevated)
+        {
+            Create_RegistryLifetime_NoExist();
+        }
+        TEST_METHOD(Create_DoNotVerifyDependencyResolution_Elevated)
+        {
+            Create_DoNotVerifyDependencyResolution();
+        }
+
+        TEST_METHOD(Create_Add_Architectures_Explicit_Elevated)
+        {
+            Create_Add_Architectures_Explicit();
+        }
+        TEST_METHOD(Create_Add_Architectures_Current_Elevated)
+        {
+            Create_Add_Architectures_Current();
+        }
+
+        TEST_METHOD(GetResolvedPackageFullName_Null_Elevated)
+        {
+            GetResolvedPackageFullName_Null();
+        }
+        TEST_METHOD(GetResolvedPackageFullName_NotFound_Elevated)
+        {
+            GetResolvedPackageFullName_NotFound();
+        }
+
+        TEST_METHOD(GetIdForPackageDependencyContext_Null_Elevated)
+        {
+            GetIdForPackageDependencyContext_Null();
+        }
+        TEST_METHOD(GetIdForPackageDependencyContext_Elevated)
+        {
+            GetIdForPackageDependencyContext();
+        }
+
+        TEST_METHOD(WinRTReentrancy_Elevated)
+        {
+            WinRTReentrancy();
+        }
+    };
 }

--- a/test/DynamicDependency/Test_WinRT/Test_WinRT.h
+++ b/test/DynamicDependency/Test_WinRT/Test_WinRT.h
@@ -222,4 +222,103 @@ namespace Test::DynamicDependency
     private:
         static wil::unique_hmodule m_bootstrapDll;
     };
+
+	class Test_WinRT_Elevated : Test_WinRT
+	{
+	public:
+        BEGIN_TEST_CLASS(Test_WinRT_Elevated)
+            //TEST_CLASS_PROPERTY(L"IsolationLevel", L"Method")
+            TEST_CLASS_PROPERTY(L"ThreadingModel", L"MTA")
+            //TEST_CLASS_PROPERTY(L"RunFixtureAs:Class", L"RestrictedUser")
+            TEST_CLASS_PROPERTY(L"RunAs", L"ElevatedUser")
+        END_TEST_CLASS()
+
+        TEST_CLASS_SETUP(Setup_Elevated)
+        {
+            return Setup();
+        }
+        TEST_CLASS_CLEANUP(Cleanup_Elevated)
+        {
+            return Cleanup();
+        }
+
+        TEST_METHOD(Create_Delete_Elevated)
+        {
+            Create_Delete();
+        }
+
+        TEST_METHOD(GetFromId_Empty_Elevated)
+        {
+            GetFromId_Empty();
+        }
+        TEST_METHOD(GetFromId_NotFound_Elevated)
+        {
+            GetFromId_NotFound();
+        }
+
+        TEST_METHOD(FullLifecycle_ProcessLifetime_Framework_WindowsAppRuntime_Elevated)
+        {
+            FullLifecycle_ProcessLifetime_Framework_WindowsAppRuntime();
+        }
+        TEST_METHOD(FullLifecycle_ProcessLifetime_Frameworks_WindowsAppRuntime_MathAdd_Elevated)
+        {
+            FullLifecycle_ProcessLifetime_Frameworks_WindowsAppRuntime_MathAdd();
+        }
+        TEST_METHOD(FullLifecycle_FilePathLifetime_Frameworks_WindowsAppRuntime_MathAdd_Elevated)
+        {
+            FullLifecycle_FilePathLifetime_Frameworks_WindowsAppRuntime_MathAdd();
+        }
+        TEST_METHOD(FullLifecycle_RegistryLifetime_Frameworks_WindowsAppRuntime_MathAdd_Elevated)
+        {
+            FullLifecycle_RegistryLifetime_Frameworks_WindowsAppRuntime_MathAdd();
+        }
+
+        TEST_METHOD(Add_Rank_A0_B10_Elevated)
+        {
+            Add_Rank_A0_B10();
+        }
+        TEST_METHOD(Add_Rank_B0prepend_A0_Elevated)
+        {
+            Add_Rank_B0prepend_A0();
+        }
+        TEST_METHOD(Add_Rank_Bneg10_A0_Elevated)
+        {
+            Add_Rank_Bneg10_A0();
+        }
+
+        TEST_METHOD(Create_FilePathLifetime_NoExist_Elevated)
+        {
+            Create_FilePathLifetime_NoExist();
+        }
+        TEST_METHOD(Create_RegistryLifetime_NoExist_Elevated)
+        {
+            Create_RegistryLifetime_NoExist();
+        }
+        TEST_METHOD(Create_DoNotVerifyDependencyResolution_Elevated)
+        {
+            Create_DoNotVerifyDependencyResolution();
+        }
+
+        TEST_METHOD(Create_Add_Architectures_Explicit_Elevated)
+        {
+            Create_Add_Architectures_Explicit();
+        }
+        TEST_METHOD(Create_Add_Architectures_Current_Elevated)
+        {
+            Create_Add_Architectures_Current();
+        }
+
+        TEST_METHOD(WinRT_RoGetActivationFactory_1_Elevated)
+        {
+            WinRT_RoGetActivationFactory_1();
+        }
+        TEST_METHOD(WinRT_RoGetActivationFactory_2_Elevated)
+        {
+            WinRT_RoGetActivationFactory_2();
+        }
+        TEST_METHOD(WinRT_RoGetActivationFactory_NotFound_Elevated)
+        {
+            WinRT_RoGetActivationFactory_NotFound();
+        }
+    };
 }


### PR DESCRIPTION
DynamicDependencies: support elevation

Expands test suite to run all tests elevated. Verified expanded test suite passes.
![image](https://user-images.githubusercontent.com/72222/152505099-acc14a0b-6527-448f-9722-eddff5262cfc.png)

https://task.ms/36589098

resolves #567 