### PR TITLE
Add AppLifecycle contract

### DIFF
--- a/dev/AppLifecycle/AppLifecycle.idl
+++ b/dev/AppLifecycle/AppLifecycle.idl
@@ -3,6 +3,10 @@
 
 namespace Microsoft.Windows.AppLifecycle
 {
+    [contractversion(2)]
+    apicontract AppLifecycleContract {};
+
+    [contract(AppLifecycleContract, 1)]
     enum ExtendedActivationKind
     {
         Launch = 0,
@@ -53,20 +57,26 @@ namespace Microsoft.Windows.AppLifecycle
         // Windows.ApplicationModel.Activation.ActivationKind.
 
         Push = 5000,
+
+        [contract(AppLifecycleContract, 2)]
         AppNotification,
     };
 
+    [contract(AppLifecycleContract, 1)]
     runtimeclass AppActivationArguments
     {
         ExtendedActivationKind Kind { get; };
         IInspectable Data{ get; };
     };
 
+    [contract(AppLifecycleContract, 1)]
     runtimeclass AppInstance
     {
         static AppInstance GetCurrent();
         static Windows.Foundation.Collections.IVector<AppInstance> GetInstances();
         static AppInstance FindOrRegisterForKey(String key);
+
+        [contract(AppLifecycleContract, 2)]
         static Windows.ApplicationModel.Core.AppRestartFailureReason Restart(String arguments);
 
         void UnregisterKey();
@@ -79,6 +89,7 @@ namespace Microsoft.Windows.AppLifecycle
         UInt32 ProcessId{ get; };
     }
 
+    [contract(AppLifecycleContract, 1)]
     static runtimeclass ActivationRegistrationManager
     {
         static void RegisterForFileTypeActivation(String[] supportedFileTypes, String logo,


### PR DESCRIPTION
The AppLifecycle types were not on an api contract in the 1.0 release. And in the meantime, there have been two additions to these types:
- The enum `ExtendedActivationKind` added `AppNotification`
- The runtimeclass `AppInstance` added the static method `Restart`.

Without adding a new contract version, these changes would create an ABI breaking change. These two additions are now in the v2 contract version.

(Note: this will need to be cherry-picked into the 1.1 release branch)