### PR TITLE
Remove the Handled property from PushNotificationReceivedEventArgs

### DIFF
--- a/dev/PushNotifications/PushNotificationManager.cpp
+++ b/dev/PushNotifications/PushNotificationManager.cpp
@@ -600,8 +600,16 @@ namespace winrt::Microsoft::Windows::PushNotifications::implementation
         auto args = winrt::make<winrt::Microsoft::Windows::PushNotifications::implementation::PushNotificationReceivedEventArgs>(payload, length);
 
         auto lock{ m_lock.lock_exclusive() };
-        m_foregroundHandlers(*this, args);
-        *foregroundHandled = args.Handled();
+        if (m_foregroundHandlers)
+        {
+            m_foregroundHandlers(*this, args);
+            *foregroundHandled = true;
+        }
+        else
+        {
+            *foregroundHandled = false;
+        }   
+        
         return S_OK;
     }
     CATCH_RETURN()

--- a/dev/PushNotifications/PushNotificationManager.cpp
+++ b/dev/PushNotifications/PushNotificationManager.cpp
@@ -599,7 +599,7 @@ namespace winrt::Microsoft::Windows::PushNotifications::implementation
     {
         auto args = winrt::make<winrt::Microsoft::Windows::PushNotifications::implementation::PushNotificationReceivedEventArgs>(payload, length);
 
-        auto lock{ m_lock.lock_exclusive() };
+        auto lock{ m_lock.lock_shared() };
         if (m_foregroundHandlers)
         {
             m_foregroundHandlers(*this, args);

--- a/dev/PushNotifications/PushNotificationReceivedEventArgs.cpp
+++ b/dev/PushNotifications/PushNotificationReceivedEventArgs.cpp
@@ -35,7 +35,6 @@ namespace winrt::Microsoft::Windows::PushNotifications::implementation
     }
 
     PushNotificationReceivedEventArgs::PushNotificationReceivedEventArgs(winrt::PushNotificationReceivedEventArgs const& args):
-        m_args(args),
         m_rawNotificationPayload(BuildPayload(args.RawNotification().ContentBytes())),
         m_unpackagedAppScenario(false)
     {

--- a/dev/PushNotifications/PushNotificationReceivedEventArgs.cpp
+++ b/dev/PushNotifications/PushNotificationReceivedEventArgs.cpp
@@ -115,33 +115,5 @@ namespace winrt::Microsoft::Windows::PushNotifications::implementation
             m_backgroundTaskInstance.Canceled(token);
         }
     }
-
-    bool PushNotificationReceivedEventArgs::Handled()
-    {
-        if (!m_unpackagedAppScenario)
-        {
-            THROW_HR_IF_NULL_MSG(E_ILLEGAL_METHOD_CALL, m_args, "Background activation cannot call this.");
-
-            return m_args.Cancel();
-        }
-        else
-        {
-            return m_handledUnpackaged;
-        }
-    }
-
-    void PushNotificationReceivedEventArgs::Handled(bool value)
-    {
-        if (!m_unpackagedAppScenario)
-        {
-            THROW_HR_IF_NULL_MSG(E_ILLEGAL_METHOD_CALL, m_args, "Background activation cannot call this.");
-
-            m_args.Cancel(value);
-        }
-        else
-        {
-            m_handledUnpackaged = value;
-        }
-    }
 }
 

--- a/dev/PushNotifications/PushNotificationReceivedEventArgs.h
+++ b/dev/PushNotifications/PushNotificationReceivedEventArgs.h
@@ -31,9 +31,7 @@ namespace winrt::Microsoft::Windows::PushNotifications::implementation
         std::vector<uint8_t> m_rawNotificationPayload;
 
         const winrt::Windows::ApplicationModel::Background::IBackgroundTaskInstance m_backgroundTaskInstance{};
-        const winrt::Windows::Networking::PushNotifications::PushNotificationReceivedEventArgs m_args = nullptr;
 
         bool m_unpackagedAppScenario;
-        bool m_handledUnpackaged = true;
     };
 }

--- a/dev/PushNotifications/PushNotificationReceivedEventArgs.h
+++ b/dev/PushNotifications/PushNotificationReceivedEventArgs.h
@@ -20,8 +20,6 @@ namespace winrt::Microsoft::Windows::PushNotifications::implementation
         winrt::Windows::ApplicationModel::Background::BackgroundTaskDeferral GetDeferral();
         winrt::event_token Canceled(winrt::Windows::ApplicationModel::Background::BackgroundTaskCanceledEventHandler const& handler);
         void Canceled(winrt::event_token const& token) noexcept;
-        bool Handled();
-        void Handled(bool value);
 
     private:
         const winrt::Windows::Storage::Streams::IBuffer m_rawNotification{};

--- a/dev/PushNotifications/PushNotifications.idl
+++ b/dev/PushNotifications/PushNotifications.idl
@@ -17,10 +17,6 @@ namespace Microsoft.Windows.PushNotifications
 
         // Subscribe to Cancelled event handler to be signalled when resource policies are no longer true like 30s wallclock timer
         event Windows.ApplicationModel.Background.BackgroundTaskCanceledEventHandler Canceled;
-
-        // Indicates if the foreground push notification will be re-posted through background activation.
-        // Default value is false, which allows re-posting.
-        Boolean Handled;
     };
 
     [feature(Feature_PushNotifications)]

--- a/test/TestApps/PushNotificationsDemoApp/main.cpp
+++ b/test/TestApps/PushNotificationsDemoApp/main.cpp
@@ -103,7 +103,6 @@ int main()
             // Do stuff to process the raw payload
             std::string payloadString(payload.begin(), payload.end());
             std::cout << "Push notification content received from FOREGROUND: " << payloadString << std::endl << std::endl;
-            args.Handled(true);
         });
 
     AppNotificationManager::Default().Register();


### PR DESCRIPTION
Update the idl and all the callers on the WindowsAppSDK and the demo and test apps.
Verified that the Push Notification tests keep passing.