### PR TITLE
Default display name when no window handle available in Notifications

### DIFF
--- a/dev/AppNotifications/AppNotificationUtility.cpp
+++ b/dev/AppNotifications/AppNotificationUtility.cpp
@@ -276,7 +276,7 @@ void Microsoft::Windows::AppNotifications::Helpers::RegisterAssets(std::wstring 
 
         wil::unique_prop_variant propVariantIcon;
         THROW_IF_FAILED(propertyStore->GetValue(PKEY_AppUserModel_RelaunchIconResource, &propVariantIcon));
-        THROW_HR_IF_MSG(E_UNEXPECTED, propVariantIcon.vt == VT_EMPTY, "You must specify a valid image filepath before calling Register().");
+        THROW_HR_IF_MSG(E_UNEXPECTED, (propVariantIcon.vt != VT_LPWSTR || propVariantIcon.pwszVal == nullptr), "You must specify a valid image filepath before calling Register().");
 
         iconFilePath = propVariantIcon.pwszVal;
 

--- a/dev/AppNotifications/AppNotificationUtility.cpp
+++ b/dev/AppNotifications/AppNotificationUtility.cpp
@@ -278,11 +278,11 @@ void Microsoft::Windows::AppNotifications::Helpers::RegisterAssets(std::wstring 
         wil::unique_prop_variant propVariantIcon;
         THROW_IF_FAILED(propertyStore->GetValue(PKEY_AppUserModel_RelaunchIconResource, &propVariantIcon));
 
-        THROW_HR_IF_MSG(E_UNEXPECTED, (propVariantIcon.vt == VT_EMPTY || propVariantIcon.pwszVal == nullptr), "You must specify a valid image filepath before calling Register().");
+        THROW_HR_IF_MSG(E_UNEXPECTED, (propVariantIcon.vt == VT_EMPTY || propVariantIcon.pwszVal == nullptr), "Icon is not specified");
 
-        THROW_HR_IF_MSG(E_UNEXPECTED, propVariantIcon.vt != VT_LPWSTR, "Provide a valid zero-terminated string of UNICODE characters");
+        THROW_HR_IF_MSG(E_UNEXPECTED, propVariantIcon.vt != VT_LPWSTR, "Icon should be a valid Unicode string");
 
-        THROW_HR_IF_MSG(E_UNEXPECTED, wcslen(propVariantIcon.pwszVal) == 0, "Provide a non empty icon string");
+        THROW_HR_IF_MSG(E_UNEXPECTED, wcslen(propVariantIcon.pwszVal) == 0, "Icon is an empty string");
 
         iconFilePath = propVariantIcon.pwszVal;
 

--- a/dev/AppNotifications/AppNotificationUtility.h
+++ b/dev/AppNotifications/AppNotificationUtility.h
@@ -60,4 +60,6 @@ namespace Microsoft::Windows::AppNotifications::Helpers
     wil::unique_cotaskmem_string ConvertUtf8StringToWideString(unsigned long length, const BYTE* utf8String);
 
     winrt::Microsoft::Windows::AppNotifications::AppNotification ToastNotificationFromToastProperties(ABI::Microsoft::Internal::ToastNotifications::INotificationProperties* properties);
+
+    std::wstring SetDisplayName();
 }

--- a/dev/AppNotifications/AppNotificationUtility.h
+++ b/dev/AppNotifications/AppNotificationUtility.h
@@ -61,5 +61,5 @@ namespace Microsoft::Windows::AppNotifications::Helpers
 
     winrt::Microsoft::Windows::AppNotifications::AppNotification ToastNotificationFromToastProperties(ABI::Microsoft::Internal::ToastNotifications::INotificationProperties* properties);
 
-    std::wstring SetDisplayName();
+    std::wstring SetDisplayNameBasedOnProcessName();
 }


### PR DESCRIPTION
Description: GetConsoleWindow in AppNotificationUtility returns a Null pointer when we are working with WinUI apps.

Fix: Fallback to default displayname and icon when console window is not available for use.