### PR TITLE
Publish all BuildOutput as a pipeline artifact, to enable running additional tests in the future.

### DIFF
--- a/build/AzurePipelinesTemplates/WindowsAppSDK-RunHelixTests-Job.yml
+++ b/build/AzurePipelinesTemplates/WindowsAppSDK-RunHelixTests-Job.yml
@@ -145,7 +145,7 @@ jobs:
   - task: CopyFiles@2
     displayName: 'Copy Microsoft.Windows.ApplicationModel.Resources.winmd to test root'
     inputs:
-      sourceFolder: $(testPayloadDir)\MrtCoreUnpackagedTests\MrtCoreUnpackagedTests
+      sourceFolder: $(testPayloadDir)\BuildOutput\$(buildConfiguration)\$(buildPlatform)\MrtCoreUnpackagedTests
       contents: |
         Microsoft.Windows.ApplicationModel.Resources.winmd
       targetFolder: $(testPayloadDir)

--- a/build/AzurePipelinesTemplates/WindowsAppSDK-RunHelixTests-Job.yml
+++ b/build/AzurePipelinesTemplates/WindowsAppSDK-RunHelixTests-Job.yml
@@ -95,12 +95,12 @@ jobs:
       restoreDirectory: packages
 
   # Download the BuildOutput from the Build stage(s).
-  - task: DownloadPipelineArtifact@0
+  - task: DownloadBuildArtifacts@0
     displayName: 'Download: BuildOutput'
     inputs:
       artifactName: 'BuildOutput'
       downloadPath: $(testPayloadDir)
-      patterns: '$(buildPlatform)/$(buildConfiguration)/**/*'
+      itemPattern: '$(buildPlatform)/$(buildConfiguration)/**/*'
 
   - powershell: |
       Write-Host ""

--- a/build/AzurePipelinesTemplates/WindowsAppSDK-RunHelixTests-Job.yml
+++ b/build/AzurePipelinesTemplates/WindowsAppSDK-RunHelixTests-Job.yml
@@ -124,28 +124,28 @@ jobs:
     inputs:
       targetType: filePath
       filePath: $(winUIHelixPipelineScripts)\GenerateHelixWorkItems.ps1
-      arguments: -TestFilePattern 'MrmUnitTest\*.dll' -TestBinaryDirectoryPath '$(testPayloadDir)' -OutputProjFile '$(helixWorkItemsDir)\MrtCore-MrmUnitTests.proj' -WorkItemPrefix 'MrtCore.MrmUnitTests.$(buildPlatform).$(buildConfiguration)' -TestNamePrefix 'MrtCore.MrmUnitTests.$(buildPlatform).$(buildConfiguration)'
+      arguments: -TestFilePattern 'BuildOutput\$(buildConfiguration)\$(buildPlatform)\MrmUnitTest\*.dll' -TestBinaryDirectoryPath '$(testPayloadDir)' -OutputProjFile '$(helixWorkItemsDir)\MrtCore-MrmUnitTests.proj' -WorkItemPrefix 'MrtCore.MrmUnitTests.$(buildPlatform).$(buildConfiguration)' -TestNamePrefix 'MrtCore.MrmUnitTests.$(buildPlatform).$(buildConfiguration)'
 
   - task: powershell@2
     displayName: 'Discover MRT Core BaseUnitTests'
     inputs:
       targetType: filePath
       filePath: $(winUIHelixPipelineScripts)\GenerateHelixWorkItems.ps1
-      arguments: -TestFilePattern 'MrmBaseUnitTests\*.dll' -TestBinaryDirectoryPath '$(testPayloadDir)' -OutputProjFile '$(helixWorkItemsDir)\MrtCore-MrmBaseUnitTests.proj' -WorkItemPrefix 'MrtCore.MrmBaseUnitTests.$(buildPlatform).$(buildConfiguration)' -TestNamePrefix 'MrtCore.MrmBaseUnitTests.$(buildPlatform).$(buildConfiguration)'
+      arguments: -TestFilePattern 'BuildOutput\$(buildConfiguration)\$(buildPlatform)\MrmBaseUnitTests\*.dll' -TestBinaryDirectoryPath '$(testPayloadDir)' -OutputProjFile '$(helixWorkItemsDir)\MrtCore-MrmBaseUnitTests.proj' -WorkItemPrefix 'MrtCore.MrmBaseUnitTests.$(buildPlatform).$(buildConfiguration)' -TestNamePrefix 'MrtCore.MrmBaseUnitTests.$(buildPlatform).$(buildConfiguration)'
 
   - task: powershell@2
     displayName: 'Discover MRT Core UnpackagedTests'
     inputs:
       targetType: filePath
       filePath: $(winUIHelixPipelineScripts)\GenerateHelixWorkItems.ps1
