### PR TITLE
Modify constructor for AppNotificationProgressData per API review

### DIFF
--- a/dev/AppNotifications/AppNotification.h
+++ b/dev/AppNotifications/AppNotification.h
@@ -43,7 +43,7 @@ namespace winrt::Microsoft::Windows::AppNotifications::implementation
 
         winrt::hstring m_payload{};
 
-        winrt::Microsoft::Windows::AppNotifications::AppNotificationProgressData m_progressData{1};
+        winrt::Microsoft::Windows::AppNotifications::AppNotificationProgressData m_progressData{ nullptr };
 
         winrt::Windows::Foundation::DateTime m_expirationTime{};
 

--- a/dev/AppNotifications/AppNotification.h
+++ b/dev/AppNotifications/AppNotification.h
@@ -43,7 +43,7 @@ namespace winrt::Microsoft::Windows::AppNotifications::implementation
 
         winrt::hstring m_payload{};
 
-        winrt::Microsoft::Windows::AppNotifications::AppNotificationProgressData m_progressData{};
+        winrt::Microsoft::Windows::AppNotifications::AppNotificationProgressData m_progressData{1};
 
         winrt::Windows::Foundation::DateTime m_expirationTime{};
 

--- a/dev/AppNotifications/AppNotificationProgressData.cpp
+++ b/dev/AppNotifications/AppNotificationProgressData.cpp
@@ -6,7 +6,6 @@ namespace winrt::Microsoft::Windows::AppNotifications::implementation
 {
     AppNotificationProgressData::AppNotificationProgressData(uint32_t sequenceNumber)
     {
-        auto lock{ m_lock.lock_exclusive() };
         THROW_HR_IF(E_INVALIDARG, sequenceNumber == 0); // The sequence number is always greater than 0
         m_sequenceNumber = sequenceNumber;
     }
@@ -18,8 +17,10 @@ namespace winrt::Microsoft::Windows::AppNotifications::implementation
     }
     void AppNotificationProgressData::SequenceNumber(uint32_t sequenceNumber)
     {
-        auto lock{ m_lock.lock_exclusive() };
         THROW_HR_IF(E_INVALIDARG, sequenceNumber == 0); // The sequence number is always greater than 0
+
+        auto lock{ m_lock.lock_exclusive() };
+
         m_sequenceNumber = sequenceNumber;
     }
     hstring AppNotificationProgressData::Title()

