### PR TITLE
Adding a non-async PowerNotificiations::EffectivePowerMode method

### DIFF
--- a/dev/PowerNotifications/PowerNotifications.h
+++ b/dev/PowerNotifications/PowerNotifications.h
@@ -548,6 +548,12 @@ namespace winrt::Microsoft::Windows::System::Power
                 co_return res;
             }
 
+            Power::EffectivePowerMode EffectivePowerMode2()
+            {
+                UpdateValuesIfNecessary(effectivePowerModeFunc);
+                return static_cast<Power::EffectivePowerMode>(m_cachedPowerMode);
+            }
+
             event_token EffectivePowerModeChanged(const PowerEventHandler& handler)
             {
                 return AddCallback(effectivePowerModeFunc, handler);
@@ -684,6 +690,11 @@ namespace winrt::Microsoft::Windows::System::Power
             static winrt::Windows::Foundation::IAsyncOperation<Power::EffectivePowerMode> EffectivePowerMode()
             {
                 return Factory()->EffectivePowerMode();
+            }
+
+            static Power::EffectivePowerMode EffectivePowerMode2()
+            {
+                return Factory()->EffectivePowerMode2();
             }
 
             static Power::UserPresenceStatus UserPresenceStatus()

--- a/dev/PowerNotifications/PowerNotifications.idl
+++ b/dev/PowerNotifications/PowerNotifications.idl
@@ -96,6 +96,7 @@ namespace Microsoft.Windows.System.Power
         static event Windows.Foundation.EventHandler<Object> SystemIdleStatusChanged;
 
         static Windows.Foundation.IAsyncOperation<EffectivePowerMode> EffectivePowerMode{ get; };
+        static EffectivePowerMode EffectivePowerMode2{ get; };
         static event Windows.Foundation.EventHandler<Object> EffectivePowerModeChanged;
 
         static UserPresenceStatus UserPresenceStatus{ get; };


### PR DESCRIPTION
The original PowerNotifications have EffectivePowerMode is an IAsyncOperation<T> typed as a property. Instead of introducing a breaking change, it was suggested to introduce a non-async version and update the documentation to use it instead. This PR adds the said API.