### PR TITLE
Deployment API: Add DeploymentInitializeOptions with an option to force update WinAppSDK packages

### DIFF
--- a/specs/Deployment/DeploymentAPI.md
+++ b/specs/Deployment/DeploymentAPI.md
@@ -141,9 +141,10 @@ ForceTargetApplicationShutDown option before passing it to this API. This option
 shutdown the application(s) associated with the package, update the package and restart the
 application(s).
 
-// TODO: If this option is set when updating main package, then whether the out of process // com
-server from the main package such as push Notifications needs to be explictly restarted // needs to
-be understood. If restart it is needed, then the API will handle explicitly restarting it.
+// OPENISSUE: If this option is set when updating main package, then whether the out of process com
+server from the main package such as push Notifications needs to be explictly restarted needs to be
+understood. If restart it is needed, then the API will handle explicitly restarting it. This is
+under investigation.
 
 When the API is updating framework package and ForceTargetApplicationShutDown option is set, then
 all dependent packages that are NOT currently in use will be immediately re-installed to refer to

--- a/specs/Deployment/DeploymentAPI.md
+++ b/specs/Deployment/DeploymentAPI.md
@@ -114,8 +114,8 @@ again.
     if (DeploymentManager.GetStatus().Status != DeploymentStatus.Ok)
     {
         // Initialize does a status check, and if the status is not OK it will attempt to get
-        // the WindowsAppRuntime into a good state by deploying packages. Unlike a simple
-        // status check, Initialize can sometimes take several seconds to deploy the packages.
+        // the WindowsAppRuntime into a good state. Unlike a simple status check, Initialize can
+        // sometimes take several seconds to deploy the packages.
         // These should be run on a separate thread so as not to hang your app while the
         // packages deploy.
         var initializeTask = Task.Run(() => DeploymentManager.Initialize());

--- a/specs/Deployment/DeploymentAPI.md
+++ b/specs/Deployment/DeploymentAPI.md
@@ -15,11 +15,11 @@ Currently, packaged apps can only declare dependencies on framework packages. In
 other packages (main, singleton) deployed, apps can use the mechanism described here as part of
 their first-run experience.
 
-> **Note that in Windows App SDK version 1.0**, only unpackaged apps that are full trust or 
-> MSIX packaged apps that have the packageManagement restricted capability have the permission 
-> to use the Deployment API to install the main and singleton package dependencies. Support for
-> partial trust MSIX packaged apps will be coming in later releases. Additionally, support for main
-> and singleton package deployment through the Microsoft Store will be coming in later releases.
+> **Note that in Windows App SDK version 1.0**, only unpackaged apps that are full trust or MSIX
+> packaged apps that have the packageManagement restricted capability have the permission to use the
+> Deployment API to install the main and singleton package dependencies. Support for partial trust
+> MSIX packaged apps will be coming in later releases. Additionally, support for main and singleton
+> package deployment through the Microsoft Store will be coming in later releases.
 
 # Description
 
@@ -108,7 +108,7 @@ Once the main and singleton packages have been deployed, they generally do not n
 again. If a user were to remove the main or singleton package, the API can be used to reinstall them
 again.
 
-```c#
+```C#
     if (DeploymentManager.GetStatus().Status != DeploymentStatus.Ok)
     {
         // Initialize does a status check, and if the status is not OK it will attempt to get
@@ -133,24 +133,24 @@ again.
 
 #### ForceTargetApplicationShutDown
 
-When this API may install newer version of one or more of the packages (i.e. an update) and
-if there are any currently running process(es) associated with that package(s) (in other words,
-if any of the packages to be updated are currently in use), then this API will fail installing
-that package. But this update to the packages can be forced by using DeploymentInitializeOptions object
-and setting ForceTargetApplicationShutDown option before passing it to this API. This option
-when set will shutdown the application(s) associated with the package, update the package
-and restart the application(s).
+When this API may install newer version of one or more of the packages (i.e. an update) and if there
+are any currently running process(es) associated with that package(s) (in other words, if any of the
+packages to be updated are currently in use), then this API will fail installing that package. But
+this update to the packages can be forced by using DeploymentInitializeOptions object and setting
+ForceTargetApplicationShutDown option before passing it to this API. This option when set will
+shutdown the application(s) associated with the package, update the package and restart the
+application(s).
 
-// TODO: If this option is set when updating main package, then whether the out of process
-// com server from the main package such as push Notifications needs to be explictly restarted
-// needs to be understood. If restart it is needed, then the API will handle explicitly restarting it.
+// TODO: If this option is set when updating main package, then whether the out of process // com
+server from the main package such as push Notifications needs to be explictly restarted // needs to
+be understood. If restart it is needed, then the API will handle explicitly restarting it.
 
-When the API is updating framework package and ForceTargetApplicationShutDown option is set,
-then all dependent packages that are NOT currently in use will be immediately re-installed
-to refer to the updated framework package and all dependent packages that are currently in use
-will be re-installed, after they shut down, to refer to the updated framework package.
+When the API is updating framework package and ForceTargetApplicationShutDown option is set, then
+all dependent packages that are NOT currently in use will be immediately re-installed to refer to
+the updated framework package and all dependent packages that are currently in use will be
+re-installed, after they shut down, to refer to the updated framework package.
 
-```c#
+```C#
     if (DeploymentManager.GetStatus().Status != DeploymentStatus.Ok)
     {
         // Create DeploymentInitializeOptions object and set ForceTargetApplicationShutDown option
@@ -178,7 +178,7 @@ will be re-installed, after they shut down, to refer to the updated framework pa
 
 # API Details
 
-```c# (but really MIDL3)
+```C# (but really MIDL3)
 namespace Microsoft.Windows.ApplicationModel.WindowsAppRuntime
 {
     /// Represents the current Deployment status of the WindowsAppRuntime
@@ -201,7 +201,7 @@ namespace Microsoft.Windows.ApplicationModel.WindowsAppRuntime
         /// Returns the first encountered error if there was an error or S_OK if no error.
         HRESULT ExtendedError{ get; };
     };
-    
+
     // TODO: https://task.ms/38272182 - add APIcontract once WinAppSDK's rules for them are defined [contract(name,version)]
     /// This object is used to specify deployment options to apply when using DeploymentManager's
     /// Initialize method
@@ -211,7 +211,7 @@ namespace Microsoft.Windows.ApplicationModel.WindowsAppRuntime
         /// shut down forcibly so that installation of the packages can continue if they are currently in use
         bool ForceTargetApplicationShutdown;
     };
-    
+
     /// Used to query deployment information for WindowsAppRuntime
     static runtimeclass DeploymentManager
     {

--- a/specs/Deployment/DeploymentAPI.md
+++ b/specs/Deployment/DeploymentAPI.md
@@ -11,9 +11,9 @@ is also needed for the framework to be serviced by the Microsoft Store. The sing
 supports a single long-running process that is brokered between apps for features like push
 notifications.
 
-Currently, packaged apps can only declare dependencies on framework packages. In order to get the
-other packages (main, singleton) deployed, apps can use the mechanism described here as part of
-their first-run experience.
+Currently, packaged apps can only declare dependencies on WinAppSDK framework package. In order to
+get the other WinAppSDK packages (main, singleton) deployed, the packaged apps can use the mechanism
+described here as part of their first-run experience.
 
 > **Note that in Windows App SDK version 1.0**, only unpackaged apps that are full trust or MSIX
 > packaged apps that have the packageManagement restricted capability have the permission to use the
@@ -30,45 +30,47 @@ application. The Deployment API enables a developer to check when the required W
 singleton packages are missing and get them installed.
 
 Since the Deployment API is part of the WinAppSDK framework package, the framework itself must be
-present. To deploy the framework package with the MSIX packaged application, the framework must be
-declared as a dependency in the application manifest with a min version specified. For instructions
-on deploying the framework package, see the
+present to use the API. To deploy the WinAppSDK framework package with the MSIX packaged
+application, the framework must be declared as a dependency in the application manifest with a min
+version specified. For instructions on deploying the framework package, see the
 [developer docs](https://docs.microsoft.com/windows/apps/windows-app-sdk/deploy-packaged-apps#deploy-the-windows-app-sdk-framework-package).
 
 If a developer prefers to have the Microsoft Store automatically service the WinAppSDK framework
-package and if features like push notifications are desired, then the main and singleton should also
-be deployed. Developers must not assume that the WinAppSDK main and singleton packages are already
-present on the system, or that the version present is the minimum version required by the
-application. Instead, the Deployment API should be used to validate that the WinAppSDK is at the
+package and if features like push notifications are desired, then the WinAppSDK main and singleton
+should also be deployed. Developers must not assume that the WinAppSDK main and singleton packages
+are already present on the system, or that the version present is the minimum version required by
+the application. Instead, the Deployment API should be used to validate that the WinAppSDK is at the
 correct version and that all required packages are present.
 
 The Deployment API addresses the following two developer scenarios:
 
 1. Does this system have the min version of the WinAppSDK main and singleton packages required by my
    app?
-2. How do I install these packages, if they are not already present on the system?
+2. How do I install the WinAppSDK main and singleton packages, if they are not already present on
+   the system?
 
 The API addresses #1 by a simple query of the version needed and a check for OS updates.
 
 #2 has two possible answers.
 
--   First, the developer can install the packages directly through the app, if possible. These MSIX
-    packages can be acquired through
+-   First, the developer can install these packages directly through the app, if possible. These
+    MSIX packages can be acquired through
     [Downloads page](https://docs.microsoft.com/windows/apps/windows-app-sdk/downloads).
--   Alternatively, MSIX packaged apps that are full trust or have the packageManagement restricted
-    capability can use the Deployment API to get these packages installed.
+-   Alternatively, unpackaged apps that are full trust or MSIX packaged apps that have the
+    packageManagement restricted capability can use the Deployment API to get these packages
+    installed.
 
 # Examples
 
 ## GetStatus
 
-This is the means by which an app or program can call to verify that all required packages are
-present to a minimum version needed by the framework loaded with the app. A process should call
+This is the means by which an app or program can call to verify that all required WinAppSDK packages
+are present to a minimum version needed by the framework loaded with the app. A process should call
 GetStatus() after process initialization and before using Windows App Runtime content (e.g. in
 main() or WinMain()).
 
 Developers call this method without parameters, as all information about the version, channel, and
-architecture are derived from the current WinAppSDK framework package loaded.
+architecture are derived from the current framework package loaded.
 
 ```C#
     DeploymentResult result = DeploymentManager.GetStatus();
@@ -131,40 +133,40 @@ again.
 
 ### DeploymentInitializeOptions
 
-#### ForceTargetApplicationShutDown
+#### ForceDeployment
 
-When this API may install newer version of one or more of the packages (i.e. an update) and if there
-are any currently running process(es) associated with that package(s) (in other words, if any of the
-packages to be updated are currently in use), then this API will fail installing that package. But
-this update to the packages can be forced by using DeploymentInitializeOptions object and setting
-ForceTargetApplicationShutDown option before passing it to this API. This option when set will
-shutdown the application(s) associated with the package, update the package and restart the
-application(s).
+When this API may install newer version of one or more of the WinAppSDK packages (i.e. an update)
+and if there are any currently running process(es) associated with these WinAppSDK package(s) (in
+other words, if any of the WinAppSDK packages to be updated are currently in use), then this API
+will fail installing that WinAppSDK package. But this update to the WinAppSDK packages can be forced
+by using DeploymentInitializeOptions object and setting ForceDeployment option before passing it to
+this API. This option when set will shutdown the application(s) associated with WinAppSDK packages,
+update the WinAppSDK packages and restart the application(s).
 
 // OPENISSUE: If this option is set when updating main package, then whether the out of process com
 server from the main package such as push Notifications needs to be explictly restarted needs to be
 understood. If restart it is needed, then the API will handle explicitly restarting it. This is
 under investigation.
 
-When the API is updating framework package and ForceTargetApplicationShutDown option is set, then
-all dependent packages that are NOT currently in use will be immediately re-installed to refer to
-the updated framework package and all dependent packages that are currently in use will be
-re-installed, after they shut down, to refer to the updated framework package.
+When the API is updating framework package and ForceDeployment option is set, then all dependent
+packages that are NOT currently in use will be immediately re-installed to refer to the updated
+framework package and all dependent packages that are currently in use will be re-installed, after
+they shutdown, to refer to the updated framework package.
 
 ```C#
     if (DeploymentManager.GetStatus().Status != DeploymentStatus.Ok)
     {
-        // Create DeploymentInitializeOptions object and set ForceTargetApplicationShutDown option
-        // to allow for force updating of the packages even if they are currently in use.
+        // Create DeploymentInitializeOptions object and set ForceDeployment option
+        // to allow for force updating of the WinAppSDK packages even if they are currently in use.
         var deploymentInitializeOptions = new DeploymentInitializeOptions();
-        deploymentInitializeOptions.ForceTargetApplicationShutdown = true;
+        deploymentInitializeOptions.ForceDeployment = true;
 
         // Initialize does a status check, and if the status is not OK it will attempt to get
         // the WindowsAppRuntime into a good state by deploying packages. Unlike a simple
         // status check, Initialize can sometimes take several seconds to deploy the packages.
         // These should be run on a separate thread so as not to hang your app while the
         // packages deploy.
-        var initializeTask = Task.Run(() => DeploymentManager.Initialize());
+        var initializeTask = Task.Run(() => DeploymentManager.Initialize(deploymentInitializeOptions));
         initializeTask.Wait();
 
         // Check the result.
@@ -208,9 +210,10 @@ namespace Microsoft.Windows.ApplicationModel.WindowsAppRuntime
     /// Initialize method
     runtimeClass DeploymentInitializeOptions
     {
-        /// Gets or sets a value that indicates whether the processes associated with the package will be
-        /// shut down forcibly so that installation of the packages can continue if they are currently in use
-        bool ForceTargetApplicationShutdown;
+        /// Gets or sets a value that indicates whether the processes associated with the
+        /// WindowsAppSDK main and singleton packages will be shutdown forcibly if they are
+        /// currently in use, when registering the WinAppSDK packages.
+        Boolean ForceDeployment;
     };
 
     /// Used to query deployment information for WindowsAppRuntime
@@ -220,11 +223,12 @@ namespace Microsoft.Windows.ApplicationModel.WindowsAppRuntime
         static DeploymentResult GetStatus();
 
         /// Checks the status of the WindowsAppRuntime of the current package and attempts to
-        /// register any missing packages that can be registered.
+        /// register any missing WinAppSDK packages.
         static DeploymentResult Initialize();
 
         /// Checks the status of the WindowsAppRuntime of the current package and attempts to
-        /// register any missing packages that can be registered while applying the DeploymentInitializeOptions passed in
+        /// register any missing WinAppSDK packages, while applying the DeploymentInitializeOptions
+        /// passed in
         static DeploymentResult Initialize(Microsoft.Windows.ApplicationModel.WindowsAppRuntime::DeploymentInitializeOptions deploymentInitializeOptions);
     };
 }

--- a/specs/Deployment/DeploymentAPI.md
+++ b/specs/Deployment/DeploymentAPI.md
@@ -140,18 +140,18 @@ and if there are any currently running process(es) associated with these WinAppS
 other words, if any of the WinAppSDK packages to be updated are currently in use), then this API
 will fail installing that WinAppSDK package. But this update to the WinAppSDK packages can be forced
 by using DeploymentInitializeOptions object and setting ForceDeployment option before passing it to
-this API. This option when set will shutdown the application(s) associated with WinAppSDK packages,
+this API. This option when set will shut down the application(s) associated with WinAppSDK packages,
 update the WinAppSDK packages and restart the application(s).
 
 // OPENISSUE: If this option is set when updating main package, then whether the out of process com
-server from the main package such as push Notifications needs to be explictly restarted needs to be
+server from the main package such as push Notifications needs to be explicitly restarted needs to be
 understood. If restart it is needed, then the API will handle explicitly restarting it. This is
 under investigation.
 
 When the API is updating framework package and ForceDeployment option is set, then all dependent
 packages that are NOT currently in use will be immediately re-installed to refer to the updated
 framework package and all dependent packages that are currently in use will be re-installed, after
-they shutdown, to refer to the updated framework package.
+they shut down, to refer to the updated framework package.
 
 ```C#
     if (DeploymentManager.GetStatus().Status != DeploymentStatus.Ok)
@@ -205,13 +205,13 @@ namespace Microsoft.Windows.ApplicationModel.WindowsAppRuntime
         HRESULT ExtendedError{ get; };
     };
 
-    // TODO: https://task.ms/38272182 - add APIcontract once WinAppSDK's rules for them are defined [contract(name,version)]
+-   // TODO: https://task.ms/38272182 - add APIcontract once WinAppSDK's rules for them are defined [contract(name,version)]
     /// This object is used to specify deployment options to apply when using DeploymentManager's
     /// Initialize method
     runtimeClass DeploymentInitializeOptions
     {
         /// Gets or sets a value that indicates whether the processes associated with the
-        /// WindowsAppSDK main and singleton packages will be shutdown forcibly if they are
+        /// WindowsAppSDK main and singleton packages will be shut down forcibly if they are
         /// currently in use, when registering the WinAppSDK packages.
         Boolean ForceDeployment;
     };
@@ -228,7 +228,7 @@ namespace Microsoft.Windows.ApplicationModel.WindowsAppRuntime
 
         /// Checks the status of the WindowsAppRuntime of the current package and attempts to
         /// register any missing WinAppSDK packages, while applying the DeploymentInitializeOptions
-        /// passed in
+        /// passed in.
         static DeploymentResult Initialize(Microsoft.Windows.ApplicationModel.WindowsAppRuntime::DeploymentInitializeOptions deploymentInitializeOptions);
     };
 }


### PR DESCRIPTION
Proposal to add DeploymentOptions object to Deployment API to allow force update of Windows App SDK packages. 