### PR TITLE
Prevent WinUI item templates from showing up in other project types

### DIFF
--- a/dev/VSIX/ItemTemplates/Desktop/CSharp/BlankWindow/WinUI.Desktop.Cs.BlankWindow.vstemplate
+++ b/dev/VSIX/ItemTemplates/Desktop/CSharp/BlankWindow/WinUI.Desktop.Cs.BlankWindow.vstemplate
@@ -10,7 +10,7 @@
     <TemplateGroupID>WinRT-Managed-UAP</TemplateGroupID>
     <AppliesTo>CSharp + SharedAssetsProject</AppliesTo>
     <NumberOfParentCategoriesToRollUp>2</NumberOfParentCategoriesToRollUp>
-    <ShowByDefault>true</ShowByDefault>
+    <ShowByDefault>false</ShowByDefault>
     <TargetPlatformName>Windows</TargetPlatformName>
     <AppIdFilter>blend</AppIdFilter>
     <LanguageTag>csharp</LanguageTag>

--- a/dev/VSIX/ItemTemplates/Desktop/CppWinRT/BlankWindow/WinUI.Desktop.CppWinRT.BlankWindow.vstemplate
+++ b/dev/VSIX/ItemTemplates/Desktop/CppWinRT/BlankWindow/WinUI.Desktop.CppWinRT.BlankWindow.vstemplate
@@ -8,7 +8,7 @@
     <ProjectType>VC</ProjectType>
     <TemplateID>WinUI.Desktop.CppWinRT.BlankWindow</TemplateID>
     <NumberOfParentCategoriesToRollUp>2</NumberOfParentCategoriesToRollUp>
-    <ShowByDefault>true</ShowByDefault>
+    <ShowByDefault>false</ShowByDefault>
     <TargetPlatformName>Windows</TargetPlatformName>
     <AppIdFilter>blend</AppIdFilter>
     <LanguageTag>cpp</LanguageTag>

--- a/dev/VSIX/ItemTemplates/Neutral/CSharp/BlankPage/WinUI.Neutral.Cs.BlankPage.vstemplate
+++ b/dev/VSIX/ItemTemplates/Neutral/CSharp/BlankPage/WinUI.Neutral.Cs.BlankPage.vstemplate
@@ -10,7 +10,7 @@
     <TemplateGroupID>WinRT-Managed-UAP</TemplateGroupID>
     <AppliesTo>CSharp + SharedAssetsProject</AppliesTo>
     <NumberOfParentCategoriesToRollUp>2</NumberOfParentCategoriesToRollUp>
-    <ShowByDefault>true</ShowByDefault>
+    <ShowByDefault>false</ShowByDefault>
     <TargetPlatformName>Windows</TargetPlatformName>
     <AppIdFilter>blend</AppIdFilter>
     <LanguageTag>csharp</LanguageTag>

--- a/dev/VSIX/ItemTemplates/Neutral/CSharp/ResourceDictionary/WinUI.Neutral.Cs.ResourceDictionary.vstemplate
+++ b/dev/VSIX/ItemTemplates/Neutral/CSharp/ResourceDictionary/WinUI.Neutral.Cs.ResourceDictionary.vstemplate
@@ -10,7 +10,7 @@
     <TemplateGroupID>WinRT-Managed-UAP</TemplateGroupID>
     <AppliesTo>CSharp + SharedAssetsProject</AppliesTo>
     <NumberOfParentCategoriesToRollUp>1</NumberOfParentCategoriesToRollUp>
-    <ShowByDefault>true</ShowByDefault>
+    <ShowByDefault>false</ShowByDefault>
     <TargetPlatformName>Windows</TargetPlatformName>
     <AppIdFilter>blend</AppIdFilter>
     <LanguageTag>csharp</LanguageTag>

--- a/dev/VSIX/ItemTemplates/Neutral/CSharp/Resw/WinUI.Neutral.Cs.Resw.vstemplate
+++ b/dev/VSIX/ItemTemplates/Neutral/CSharp/Resw/WinUI.Neutral.Cs.Resw.vstemplate
@@ -8,7 +8,7 @@
     <ProjectType>CSharp</ProjectType>
     <TemplateID>WinUI.Cs.Neutral.Resw</TemplateID>
     <NumberOfParentCategoriesToRollUp>1</NumberOfParentCategoriesToRollUp>
