### PR TITLE
Fix missing quote in Installer vcxproj

### DIFF
--- a/installer/dev/WindowsAppRuntimeInstall.vcxproj
+++ b/installer/dev/WindowsAppRuntimeInstall.vcxproj
@@ -100,7 +100,7 @@
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <PreprocessorDefinitions>NDEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <AdditionalIncludeDirectories Condition="'$(Configuration)">$(RepoRoot)\dev\Common;$(RepoRoot)\WindowsAppSDK\installer\dev\Telemetry;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories Condition="'$(Configuration)'">$(RepoRoot)\dev\Common;$(RepoRoot)\WindowsAppSDK\installer\dev\Telemetry;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>


### PR DESCRIPTION
Fix missing quote in Installer vcxproj.
This will fix the build break in WinAppSDK Nightly builds that checks out these files