### PR TITLE
Remove the Handled property from PushNotificationReceivedEventArgs

### DIFF
--- a/dev/PushNotifications/PushNotificationChannel.cpp
+++ b/dev/PushNotifications/PushNotificationChannel.cpp
@@ -121,8 +121,16 @@ namespace winrt::Microsoft::Windows::PushNotifications::implementation
     HRESULT __stdcall PushNotificationChannel::InvokeAll(_In_ ULONG length, _In_ byte* payload, _Out_ BOOL* foregroundHandled) noexcept try
     {
         auto args = winrt::make<winrt::Microsoft::Windows::PushNotifications::implementation::PushNotificationReceivedEventArgs>(payload, length);
-        m_foregroundHandlers(*this, args);
-        *foregroundHandled = args.Handled();
+        if (m_foregroundHandlers)
+        {
+            m_foregroundHandlers(*this, args);
+            *foregroundHandled = true;
+        }
+        else
+        {
+            *foregroundHandled = false;
+        }
+
         return S_OK;
     }
     CATCH_RETURN()

--- a/dev/PushNotifications/PushNotificationReceivedEventArgs.cpp
+++ b/dev/PushNotifications/PushNotificationReceivedEventArgs.cpp
@@ -115,33 +115,5 @@ namespace winrt::Microsoft::Windows::PushNotifications::implementation
             m_backgroundTaskInstance.Canceled(token);
         }
     }
-
-    bool PushNotificationReceivedEventArgs::Handled()
-    {
-        if (!m_unpackagedAppScenario)
-        {
-            THROW_HR_IF_NULL_MSG(E_ILLEGAL_METHOD_CALL, m_args, "Background activation cannot call this.");
-
-            return m_args.Cancel();
-        }
-        else
-        {
-            return m_handledUnpackaged;
-        }
-    }
-
-    void PushNotificationReceivedEventArgs::Handled(bool value)
-    {
-        if (!m_unpackagedAppScenario)
-        {
-            THROW_HR_IF_NULL_MSG(E_ILLEGAL_METHOD_CALL, m_args, "Background activation cannot call this.");
-
-            m_args.Cancel(value);
-        }
-        else
-        {
-            m_handledUnpackaged = value;
-        }
-    }
 }
 

--- a/dev/PushNotifications/PushNotificationReceivedEventArgs.h
+++ b/dev/PushNotifications/PushNotificationReceivedEventArgs.h
@@ -20,8 +20,6 @@ namespace winrt::Microsoft::Windows::PushNotifications::implementation
         winrt::Windows::ApplicationModel::Background::BackgroundTaskDeferral GetDeferral();
         winrt::event_token Canceled(winrt::Windows::ApplicationModel::Background::BackgroundTaskCanceledEventHandler const& handler);
         void Canceled(winrt::event_token const& token) noexcept;
-        bool Handled();
-        void Handled(bool value);
 
     private:
         const winrt::Windows::Storage::Streams::IBuffer m_rawNotification{};

--- a/dev/PushNotifications/PushNotifications.idl
+++ b/dev/PushNotifications/PushNotifications.idl
@@ -17,10 +17,6 @@ namespace Microsoft.Windows.PushNotifications
 
         // Subscribe to Cancelled event handler to be signalled when resource policies are no longer true like 30s wallclock timer
         event Windows.ApplicationModel.Background.BackgroundTaskCanceledEventHandler Canceled;
-
-        // Indicates if the foreground push notification will be re-posted through background activation.
-        // Default value is false, which allows re-posting.
-        Boolean Handled;
     };
 
     [feature(Feature_PushNotifications)]

--- a/test/TestApps/PushNotificationsDemoApp/main.cpp
+++ b/test/TestApps/PushNotificationsDemoApp/main.cpp
@@ -59,7 +59,6 @@ winrt::Windows::Foundation::IAsyncOperation<PushNotificationChannel> RequestChan
                 // Do stuff to process the raw payload
                 std::string payloadString(payload.begin(), payload.end());
                 std::cout << "Push notification content received from FOREGROUND: " << payloadString << std::endl << std::endl;
-                args.Handled(true);
             });
         // Caller's responsibility to keep the channel alive
         co_return result.Channel();

--- a/test/TestApps/ToastNotificationsDemoApp/main.cpp
+++ b/test/TestApps/ToastNotificationsDemoApp/main.cpp
@@ -64,7 +64,6 @@ winrt::IAsyncOperation<winrt::PushNotificationChannel> RequestChannelAsync()
                 // Do stuff to process the raw payload
                 std::string payloadString(payload.begin(), payload.end());
                 std::cout << "Push notification content received from FOREGROUND: " << payloadString << std::endl << std::endl;
-                args.Handled(true);
             });
         // Caller's responsibility to keep the channel alive
         co_return result.Channel();


### PR DESCRIPTION
Update the idl and all the callers on the WindowsAppSDK and the demo and test apps.
Verified that the Push Notification tests keep passing.