--- a/dev/AppNotifications/AppNotificationProgressData.cpp
+++ b/dev/AppNotifications/AppNotificationProgressData.cpp
@@ -4,6 +4,12 @@
 
 namespace winrt::Microsoft::Windows::AppNotifications::implementation
 {
+    AppNotificationProgressData::AppNotificationProgressData(uint32_t sequenceNumber)
+    {
+        auto lock{ m_lock.lock_exclusive() };
+        THROW_HR_IF(E_INVALIDARG, sequenceNumber == 0); // The sequence number is always greater than 0
+        m_sequenceNumber = sequenceNumber;
+    }
     uint32_t AppNotificationProgressData::SequenceNumber()
     {
         auto lock{ m_lock.lock_shared() };

--- a/dev/AppNotifications/AppNotificationProgressData.h
+++ b/dev/AppNotifications/AppNotificationProgressData.h
@@ -6,7 +6,7 @@ namespace winrt::Microsoft::Windows::AppNotifications::implementation
     struct AppNotificationProgressData : AppNotificationProgressDataT<AppNotificationProgressData>
     {
         AppNotificationProgressData() = default;
-
+        AppNotificationProgressData(uint32_t sequenceNumber);
         uint32_t SequenceNumber();
         void SequenceNumber(uint32_t sequenceNumber);
         hstring Title();
@@ -19,7 +19,7 @@ namespace winrt::Microsoft::Windows::AppNotifications::implementation
         void Status(hstring const& progressStatus);
 
     private:
-        uint32_t m_sequenceNumber{};
+        uint32_t m_sequenceNumber = 1;
         hstring m_title;
         double m_progressValue{};
         hstring m_progressValueString;

--- a/dev/AppNotifications/AppNotificationUtility.cpp
+++ b/dev/AppNotifications/AppNotificationUtility.cpp
@@ -355,9 +355,8 @@ winrt::Microsoft::Windows::AppNotifications::AppNotification Microsoft::Windows:
     THROW_IF_FAILED(properties->get_ToastProgressData(toastProgressData.put()));
     if (toastProgressData)
     {
+        // Sequence number is a transient property and we give it a default non-zero value of 1 in the ctor
         winrt::AppNotificationProgressData progressData{ 1 };
-
-        // SequenceNumber is transient and thus,  left to its default.
 
         wil::unique_hstring status{};
         THROW_IF_FAILED(toastProgressData->get_Status(&status));

--- a/dev/AppNotifications/AppNotificationUtility.cpp
+++ b/dev/AppNotifications/AppNotificationUtility.cpp
@@ -367,7 +367,7 @@ winrt::Microsoft::Windows::AppNotifications::AppNotification Microsoft::Windows:
         progressData.Title(wil::str_raw_ptr(title));
 
         double progressValue{};
-        toastProgressData->get_Value(&progressValue);
+        THROW_IF_FAILED(toastProgressData->get_Value(&progressValue));
         progressData.Value(progressValue);
 
         wil::unique_hstring progressValueString{};

--- a/dev/AppNotifications/AppNotificationUtility.cpp
+++ b/dev/AppNotifications/AppNotificationUtility.cpp
@@ -355,7 +355,7 @@ winrt::Microsoft::Windows::AppNotifications::AppNotification Microsoft::Windows:
     THROW_IF_FAILED(properties->get_ToastProgressData(toastProgressData.put()));
     if (toastProgressData)
     {
-        winrt::AppNotificationProgressData progressData{};
+        winrt::AppNotificationProgressData progressData{ 1 };
 
         // SequenceNumber is transient and thus,  left to its default.
 

--- a/dev/AppNotifications/AppNotifications.idl
+++ b/dev/AppNotifications/AppNotifications.idl
@@ -21,9 +21,10 @@ namespace Microsoft.Windows.AppNotifications
     runtimeclass AppNotificationProgressData
     {
         // Initializes a new Instance of NotificationProgressData
-        AppNotificationProgressData();
+        // The sequence number is non-zero or this will throw.
+        AppNotificationProgressData(UInt32 sequenceNumber);
 
-        // Gets or sets the sequence number of this notification data.
+        // Gets or sets a non-zero sequence number of this notification data.
         // When multiple NotificationProgressData objects are received, the system displays the data with the greatest non-zero number. 
         UInt32 SequenceNumber;
 

--- a/dev/AppNotifications/NotificationProgressData.cpp
+++ b/dev/AppNotifications/NotificationProgressData.cpp
@@ -18,8 +18,12 @@ namespace ToastABI
 }
 
 NotificationProgressData::NotificationProgressData(winrt::AppNotificationProgressData const& progressData)
+    : m_progressData(progressData.SequenceNumber())
 {
-    m_progressData = progressData;
+    m_progressData.Status(progressData.Status());
+    m_progressData.Title(progressData.Title());
+    m_progressData.Value(progressData.Value());
+    m_progressData.ValueStringOverride(progressData.ValueStringOverride());
 }
 
 STDMETHODIMP NotificationProgressData::get_SequenceNumber(_Out_ unsigned int* value) noexcept

--- a/dev/AppNotifications/NotificationProperties.cpp
+++ b/dev/AppNotifications/NotificationProperties.cpp
@@ -44,7 +44,10 @@ NotificationProperties::NotificationProperties(winrt::AppNotification const& toa
 
     m_expiresOnReboot = toastNotification.ExpiresOnReboot();
 
-    m_toastProgressData = winrt::make_self<NotificationProgressData>(toastNotification.Progress());
+    if (toastNotification.Progress() != nullptr)
+    {
+        m_toastProgressData = winrt::make_self<NotificationProgressData>(toastNotification.Progress());
+    }
 }
 
 STDMETHODIMP_(HRESULT __stdcall) NotificationProperties::get_NotificationId(_Out_ unsigned int* notificationId) noexcept
@@ -131,8 +134,11 @@ STDMETHODIMP_(HRESULT __stdcall) NotificationProperties::get_ExpiresOnReboot(_Ou
 STDMETHODIMP_(HRESULT __stdcall) NotificationProperties::get_ToastProgressData(_Out_ ToastABI::IToastProgressData** progressData) noexcept
 {
     auto lock{ m_lock.lock_shared() };
-
-    m_toastProgressData.copy_to(progressData);
+    *progressData = nullptr;
+    if (m_toastProgressData != nullptr)
+    {
+        m_toastProgressData.copy_to(progressData);
+    }
 
     return S_OK;
 }

--- a/dev/AppNotifications/NotificationProperties.cpp
+++ b/dev/AppNotifications/NotificationProperties.cpp
@@ -133,8 +133,8 @@ STDMETHODIMP_(HRESULT __stdcall) NotificationProperties::get_ExpiresOnReboot(_Ou
 
 STDMETHODIMP_(HRESULT __stdcall) NotificationProperties::get_ToastProgressData(_Out_ ToastABI::IToastProgressData** progressData) noexcept
 {
-    auto lock{ m_lock.lock_shared() };
     *progressData = nullptr;
+    auto lock{ m_lock.lock_shared() };
     if (m_toastProgressData != nullptr)
     {
         m_toastProgressData.copy_to(progressData);

--- a/dev/AppNotifications/NotificationProperties.h
+++ b/dev/AppNotifications/NotificationProperties.h
@@ -48,5 +48,5 @@ private:
 
     bool m_expiresOnReboot = false;
 
-    winrt::com_ptr<ABI::Microsoft::Internal::ToastNotifications::IToastProgressData> m_toastProgressData;
+    winrt::com_ptr<ABI::Microsoft::Internal::ToastNotifications::IToastProgressData> m_toastProgressData{ nullptr };
 };

--- a/test/TestApps/ToastNotificationsTestApp/main.cpp
+++ b/test/TestApps/ToastNotificationsTestApp/main.cpp
@@ -197,19 +197,13 @@ winrt::AppNotificationProgressData GetToastProgressData(
     std::wstring const& title,
     double const& progressValue,
     std::wstring const& progressValueString,
-    bool setSequence,
     uint32_t sequenceNumber)
 {
-    winrt::AppNotificationProgressData progressData{};
+    winrt::AppNotificationProgressData progressData{sequenceNumber};
     progressData.Status(status);
     progressData.Title(title);
     progressData.Value(progressValue);
     progressData.ValueStringOverride(progressValueString);
-    if (setSequence)
-    {
-        progressData.SequenceNumber(sequenceNumber);
-    }
-
     return progressData;
 }
 
@@ -413,7 +407,7 @@ bool VerifyToastProgressDataFromToast()
 {
     winrt::AppNotification toast{ CreateToastNotification() };
 
-    winrt::AppNotificationProgressData progressData{};
+    winrt::AppNotificationProgressData progressData{ 1 };
     progressData.Status(L"SomeStatus");
     progressData.Title(L"SomeTitle");
     progressData.Value(0.14);
@@ -438,6 +432,11 @@ bool VerifyToastProgressDataFromToast()
     }
 
     if (progressDataFromToast.ValueStringOverride() != L"14%")
+    {
+        return false;
+    }
+
+    if (progressDataFromToast.SequenceNumber() != 1)
     {
         return false;
     }
@@ -574,7 +573,7 @@ bool VerifyUpdateToastProgressDataUsingValidTagAndValidGroup()
             toastNotificationManager.UnregisterAll();
         });
 
-    winrt::AppNotificationProgressData progressData = GetToastProgressData(L"PStatus", L"PTitle", 0.10, L"10%", true, 1);
+    winrt::AppNotificationProgressData progressData = GetToastProgressData(L"PStatus", L"PTitle", 0.10, L"10%", 1);
 
     auto progressResultOperation = winrt::AppNotificationManager::Default().UpdateAsync(progressData, L"PTag", L"PGroup");
     return ProgressResultOperationHelper(progressResultOperation, winrt::AppNotificationProgressResult::Succeeded);
@@ -592,7 +591,7 @@ bool VerifyUpdateToastProgressDataUsingValidTagAndValidGroup_Unpackaged()
 
     PostToastHelper(L"Tag", L"Group");
 
-    winrt::AppNotificationProgressData progressData = GetToastProgressData(L"SomeStatus", L"SomeTitle", 0.14, L"14%", true, 1);
+    winrt::AppNotificationProgressData progressData = GetToastProgressData(L"SomeStatus", L"SomeTitle", 0.14, L"14%", 1);
 
     auto progressResultOperation = toastNotificationManager.UpdateAsync(progressData, L"Tag", L"Group");
     return ProgressResultOperationHelper(progressResultOperation, winrt::AppNotificationProgressResult::Succeeded);
@@ -610,7 +609,7 @@ bool VerifyUpdateToastProgressDataUsingValidTagAndEmptyGroup()
 
     PostToastHelper(L"PTag", L"");
 
-    winrt::AppNotificationProgressData progressData = GetToastProgressData(L"PStatus", L"PTitle", 0.10, L"10%", true, 1);
+    winrt::AppNotificationProgressData progressData = GetToastProgressData(L"PStatus", L"PTitle", 0.10, L"10%", 1);
 
     auto progressResultOperation = winrt::AppNotificationManager::Default().UpdateAsync(progressData, L"PTag");
     return ProgressResultOperationHelper(progressResultOperation, winrt::AppNotificationProgressResult::Succeeded);
@@ -628,7 +627,7 @@ bool VerifyUpdateToastProgressDataUsingValidTagAndEmptyGroup_Unpackaged()
 
     PostToastHelper(L"Tag", L"");
 
-    winrt::AppNotificationProgressData progressData = GetToastProgressData(L"SomeStatus", L"SomeTitle", 0.14, L"14%", true, 1);
+    winrt::AppNotificationProgressData progressData = GetToastProgressData(L"SomeStatus", L"SomeTitle", 0.14, L"14%", 1);
 
     auto progressResultOperation = toastNotificationManager.UpdateAsync(progressData, L"Tag");
     return ProgressResultOperationHelper(progressResultOperation, winrt::AppNotificationProgressResult::Succeeded);
@@ -645,7 +644,7 @@ bool VerifyToastUpdateZeroSequenceFail_Unpackaged()
         });
     PostToastHelper(L"Tag", L"");
 
-    winrt::AppNotificationProgressData progressData = GetToastProgressData(L"SomeStatus", L"SomeTitle", 0.14, L"14%", false, 1);
+    winrt::AppNotificationProgressData progressData = GetToastProgressData(L"SomeStatus", L"SomeTitle", 0.14, L"14%", 1);
 
     auto progressResultOperation = toastNotificationManager.UpdateAsync(progressData, L"Tag");
 
@@ -672,7 +671,7 @@ bool VerifyUpdateToastProgressDataUsingEmptyTagAndValidGroup()
                 toastNotificationManager.UnregisterAll();
             });
 
-        winrt::AppNotificationProgressData progressData = GetToastProgressData(L"PStatus", L"PTitle", 0.10, L"10%", true, 1);
+        winrt::AppNotificationProgressData progressData = GetToastProgressData(L"PStatus", L"PTitle", 0.10, L"10%", 1);
 
         auto progressResultOperation = winrt::AppNotificationManager::Default().UpdateAsync(progressData, L"", L"Group").get();
     }
@@ -695,7 +694,7 @@ bool VerifyUpdateToastProgressDataUsingEmptyTagAndEmptyGroup()
                 toastNotificationManager.UnregisterAll();
             });
 
