### PR TITLE
Add button to allow publishing even if there are test failures

### DIFF
--- a/build/ProjectReunion-BuildFoundation.yml
+++ b/build/ProjectReunion-BuildFoundation.yml
@@ -494,7 +494,7 @@ jobs:
   dependsOn: 
   - CreateNugetPackage
   - WinAppSDKIntegrationBuildAndTest
-  condition: or(succeeded(), eq(parameters.IgnoreFailures, 'true'))
+  condition: or(succeeded(), eq(${{ parameters.IgnoreFailures }}, 'true'))
   pool: $(ProjectReunionBuildPool)
   variables:
     WindowsAppSDKPackageVersion: $[ dependencies.CreateNugetPackage.outputs['SetVersion.packageVersion'] ]


### PR DESCRIPTION
Add button to allow publishing even if there are test failures.

After investigation of the integration test failures from the internal build, I believe the issue stems from the Foundation package being not updated in the WinUI first. So we need the ability to just publish the package even if there are integration test failures so it can propogate through WinUI before making it to Internal. 