### PR TITLE
Fix race condition and crash in AppInstance.FindOrRegisterForKey("key")

### DIFF
--- a/dev/AppLifecycle/AppInstance.cpp
+++ b/dev/AppLifecycle/AppInstance.cpp
@@ -542,6 +542,8 @@ namespace winrt::Microsoft::Windows::AppLifecycle::implementation
 
     hstring AppInstance::Key()
     {
+        auto releaseOnExit = m_dataMutex.acquire();
+
         if (m_key.IsValid())
         {
             return winrt::hstring(m_key.Get());

--- a/dev/AppLifecycle/AppInstance.cpp
+++ b/dev/AppLifecycle/AppInstance.cpp
@@ -576,9 +576,7 @@ namespace winrt::Microsoft::Windows::AppLifecycle::implementation
 
         // We keep the mutex as a live member to ensure all other instances continue
         // to get an 'open' instead of a 'create' due to it already existing.
-        m_keyCreationMutex.create(mutexName.c_str(), 0, MUTEX_ALL_ACCESS);
-
-        bool currentIsKeyOwner = (GetLastError() != ERROR_ALREADY_EXISTS);
+        bool isCurrentKeyOwner = m_keyCreationMutex.try_create(mutexName.c_str(), 0, MUTEX_ALL_ACCESS);
         if (currentIsKeyOwner)
         {
             m_key.Resize((key.length() + 1) * sizeof(key.data()[0]));

--- a/dev/AppLifecycle/AppInstance.cpp
+++ b/dev/AppLifecycle/AppInstance.cpp
@@ -576,7 +576,7 @@ namespace winrt::Microsoft::Windows::AppLifecycle::implementation
 
         // We keep the mutex as a live member to ensure all other instances continue
         // to get an 'open' instead of a 'create' due to it already existing.
-        bool isCurrentKeyOwner = m_keyCreationMutex.try_create(mutexName.c_str(), 0, MUTEX_ALL_ACCESS);
+        bool currentIsKeyOwner = m_keyCreationMutex.try_create(mutexName.c_str(), 0, MUTEX_ALL_ACCESS);
         if (currentIsKeyOwner)
         {
             m_key.Resize((key.length() + 1) * sizeof(key.data()[0]));

--- a/dev/AppLifecycle/SharedMemory.h
+++ b/dev/AppLifecycle/SharedMemory.h
@@ -52,7 +52,10 @@ public:
     {
         auto name = m_name;
         Reset();
-        Open(name, size);
+
+        m_name = name;
+        OpenInternal(size);
+        m_view.get()->size = size;
     }
 
     const size_t Size()


### PR DESCRIPTION
This PR fixes a race condition and a crash.

Crash was observed together with @aeloros during resizing of the shared memory for the Key when there is a lot of contention on the shared memory.

The race condition can happen when two instances call FindOrRegisterForKey. Consider instance1 and instance2.
- Instance1 acquires the keyCreationMutex, meaning that it will become the instance for the provided key. 
- While Instance1 is updating the key, Instance2 finds that the mutex is already created and so it moves on to iterate the instances to find the instance with the provided key. It can for a short period of time read the key before Instance1 can update it.

This PR protects the read of the Key with the same mutex as the write.

Fixes ADO bug 38344737

Verified the changes with a local build of Microsoft.WIndowsAppRuntime.dll