### PR TITLE
Modify the CoRegister for Com Activation so if there are not notification handlers registered a new process will be launched every time

### DIFF
--- a/dev/AppNotifications/AppNotificationManager.cpp
+++ b/dev/AppNotifications/AppNotificationManager.cpp
@@ -82,7 +82,7 @@ namespace winrt::Microsoft::Windows::AppNotifications::implementation
             AppModel::Identity::IsPackagedProcess() ? details.TaskClsid() : winrt::guid(storedComActivatorString),
             winrt::make<AppNotificationActivationCallbackFactory>().get(),
             CLSCTX_LOCAL_SERVER,
-            REGCLS_MULTIPLEUSE,
+            GetAppNotificationHandlers() ? REGCLS_MULTIPLEUSE : REGCLS_SINGLEUSE,
             &s_notificationComActivatorRegistration));
 
         GetWaitHandleForArgs().create();

--- a/dev/PushNotifications/PushNotificationChannel.cpp
+++ b/dev/PushNotifications/PushNotificationChannel.cpp
@@ -137,8 +137,17 @@ namespace winrt::Microsoft::Windows::PushNotifications::implementation
     HRESULT __stdcall PushNotificationChannel::InvokeAll(_In_ ULONG length, _In_ byte* payload, _Out_ BOOL* foregroundHandled) noexcept try
     {
         auto args = winrt::make<winrt::Microsoft::Windows::PushNotifications::implementation::PushNotificationReceivedEventArgs>(payload, length);
-        (*g_pushNotificationHandlers)(*this, args);
-        *foregroundHandled = args.Handled();
+
+        if (bool(*g_pushNotificationHandlers))
+        {
+            (*g_pushNotificationHandlers)(*this, args);
+            *foregroundHandled = true;
+        }
+        else
+        {
+            *foregroundHandled = false;
+        }
+
         return S_OK;
     }
     CATCH_RETURN()

--- a/dev/PushNotifications/PushNotificationChannel.h
+++ b/dev/PushNotifications/PushNotificationChannel.h
@@ -17,12 +17,9 @@ namespace winrt::Microsoft::Windows::PushNotifications::implementation
 
     struct PushNotificationChannel : PushNotificationChannelT<PushNotificationChannel, IWpnForegroundSink, ABI::Microsoft::Internal::PushNotifications::INotificationListener>
     {
-        PushNotificationChannel(struct ChannelDetails channelInfo)
-        {
-            THROW_HR_IF(E_NOTIMPL, !::Microsoft::Windows::PushNotifications::Feature_PushNotifications::IsEnabled());
+        PushNotificationChannel(struct ChannelDetails channelInfo);
 
-            std::swap(m_channelInfo, channelInfo);
-        };
+        ~PushNotificationChannel();
 
         winrt::Windows::Foundation::Uri Uri();
         winrt::Windows::Foundation::DateTime ExpirationTime();
@@ -40,7 +37,6 @@ namespace winrt::Microsoft::Windows::PushNotifications::implementation
     private:
         struct ChannelDetails m_channelInfo{};
 
-        winrt::event<PushNotificationEventHandler> m_foregroundHandlers;
         wil::srwlock m_lock;
     };
 }

--- a/dev/PushNotifications/PushNotificationManager.cpp
+++ b/dev/PushNotifications/PushNotificationManager.cpp
@@ -342,7 +342,7 @@ namespace winrt::Microsoft::Windows::PushNotifications::implementation
                     taskClsid,
                     winrt::make<PushNotificationBackgroundTaskFactory>().get(),
                     CLSCTX_LOCAL_SERVER,
-                    REGCLS_MULTIPLEUSE,
+                    PushNotificationHelpers::AreHandlersRegistered() ? REGCLS_MULTIPLEUSE : REGCLS_SINGLEUSE,
                     &s_comActivatorRegistration));
             }
 

--- a/dev/PushNotifications/PushNotificationReceivedEventArgs.cpp
+++ b/dev/PushNotifications/PushNotificationReceivedEventArgs.cpp
@@ -115,33 +115,5 @@ namespace winrt::Microsoft::Windows::PushNotifications::implementation
             m_backgroundTaskInstance.Canceled(token);
         }
     }