-      arguments: -TestFilePattern 'MrtCoreUnpackagedTests\*.dll' -TestBinaryDirectoryPath '$(testPayloadDir)' -OutputProjFile '$(helixWorkItemsDir)\MrtCore-MrtCoreUnpackagedTests.proj' -WorkItemPrefix 'MrtCore.MrtCoreUnpackagedTests.$(buildPlatform).$(buildConfiguration)' -TestNamePrefix 'MrtCore.MrtCoreUnpackagedTests.$(buildPlatform).$(buildConfiguration)'
+      arguments: -TestFilePattern 'BuildOutput\$(buildConfiguration)\$(buildPlatform)\MrtCoreUnpackagedTests\*.dll' -TestBinaryDirectoryPath '$(testPayloadDir)' -OutputProjFile '$(helixWorkItemsDir)\MrtCore-MrtCoreUnpackagedTests.proj' -WorkItemPrefix 'MrtCore.MrtCoreUnpackagedTests.$(buildPlatform).$(buildConfiguration)' -TestNamePrefix 'MrtCore.MrtCoreUnpackagedTests.$(buildPlatform).$(buildConfiguration)'
 
   # In Helix, test folders are under subfolders of TAEF. MRTCore UnpackagedTests use reg-free WinRT activation. It requires the winmd file
   # under same folder as the executable.
   - task: CopyFiles@2
     displayName: 'Copy Microsoft.Windows.ApplicationModel.Resources.winmd to test root'
     inputs:
-      sourceFolder: $(testPayloadDir)\MrtCoreUnpackagedTests
+      sourceFolder: $(testPayloadDir)\MrtCoreUnpackagedTests\MrtCoreUnpackagedTests
       contents: |
         Microsoft.Windows.ApplicationModel.Resources.winmd
       targetFolder: $(testPayloadDir)

--- a/build/AzurePipelinesTemplates/WindowsAppSDK-RunHelixTests-Job.yml
+++ b/build/AzurePipelinesTemplates/WindowsAppSDK-RunHelixTests-Job.yml
@@ -45,6 +45,8 @@ jobs:
     # This directory contains the Test payload, Helix test binaries and scripts. It is sent to the Helix machines.
     # Note: TAEF must be present in this directory, as GenerateHelixWorkItems.ps1 expects to invoke te.exe from here.
     # We download the BuildOutput artifact from the prior build stage(s) under this path.
+    # However, the artifacts also has it's down folder structure, which makes the resulting directory structure look like this:
+    #   $(Build.SourcesDirectory)\BuildOutput\$(buildConfiguration)\$(buildPlatform)\HelixTests\BuildOutput\$(buildConfiguration)\$(buildPlatform)
     testPayloadDir: $(Build.SourcesDirectory)\BuildOutput\$(buildConfiguration)\$(buildPlatform)\HelixTests
 
     # The generated .proj files are placed here.
@@ -95,6 +97,7 @@ jobs:
       restoreDirectory: packages
 
   # Download the BuildOutput from the Build stage(s).
+  # We only bring down the relevant content for this build config (Debug/Release) & platform, to save some space and time.
   - task: DownloadBuildArtifacts@0
     displayName: 'Download: BuildOutput'
     inputs:
@@ -107,15 +110,6 @@ jobs:
       Write-Host "$(Build.SourcesDirectory)"
       Tree /F /A $(Build.SourcesDirectory)
     displayName: 'DIAG: dir'