-    <ShowByDefault>true</ShowByDefault>
+    <ShowByDefault>false</ShowByDefault>
     <TargetPlatformName>Windows</TargetPlatformName>
     <AppIdFilter>blend</AppIdFilter>
     <LanguageTag>csharp</LanguageTag>

--- a/dev/VSIX/ItemTemplates/Neutral/CSharp/TemplatedControl/WinUI.Neutral.Cs.TemplatedControl.vstemplate
+++ b/dev/VSIX/ItemTemplates/Neutral/CSharp/TemplatedControl/WinUI.Neutral.Cs.TemplatedControl.vstemplate
@@ -10,7 +10,7 @@
     <TemplateGroupID>WinRT-Managed-UAP</TemplateGroupID>
     <AppliesTo>CSharp + SharedAssetsProject</AppliesTo>
     <NumberOfParentCategoriesToRollUp>2</NumberOfParentCategoriesToRollUp>
-    <ShowByDefault>true</ShowByDefault>
+    <ShowByDefault>false</ShowByDefault>
     <TargetPlatformName>Windows</TargetPlatformName>
     <AppIdFilter>blend</AppIdFilter>
     <LanguageTag>csharp</LanguageTag>

--- a/dev/VSIX/ItemTemplates/Neutral/CSharp/UserControl/WinUI.Neutral.Cs.UserControl.vstemplate
+++ b/dev/VSIX/ItemTemplates/Neutral/CSharp/UserControl/WinUI.Neutral.Cs.UserControl.vstemplate
@@ -10,7 +10,7 @@
     <TemplateGroupID>WinRT-Managed-UAP</TemplateGroupID>
     <AppliesTo>CSharp + SharedAssetsProject</AppliesTo>
     <NumberOfParentCategoriesToRollUp>2</NumberOfParentCategoriesToRollUp>
-    <ShowByDefault>true</ShowByDefault>
+    <ShowByDefault>false</ShowByDefault>
     <TargetPlatformName>Windows</TargetPlatformName>
     <AppIdFilter>blend</AppIdFilter>
     <LanguageTag>csharp</LanguageTag>

--- a/dev/VSIX/ItemTemplates/Neutral/CppWinRT/BlankPage/WinUI.Neutral.CppWinRT.BlankPage.vstemplate
+++ b/dev/VSIX/ItemTemplates/Neutral/CppWinRT/BlankPage/WinUI.Neutral.CppWinRT.BlankPage.vstemplate
@@ -8,7 +8,7 @@
     <ProjectType>VC</ProjectType>
     <TemplateID>WinUI.Neutral.CppWinRT.BlankPage</TemplateID>
     <NumberOfParentCategoriesToRollUp>2</NumberOfParentCategoriesToRollUp>
-    <ShowByDefault>true</ShowByDefault>
+    <ShowByDefault>false</ShowByDefault>
     <TargetPlatformName>Windows</TargetPlatformName>
     <AppIdFilter>blend</AppIdFilter>
     <LanguageTag>cpp</LanguageTag>

--- a/dev/VSIX/ItemTemplates/Neutral/CppWinRT/ResourceDictionary/WinUI.Neutral.CppWinRT.ResourceDictionary.vstemplate
+++ b/dev/VSIX/ItemTemplates/Neutral/CppWinRT/ResourceDictionary/WinUI.Neutral.CppWinRT.ResourceDictionary.vstemplate
@@ -8,7 +8,7 @@
     <ProjectType>VC</ProjectType>
     <TemplateID>WinUI.Neutral.CppWinRT.ResourceDictionary</TemplateID>
     <NumberOfParentCategoriesToRollUp>1</NumberOfParentCategoriesToRollUp>
-    <ShowByDefault>true</ShowByDefault>
+    <ShowByDefault>false</ShowByDefault>
     <TargetPlatformName>Windows</TargetPlatformName>
     <AppIdFilter>blend</AppIdFilter>
     <LanguageTag>cpp</LanguageTag>