-
-    bool PushNotificationReceivedEventArgs::Handled()
-    {
-        if (!m_unpackagedAppScenario)
-        {
-            THROW_HR_IF_NULL_MSG(E_ILLEGAL_METHOD_CALL, m_args, "Background activation cannot call this.");
-
-            return m_args.Cancel();
-        }
-        else
-        {
-            return m_handledUnpackaged;
-        }
-    }
-
-    void PushNotificationReceivedEventArgs::Handled(bool value)
-    {
-        if (!m_unpackagedAppScenario)
-        {
-            THROW_HR_IF_NULL_MSG(E_ILLEGAL_METHOD_CALL, m_args, "Background activation cannot call this.");
-
-            m_args.Cancel(value);
-        }
-        else
-        {
-            m_handledUnpackaged = value;
-        }
-    }
 }
 

--- a/dev/PushNotifications/PushNotificationReceivedEventArgs.h
+++ b/dev/PushNotifications/PushNotificationReceivedEventArgs.h
@@ -20,8 +20,6 @@ namespace winrt::Microsoft::Windows::PushNotifications::implementation
         winrt::Windows::ApplicationModel::Background::BackgroundTaskDeferral GetDeferral();
         winrt::event_token Canceled(winrt::Windows::ApplicationModel::Background::BackgroundTaskCanceledEventHandler const& handler);
         void Canceled(winrt::event_token const& token) noexcept;
-        bool Handled();
-        void Handled(bool value);
 
     private:
         const winrt::Windows::Storage::Streams::IBuffer m_rawNotification{};

--- a/dev/PushNotifications/PushNotificationUtility.h
+++ b/dev/PushNotifications/PushNotificationUtility.h
@@ -135,4 +135,6 @@ namespace winrt::Microsoft::Windows::PushNotifications::Helpers
     {
         return AppModel::Identity::IsPackagedProcess() && IsBackgroundTaskBuilderAvailable();
     }
+
+    bool AreHandlersRegistered();
 }

--- a/dev/PushNotifications/PushNotifications.idl
+++ b/dev/PushNotifications/PushNotifications.idl
@@ -17,10 +17,6 @@ namespace Microsoft.Windows.PushNotifications
 
         // Subscribe to Cancelled event handler to be signalled when resource policies are no longer true like 30s wallclock timer
         event Windows.ApplicationModel.Background.BackgroundTaskCanceledEventHandler Canceled;
-
-        // Indicates if the foreground push notification will be re-posted through background activation.
-        // Default value is false, which allows re-posting.
-        Boolean Handled;
     };
 
     [feature(Feature_PushNotifications)]

--- a/test/TestApps/PushNotificationsDemoApp/main.cpp
+++ b/test/TestApps/PushNotificationsDemoApp/main.cpp
@@ -59,7 +59,6 @@ winrt::Windows::Foundation::IAsyncOperation<PushNotificationChannel> RequestChan
                 // Do stuff to process the raw payload
                 std::string payloadString(payload.begin(), payload.end());
                 std::cout << "Push notification content received from FOREGROUND: " << payloadString << std::endl << std::endl;
-                args.Handled(true);
             });
         // Caller's responsibility to keep the channel alive
         co_return result.Channel();

--- a/test/TestApps/ToastNotificationsDemoApp/main.cpp
+++ b/test/TestApps/ToastNotificationsDemoApp/main.cpp
@@ -64,7 +64,6 @@ winrt::IAsyncOperation<winrt::PushNotificationChannel> RequestChannelAsync()
                 // Do stuff to process the raw payload
                 std::string payloadString(payload.begin(), payload.end());
                 std::cout << "Push notification content received from FOREGROUND: " << payloadString << std::endl << std::endl;
-                args.Handled(true);
             });
         // Caller's responsibility to keep the channel alive
         co_return result.Channel();


### PR DESCRIPTION
When registering an activator for Toast check if there are handlers registered with the Toast Notification Manager, if so then use the multi use flag in CoRegister otherwise use the single use flag to launch a new process each time.

For the registration of Push Notification activators the code assumes that there is only one Push Notification Channel at a time. With this in mind the handlers are stored in a static event in Push Notification Channel that gets initialized each time a channel is created and reset each time a channel is destroyed. Now, when the Push Notification Manager registers an activator it uses a helper function to see if an existing channel has handlers associated with it, if so it uses the multi use flag and the single use one otherwise.

Also in this PR the Handled property was removed from PushNotificationReceivedEventArgs and now as long as there are foreground handlers the notification is going to be considered handled.