### PR TITLE
Address Bug in Registry access Read/Write operations

### DIFF
--- a/build/NuSpecs/AppxManifest.xml
+++ b/build/NuSpecs/AppxManifest.xml
@@ -55,11 +55,13 @@
 
           <!-- PowerNotifications -->
           <ActivatableClass ActivatableClassId="Microsoft.Windows.System.Power.PowerManager" ThreadingModel="both" />
-		  
-		  <!-- ToastNotifications -->
-		  <ActivatableClass ActivatableClassId="Microsoft.Windows.ToastNotifications.ToastActivationInfo" ThreadingModel="both" />
-		  <ActivatableClass ActivatableClassId="Microsoft.Windows.ToastNotifications.ToastAssets" ThreadingModel="both" />
-		  <ActivatableClass ActivatableClassId="Microsoft.Windows.ToastNotifications.ToastNotificationManager" ThreadingModel="both" />
+
+          <!-- AppNotifications -->
+          <ActivatableClass ActivatableClassId="Microsoft.Windows.AppNotifications.AppNotificationActivationInfo" ThreadingModel="both" />
+          <ActivatableClass ActivatableClassId="Microsoft.Windows.AppNotifications.AppNotificationManager" ThreadingModel="both" />
+          <ActivatableClass ActivatableClassId="Microsoft.Windows.AppNotifications.AppNotification" ThreadingModel="both" />
+          <ActivatableClass ActivatableClassId="Microsoft.Windows.AppNotifications.AppNotificationProgressData" ThreadingModel="both" />
+          <ActivatableClass ActivatableClassId="Microsoft.Windows.AppNotifications.AppNotificationProgressResult" ThreadingModel="both" />
 
           <!-- AccessControl -->
           <ActivatableClass ActivatableClassId="Microsoft.Windows.Security.AccessControl.SecurityDescriptorHelpers" ThreadingModel="both" />

--- a/build/NuSpecs/AppxManifest.xml
+++ b/build/NuSpecs/AppxManifest.xml
@@ -57,11 +57,11 @@
           <ActivatableClass ActivatableClassId="Microsoft.Windows.System.Power.PowerManager" ThreadingModel="both" />
 
           <!-- AppNotifications -->
-          <ActivatableClass ActivatableClassId="Microsoft.Windows.AppNotifications.AppNotificationActivationInfo" ThreadingModel="both" />
           <ActivatableClass ActivatableClassId="Microsoft.Windows.AppNotifications.AppNotificationManager" ThreadingModel="both" />
           <ActivatableClass ActivatableClassId="Microsoft.Windows.AppNotifications.AppNotification" ThreadingModel="both" />
           <ActivatableClass ActivatableClassId="Microsoft.Windows.AppNotifications.AppNotificationProgressData" ThreadingModel="both" />
           <ActivatableClass ActivatableClassId="Microsoft.Windows.AppNotifications.AppNotificationProgressResult" ThreadingModel="both" />
+          <ActivatableClass ActivatableClassId="Microsoft.Windows.AppNotifications.AppNotificationActivatedEventArgs" ThreadingModel="both" />
 
           <!-- AccessControl -->
           <ActivatableClass ActivatableClassId="Microsoft.Windows.Security.AccessControl.SecurityDescriptorHelpers" ThreadingModel="both" />

--- a/build/NuSpecs/AppxManifest.xml
+++ b/build/NuSpecs/AppxManifest.xml
@@ -60,7 +60,6 @@
           <ActivatableClass ActivatableClassId="Microsoft.Windows.AppNotifications.AppNotificationManager" ThreadingModel="both" />
           <ActivatableClass ActivatableClassId="Microsoft.Windows.AppNotifications.AppNotification" ThreadingModel="both" />
           <ActivatableClass ActivatableClassId="Microsoft.Windows.AppNotifications.AppNotificationProgressData" ThreadingModel="both" />
-          <ActivatableClass ActivatableClassId="Microsoft.Windows.AppNotifications.AppNotificationProgressResult" ThreadingModel="both" />
           <ActivatableClass ActivatableClassId="Microsoft.Windows.AppNotifications.AppNotificationActivatedEventArgs" ThreadingModel="both" />
 
           <!-- AccessControl -->