--- a/dev/VSIX/ItemTemplates/Neutral/CppWinRT/Resw/WinUI.Neutral.CppWinRT.Resw.vstemplate
+++ b/dev/VSIX/ItemTemplates/Neutral/CppWinRT/Resw/WinUI.Neutral.CppWinRT.Resw.vstemplate
@@ -8,7 +8,7 @@
     <ProjectType>VC</ProjectType>
     <TemplateID>WinUI.CppWinRT.Neutral.Resw</TemplateID>
     <NumberOfParentCategoriesToRollUp>1</NumberOfParentCategoriesToRollUp>
-    <ShowByDefault>true</ShowByDefault>
+    <ShowByDefault>false</ShowByDefault>
     <TargetPlatformName>Windows</TargetPlatformName>
     <AppIdFilter>blend</AppIdFilter>
     <LanguageTag>cpp</LanguageTag>

--- a/dev/VSIX/ItemTemplates/Neutral/CppWinRT/TemplatedControl/WinUI.Neutral.CppWinRT.TemplatedControl.vstemplate
+++ b/dev/VSIX/ItemTemplates/Neutral/CppWinRT/TemplatedControl/WinUI.Neutral.CppWinRT.TemplatedControl.vstemplate
@@ -8,7 +8,7 @@
     <ProjectType>VC</ProjectType>
     <TemplateID>WinUI.Neutral.CppWinRT.TemplatedControl</TemplateID>
     <NumberOfParentCategoriesToRollUp>2</NumberOfParentCategoriesToRollUp>
-    <ShowByDefault>true</ShowByDefault>
+    <ShowByDefault>false</ShowByDefault>
     <TargetPlatformName>Windows</TargetPlatformName>
     <AppIdFilter>blend</AppIdFilter>
     <LanguageTag>cpp</LanguageTag>

--- a/dev/VSIX/ItemTemplates/Neutral/CppWinRT/UserControl/WinUI.Neutral.CppWinRT.UserControl.vstemplate
+++ b/dev/VSIX/ItemTemplates/Neutral/CppWinRT/UserControl/WinUI.Neutral.CppWinRT.UserControl.vstemplate
@@ -8,7 +8,7 @@
     <ProjectType>VC</ProjectType>
     <TemplateID>WinUI.Neutral.CppWinRT.UserControl</TemplateID>
     <NumberOfParentCategoriesToRollUp>2</NumberOfParentCategoriesToRollUp>
-    <ShowByDefault>true</ShowByDefault>
+    <ShowByDefault>false</ShowByDefault>
     <TargetPlatformName>Windows</TargetPlatformName>
     <AppIdFilter>blend</AppIdFilter>
     <LanguageTag>cpp</LanguageTag>


### PR DESCRIPTION
### Problem
WinUI item templates are appearing in projects where they do not belong. For example, here they are appearing in a C# console application:
![image](https://user-images.githubusercontent.com/59936622/158894587-cbb606b4-58e0-45c7-818d-cda256ca071c.png)

### Solution
In the .vstemplate files for each project item, there is a [TemplateGroupID property](https://docs.microsoft.com/en-us/visualstudio/extensibility/templategroupid-element-visual-studio-templates?view=vs-2022) that specifies what kind of project an item templates will show up in. The WinUI item templates correctly set this property. However, there is a [ShowByDefault property](https://docs.microsoft.com/en-us/visualstudio/extensibility/showbydefault-visual-studio-templates?view=vs-2022) which specifies that the template will only be displayed under the specified `TemplateGroupID` when set to `false`.

The current WinUI item templates have `ShowByDefault` set to `true` and the solution here it to set them to `false`.

### Demo
The item templates no longer appear in a C# console application:
![image](https://user-images.githubusercontent.com/59936622/159384388-65105f1e-6e5f-4cf2-a67e-cde75bc295bb.png)

And they still appear in a WinUI app:
![image](https://user-images.githubusercontent.com/59936622/159384490-b6e7844f-17e1-455e-8cbc-04add9678edf.png)

### Work Item
[Bug 1433670](https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1433670): WinUI C# templates are available to incompatible projects