-        winrt::AppNotificationProgressData progressData = GetToastProgressData(L"PStatus", L"PTitle", 0.10, L"10%", true, 1);
+        winrt::AppNotificationProgressData progressData = GetToastProgressData(L"PStatus", L"PTitle", 0.10, L"10%", 1);
 
         auto progressResultOperation = winrt::AppNotificationManager::Default().UpdateAsync(progressData, L"", L"").get();
     }
@@ -718,7 +717,7 @@ bool VerifyToastProgressDataSequence0Fail()
                 toastNotificationManager.UnregisterAll();
             });
 
-        winrt::AppNotificationProgressData progressData = GetToastProgressData(L"PStatus", L"PTitle", 0.10, L"10%", true, 0);
+        winrt::AppNotificationProgressData progressData = GetToastProgressData(L"PStatus", L"PTitle", 0.10, L"10%", 0);
     }
     catch (...)
     {
@@ -740,7 +739,7 @@ bool VerifyFailedUpdateNotificationDataWithNonExistentTagAndGroup()
 
     PostToastHelper(L"PTag", L"PGroup");
 
-    winrt::AppNotificationProgressData progressData = GetToastProgressData(L"PStatus", L"PTitle", 0.10, L"10%", true, 1);
+    winrt::AppNotificationProgressData progressData = GetToastProgressData(L"PStatus", L"PTitle", 0.10, L"10%", 1);
 
     auto progressResultOperation = winrt::AppNotificationManager::Default().UpdateAsync(progressData, L"NonExistentTag", L"NonExistentGroup");
     return ProgressResultOperationHelper(progressResultOperation, winrt::AppNotificationProgressResult::AppNotificationNotFound);
@@ -757,7 +756,7 @@ bool VerifyFailedUpdateNotificationDataWithNonExistentTagAndGroup_Unpackaged()
 
     PostToastHelper(L"Tag", L"Group");
 
-    winrt::AppNotificationProgressData progressData = GetToastProgressData(L"SomeStatus", L"SomeTitle", 0.14, L"14%", true, 1);
+    winrt::AppNotificationProgressData progressData = GetToastProgressData(L"SomeStatus", L"SomeTitle", 0.14, L"14%", 1);
 
     auto progressResultOperation = toastNotificationManager.UpdateAsync(progressData, L"NonExistentTag", L"NonExistentGroup");
     return ProgressResultOperationHelper(progressResultOperation, winrt::AppNotificationProgressResult::AppNotificationNotFound);
@@ -773,7 +772,7 @@ bool VerifyFailedUpdateNotificationDataWithoutPostToast()
             toastNotificationManager.UnregisterAll();
         });
 