-
-  # # Publish the full testPayloadDir contents.
-  # # This is not required, but can be useful for debugging purposes.
-  # - task: PublishBuildArtifacts@1
-  #   displayName: 'Publish testPayloadDir'
-  #   condition: always()
-  #   inputs:
-  #     PathtoPublish: $(testPayloadDir)
-  #     artifactName: HelixTestPayloadDir_$(buildPlatform)_$(buildConfiguration)
 
   # Discover the TAEF test binaries to run and generate the Helix Work Items for them.
   # Note: There are 4 test suites for MRT Core. We currently run 3 of them in Helix.

--- a/build/AzurePipelinesTemplates/WindowsAppSDK-RunHelixTests-Job.yml
+++ b/build/AzurePipelinesTemplates/WindowsAppSDK-RunHelixTests-Job.yml
@@ -100,7 +100,7 @@ jobs:
     inputs:
       artifactName: 'BuildOutput'
       downloadPath: $(testPayloadDir)
-      itemPattern: 'BuildOutput/$(buildPlatform)/$(buildConfiguration)/**/*'
+      itemPattern: 'BuildOutput/$(buildConfiguration)/$(buildPlatform)/**/*'
 
   - powershell: |
       Write-Host ""

--- a/build/AzurePipelinesTemplates/WindowsAppSDK-RunHelixTests-Job.yml
+++ b/build/AzurePipelinesTemplates/WindowsAppSDK-RunHelixTests-Job.yml
@@ -100,7 +100,7 @@ jobs:
     inputs:
       artifactName: 'BuildOutput'
       downloadPath: $(testPayloadDir)
-      itemPattern: '$(buildPlatform)/$(buildConfiguration)/**/*'
+      itemPattern: 'BuildOutput/$(buildPlatform)/$(buildConfiguration)/**/*'
 
   - powershell: |
       Write-Host ""

--- a/build/AzurePipelinesTemplates/WindowsAppSDK-RunHelixTests-Job.yml
+++ b/build/AzurePipelinesTemplates/WindowsAppSDK-RunHelixTests-Job.yml
@@ -105,12 +105,6 @@ jobs:
       downloadPath: $(testPayloadDir)
       itemPattern: 'BuildOutput/$(buildConfiguration)/$(buildPlatform)/**/*'
 
-  - powershell: |
-      Write-Host ""
-      Write-Host "$(Build.SourcesDirectory)"
-      Tree /F /A $(Build.SourcesDirectory)
-    displayName: 'DIAG: dir'
-
   # Discover the TAEF test binaries to run and generate the Helix Work Items for them.
   # Note: There are 4 test suites for MRT Core. We currently run 3 of them in Helix.
   - task: powershell@2

--- a/build/AzurePipelinesTemplates/WindowsAppSDK-RunHelixTests-Job.yml
+++ b/build/AzurePipelinesTemplates/WindowsAppSDK-RunHelixTests-Job.yml
@@ -44,6 +44,7 @@ jobs:
 
     # This directory contains the Test payload, Helix test binaries and scripts. It is sent to the Helix machines.
     # Note: TAEF must be present in this directory, as GenerateHelixWorkItems.ps1 expects to invoke te.exe from here.
+    # We download the BuildOutput artifact from the prior build stage(s) under this path.
     testPayloadDir: $(Build.SourcesDirectory)\BuildOutput\$(buildConfiguration)\$(buildPlatform)\HelixTests
 
     # The generated .proj files are placed here.
@@ -93,21 +94,28 @@ jobs:
       nugetConfigPath: nuget.config
       restoreDirectory: packages
 
-  # Download the MRT Core test binaries
-  - task: DownloadBuildArtifacts@0
-    displayName: 'Download: Binaries'
+  # Download the BuildOutput from the Build stage(s).
+  - task: DownloadPipelineArtifact@0
+    displayName: 'Download: BuildOutput'
     inputs:
-      artifactName: 'mrtcore_test_binaries_$(buildPlatform)'
+      artifactName: 'BuildOutput'
       downloadPath: $(testPayloadDir)
+      patterns: '$(buildPlatform)/$(buildConfiguration)/**/*'
 
