### PR TITLE
Fix bug in GetExeNameFromFilePath

### DIFF
--- a/dev/PushNotifications/PushNotificationUtility.h
+++ b/dev/PushNotifications/PushNotificationUtility.h
@@ -158,8 +158,14 @@ namespace winrt::Microsoft::Windows::PushNotifications::Helpers
     inline std::wstring GetExeNameFromPath(std::wstring const& exePath)
     {
         size_t pos{ exePath.rfind(L"\\") };
-        THROW_HR_IF(E_UNEXPECTED, pos == std::wstring::npos);
-        return exePath.substr(pos + 1); // One after the delimiter
+        if (pos != std::wstring::npos)
+        {
+            return exePath.substr(pos + 1); // One after the delimiter
+        }
+        else
+        {
+            return exePath;
+        }
     }
 
     inline winrt::guid GetComRegistrationFromRegistry(const std::wstring argumentToCheck)

--- a/dev/PushNotifications/PushNotificationUtility.h
+++ b/dev/PushNotifications/PushNotificationUtility.h
@@ -9,6 +9,7 @@
 #include "wil/stl.h"
 #include "wil/win32_helpers.h"
 #include "PushBackgroundTaskInstance.h"
+#include <filesystem>
 
 namespace winrt
 {
@@ -155,19 +156,6 @@ namespace winrt::Microsoft::Windows::PushNotifications::Helpers
     }
     CATCH_RETURN()
 
-    inline std::wstring GetExeNameFromPath(std::wstring const& exePath)
-    {
-        size_t pos{ exePath.rfind(L"\\") };
-        if (pos != std::wstring::npos)
-        {
-            return exePath.substr(pos + 1); // One after the delimiter
-        }
-        else
-        {
-            return exePath;
-        }
-    }
-
     inline winrt::guid GetComRegistrationFromRegistry(const std::wstring argumentToCheck)
     {
         wil::unique_cotaskmem_string packagedFullName;
@@ -253,12 +241,12 @@ namespace winrt::Microsoft::Windows::PushNotifications::Helpers
                     &exeBuffer,
                     &exeBufferLength));
 
-                std::wstring exeString{ GetExeNameFromPath(exeBuffer) };
+                std::wstring exeString{ std::filesystem::path(exeBuffer).filename() };
 
                 wil::unique_cotaskmem_string exePath;
                 THROW_IF_FAILED(wil::GetModuleFileNameExW(GetCurrentProcess(), nullptr, exePath));
 
-                std::wstring exeToCheck{ GetExeNameFromPath(exePath.get()) };
+                std::wstring exeToCheck{ std::filesystem::path(exePath.get()).filename() };
 
                 THROW_HR_IF_MSG(E_FAIL, exeString != exeToCheck, "Caller RegistrationProcess is not the same as manifest defined COM Server!");
 


### PR DESCRIPTION
There is a case where the exe is not in a filepath in the registry but is a standalone exe. This fixes that scenario.