-    winrt::AppNotificationProgressData progressData = GetToastProgressData(L"PStatus", L"PTitle", 0.10, L"10%", true, 1);
+    winrt::AppNotificationProgressData progressData = GetToastProgressData(L"PStatus", L"PTitle", 0.10, L"10%", 1);
 
     auto progressResultOperation = winrt::AppNotificationManager::Default().UpdateAsync(progressData, L"Tag", L"Group");
     return ProgressResultOperationHelper(progressResultOperation, winrt::AppNotificationProgressResult::AppNotificationNotFound);
@@ -788,7 +787,7 @@ bool VerifyFailedUpdateNotificationDataWithoutPostToast_Unpackaged()
             toastNotificationManager.UnregisterAll();
         });
 
-    winrt::AppNotificationProgressData progressData = GetToastProgressData(L"SomeStatus", L"SomeTitle", 0.14, L"14%", true, 1);
+    winrt::AppNotificationProgressData progressData = GetToastProgressData(L"SomeStatus", L"SomeTitle", 0.14, L"14%", 1);
     auto progressResultOperation = toastNotificationManager.UpdateAsync(progressData, L"SomeRandomTag", L"SomeRandomGroup");
     return ProgressResultOperationHelper(progressResultOperation, winrt::AppNotificationProgressResult::AppNotificationNotFound);
 }
