### PR TITLE
Enabling projections for Environment Manager.

### DIFF
--- a/dev/Projections/CS/Microsoft.Windows.System/Microsoft.Windows.System.Projection.csproj
+++ b/dev/Projections/CS/Microsoft.Windows.System/Microsoft.Windows.System.Projection.csproj
@@ -36,7 +36,7 @@
 
   <ItemGroup>
     <Reference Include="Microsoft.Windows.System">
-      <HintPath>$(OutDir)..\WindowsAppSDK_DLL\StrippedWinMD\Microsoft.Windows.System.winmd</HintPath>
+      <HintPath>$(OutDir)..\WindowsAppRuntime_DLL\StrippedWinMD\Microsoft.Windows.System.winmd</HintPath>
       <IsWinMDFile>true</IsWinMDFile>
     </Reference>
   </ItemGroup>


### PR DESCRIPTION
I used the wrong path for the HintPath node in the csproj for Environment Manager.  Manually verified that C# can use Environment Variables.