### PR TITLE
Fix AppNotification activation when no foreground handlers defined

### DIFF
--- a/dev/AppNotifications/AppNotificationManager.cpp
+++ b/dev/AppNotifications/AppNotificationManager.cpp
@@ -167,11 +167,13 @@ namespace winrt::Microsoft::Windows::AppNotifications::implementation
 
             std::wstring commandLine{ GetCommandLine() };
 
-            // If the app was not launched due to ToastActivation, we will invoke the foreground handler.
+            // If the app was not launched due to ToastActivation, we will launch a new instance or invoke the foreground handlers.
             // Otherwise we store the EventArgs and signal to the Main thread
             auto pos{ commandLine.find(c_notificationActivatedArgument) };
-            if (pos == std::wstring::npos) // !AppNotification
+            if (pos == std::wstring::npos) // Any launch kind that is not AppNotification
             {
+                // If the Process was launched due to other Activation Kinds, we will need to
+                // re-route the payload to a new process if there are no registered event handlers.
                 if (!m_notificationHandlers)
                 {
                     winrt::guid registeredClsid{ GUID_NULL };

--- a/dev/AppNotifications/AppNotificationManager.cpp
+++ b/dev/AppNotifications/AppNotificationManager.cpp
@@ -189,7 +189,7 @@ namespace winrt::Microsoft::Windows::AppNotifications::implementation
                     }
 
                     auto notificationCallback{ winrt::create_instance<INotificationActivationCallback>(registeredClsid, CLSCTX_ALL) };
-                    notificationCallback->Activate(appUserModelId, invokedArgs, data, dataCount);
+                    THROW_IF_FAILED(notificationCallback->Activate(appUserModelId, invokedArgs, data, dataCount));
                 }
                 else
                 {

--- a/dev/AppNotifications/AppNotificationManager.cpp
+++ b/dev/AppNotifications/AppNotificationManager.cpp
@@ -144,7 +144,7 @@ namespace winrt::Microsoft::Windows::AppNotifications::implementation
     }
 
     HRESULT __stdcall AppNotificationManager::Activate(
-        LPCWSTR /* appUserModelId */,
+        LPCWSTR appUserModelId,
         LPCWSTR invokedArgs,
         [[maybe_unused]] NOTIFICATION_USER_INPUT_DATA const* data,
         [[maybe_unused]] ULONG dataCount) noexcept try
@@ -188,8 +188,8 @@ namespace winrt::Microsoft::Windows::AppNotifications::implementation
                         registeredClsid = winrt::guid(storedComActivatorString.substr(1, storedComActivatorString.size() - 2));
                     }
 
-                    auto notificationCallback = winrt::create_instance<INotificationActivationCallback>(registeredClsid, CLSCTX_ALL);
-                    notificationCallback->Activate(L"", invokedArgs, data, dataCount);
+                    auto notificationCallback{ winrt::create_instance<INotificationActivationCallback>(registeredClsid, CLSCTX_ALL) };
+                    notificationCallback->Activate(appUserModelId, invokedArgs, data, dataCount);
                 }
                 else
                 {

--- a/test/TestApps/ToastNotificationsDemoApp/main.cpp
+++ b/test/TestApps/ToastNotificationsDemoApp/main.cpp
@@ -113,15 +113,17 @@ std::wstring GetEnumString(winrt::AppNotificationSetting const& setting)
     return enumMapping[setting];
 }
 
-winrt::AppNotification CreateToastNotification(winrt::hstring message)
-{
-    winrt::hstring xmlPayload{ L"<toast>" + message + L"</toast>" };
-    return winrt::AppNotification(xmlPayload);
-}
-
 winrt::AppNotification CreateToastNotification()
 {
-    return CreateToastNotification(L"intrepidToast");
+    winrt::hstring payload =
+        LR"(<toast launch="action = viewDownload &amp; downloadId = 9438108">
+        <visual>
+            <binding template = "ToastGeneric">
+                <text>Downloading this week's new music...</text>
+            </binding>
+        </visual>
+    </toast>)";
+    return winrt::AppNotification(payload);
 }
 
 bool PostToastHelper(std::wstring const& tag, std::wstring const& group)

--- a/test/TestApps/ToastNotificationsDemoAppPackage/Package.appxmanifest
+++ b/test/TestApps/ToastNotificationsDemoAppPackage/Package.appxmanifest
@@ -53,11 +53,6 @@
 				</com:ExeServer>
 			</com:ComServer>
 		</com:Extension>
-		<uap:Extension Category="windows.protocol" EntryPoint="Windows.FullTrustApplication">
-			<uap:Protocol Name="packagedtoast-protocol">
-				<uap:DisplayName>WindowsAppRuntimeTestProtocol</uap:DisplayName>
-        </uap:Protocol>
-		</uap:Extension>
 		<com:Extension Category="windows.comServer">
 			<com:ComServer>
 				<com:ExeServer Executable="ToastNotificationsDemoApp\ToastNotificationsDemoApp.exe" DisplayName="SampleBackgroundApp" Arguments="----WindowsAppRuntimePushServer:">


### PR DESCRIPTION
There was a bug with using REG_SINGLEUSE on app launch for AppNotification activation. The issue was that the com object was not activated the first time and only on the second activation would another process be created.

Now if the app has no foreground handlers, was launched by any ExtendedActivationKind that is not AppNotification, and receives a AppNotification activation, we CoCreateInstance the app and propagate the arguments through Activate.