-  # Publish the full testPayloadDir contents.
-  # This is not required, but can be useful for debugging purposes.
-  - task: PublishBuildArtifacts@1
-    displayName: 'Publish testPayloadDir'
-    condition: always()
-    inputs:
-      PathtoPublish: $(testPayloadDir)
-      artifactName: HelixTestPayloadDir_$(buildPlatform)_$(buildConfiguration)
+  - powershell: |
+      Write-Host ""
+      Write-Host "$(Build.SourcesDirectory)"
+      Tree /F /A $(Build.SourcesDirectory)
+    displayName: 'DIAG: dir'
+
+  # # Publish the full testPayloadDir contents.
+  # # This is not required, but can be useful for debugging purposes.
+  # - task: PublishBuildArtifacts@1
+  #   displayName: 'Publish testPayloadDir'
+  #   condition: always()
+  #   inputs:
+  #     PathtoPublish: $(testPayloadDir)
+  #     artifactName: HelixTestPayloadDir_$(buildPlatform)_$(buildConfiguration)
 
   # Discover the TAEF test binaries to run and generate the Helix Work Items for them.
   # Note: There are 4 test suites for MRT Core. We currently run 3 of them in Helix.
@@ -116,28 +124,28 @@ jobs:
     inputs:
       targetType: filePath
       filePath: $(winUIHelixPipelineScripts)\GenerateHelixWorkItems.ps1
-      arguments: -TestFilePattern 'mrtcore_test_binaries_$(buildPlatform)\MrmUnitTest\*.dll' -TestBinaryDirectoryPath '$(testPayloadDir)' -OutputProjFile '$(helixWorkItemsDir)\MrtCore-MrmUnitTests.proj' -WorkItemPrefix 'MrtCore.MrmUnitTests.$(buildPlatform).$(buildConfiguration)' -TestNamePrefix 'MrtCore.MrmUnitTests.$(buildPlatform).$(buildConfiguration)'
+      arguments: -TestFilePattern 'MrmUnitTest\*.dll' -TestBinaryDirectoryPath '$(testPayloadDir)' -OutputProjFile '$(helixWorkItemsDir)\MrtCore-MrmUnitTests.proj' -WorkItemPrefix 'MrtCore.MrmUnitTests.$(buildPlatform).$(buildConfiguration)' -TestNamePrefix 'MrtCore.MrmUnitTests.$(buildPlatform).$(buildConfiguration)'
 
   - task: powershell@2
     displayName: 'Discover MRT Core BaseUnitTests'
     inputs:
       targetType: filePath
       filePath: $(winUIHelixPipelineScripts)\GenerateHelixWorkItems.ps1
-      arguments: -TestFilePattern 'mrtcore_test_binaries_$(buildPlatform)\MrmBaseUnitTests\*.dll' -TestBinaryDirectoryPath '$(testPayloadDir)' -OutputProjFile '$(helixWorkItemsDir)\MrtCore-MrmBaseUnitTests.proj' -WorkItemPrefix 'MrtCore.MrmBaseUnitTests.$(buildPlatform).$(buildConfiguration)' -TestNamePrefix 'MrtCore.MrmBaseUnitTests.$(buildPlatform).$(buildConfiguration)'
+      arguments: -TestFilePattern 'MrmBaseUnitTests\*.dll' -TestBinaryDirectoryPath '$(testPayloadDir)' -OutputProjFile '$(helixWorkItemsDir)\MrtCore-MrmBaseUnitTests.proj' -WorkItemPrefix 'MrtCore.MrmBaseUnitTests.$(buildPlatform).$(buildConfiguration)' -TestNamePrefix 'MrtCore.MrmBaseUnitTests.$(buildPlatform).$(buildConfiguration)'
 
   - task: powershell@2
     displayName: 'Discover MRT Core UnpackagedTests'
     inputs:
       targetType: filePath
       filePath: $(winUIHelixPipelineScripts)\GenerateHelixWorkItems.ps1
