### PR TITLE
Revert try_create use as it breaks single instancing.

### DIFF
--- a/dev/AppLifecycle/AppInstance.cpp
+++ b/dev/AppLifecycle/AppInstance.cpp
@@ -579,7 +579,11 @@ namespace winrt::Microsoft::Windows::AppLifecycle::implementation
 
         // We keep the mutex as a live member to ensure all other instances continue
         // to get an 'open' instead of a 'create' due to it already existing.
-        bool currentIsKeyOwner = m_keyCreationMutex.try_create(mutexName.c_str(), 0, MUTEX_ALL_ACCESS);
+        // try_create returns true for a named mutex that already exists
+        // and so we can't rely on try_create and have to explicitly check GetLastError().
+        m_keyCreationMutex.create(mutexName.c_str(), 0, MUTEX_ALL_ACCESS);
+
+        bool currentIsKeyOwner = (GetLastError() != ERROR_ALREADY_EXISTS);
         if (currentIsKeyOwner)
         {
             m_key.Resize((key.length() + 1) * sizeof(key.data()[0]));


### PR DESCRIPTION
This PR reverts a suggestion made in #2211 to use try_create. try_create returns true even if the named mutex already exists since it calls CreateMutexExW and so we have to manually check GetLastError(). This behaviour is documented at: https://docs.microsoft.com/en-us/windows/win32/api/synchapi/nf-synchapi-createmutexexw