@@ -831,7 +830,7 @@ bool VerifyGetAllAsyncWithOneActiveToast()
     toast.Priority(winrt::AppNotificationPriority::High);
     toast.SuppressDisplay(true);
 
-    winrt::AppNotificationProgressData progressData = GetToastProgressData(L"SomeStatus", L"SomeTitle", 0.14, L"14%", false, 0);
+    winrt::AppNotificationProgressData progressData = GetToastProgressData(L"SomeStatus", L"SomeTitle", 0.14, L"14%", 1);
     toast.Progress(progressData);
 
     auto toastNotificationManager = winrt::AppNotificationManager::Default();
@@ -906,12 +905,12 @@ bool VerifyGetAllAsyncIgnoresUpdatesToProgressData()
     winrt::AppNotification toast{ CreateToastNotification() };
     toast.Tag(L"Tag");
     toast.Group(L"Group");
-    winrt::AppNotificationProgressData initialProgressData = GetToastProgressData(L"Initial Status", L"Initial Title", 0.05, L"5%", true, 1);
+    winrt::AppNotificationProgressData initialProgressData = GetToastProgressData(L"Initial Status", L"Initial Title", 0.05, L"5%", 1);
     toast.Progress(initialProgressData);
 
     toastNotificationManager.Show(toast);
 
-    winrt::AppNotificationProgressData updatedProgressData = GetToastProgressData(L"Updated Status", L"Updated Title", 0.14, L"14%", true, 2);
+    winrt::AppNotificationProgressData updatedProgressData = GetToastProgressData(L"Updated Status", L"Updated Title", 0.14, L"14%", 1);
     auto progressResultOperation = toastNotificationManager.UpdateAsync(updatedProgressData, L"Tag", L"Group");
     if (!ProgressResultOperationHelper(progressResultOperation, winrt::AppNotificationProgressResult::Succeeded))
     {

--- a/test/TestApps/ToastNotificationsTestApp/main.cpp
+++ b/test/TestApps/ToastNotificationsTestApp/main.cpp
@@ -642,20 +642,15 @@ bool VerifyToastUpdateZeroSequenceFail_Unpackaged()
         [&] {
             toastNotificationManager.UnregisterAll();
         });
-    PostToastHelper(L"Tag", L"");
 
-    winrt::AppNotificationProgressData progressData = GetToastProgressData(L"SomeStatus", L"SomeTitle", 0.14, L"14%", 1);
-
-    auto progressResultOperation = toastNotificationManager.UpdateAsync(progressData, L"Tag");
-
-    if (progressResultOperation.wait_for(std::chrono::seconds(2)) == winrt::AsyncStatus::Completed)
+    winrt::AppNotificationProgressData progressData = GetToastProgressData(L"PStatus", L"PTitle", 0.10, L"10%", 1);
+    try
     {
-        return false;
+        progressData.SequenceNumber(0);
     }
-    else
+    catch (...)
     {
-        progressResultOperation.Cancel();
-        return true;
+        return winrt::to_hresult() == E_INVALIDARG;
     }
 }
 


### PR DESCRIPTION
Per API review feedback, we need a ctor that takes in a sequence number. Sequence number needs to be non-zero and enforced, otherwise we throw.