-      arguments: -TestFilePattern 'mrtcore_test_binaries_$(buildPlatform)\MrtCoreUnpackagedTests\*.dll' -TestBinaryDirectoryPath '$(testPayloadDir)' -OutputProjFile '$(helixWorkItemsDir)\MrtCore-MrtCoreUnpackagedTests.proj' -WorkItemPrefix 'MrtCore.MrtCoreUnpackagedTests.$(buildPlatform).$(buildConfiguration)' -TestNamePrefix 'MrtCore.MrtCoreUnpackagedTests.$(buildPlatform).$(buildConfiguration)'
+      arguments: -TestFilePattern 'MrtCoreUnpackagedTests\*.dll' -TestBinaryDirectoryPath '$(testPayloadDir)' -OutputProjFile '$(helixWorkItemsDir)\MrtCore-MrtCoreUnpackagedTests.proj' -WorkItemPrefix 'MrtCore.MrtCoreUnpackagedTests.$(buildPlatform).$(buildConfiguration)' -TestNamePrefix 'MrtCore.MrtCoreUnpackagedTests.$(buildPlatform).$(buildConfiguration)'
 
   # In Helix, test folders are under subfolders of TAEF. MRTCore UnpackagedTests use reg-free WinRT activation. It requires the winmd file
   # under same folder as the executable.
   - task: CopyFiles@2
     displayName: 'Copy Microsoft.Windows.ApplicationModel.Resources.winmd to test root'
     inputs:
-      sourceFolder: $(testPayloadDir)\mrtcore_test_binaries_$(buildPlatform)\MrtCoreUnpackagedTests
+      sourceFolder: $(testPayloadDir)\MrtCoreUnpackagedTests
       contents: |
         Microsoft.Windows.ApplicationModel.Resources.winmd
       targetFolder: $(testPayloadDir)

--- a/build/ProjectReunion-CI.yml
+++ b/build/ProjectReunion-CI.yml
@@ -3,6 +3,8 @@ name: $(BuildDefinitionName)_$(date:yyMM).$(date:dd)$(rev:rrr)
 variables:
 - template: WindowsAppSDK-Versions.yml
 - template: WindowsAppSDK-CommonVariables.yml
+- name: buildOutputDir
+  value: $(Build.SourcesDirectory)\BuildOutput
 
 jobs:
 - job: CredScan
@@ -55,7 +57,6 @@ jobs:
         buildConfiguration: 'Release'
 
   variables:
-    buildOutputDir : $(Build.SourcesDirectory)\BuildOutput
     publishDir : $(Build.ArtifactStagingDirectory)
   steps:
   - template: AzurePipelinesTemplates\WindowsAppSDK-BuildDevProject-Steps.yml
@@ -63,6 +64,12 @@ jobs:
       channel: ${{ variables.channel }}
 
   - template: AzurePipelinesTemplates\WindowsAppSDK-PublishProjectOutput-Steps.yml
+
+  - task: PublishBuildArtifacts@1
+    displayName: 'Publish BuildOutput'
+    inputs:
+      PathtoPublish: '$(buildOutputDir)'
+      artifactName: BuildOutput
 
   - task: BinSkim@3
     inputs:
@@ -110,12 +117,19 @@ jobs:
     parameters:
       buildJobName: 'BuildMRTCore'
 
+  - task: PublishBuildArtifacts@1
+    displayName: 'Publish BuildOutput'
+    inputs:
+      PathtoPublish: '$(buildOutputDir)'
+      artifactName: BuildOutput
+
   - task: BinSkim@3
     inputs:
       InputType: 'Basic'
       Function: 'analyze'
       AnalyzeTarget: '$(Build.ArtifactStagingDirectory)\*.dll;$(Build.ArtifactStagingDirectory)\*.exe'
       AnalyzeVerbose: true
+
   - task: PostAnalysis@1
     inputs:
       AllTools: false

--- a/build/ProjectReunion-CI.yml
+++ b/build/ProjectReunion-CI.yml
@@ -69,7 +69,7 @@ jobs:
     displayName: 'Publish BuildOutput'
     inputs:
       artifactName: BuildOutput
-      targetPath: '$(buildOutputDir)'
+      PathtoPublish: '$(buildOutputDir)'
 
   - task: BinSkim@3
     inputs:
@@ -121,7 +121,7 @@ jobs:
     displayName: 'Publish BuildOutput'
     inputs:
       artifactName: BuildOutput
