### PR TITLE
Move CSWinRT to Toolset Dependencies in Version.Details.xml

### DIFF
--- a/build/scripts/ConvertVersionDetailsToPackageConfig.ps1
+++ b/build/scripts/ConvertVersionDetailsToPackageConfig.ps1
@@ -27,12 +27,9 @@ foreach ($dependency in $buildConfig.Dependencies.ProductDependencies.Dependency
         Write-Host "##vso[task.setvariable variable=AppLicensingInternalPackageVersion;]$ver"
     }
 
-    $excluded = $name.StartsWith("CsWinRT.Dependency.")
-    if (-not $excluded)
-    {
-        $packagesText += '	<package id="' + $name + '" version="' + $ver + '" targetFramework="native" />
+    $packagesText += '	<package id="' + $name + '" version="' + $ver + '" targetFramework="native" />
 '
-    }
+
 }
 $packagesText +=
 @"

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -1,6 +1,12 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Dependencies>
   <ProductDependencies>
+    <Dependency Name="Microsoft.WindowsAppSDK.AppLicensingInternal.TransportPackage" Version="1.0.0-preview1.20211111.12">
+      <Uri>https://dev.azure.com/microsoft/ProjectReunion/_git/ProjectReunionClosed</Uri>
+      <Sha>a3b6cd2d041c342d4a5ac2ed0c90c30e9ed08f15</Sha>
+    </Dependency>
+  </ProductDependencies>
+  <ToolsetDependencies>
     <Dependency Name="Microsoft.Windows.CsWinRT" Version="1.5.0-prerelease.220124.4">
       <Uri>https://github.com/microsoft/CsWinRT</Uri>
       <Sha>c90d2e33c650b65377a3eb046f1f449d56e2ab7d</Sha>
@@ -18,12 +24,6 @@
       <Uri>https://github.com/microsoft/CsWinRT</Uri>
       <Sha>c90d2e33c650b65377a3eb046f1f449d56e2ab7d</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.WindowsAppSDK.AppLicensingInternal.TransportPackage" Version="1.0.0-preview1.20211111.12">
-      <Uri>https://dev.azure.com/microsoft/ProjectReunion/_git/ProjectReunionClosed</Uri>
-      <Sha>a3b6cd2d041c342d4a5ac2ed0c90c30e9ed08f15</Sha>
-    </Dependency>
-  </ProductDependencies>
-  <ToolsetDependencies>
     <Dependency Name="Microsoft.WinAppSDK.EngCommon" Version="1.1.0-20220125.0-CI">
       <Uri>https://dev.azure.com/microsoft/ProjectReunion/_git/ProjectReunionInternal</Uri>
       <Sha>b47c1d3b4a3e2c6b390e93cb133bbd7d83b56ad6</Sha>

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -11,7 +11,7 @@
       <Uri>https://github.com/microsoft/CsWinRT</Uri>
       <Sha>c90d2e33c650b65377a3eb046f1f449d56e2ab7d</Sha>
     </Dependency>
-    <Dependency Name="CsWinRT.Dependency.DotNetCoreSdkn" Version="5.0.404">
+    <Dependency Name="CsWinRT.Dependency.DotNetCoreSdk" Version="5.0.404">
       <Uri>https://github.com/microsoft/CsWinRT</Uri>
       <Sha>
       </Sha>


### PR DESCRIPTION
This allows us to not have an exclude list in the ConvertToVersionDetails powershell script. 