--- a/dev/AppNotifications/AppNotificationManager.cpp
+++ b/dev/AppNotifications/AppNotificationManager.cpp
@@ -58,10 +58,10 @@ namespace winrt::Microsoft::Windows::AppNotifications::implementation
         std::wstring storedComActivatorString;
         if (!PushNotificationHelpers::IsPackagedAppScenario())
         {
-            std::wstring toastAppId{ RetrieveNotificationAppId() };
+            std::wstring notificationId{ RetrieveNotificationAppId() };
             if (!AppModel::Identity::IsPackagedProcess())
             {
-                THROW_IF_FAILED(PushNotifications_RegisterFullTrustApplication(toastAppId.c_str(), GUID_NULL));
+                THROW_IF_FAILED(PushNotifications_RegisterFullTrustApplication(notificationId.c_str(), GUID_NULL));
 
                 storedComActivatorString = RegisterComActivatorGuidAndAssets();
                 // Remove braces around the guid string
@@ -71,7 +71,7 @@ namespace winrt::Microsoft::Windows::AppNotifications::implementation
             wil::unique_cotaskmem_string processName;
             THROW_IF_FAILED(GetCurrentProcessPath(processName));
             auto notificationPlatform{ PushNotificationHelpers::GetNotificationPlatform() };
-            THROW_IF_FAILED(notificationPlatform->AddToastRegistrationMapping(processName.get(), toastAppId.c_str()));
+            THROW_IF_FAILED(notificationPlatform->AddToastRegistrationMapping(processName.get(), notificationId.c_str()));
         }
 
         winrt::guid registeredClsid{ GUID_NULL };
@@ -120,13 +120,13 @@ namespace winrt::Microsoft::Windows::AppNotifications::implementation
 
         if (!AppModel::Identity::IsPackagedProcess())
         {
-            std::wstring toastAppId{ RetrieveNotificationAppId() };
+            std::wstring notificationId{ RetrieveNotificationAppId() };
             std::wstring storedComActivatorString;
-            THROW_IF_WIN32_ERROR(GetActivatorGuid(storedComActivatorString));
+            THROW_IF_FAILED(GetActivatorGuid(storedComActivatorString));
             UnRegisterComServer(storedComActivatorString);
             
             UnRegisterNotificationAppIdentifierFromRegistry();
-            THROW_IF_FAILED(PushNotifications_UnregisterFullTrustApplication(toastAppId.c_str()));
+            THROW_IF_FAILED(PushNotifications_UnregisterFullTrustApplication(notificationId.c_str()));
         }
     }
 

--- a/dev/AppNotifications/AppNotificationUtility.cpp
+++ b/dev/AppNotifications/AppNotificationUtility.cpp
@@ -49,7 +49,7 @@ std::wstring Microsoft::Windows::AppNotifications::Helpers::RetrieveUnpackagedNo
         std::wstring subKey{ c_appIdentifierPath + ConvertPathToKey(wideStringProcessName) };
 
         wil::unique_hkey hKey;
