### PR TITLE
[MRT Core] Add support for VS's FastUpToDate check in MRT Core.

### DIFF
--- a/build/publish-mrt.yml
+++ b/build/publish-mrt.yml
@@ -112,7 +112,6 @@ steps:
       native\MrtCore.C.props
       native\MrtCore.props
       native\MrtCore.targets
-      ProjectItemsSchema.xaml
       README.md
     TargetFolder: '$(Build.ArtifactStagingDirectory)\fullnuget\build'
     flattenFolders: false

--- a/build/publish-mrt.yml
+++ b/build/publish-mrt.yml
@@ -112,6 +112,7 @@ steps:
       native\MrtCore.C.props
       native\MrtCore.props
       native\MrtCore.targets
+      ProjectItemsSchema.xaml
       README.md
     TargetFolder: '$(Build.ArtifactStagingDirectory)\fullnuget\build'
     flattenFolders: false

--- a/dev/MRTCore/packaging/MrtCore.PriGen.targets
+++ b/dev/MRTCore/packaging/MrtCore.PriGen.targets
@@ -1585,7 +1585,7 @@
     </ValidateConfiguration>
   </Target>
 
-  <!-- Ensure Fast Up To Date picks up changes to PRI related files. -->
+  <!-- Configure Fast Up To Date for PRI generation. Please see the comment in ProjectItemsSchema.xaml for more info. -->
 
   <ItemGroup>
     <PropertyPageSchema Include="$(MSBuildThisFileDirectory)ProjectItemsSchema.xaml" />
@@ -1599,19 +1599,18 @@
     </_MrtCoreUpToDateCheckInputDependsOn>
   </PropertyGroup>
 
-  <!-- Inform the fast up-to-date check of the inputs for PRI generation -->
+  <!-- Inform the fast up-to-date check of the inputs for PRI generation. -->
   <Target Name="_MrtCoreUpToDateCheckInput" DependsOnTargets="$(_MrtCoreUpToDateCheckInputDependsOn)" BeforeTargets="CollectUpToDateCheckInputDesignTime">
-    <!-- 
-        Copied from the MRT Core target _GenerateProjectPriConfigurationFiles.
-        @(_LayoutFile),  @(_EmbedFile), and @(_PRIResourceFiltered) are ultimately inputs to the MRT Core indexer, 
-        but they're populated by _GenerateProjectPriConfigurationFiles which does work (runs a tool to generate the indexer configuration files)
-        that we don't need during a design-time build, so we hoist them out to avoid calling the target.
+        <!-- 
+        Copied from the target _GenerateProjectPriConfigurationFiles. @(_LayoutFile),  @(_EmbedFile), and @(_PRIResourceFiltered) are ultimately inputs to
+        the MRT Core indexer, but they're populated by _GenerateProjectPriConfigurationFiles which does work (runs a tool to generate the indexer
+        configuration files) that we don't need during a design-time build, so we hoist them out to avoid calling the target.
         -->
     <ItemGroup>
-    <!--
-        First, build out the complete list of files we want to consider for the layout.
-        Then exclude anything that matches any pattern or filename listed in _AppxLayoutAssetPackageFiles.
-        We could do this as a 'Remove' operation, but by building an oracle we don't modify, we simplify future manipulations of this data set.
+        <!--
+        First, build out the complete list of files we want to consider for the layout. Then exclude anything that matches any pattern or filename listed in
+        _AppxLayoutAssetPackageFiles. We could do this as a 'Remove' operation, but by building an oracle we don't modify, we simplify future manipulations of
+        this data set.
         -->
       <_LayoutFileSource Include="@(PackagingOutputs)" Condition="'%(OutputGroup)' == 'ContentFilesProjectOutputGroup' and '%(ProjectName)' == '$(ProjectName)'" />
       <_LayoutFileSource Include="@(PackagingOutputs)" Condition="'%(OutputGroup)' == 'CustomOutputGroupForPackaging' and '%(ProjectName)' == '$(ProjectName)'" />

--- a/dev/MRTCore/packaging/MrtCore.PriGen.targets
+++ b/dev/MRTCore/packaging/MrtCore.PriGen.targets
@@ -1584,4 +1584,70 @@
       Platform="$(Platform)">
     </ValidateConfiguration>
   </Target>
