### PR TITLE
Modify the CoRegister for Com Activation so if there are not notification handlers registered a new process will be launched every time

### DIFF
--- a/dev/AppNotifications/AppNotificationManager.cpp
+++ b/dev/AppNotifications/AppNotificationManager.cpp
@@ -86,6 +86,9 @@ namespace winrt::Microsoft::Windows::AppNotifications::implementation
         {
             auto lock{ m_lock.lock_exclusive() };
             THROW_HR_IF_MSG(E_INVALIDARG, m_notificationComActivatorRegistration, "Already Registered for App Notifications!");
+
+            // Check if the caller has registered event handlers, if so the REGCLS_MULTIPLEUSE flag will cause COM to ensure that all activators
+            // are routed improc, otherwise with REGCLS_MULTIPLEUSE COM will launch a new process of the Win32 app for each invocation.
             THROW_IF_FAILED(::CoRegisterClassObject(
                 AppModel::Identity::IsPackagedProcess() ? registeredClsid : winrt::guid(storedComActivatorString),
                 winrt::make<AppNotificationManagerFactory>().get(),

--- a/dev/AppNotifications/AppNotificationManager.cpp
+++ b/dev/AppNotifications/AppNotificationManager.cpp
@@ -90,7 +90,7 @@ namespace winrt::Microsoft::Windows::AppNotifications::implementation
                 AppModel::Identity::IsPackagedProcess() ? registeredClsid : winrt::guid(storedComActivatorString),
                 winrt::make<AppNotificationManagerFactory>().get(),
                 CLSCTX_LOCAL_SERVER,
-                REGCLS_MULTIPLEUSE,
+                m_notificationHandlers ? REGCLS_MULTIPLEUSE : REGCLS_SINGLEUSE,
                 &m_notificationComActivatorRegistration));
         }
     }

--- a/dev/AppNotifications/AppNotificationManager.cpp
+++ b/dev/AppNotifications/AppNotificationManager.cpp
@@ -88,7 +88,7 @@ namespace winrt::Microsoft::Windows::AppNotifications::implementation
             THROW_HR_IF_MSG(E_INVALIDARG, m_notificationComActivatorRegistration, "Already Registered for App Notifications!");
 
             // Check if the caller has registered event handlers, if so the REGCLS_MULTIPLEUSE flag will cause COM to ensure that all activators
-            // are routed improc, otherwise with REGCLS_MULTIPLEUSE COM will launch a new process of the Win32 app for each invocation.
+            // are routed inproc, otherwise with REGCLS_MULTIPLEUSE COM will launch a new process of the Win32 app for each invocation.
             THROW_IF_FAILED(::CoRegisterClassObject(
                 AppModel::Identity::IsPackagedProcess() ? registeredClsid : winrt::guid(storedComActivatorString),
                 winrt::make<AppNotificationManagerFactory>().get(),


### PR DESCRIPTION
When registering an activator for Toast check if there are handlers registered with the Toast Notification Manager, if so then use the multi use flag in CoRegister otherwise use the single use flag to launch a new process each time.