### PR TITLE
Update MSIX package names' spec

### DIFF
--- a/specs/Deployment/MSIXPackageVersioning.md
+++ b/specs/Deployment/MSIXPackageVersioning.md
@@ -81,9 +81,9 @@ for more details.
 Windows App SDK 1.0 has 4 MSIX packages
 
 * `Microsoft.WindowsAppRuntime` aka **WARfwk**
-* `Microsoft.WindowsAppRuntime.Main` aka **WARmain**
+* `MicrosoftCorporationII.WinAppRuntime.Main` aka **WARmain**
 * `Microsoft.WindowsAppRuntime.Singleton` aka **WARsingleton**
-* `Microsoft.WindowsAppRuntime.DDLM` aka **WARddlm**
+* `Microsoft.WinAppRuntime.DDLM` aka **WARddlm**
 
 WARsingleton supplements WARmain to provide a mechanism for features needing singular global
 behavior across all versions of Windows App SDK. See [Windows App SDK: MSIX Packages](https://github.com/microsoft/WindowsAppSDK/blob/main/specs/Deployment/MSIXPackage.md)
@@ -393,11 +393,17 @@ MinVersion
 Windows App SDK 0.8+ has 3 MSIX packages. We have choices for package Name patterns for 0.8 and 1.x.
 
 Assuming Breaking Change Boundary for v0.x and v1+'s decision are `Major.Minor` version we have the
-following naming patterns...
+following naming patterns release 0.x...
 
 * WARfwk: `Microsoft.WindowsAppRuntime.<rmajor>.<rminor>[-tag]`
 * WARmain: `Microsoft.WindowsAppRuntime.Main.<rmajor>.<rminor>[-tag]`
 * WARddlm: `Microsoft.WindowsAppRuntime.DDLM.<major>.<minor>.<build>.<revision>-<shortarchitecture>[-shorttag]`
+
+and release 1.x...
+
+* WARfwk: `Microsoft.WindowsAppRuntime.<rmajor>.<rminor>[-tag]`
+* WARmain: `MicrosoftCorporationII.WinAppRuntime.Main.<rmajor>.<rminor>[-shorttag]`
+* WARddlm: `Microsoft.WinAppRuntime.DDLM.<major>.<minor>.<build>.<revision>-<shortarchitecture>[-shorttag]`
 
 where
 
@@ -429,21 +435,21 @@ This leads to package Name length issues even for common cases:
 |WARfwk |Microsoft.WindowsAppRuntime.1.15-preview1|41|
 |WARmain|Microsoft.WindowsAppRuntime.Main.1.15-preview1|46|
 |WARmain|Microsoft.WindowsAppRuntime.Singleton-preview1|46|
-|WARddlm|Microsoft.WindowsAppRuntime.DDLM.1.15.12345.24680-arm64-preview1|**<span style="color:red">64</span>**|
+|WARddlm|Microsoft.WinAppRuntime.DDLM.1.15.12345.24680-arm64-preview1|**<span style="color:red">64</span>**|
 
 |Package|Min|MinLength|
 | --- | :--- | :---: |
 |WARfwk |Microsoft.WindowsAppRuntime.1.0-preview1|40|
 |WARmain|Microsoft.WindowsAppRuntime.Main.1.0-preview1|45|
 |WARmain|Microsoft.WindowsAppRuntime.Singleton-preview1|46|
-|WARddlm|Microsoft.WindowsAppRuntime.DDLM.1.0.0.0-arm64-preview1|**<span style="color:red">52</span>**|
+|WARddlm|Microsoft.WinAppRuntime.DDLM.1.0.0.0-arm64-preview1|**<span style="color:red">52</span>**|
 
 |Package|Max|MaxLength|
 | --- | :--- | :---: |
 |WARfwk |Microsoft.WindowsAppRuntime.65535.65535-preview1|48|
-|WARmain|Microsoft.WindowsAppRuntime.Main.65535.65535-preview1|**<span style="color:red">60</span>**|
+|WARmain|Microsoft.WindowsAppRuntime.Main.65535.65535-preview1|53|
 |WARmain|Microsoft.WindowsAppRuntime.Singleton-preview1|46|
-|WARddlm|Microsoft.WindowsAppRuntime.DDLM.65535.65535.65535.65535-arm64-preview1|**<span style="color:red">71</span>**|
+|WARddlm|Microsoft.WinAppRuntime.DDLM.65535.65535.65535.65535-arm64-preview1|**<span style="color:red">71</span>**|
 
 Possible options we can use to shorten package Name:
 
@@ -451,8 +457,8 @@ Possible options we can use to shorten package Name:
 * Dictate max values e.g. Major=0-99
 * Encode values as base-16
 * Replace -channel with a shorter string e.g. replace "-preview" with "-pre", "-p", "p"
-* Encode the channel name in the delimiter between name+version e.g. Microsoft.WindowsAppRuntime.DDLM<span style="color:red; font-size:xx-large"><b>.preview1</b></span>.1.0.0.0-arm64
-* Encode tag in the delimiter between version+architecture e.g. Microsoft.WindowsAppRuntime.DDLM.1.0.0.0<span style="color:red"><b>p1</b></span>arm64 using P1 for Preview1, E1=Experimental1, ...
+* Encode the channel name in the delimiter between name+version e.g. Microsoft.WinAppRuntime.DDLM<span style="color:red; font-size:xx-large"><b>.preview1</b></span>.1.0.0.0-arm64
+* Encode tag in the delimiter between version+architecture e.g. Microsoft.WinAppRuntime.DDLM.1.0.0.0<span style="color:red"><b>p1</b></span>arm64 using P1 for Preview1, E1=Experimental1, ...
 * Name WARddlm differently from WARfwk and WARmain e.g. use "-p1" for WARddlm regardless if WARfwk and WARmain use "-preview1"
 * ???
 
@@ -469,10 +475,10 @@ Windows App SDK 0.8 will use package Names of...
 * WARfwk: `Microsoft.WindowsAppRuntime.<rmajor>.<rminor>[-tag]`
 * WARmain: `Microsoft.WindowsAppRuntime.Main.<rmajor>.<rminor>[-tag]`
 * WARsingleton: `Microsoft.WindowsAppRuntime.Singleton[-tag]`
-* WARddlm: `Microsoft.WindowsAppRuntime.DDLM.<major>.<minor>.<build>.<revision>-<shortarchitecture>[-shorttag]`
+* WARddlm: `Microsoft.WinAppRuntime.DDLM.<major>.<minor>.<build>.<revision>-<shortarchitecture>[-shorttag]`
 
 Using Decision 5: Version Encoding = Option D (NPPP.E.B.0) WARddlm's maximum package Name length is
-`Microsoft.WindowsAppRuntime.DDLM.1714.3944.123.24680-arm64-p3` = 58 characters. This can be reduced
+`Microsoft.WinAppRuntime.DDLM.1714.3944.123.24680-arm64-p3` = 58 characters. This can be reduced
 with the following rules:
 
 * Major version <= 99
@@ -508,7 +514,7 @@ i.e. format encoding `NPPP.E.B.0`. See
 length constraints. The specific packages Names in Windows App SDK 1.0:
 
 * WARfwk: `Microsoft.WindowsAppRuntime.<rmajor>.<rminor>[-tag]`
-* WARmain: `Microsoft.WindowsAppRuntime.Main.<rmajor>.<rminor>[-tag]`
+* WARmain: `MicrosoftCorporationII.WinAppRuntime.Main.<rmajor>.<rminor>[-shorttag]`
 * WARmain: `Microsoft.WindowsAppRuntime.Singleton[-tag]`
 * WARddlm: `Microsoft.WinAppRuntime.DDLM.<major>.<minor>.<build>.<revision>-<shortarchitecture>[-shorttag]`
 

--- a/specs/Deployment/MSIXPackages.md
+++ b/specs/Deployment/MSIXPackages.md
@@ -7,8 +7,9 @@
     - [2.1.4. Dynamic Dependency Lifetime Manager (DDLM)](#214-dynamic-dependency-lifetime-manager-ddlm)
 - [3. Package Naming](#3-package-naming)
   - [3.1. Package Naming - SubName](#31-package-naming---subname)
-  - [3.2. Package Naming - Singleton](#32-package-naming---singleton)
-  - [3.3. Package Naming - DDLM](#33-package-naming---ddlm)
+  - [3.2. Package Naming - Singleton](#32-package-naming---main)
+  - [3.3. Package Naming - Singleton](#33-package-naming---singleton)
+  - [3.4. Package Naming - DDLM](#34-package-naming---ddlm)
 - [4. Package Versioning](#4-package-versioning)
 
 # 1. Background
@@ -110,9 +111,9 @@ SDK 1.0, 1.1 and 2.0 (Stable) are installed on an x86 system, the user will have
 * Microsoft.WindowsAppRuntime.1.0
 * Microsoft.WindowsAppRuntime.1.1
 * Microsoft.WindowsAppRuntime.2.0
-* Microsoft.WindowsAppRuntime.Main.1.0
-* Microsoft.WindowsAppRuntime.Main.1.1
-* Microsoft.WindowsAppRuntime.Main.2.0
+* MicrosoftCorporationII.WinAppRuntime.Main.1.0
+* MicrosoftCorporationII.WinAppRuntime.Main.1.1
+* MicrosoftCorporationII.WinAppRuntime.Main.2.0
 * Microsoft.WindowsAppRuntime.Singleton (version 2.0)
 * Microsoft.WinAppRuntime.DDLM.0.146.711.0-x8
 * Microsoft.WinAppRuntime.DDLM.1000.328.1510.0-x8
@@ -159,11 +160,24 @@ The following SubName values are used:
 | SubName | Package | Example |
 |-|-|-|
 | | Framework | Microsoft.WindowsAppRuntime.1.0-experimental1 |
-| Main | Main | Microsoft.WindowsAppRuntime.Main.1.0-experimental1 |
+| Main | Main | MicrosoftCorporationII.WinAppRuntime.Main.1.0-e1 |
 | Singleton | Singleton | Microsoft.WindowsAppRuntime.Singleton-experimental1 |
-| DDLM | Dynamic Dependency Lifetime Manager (DDLM) | Microsoft.WinAppRuntime.DDLM.7.3944.123.1-x6-e1 |
+| DDLM | Dynamic Dependency Lifetime Manager (DDLM) | Microsoft.WinAppRuntime.DDLM.0.146.711.0-x6-e1 |
 
-## 3.2. Package Naming - Singleton
+## 3.2. Package Naming - Main
+
+The Main package follows a different naming scheme
+
+* Name = MicrosoftCcorporationII.WinAppRuntime.Main.\<ReleaseMajorMinor\>[-ShortVersionTag]
+
+where
+
+* ReleaseMajorMinor = project release major.minor version number. See the [MSIX Package Versioning](https://github.com/microsoft/WindowsAppSDK/blob/main/specs/deployment/MSIXPackageVersioning.md) for more details.
+* ShortVersionTag = short form of the VersionTag
+
+ShortVersionTag is derived from a VersionTag by combining the 1st letter and the last digit (if any) for non-Stable channels (ShortVeresionTag is blank for the Stable channel, just like VersionTag).
+
+## 3.3. Package Naming - Singleton
 
 The Singleton package follows a different naming scheme
 
@@ -176,7 +190,7 @@ compared to other package Names, lacking any version information.
 
 See [2.1.3. Role - Singleton](#213-role---singleton) for more information.
 
-## 3.3. Package Naming - DDLM
+## 3.4. Package Naming - DDLM
 
 DDLM packages follow a different naming scheme
 


### PR DESCRIPTION
Update MSIX package names' spec to match actual 1.0 behavior (missed updating spec when we updated code for 1.0-stable)