+
+  <!-- Ensure Fast Up To Date picks up changes to PRI related files. -->
+
+  <ItemGroup>
+    <PropertyPageSchema Include="$(MSBuildThisFileDirectory)ProjectItemsSchema.xaml" />
+  </ItemGroup>
+
+  <PropertyGroup>
+    <_MrtCoreUpToDateCheckInputDependsOn>
+      $(_MrtCoreUpToDateCheckInputDependsOn);
+      GetMrtPackagingOutputs;
+      _GetPriFilesFromPayload;
+    </_MrtCoreUpToDateCheckInputDependsOn>
+  </PropertyGroup>
+
+  <!-- Inform the fast up-to-date check of the inputs for PRI generation -->
+  <Target Name="_MrtCoreUpToDateCheckInput" DependsOnTargets="$(_MrtCoreUpToDateCheckInputDependsOn)" BeforeTargets="CollectUpToDateCheckInputDesignTime">
+    <!-- 
+        Copied from the MRT Core target _GenerateProjectPriConfigurationFiles.
+        @(_LayoutFile),  @(_EmbedFile), and @(_PRIResourceFiltered) are ultimately inputs to the MRT Core indexer, 
+        but they're populated by _GenerateProjectPriConfigurationFiles which does work (runs a tool to generate the indexer configuration files)
+        that we don't need during a design-time build, so we hoist them out to avoid calling the target.
+        -->
+    <ItemGroup>
+    <!--
+        First, build out the complete list of files we want to consider for the layout.
+        Then exclude anything that matches any pattern or filename listed in _AppxLayoutAssetPackageFiles.
+        We could do this as a 'Remove' operation, but by building an oracle we don't modify, we simplify future manipulations of this data set.
+        -->
+      <_LayoutFileSource Include="@(PackagingOutputs)" Condition="'%(OutputGroup)' == 'ContentFilesProjectOutputGroup' and '%(ProjectName)' == '$(ProjectName)'" />
+      <_LayoutFileSource Include="@(PackagingOutputs)" Condition="'%(OutputGroup)' == 'CustomOutputGroupForPackaging' and '%(ProjectName)' == '$(ProjectName)'" />
+      <_LayoutFile Include="@(_LayoutFileSource)" Exclude="@(_AppxLayoutAssetPackageFiles)" />
+
+      <_EmbedFile Include="@(PackagingOutputs)" Condition="'%(OutputGroup)' == 'EmbedOutputGroupForPackaging' and '%(ProjectName)' == '$(ProjectName)'"/>
+
+      <!-- If we have the .xbf, we don't need the .xaml file. -->
+      <_LayoutFileXbfXaml Include="$([System.IO.Path]::ChangeExtension('%(_LayoutFile.Identity)','.xaml'))" Condition="'%(Extension)' == '.xbf'" />
+      <_LayoutFile Remove="@(_LayoutFileXbfXaml)" />
+
+      <!-- Filter out PRIResource files which are marked by C++ project system as ExcludedFromBuild. -->
+      <_PRIResourceFiltered Include="@(PRIResource)" Condition="'%(PRIResource.ExcludedFromBuild)' != 'true'" />
+    </ItemGroup>
+
+    <ItemGroup>
+      <_UpToDateCheckInputTemp Include="@(SourceAppxManifest)" Set="PRIGeneration" />
+      <_UpToDateCheckInputTemp Include="@(_LayoutFile)" Condition="'%(Extension)'!='.xbf'" Set="PRIGeneration" />
+      <_UpToDateCheckInputTemp Include="@(_EmbedFile)" Set="PRIGeneration" />
+      <_UpToDateCheckInputTemp Include="@(_PRIResourceFiltered)" Set="PRIGeneration" />
+      <_UpToDateCheckInputTemp Include="@(_PriFilesFromPayload)" Set="PRIGeneration" />
+    </ItemGroup>
+
+    <RemoveDuplicates Inputs="@(_UpToDateCheckInputTemp)">
+      <Output TaskParameter="Filtered" ItemName="_UpToDateCheckInputDeduplicated" />
+    </RemoveDuplicates>
+
+    <ItemGroup>
+      <UpToDateCheckInput Include="@(_UpToDateCheckInputDeduplicated)" />
+    </ItemGroup>
+  </Target>
+
+  <!-- Inform the fast up-to-date check of the outputs from PRI generation. -->
+  <Target Name="_MrtCoreUpToDateCheckBuilt" BeforeTargets="CollectUpToDateCheckBuiltDesignTime">
+    <ItemGroup>
+      <UpToDateCheckBuilt Include="$(ProjectPriFullPath)" Set="PRIGeneration" />
+    </ItemGroup>
+  </Target>
 </Project>

--- a/dev/MRTCore/packaging/MrtCore.PriGen.targets
+++ b/dev/MRTCore/packaging/MrtCore.PriGen.targets
@@ -1628,7 +1628,7 @@
 
     <ItemGroup>
       <_UpToDateCheckInputTemp Include="@(SourceAppxManifest)" Set="PRIGeneration" />
