### PR TITLE
Rename unique_package_dependency_context

### DIFF
--- a/dev/DynamicDependency/API/M.AM.DD.PackageDependency.cpp
+++ b/dev/DynamicDependency/API/M.AM.DD.PackageDependency.cpp
@@ -95,7 +95,7 @@ namespace winrt::Microsoft::Windows::ApplicationModel::DynamicDependency::implem
     {
         const auto rank{ MDD_PACKAGE_DEPENDENCY_RANK_DEFAULT };
         const auto mddOptions{ MddAddPackageDependencyOptions::None };
-        wil::unique_package_dependency_context packageDependencyContext;
+        wil::unique_mdd_package_dependency_context packageDependencyContext;
         winrt::check_hresult(MddAddPackageDependency(m_id.c_str(), rank, mddOptions, &packageDependencyContext, nullptr));
         auto context{ winrt::make<implementation::PackageDependencyContext>(packageDependencyContext.get()) };
         packageDependencyContext.release();
@@ -106,7 +106,7 @@ namespace winrt::Microsoft::Windows::ApplicationModel::DynamicDependency::implem
     {
         const auto rank{ options.Rank() };
         const auto mddOptions{ ::Microsoft::Windows::ApplicationModel::DynamicDependency::ToAddOptions(options) };
-        wil::unique_package_dependency_context packageDependencyContext;
+        wil::unique_mdd_package_dependency_context packageDependencyContext;
         winrt::check_hresult(MddAddPackageDependency(m_id.c_str(), rank, mddOptions, &packageDependencyContext, nullptr));
         auto context{ winrt::make<implementation::PackageDependencyContext>(packageDependencyContext.get()) };
         packageDependencyContext.release();

--- a/dev/DynamicDependency/API/wil_msixdynamicdependency.h
+++ b/dev/DynamicDependency/API/wil_msixdynamicdependency.h
@@ -10,7 +10,7 @@ typedef unique_any<DLL_DIRECTORY_COOKIE, decltype(&::RemoveDllDirectory), ::Remo
 
 #if defined(MSIXDYNAMICDEPENDENCY_H) && !defined(__WIL_MSIXDYNAMICDEPENDENCY_H)
 #define __WIL_MSIXDYNAMICDEPENDENCY_H
-typedef unique_any<MDD_PACKAGEDEPENDENCY_CONTEXT, decltype(&::MddRemovePackageDependency), ::MddRemovePackageDependency> unique_package_dependency_context;
+typedef unique_any<MDD_PACKAGEDEPENDENCY_CONTEXT, decltype(&::MddRemovePackageDependency), ::MddRemovePackageDependency> unique_mdd_package_dependency_context;
 #endif // __WIL_MSIXDYNAMICDEPENDENCY_H
 
 #if defined(_APPMODEL_H_) && !defined(__WIL_APPMODEL_H_) && WINAPI_FAMILY_PARTITION(WINAPI_PARTITION_DESKTOP)

--- a/dev/WindowsAppRuntime_BootstrapDLL/wil_msixdynamicdependency.h
+++ b/dev/WindowsAppRuntime_BootstrapDLL/wil_msixdynamicdependency.h
@@ -10,7 +10,7 @@ typedef unique_any<DLL_DIRECTORY_COOKIE, decltype(&::RemoveDllDirectory), ::Remo
 
 #if defined(MSIXDYNAMICDEPENDENCY_H) && !defined(__WIL_MSIXDYNAMICDEPENDENCY_H)
 #define __WIL_MSIXDYNAMICDEPENDENCY_H
-typedef unique_any<MDD_PACKAGEDEPENDENCY_CONTEXT, decltype(&::MddRemovePackageDependency), ::MddRemovePackageDependency> unique_package_dependency_context;
+typedef unique_any<MDD_PACKAGEDEPENDENCY_CONTEXT, decltype(&::MddRemovePackageDependency), ::MddRemovePackageDependency> unique_mdd_package_dependency_context;
 #endif // __WIL_MSIXDYNAMICDEPENDENCY_H
 
 #if defined(_APPMODEL_H_) && !defined(__WIL_APPMODEL_H_) && WINAPI_FAMILY_PARTITION(WINAPI_PARTITION_DESKTOP)


### PR DESCRIPTION
Rename `unique_package_dependency_context` to `unique_mdd_package_dependency_context`

This is a specialization of WIL's `unique_any` for WinAppSDK's `MDD_PACKAGEDEPENDENCY_CONTEXT`.

This rename is to prevent conflicts with a WIL specialization for Windows' `PACKAGEDEPENDENCY_CONTEXT` (i.e. the OS Dynamic Dependnecy API).