-      targetPath: '$(buildOutputDir)'
+      PathtoPublish: '$(buildOutputDir)'
 
   - task: BinSkim@3
     inputs:

--- a/build/ProjectReunion-CI.yml
+++ b/build/ProjectReunion-CI.yml
@@ -65,11 +65,12 @@ jobs:
 
   - template: AzurePipelinesTemplates\WindowsAppSDK-PublishProjectOutput-Steps.yml
 
-  - task: PublishBuildArtifacts@1
+  - task: PublishPipelineArtifact@1
     displayName: 'Publish BuildOutput'
     inputs:
-      PathtoPublish: '$(buildOutputDir)'
+      artifactType: pipeline
       artifactName: BuildOutput
+      targetPath: '$(buildOutputDir)'
 
   - task: BinSkim@3
     inputs:
@@ -117,11 +118,12 @@ jobs:
     parameters:
       buildJobName: 'BuildMRTCore'
 
-  - task: PublishBuildArtifacts@1
+  - task: PublishPipelineArtifact@1
     displayName: 'Publish BuildOutput'
     inputs:
-      PathtoPublish: '$(buildOutputDir)'
+      artifactType: pipeline
       artifactName: BuildOutput
+      targetPath: '$(buildOutputDir)'
 
   - task: BinSkim@3
     inputs:

--- a/build/ProjectReunion-CI.yml
+++ b/build/ProjectReunion-CI.yml
@@ -65,10 +65,9 @@ jobs:
 
   - template: AzurePipelinesTemplates\WindowsAppSDK-PublishProjectOutput-Steps.yml
 
-  - task: PublishPipelineArtifact@1
+  - task: PublishBuildArtifacts@1
     displayName: 'Publish BuildOutput'
     inputs:
-      artifactType: pipeline
       artifactName: BuildOutput
       targetPath: '$(buildOutputDir)'
 
@@ -118,10 +117,9 @@ jobs:
     parameters:
       buildJobName: 'BuildMRTCore'
 
-  - task: PublishPipelineArtifact@1
+  - task: PublishBuildArtifacts@1
     displayName: 'Publish BuildOutput'
     inputs:
-      artifactType: pipeline
       artifactName: BuildOutput
       targetPath: '$(buildOutputDir)'
 

--- a/build/build-mrt.yml
+++ b/build/build-mrt.yml
@@ -180,26 +180,6 @@ steps:
     platform: '$(buildPlatform)'
     configuration: '$(buildConfiguration)'
 
-# Copy and Publish the test binaries so we can run them in Helix later.
-- task: CopyFiles@2
-  displayName: 'copy mrtcore test binaries'
-  condition: and(succeeded(), or(eq(variables['buildPlatform'], 'x86'), eq(variables['buildPlatform'], 'x64')))
-  inputs:
-    SourceFolder: '${{ parameters.MRTBinariesDirectory }}\Release\$(buildPlatform)'
-    Contents: |
-      MrmBaseUnitTests\**
-      MrmUnitTest\**
-      MrtCoreManagedTest\**
-      MrtCoreUnpackagedTests\**
-    TargetFolder: '$(Agent.TempDirectory)\mrt_testbin\$(buildPlatform)'
-
-- task: PublishBuildArtifacts@1
-  displayName: 'Publish mrtcore test binaries'
-  condition: and(succeeded(), or(eq(variables['buildPlatform'], 'x86'), eq(variables['buildPlatform'], 'x64')))
-  inputs:
-    PathtoPublish: '$(Agent.TempDirectory)\mrt_testbin\$(buildPlatform)'
-    artifactName: mrtcore_test_binaries_$(buildPlatform)
-
 - task: ComponentGovernanceComponentDetection@0
   inputs:
     scanType: 'Register'


### PR DESCRIPTION
This change modifies the build pipeline to publish the entire `BuildOutput` folder as an artifact, so that we can download it later  in the test stage of the pipeline, and then push it over to Helix. (This is make enabling more tests in Helix easier in the future.)

This also removes the previous build artifact that was published containing the MRT Core test binaries, and uses the `BuildOutput` artifact instead for running the MRT cores. 
(So this is doing both Step 1 & 2 together at the same time.)