-      <_UpToDateCheckInputTemp Include="@(_LayoutFile)" Condition="'%(Extension)'!='.xbf'" Set="PRIGeneration" />
+      <_UpToDateCheckInputTemp Include="@(_LayoutFile)" Set="PRIGeneration" />
       <_UpToDateCheckInputTemp Include="@(_EmbedFile)" Set="PRIGeneration" />
       <_UpToDateCheckInputTemp Include="@(_PRIResourceFiltered)" Set="PRIGeneration" />
       <_UpToDateCheckInputTemp Include="@(_PriFilesFromPayload)" Set="PRIGeneration" />

--- a/dev/MRTCore/packaging/MrtCore.PriGen.targets
+++ b/dev/MRTCore/packaging/MrtCore.PriGen.targets
@@ -1587,6 +1587,10 @@
 
   <!-- Ensure Fast Up To Date picks up changes to PRI related files. -->
 
+  <ItemGroup>
+    <PropertyPageSchema Include="$(MSBuildThisFileDirectory)ProjectItemsSchema.xaml" />
+  </ItemGroup>
+
   <PropertyGroup>
     <_MrtCoreUpToDateCheckInputDependsOn>
       $(_MrtCoreUpToDateCheckInputDependsOn);

--- a/dev/MRTCore/packaging/MrtCore.PriGen.targets
+++ b/dev/MRTCore/packaging/MrtCore.PriGen.targets
@@ -1587,10 +1587,6 @@
 
   <!-- Ensure Fast Up To Date picks up changes to PRI related files. -->
 
-  <ItemGroup>
-    <PropertyPageSchema Include="$(MSBuildThisFileDirectory)ProjectItemsSchema.xaml" />
-  </ItemGroup>
-
   <PropertyGroup>
     <_MrtCoreUpToDateCheckInputDependsOn>
       $(_MrtCoreUpToDateCheckInputDependsOn);

--- a/dev/MRTCore/packaging/ProjectItemsSchema.xaml
+++ b/dev/MRTCore/packaging/ProjectItemsSchema.xaml
@@ -1,4 +1,0 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<ProjectSchemaDefinitions xmlns="http://schemas.microsoft.com/build/2009/properties">
-    <ItemType Name="PRIResource" DisplayName="Resource" UpToDateCheckInput="false"/>
-</ProjectSchemaDefinitions>

--- a/dev/MRTCore/packaging/ProjectItemsSchema.xaml
+++ b/dev/MRTCore/packaging/ProjectItemsSchema.xaml
@@ -1,0 +1,4 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<ProjectSchemaDefinitions xmlns="http://schemas.microsoft.com/build/2009/properties">
+    <ItemType Name="PRIResource" DisplayName="Resource" UpToDateCheckInput="false"/>
+</ProjectSchemaDefinitions>

--- a/dev/MRTCore/packaging/ProjectItemsSchema.xaml
+++ b/dev/MRTCore/packaging/ProjectItemsSchema.xaml
@@ -1,4 +1,13 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <ProjectSchemaDefinitions xmlns="http://schemas.microsoft.com/build/2009/properties">
-    <ItemType Name="PRIResource" DisplayName="Resource" UpToDateCheckInput="false"/>
+    <!--
+    The “UpToDateCheckInput” attribute on the ItemType definition informs the Fast Up To Date (FUTD) system that it
+    should be tracked as part of the *default* set of inputs/outputs. This isn’t the behavior we want, though, because
+    .resw files are not an input that influence the “default” set of outputs (e.g. .dll/.exe/.pdb); the timestamp of
+    .resw files should not be compared with that of the .dll/.exe/.pdb because there’s no correlation between the two.
+    So we override the built-in ItemType definition with our own, which turns off the automatic tracking, and then
+    in MrtCore.PriGen.targets explicitly add *.resw to @(UpToDateCheckInputs) as part of a custom FUTD set for the
+    output of the project PRI file.
+    -->
+    <ItemType Name="PRIResource" UpToDateCheckInput="false"/>
 </ProjectSchemaDefinitions>


### PR DESCRIPTION
**Description**
Please see issue: https://github.com/microsoft/WindowsAppSDK/issues/1898

**Credit**
The fix here is from @evelynwu-msft (thanks Evelyn!) with two modifications from me.

**How verified**
Used https://github.com/microsoft/WindowsAppSDK/issues/1898#issuecomment-1058629425 with the following modifications:
- Upgraded the NuGet package to WAS 1.0.
- Commented out the contents of Directory.Build.targets.
- Moved fix into MrtCore.PriGen.targets in the NuGet pkg with the None ItemGroup removal bit removed (it's not needed, and if kept, will introduce an issue).
- Removed the change to the DisplayName (changes the name displayed in the Build Action drop-down list where there is already a "Resource").

Without and with fix:
- Delete string in RESW in the StringResources project.
- Build the solution.
- Add string in RESW in the StringResources project.
- Build the solution.

With the fix, all 4 projects are built, and without, only 2 are built (StringResources and the WAPPROJ project).