-        THROW_IF_FAILED(RegCreateKeyEx(
+        THROW_IF_WIN32_ERROR(RegCreateKeyEx(
             HKEY_CURRENT_USER,
             subKey.c_str(),
             0,
@@ -62,7 +62,7 @@ std::wstring Microsoft::Windows::AppNotifications::Helpers::RetrieveUnpackagedNo
 
         WCHAR registeredGuidBuffer[GUID_LENGTH];
         DWORD bufferLength = sizeof(registeredGuidBuffer);
-        HRESULT status = RegGetValueW(
+        auto status = RegGetValueW(
             hKey.get(),
             nullptr /* lpValue */,
             L"NotificationGUID",
@@ -84,7 +84,7 @@ std::wstring Microsoft::Windows::AppNotifications::Helpers::RetrieveUnpackagedNo
             return guidWideStr;
         }
 
-        THROW_HR_IF(status, FAILED_WIN32(status));
+        THROW_IF_WIN32_ERROR(status);
         return registeredGuidBuffer;
     }
 }
@@ -109,7 +109,7 @@ void Microsoft::Windows::AppNotifications::Helpers::RegisterComServer(wil::uniqu
     //subKey: Software\Classes\CLSID\{comActivatorGuidString}\LocalServer32
     std::wstring subKey{ c_clsIdPath + clsid.get() + LR"(\LocalServer32)" };
 
-    THROW_IF_FAILED(RegCreateKeyEx(
+    THROW_IF_WIN32_ERROR(RegCreateKeyEx(
         HKEY_CURRENT_USER,
         subKey.c_str(),
         0,
@@ -128,13 +128,22 @@ void Microsoft::Windows::AppNotifications::Helpers::RegisterComServer(wil::uniqu
 void Microsoft::Windows::AppNotifications::Helpers::UnRegisterComServer(std::wstring const& clsid)
 {
     wil::unique_hkey hKey;
-    //subKey: Software\Classes\CLSID\{comActivatorGuidString}\LocalServer32
-    std::wstring subKey{ c_clsIdPath + clsid + LR"(\LocalServer32)" };
+    //clsidPath: Software\Classes\CLSID\{comActivatorGuidString}
+    std::wstring clsidPath{ c_clsIdPath + clsid };
 
-    THROW_IF_FAILED(RegDeleteKeyEx(
+    //subKey: Software\Classes\CLSID\{comActivatorGuidString}\LocalServer32
+    std::wstring subKey{ clsidPath + LR"(\LocalServer32)" };
+
+    THROW_IF_WIN32_ERROR(RegDeleteKeyEx(
         HKEY_CURRENT_USER,
         subKey.c_str(),
-        KEY_WOW64_64KEY,
+        KEY_ALL_ACCESS,
+        0));
+
+    THROW_IF_WIN32_ERROR(RegDeleteKeyEx(
+        HKEY_CURRENT_USER,
+        clsidPath.c_str(),
+        KEY_ALL_ACCESS,
         0));
 }
 
@@ -142,20 +151,16 @@ void Microsoft::Windows::AppNotifications::Helpers::UnRegisterNotificationAppIde
 {
     wil::unique_cotaskmem_string appId;
 
-    if (SUCCEEDED(GetCurrentProcessExplicitAppUserModelID(&appId)))
-    {
-        return;
-    }
     std::wstring notificationAppId{ RetrieveNotificationAppId() };
 
     wil::unique_hkey hKey;
     //subKey: \Software\Classes\AppUserModelId\{AppGUID}
     std::wstring subKey{ c_appIdentifierPath + notificationAppId };
 
-    THROW_IF_FAILED(RegDeleteKeyEx(
+    THROW_IF_WIN32_ERROR(RegDeleteKeyEx(
         HKEY_CURRENT_USER,
         subKey.c_str(),
-        KEY_WOW64_64KEY,
+        KEY_ALL_ACCESS,
         0));
 }
 
@@ -166,7 +171,7 @@ HRESULT Microsoft::Windows::AppNotifications::Helpers::GetActivatorGuid(std::wst
     std::wstring subKey{ c_appIdentifierPath + notificationAppId };
 
     wil::unique_hkey hKey;
-    THROW_IF_FAILED(RegCreateKeyEx(
+    THROW_IF_WIN32_ERROR(RegCreateKeyEx(
         HKEY_CURRENT_USER,
         subKey.c_str(),
         0,
@@ -179,17 +184,36 @@ HRESULT Microsoft::Windows::AppNotifications::Helpers::GetActivatorGuid(std::wst
 
     WCHAR activatorGuidBuffer[GUID_LENGTH];
     DWORD bufferLength = sizeof(activatorGuidBuffer);
-    HRESULT status = RegGetValueW(
+    THROW_IF_WIN32_ERROR(RegGetValueW(
         hKey.get(),
         nullptr /* lpValue */,
         L"CustomActivator",
         RRF_RT_REG_SZ,
         nullptr /* pdwType */,
         &activatorGuidBuffer,
-        &bufferLength);
+        &bufferLength));
 
     activatorGuid = activatorGuidBuffer;
-    return status;
+
+    // We want to verify the integrity of this COM registration in path: Software\Classes\CLSID\{comActivatorGuidString}\LocalServer32
+    // This would indicate data corruption in which case we create a new activator entry later on.
+    subKey = c_clsIdPath + activatorGuid + LR"(\LocalServer32)";
+    auto status = RegOpenKeyEx(
+        HKEY_CURRENT_USER,
+        subKey.c_str(),
+        0,
+        KEY_READ,
+        &hKey);
+
+    // If there is an activator GUID mismatch in the 2 paths, we should return ERROR_FILE_NOT_FOUND so that we can recreate the ActivatorGuid in the upper layers
+    if (FAILED_WIN32(status))
+    {
+        return HRESULT_FROM_WIN32(ERROR_FILE_NOT_FOUND);
+    }
+    else
+    {
+        return S_OK;
+    }
 }
 CATCH_RETURN()
 
@@ -199,7 +223,7 @@ void Microsoft::Windows::AppNotifications::Helpers::RegisterAssets(std::wstring 
     // subKey: \Software\Classes\AppUserModelId\{AppGUID}
     std::wstring subKey{ c_appIdentifierPath + appId };
 
-    THROW_IF_FAILED(RegCreateKeyEx(
+    THROW_IF_WIN32_ERROR(RegCreateKeyEx(
         HKEY_CURRENT_USER,
         subKey.c_str(),
         0,
@@ -274,11 +298,9 @@ void Microsoft::Windows::AppNotifications::Helpers::RegisterAssets(std::wstring 
 std::wstring Microsoft::Windows::AppNotifications::Helpers::RegisterComActivatorGuidAndAssets()
 {
     std::wstring registeredGuid;
-    HRESULT status = GetActivatorGuid(registeredGuid);
+    auto hr = GetActivatorGuid(registeredGuid);
 
-    THROW_HR_IF(status, FAILED(status) && status != HRESULT_FROM_WIN32(ERROR_FILE_NOT_FOUND));
-
-    if (status == ERROR_FILE_NOT_FOUND)
+    if (hr == HRESULT_FROM_WIN32(ERROR_FILE_NOT_FOUND))
     {
         // Get process name to identify the app 
         wil::unique_cotaskmem_string processName;
@@ -294,6 +316,10 @@ std::wstring Microsoft::Windows::AppNotifications::Helpers::RegisterComActivator
         RegisterComServer(processName, comActivatorGuidString);
 
         registeredGuid = comActivatorGuidString.get();
+    }
+    else
+    {
+        THROW_IF_FAILED(hr);
     }
 
     std::wstring notificationAppId{ RetrieveNotificationAppId() };

--- a/dev/AppNotifications/AppNotificationUtility.h
+++ b/dev/AppNotifications/AppNotificationUtility.h
@@ -32,7 +32,7 @@ namespace Microsoft::Windows::AppNotifications::Helpers
 
     inline void RegisterValue(wil::unique_hkey const& hKey, PCWSTR const& key, const BYTE* value, DWORD const& valueType, size_t const& size)
     {
-        THROW_IF_FAILED(RegSetValueExW(hKey.get(), key, 0, valueType, value, (DWORD)size));
+        THROW_IF_WIN32_ERROR(RegSetValueExW(hKey.get(), key, 0, valueType, value, static_cast<DWORD>(size)));
     }
 
     inline wil::unique_hstring safe_make_unique_hstring(PCWSTR str)

--- a/test/Deployment/data/WindowsAppRuntime.Test.Framework/appxmanifest.xml
+++ b/test/Deployment/data/WindowsAppRuntime.Test.Framework/appxmanifest.xml
@@ -74,11 +74,11 @@
     <Extension Category="windows.activatableClass.inProcessServer">
         <InProcessServer>
             <Path>Microsoft.WindowsAppRuntime.dll</Path>
-            <ActivatableClass ActivatableClassId="Microsoft.Windows.AppNotifications.AppNotificationActivationInfo" ThreadingModel="both" />
             <ActivatableClass ActivatableClassId="Microsoft.Windows.AppNotifications.AppNotificationManager" ThreadingModel="both" />
             <ActivatableClass ActivatableClassId="Microsoft.Windows.AppNotifications.AppNotification" ThreadingModel="both" />
             <ActivatableClass ActivatableClassId="Microsoft.Windows.AppNotifications.AppNotificationProgressData" ThreadingModel="both" />
             <ActivatableClass ActivatableClassId="Microsoft.Windows.AppNotifications.AppNotificationProgressResult" ThreadingModel="both" />
+            <ActivatableClass ActivatableClassId="Microsoft.Windows.AppNotifications.AppNotificationActivatedEventArgs" ThreadingModel="both" />
         </InProcessServer>
     </Extension>
     <Extension Category="windows.activatableClass.inProcessServer">

--- a/test/Deployment/data/WindowsAppRuntime.Test.Framework/appxmanifest.xml
+++ b/test/Deployment/data/WindowsAppRuntime.Test.Framework/appxmanifest.xml
@@ -77,7 +77,6 @@
             <ActivatableClass ActivatableClassId="Microsoft.Windows.AppNotifications.AppNotificationManager" ThreadingModel="both" />
             <ActivatableClass ActivatableClassId="Microsoft.Windows.AppNotifications.AppNotification" ThreadingModel="both" />
             <ActivatableClass ActivatableClassId="Microsoft.Windows.AppNotifications.AppNotificationProgressData" ThreadingModel="both" />
-            <ActivatableClass ActivatableClassId="Microsoft.Windows.AppNotifications.AppNotificationProgressResult" ThreadingModel="both" />
             <ActivatableClass ActivatableClassId="Microsoft.Windows.AppNotifications.AppNotificationActivatedEventArgs" ThreadingModel="both" />
         </InProcessServer>
     </Extension>

--- a/test/DynamicDependency/data/Microsoft.WindowsAppRuntime.Framework/appxmanifest.xml
+++ b/test/DynamicDependency/data/Microsoft.WindowsAppRuntime.Framework/appxmanifest.xml
@@ -74,11 +74,11 @@
     <Extension Category="windows.activatableClass.inProcessServer">
         <InProcessServer>
             <Path>Microsoft.WindowsAppRuntime.dll</Path>
-            <ActivatableClass ActivatableClassId="Microsoft.Windows.AppNotifications.AppNotificationActivationInfo" ThreadingModel="both" />
             <ActivatableClass ActivatableClassId="Microsoft.Windows.AppNotifications.AppNotificationManager" ThreadingModel="both" />
             <ActivatableClass ActivatableClassId="Microsoft.Windows.AppNotifications.AppNotification" ThreadingModel="both" />
             <ActivatableClass ActivatableClassId="Microsoft.Windows.AppNotifications.AppNotificationProgressData" ThreadingModel="both" />
             <ActivatableClass ActivatableClassId="Microsoft.Windows.AppNotifications.AppNotificationProgressResult" ThreadingModel="both" />
+            <ActivatableClass ActivatableClassId="Microsoft.Windows.AppNotifications.AppNotificationActivatedEventArgs" ThreadingModel="both" />
         </InProcessServer>
     </Extension>
     <Extension Category="windows.activatableClass.inProcessServer">

--- a/test/DynamicDependency/data/Microsoft.WindowsAppRuntime.Framework/appxmanifest.xml
+++ b/test/DynamicDependency/data/Microsoft.WindowsAppRuntime.Framework/appxmanifest.xml
@@ -77,7 +77,6 @@
             <ActivatableClass ActivatableClassId="Microsoft.Windows.AppNotifications.AppNotificationManager" ThreadingModel="both" />
             <ActivatableClass ActivatableClassId="Microsoft.Windows.AppNotifications.AppNotification" ThreadingModel="both" />
             <ActivatableClass ActivatableClassId="Microsoft.Windows.AppNotifications.AppNotificationProgressData" ThreadingModel="both" />
-            <ActivatableClass ActivatableClassId="Microsoft.Windows.AppNotifications.AppNotificationProgressResult" ThreadingModel="both" />
             <ActivatableClass ActivatableClassId="Microsoft.Windows.AppNotifications.AppNotificationActivatedEventArgs" ThreadingModel="both" />
         </InProcessServer>
     </Extension>


### PR DESCRIPTION
This fixes an issue where we assumed that Registry operations return HRESULTS rather than Win32 Status error messages. We have identified and fixed this issue.

Unit tests pass after fixing some bugs.