### PR TITLE
List of contracts across WinApSDK

### DIFF
--- a/specs/WinRT/WinRTAPIContracts.md
+++ b/specs/WinRT/WinRTAPIContracts.md
@@ -120,5 +120,5 @@ TODO:Start of the list. Needs review and undoubtedly correction and additions (e
 | ---                | ---           | WindowsAppSDKContract           | Microsoft.Foundation                                 |1,2,3    |
 
 <sup>1</sup> Only for use by IXP.<BR>
-<sup>2</sup> This contract is misnamed. It should be called `InteractiveExperiencesContract` in the `Windows.UI.Composition` namespace.<BR>
+<sup>2</sup> This contract is misnamed. It should have been named `InteractiveExperiencesContract` in the `Windows.UI.Composition` namespace.<BR>
 <sup>3</sup> This contract is misversioned. It should have been `[contract(...,1)]` instead of `[contract(...,1.1)]`. The next contract version will be `[contract(...,2)]`.<BR>

--- a/specs/WinRT/WinRTAPIContracts.md
+++ b/specs/WinRT/WinRTAPIContracts.md
@@ -22,18 +22,22 @@ WinRT APIs.
    1. One contract per feature/component/sub-system
    2. Contracts will not span across a transport package/repo
 2. **Contract Version**<BR>
-Contracts versions are a single number with no minor version, no "x.y".  The contract version is
-frozen on a stable release.  Any changes after a stable release requires the version to be incremented.
+Contracts versions are a single number with no minor version, no "x.y". The contract version is
+frozen on a stable release. Any changes after a stable release requires the version to be incremented.
 3. **Enforcement**<BR>
 The build system has gates that enforce contract versioning to verify that contract is present,
  up to date, and there are no conflicts between APIs.
 4. **Contract Migration**<BR>
 This spec does not deal with contract migration. A separate spec will be available for contract
 migration if, and when, it is needed.
-5. **Internal contracts**<BR>
-All internal WinRT APIs have a contract, and the version is 1. The version is never updated.
-6. **Contract naming**<BR>
-Contract names must end with the word `Contract`.
+5. **Contract naming**<BR>
+Contract names must end with `Contract`.
+6. **Internal contracts**<BR>
+Internal contracts follow additional rules:
+    1. All internal WinRT APIs have an internal contract.
+    2. Internal contracts are tagged with `[internal]`.
+    3. Internal contracts are always version 1. The version is never updated.
+    4. Internal contract names must end with `InternalContract`
 
 # 3. Adding a new contract
 Contract placement is part of an API review. When adding a new API, the API team will
@@ -98,16 +102,19 @@ The list of all contracts defined across Windows App SDK
 
 TODO:Start of the list. Needs review and undoubtedly correction and additions (e.g. IXP)
 
-| Feature            | Repository    | Contract                        | NamespaceMicrosoft.Windows.System.Power              | Comment |
-|--------------------|---------------|---------------------------------|------------------------------------------------------|---------|
-| AccessControl      | windowsappsdk | AccessControlContract           | Microsoft.Windows.Security.AccessControl             |         |
-| AppLifecycle       | windowsappsdk | AppLifecycleContract            | Microsoft.Windows.AppLifecycle                       |         |
-| AppNotifications   | windowsappsdk | WindowsAppNotificationsContract | Microsoft.Windows.AppNotifications                   |         |
-| Deployment         | windowsappsdk | DeploymentManagerContract       | Microsoft.Windows.ApplicationModel.WindowsAppRuntime |         |
-| DynamicDependency  | windowsappsdk | DynamicDependencyContract       | Microsoft.Windows.ApplicationModel.DynamicDependency |         |
-| EnvironmentManager | windowsappsdk | EnvironmentManagerContracct     | Microsoft.Windows.System                             |         |
-| MRTCore            | windowsappsdk | MrtContract                     | Microsoft.Windows.ApplicationModel.Resources         |         |
-| PowerNotifications | windowsappsdk | PowerNotificationsContract      | Microsoft.Windows.System.Power                       |         |
-| PushNotifications  | windowsappsdk | PushNotificationsContract       | Microsoft.Windows.PushNotifications                  |         |
-| WinUI              | winui         | WinUIContract                   | Microsoft.UI.Xaml                                    |         |
-| WinUI              | winui         | WinUIControlsContract           | Microsoft.UI.Xaml.Controls                           |         |
+| Feature            | Repository    | Contract                        | NamespaceMicrosoft.Windows.System.Power              | Comment  |
+|--------------------|---------------|---------------------------------|------------------------------------------------------|----------|
+| AccessControl      | windowsappsdk | AccessControlContract           | Microsoft.Windows.Security.AccessControl             |          |
+| AppLifecycle       | windowsappsdk | AppLifecycleContract            | Microsoft.Windows.AppLifecycle                       |          |
+| AppNotifications   | windowsappsdk | WindowsAppNotificationsContract | Microsoft.Windows.AppNotifications                   |          |
+| Deployment         | windowsappsdk | DeploymentManagerContract       | Microsoft.Windows.ApplicationModel.WindowsAppRuntime |          |
+| DynamicDependency  | windowsappsdk | DynamicDependencyContract       | Microsoft.Windows.ApplicationModel.DynamicDependency |          |
+| EnvironmentManager | windowsappsdk | EnvironmentManagerContracct     | Microsoft.Windows.System                             |          |
+| MRTCore            | windowsappsdk | MrtContract                     | Microsoft.Windows.ApplicationModel.Resources         |          |
+| PowerNotifications | windowsappsdk | PowerNotificationsContract      | Microsoft.Windows.System.Power                       |          |
+| PushNotifications  | windowsappsdk | PushNotificationsContract       | Microsoft.Windows.PushNotifications                  |          |
+| WinUI              | winui         | HostingContract                 | Microsoft.UI.Xaml.Hosting                            |          |
+| WinUI              | winui         | WinUIContract                   | Microsoft.UI.Xaml                                    |          |
+| WinUI              | winui         | WinUIControlsContract           | Microsoft.UI.Xaml.Controls                           |          |
+| WinUI              | winui         | XamlDirectContract              | Microsoft.UI.Xaml.Core.Direct                        |          |
+| ---                | ---           | WindowsAppSDKContract           | Microsoft.Foundation                                 |Do not use|

--- a/specs/WinRT/WinRTAPIContracts.md
+++ b/specs/WinRT/WinRTAPIContracts.md
@@ -102,7 +102,7 @@ The list of all contracts defined across Windows App SDK
 
 TODO:Start of the list. Needs review and undoubtedly correction and additions (e.g. IXP)
 
-| Feature            | Repository    | Contract                        | NamespaceMicrosoft.Windows.System.Power              | Comment  |
+| Feature            | Repository    | Contract                        | Namespace                                            | Comment  |
 |--------------------|---------------|---------------------------------|------------------------------------------------------|----------|
 | AccessControl      | windowsappsdk | AccessControlContract           | Microsoft.Windows.Security.AccessControl             |          |
 | AppLifecycle       | windowsappsdk | AppLifecycleContract            | Microsoft.Windows.AppLifecycle                       |          |

--- a/specs/WinRT/WinRTAPIContracts.md
+++ b/specs/WinRT/WinRTAPIContracts.md
@@ -1,7 +1,14 @@
-# New Document
-# Windows App SDK API Contracts
+- [1. Windows App SDK API Contracts](#1-windows-app-sdk-api-contracts)
+- [2. Architectural Decisions](#2-architectural-decisions)
+- [3. Adding a new contract](#3-adding-a-new-contract)
+  - [3.1. Example](#31-example)
+- [4. Missing contracts is a ship blocker](#4-missing-contracts-is-a-ship-blocker)
+  - [4.1. Gate check-ins](#41-gate-check-ins)
+- [5. Telemetry](#5-telemetry)
+- [6. All Contracts in Windows App SDK](#6-all-contracts-in-windows-app-sdk)
 
-## Summary
+# 1. Windows App SDK API Contracts
+
 Customers trust that Microsoft products are sound. As Windows App SDK evolves and more developers
 use Windows App SDK in their own projects Windows App SDK needs a way, at build time and run time,
 to allow apps to light up API features and to gracefully degrade. This can be achieved by looking
@@ -10,36 +17,37 @@ at the deltas between APIs.
 In order to allow apps to depend on API versions Windows App SDK will add contracts to all their
 WinRT APIs.
 
-## Architecture Decisions
-1. Contract boundaries
-   1. One contract per feature/component/sub-system.
-   2. Contracts will not span across a transport package/repo.
-2. Contract numbering  
+# 2. Architectural Decisions
+1. **Contract Boundaries**<BR>
+   1. One contract per feature/component/sub-system
+   2. Contracts will not span across a transport package/repo
+2. **Contract Version**<BR>
 Contracts versions are a single number with no minor version, no "x.y".  The contract version is
 frozen on a stable release.  Any changes after a stable release requires the version to be incremented.
-3. Enforcement  
+3. **Enforcement**<BR>
 The build system has gates that enforce contract versioning to verify that contract is present,
  up to date, and there are no conflicts between APIs.
-4. Contract migration  
+4. **Contract Migration**<BR>
 This spec does not deal with contract migration. A separate spec will be available for contract
 migration if, and when, it is needed.
-5. Internal contracts  
-All WinRT internal APIs have a contract, and the version is 1. The version is never updated.
-6. Contract naming  
-Contract names need to end with the word `Contract`.
+5. **Internal contracts**<BR>
+All internal WinRT APIs have a contract, and the version is 1. The version is never updated.
+6. **Contract naming**<BR>
+Contract names must end with the word `Contract`.
 
-## Adding a new contract
+# 3. Adding a new contract
 Contract placement is part of an API review. When adding a new API, the API team will
 talk about what contract the API will go under.
 
-## Example
-```
+## 3.1. Example
+
+```c# (really midl3)
 namespace Microsoft.Windows.System
 {
     [contractversion(1)]
-    apicontract WindowsSystemContract {}
-    
-    [Contract(MicrosoftWindowsSystem, 1)]
+    apicontract EnvironmentManagerContract {}
+
+    [Contract(EnvironmentManagerContract, 1)]
     runtimeclass EnvironmentManager
     {
         static EnvironmentManager GetForProcess();
@@ -62,27 +70,44 @@ namespace Microsoft.Windows.System
     }
 }
 ```
-## 1.1 ship blocker
-Any APIs that changed between 1.0 and 1.1 need to add a contract or 1.1 will not ship.
 
-## Telemetry
-API specific telemetry will not be collected because it does not provide any additional information
-compared to the Windows App SDK version.
+# 4. Missing contracts is a ship blocker
+WinRT APIs without a contract are a shipblocking bug.
 
-## Gate check-ins
+## 4.1. Gate check-ins
 Because the contracts are used for API versions there will need to be work done in the build system
 to make sure
 1. All APIs have contracts
 2. Each contract is correct. This means version and name.
 3. All Contracts and dependencies work with each other.
-4. Contracts/Types in releases honor the source/binary/behavior compatibility rules e.g. 
+4. Contracts/Types in releases honor the source/binary/behavior compatibility rules e.g.
 contracts/types in a stable release doesn't change in future releases of the same major version
 (e.g. contracts/types in 1.1 don't change in 1.2, 1.3, ...)
 
 The builds that check for contracts compatibility are:
 1. Nightly
-2. Release 
+2. Release
 3. PR
 
-## Open issues
-None.
+# 5. Telemetry
+API contract version specific telemetry will not be collected because it does not provide any
+additional information compared to the Windows App SDK version.
+
+# 6. All Contracts in Windows App SDK
+The list of all contracts defined across Windows App SDK
+
+TODO:Start of the list. Needs review and undoubtedly correction and additions (e.g. IXP)
+
+| Feature            | Repository    | Contract                        | NamespaceMicrosoft.Windows.System.Power              | Comment |
+|--------------------|---------------|---------------------------------|------------------------------------------------------|---------|
+| AccessControl      | windowsappsdk | AccessControlContract           | Microsoft.Windows.Security.AccessControl             |         |
+| AppLifecycle       | windowsappsdk | AppLifecycleContract            | Microsoft.Windows.AppLifecycle                       |         |
+| AppNotifications   | windowsappsdk | WindowsAppNotificationsContract | Microsoft.Windows.AppNotifications                   |         |
+| Deployment         | windowsappsdk | DeploymentManagerContract       | Microsoft.Windows.ApplicationModel.WindowsAppRuntime |         |
+| DynamicDependency  | windowsappsdk | DynamicDependencyContract       | Microsoft.Windows.ApplicationModel.DynamicDependency |         |
+| EnvironmentManager | windowsappsdk | EnvironmentManagerContracct     | Microsoft.Windows.System                             |         |
+| MRTCore            | windowsappsdk | MrtContract                     | Microsoft.Windows.ApplicationModel.Resources         |         |
+| PowerNotifications | windowsappsdk | PowerNotificationsContract      | Microsoft.Windows.System.Power                       |         |
+| PushNotifications  | windowsappsdk | PushNotificationsContract       | Microsoft.Windows.PushNotifications                  |         |
+| WinUI              | winui         | WinUIContract                   | Microsoft.UI.Xaml                                    |         |
+| WinUI              | winui         | WinUIControlsContract           | Microsoft.UI.Xaml.Controls                           |         |

--- a/specs/WinRT/WinRTAPIContracts.md
+++ b/specs/WinRT/WinRTAPIContracts.md
@@ -118,5 +118,5 @@ The list of all contracts defined across Windows App SDK
 | ---                | ---           | WindowsAppSDKContract           | Microsoft.Foundation                                 |1,2,3    |
 
 <sup>1</sup> Only for use by IXP.<BR>
-<sup>2</sup> This contract is misnamed. It should have been named `InteractiveExperiencesContract` in the `Windows.UI.Composition` namespace.<BR>
+<sup>2</sup> This contract is misnamed. It should have been `InteractiveExperiencesContract` in the `Windows.UI.Composition` namespace.<BR>
 <sup>3</sup> This contract is misversioned. It should have been `[contract(...,1)]` instead of `[contract(...,1.1)]`. The next contract version will be `[contract(...,2)]`.<BR>

--- a/specs/WinRT/WinRTAPIContracts.md
+++ b/specs/WinRT/WinRTAPIContracts.md
@@ -102,19 +102,23 @@ The list of all contracts defined across Windows App SDK
 
 TODO:Start of the list. Needs review and undoubtedly correction and additions (e.g. IXP)
 
-| Feature            | Repository    | Contract                        | Namespace                                            | Comment  |
-|--------------------|---------------|---------------------------------|------------------------------------------------------|----------|
-| AccessControl      | windowsappsdk | AccessControlContract           | Microsoft.Windows.Security.AccessControl             |          |
-| AppLifecycle       | windowsappsdk | AppLifecycleContract            | Microsoft.Windows.AppLifecycle                       |          |
-| AppNotifications   | windowsappsdk | WindowsAppNotificationsContract | Microsoft.Windows.AppNotifications                   |          |
-| Deployment         | windowsappsdk | DeploymentManagerContract       | Microsoft.Windows.ApplicationModel.WindowsAppRuntime |          |
-| DynamicDependency  | windowsappsdk | DynamicDependencyContract       | Microsoft.Windows.ApplicationModel.DynamicDependency |          |
-| EnvironmentManager | windowsappsdk | EnvironmentManagerContracct     | Microsoft.Windows.System                             |          |
-| MRTCore            | windowsappsdk | MrtContract                     | Microsoft.Windows.ApplicationModel.Resources         |          |
-| PowerNotifications | windowsappsdk | PowerNotificationsContract      | Microsoft.Windows.System.Power                       |          |
-| PushNotifications  | windowsappsdk | PushNotificationsContract       | Microsoft.Windows.PushNotifications                  |          |
-| WinUI              | winui         | HostingContract                 | Microsoft.UI.Xaml.Hosting                            |          |
-| WinUI              | winui         | WinUIContract                   | Microsoft.UI.Xaml                                    |          |
-| WinUI              | winui         | WinUIControlsContract           | Microsoft.UI.Xaml.Controls                           |          |
-| WinUI              | winui         | XamlDirectContract              | Microsoft.UI.Xaml.Core.Direct                        |          |
-| ---                | ---           | WindowsAppSDKContract           | Microsoft.Foundation                                 |Only for use by IXP.<P>Misnomer. Should be called InteractiveExperiences in the Windows.UI.Composition namespace.|
+| Feature            | Repository    | Contract                        | Namespace                                            | Comment |
+|--------------------|---------------|---------------------------------|------------------------------------------------------|---------|
+| AccessControl      | windowsappsdk | AccessControlContract           | Microsoft.Windows.Security.AccessControl             |         |
+| AppLifecycle       | windowsappsdk | AppLifecycleContract            | Microsoft.Windows.AppLifecycle                       |         |
+| AppNotifications   | windowsappsdk | WindowsAppNotificationsContract | Microsoft.Windows.AppNotifications                   |         |
+| Deployment         | windowsappsdk | DeploymentManagerContract       | Microsoft.Windows.ApplicationModel.WindowsAppRuntime |         |
+| DynamicDependency  | windowsappsdk | DynamicDependencyContract       | Microsoft.Windows.ApplicationModel.DynamicDependency |         |
+| EnvironmentManager | windowsappsdk | EnvironmentManagerContracct     | Microsoft.Windows.System                             |         |
+| MRTCore            | windowsappsdk | MrtContract                     | Microsoft.Windows.ApplicationModel.Resources         |         |
+| PowerNotifications | windowsappsdk | PowerNotificationsContract      | Microsoft.Windows.System.Power                       |         |
+| PushNotifications  | windowsappsdk | PushNotificationsContract       | Microsoft.Windows.PushNotifications                  |         |
+| WinUI              | winui         | HostingContract                 | Microsoft.UI.Xaml.Hosting                            |         |
+| WinUI              | winui         | WinUIContract                   | Microsoft.UI.Xaml                                    |         |
+| WinUI              | winui         | WinUIControlsContract           | Microsoft.UI.Xaml.Controls                           |         |
+| WinUI              | winui         | XamlDirectContract              | Microsoft.UI.Xaml.Core.Direct                        |         |
+| ---                | ---           | WindowsAppSDKContract           | Microsoft.Foundation                                 |1,2,3    |
+
+<sup>1</sup> Only for use by IXP.
+<sup>2</sup> This contract is misnamed. It should be called `InteractiveExperiencesContract` in the `Windows.UI.Composition` namespace.
+<sup>3</sup> This contract is misversioned. It should have been `[contract(...,1)]` instead of `[contract(...,1.1)]`. The next contract version will be `[contract(...,2)]`.

--- a/specs/WinRT/WinRTAPIContracts.md
+++ b/specs/WinRT/WinRTAPIContracts.md
@@ -117,4 +117,4 @@ TODO:Start of the list. Needs review and undoubtedly correction and additions (e
 | WinUI              | winui         | WinUIContract                   | Microsoft.UI.Xaml                                    |          |
 | WinUI              | winui         | WinUIControlsContract           | Microsoft.UI.Xaml.Controls                           |          |
 | WinUI              | winui         | XamlDirectContract              | Microsoft.UI.Xaml.Core.Direct                        |          |
-| ---                | ---           | WindowsAppSDKContract           | Microsoft.Foundation                                 |Misnomer. Should be called InteractiveExperiences in the Windows.UI.Composition namespace. Only for use by IXP.|
+| ---                | ---           | WindowsAppSDKContract           | Microsoft.Foundation                                 |Only for use by IXP.<P>Misnomer. Should be called InteractiveExperiences in the Windows.UI.Composition namespace.|

--- a/specs/WinRT/WinRTAPIContracts.md
+++ b/specs/WinRT/WinRTAPIContracts.md
@@ -104,7 +104,7 @@ The list of all contracts defined across Windows App SDK
 |--------------------|---------------|---------------------------------|------------------------------------------------------|---------|
 | AccessControl      | windowsappsdk | AccessControlContract           | Microsoft.Windows.Security.AccessControl             |         |
 | AppLifecycle       | windowsappsdk | AppLifecycleContract            | Microsoft.Windows.AppLifecycle                       |         |
-| AppNotifications   | windowsappsdk | WindowsAppNotificationsContract | Microsoft.Windows.AppNotifications                   |         |
+| AppNotifications   | windowsappsdk | AppNotificationsContract        | Microsoft.Windows.AppNotifications                   |         |
 | Deployment         | windowsappsdk | DeploymentManagerContract       | Microsoft.Windows.ApplicationModel.WindowsAppRuntime |         |
 | DynamicDependency  | windowsappsdk | DynamicDependencyContract       | Microsoft.Windows.ApplicationModel.DynamicDependency |         |
 | EnvironmentManager | windowsappsdk | EnvironmentManagerContracct     | Microsoft.Windows.System                             |         |

--- a/specs/WinRT/WinRTAPIContracts.md
+++ b/specs/WinRT/WinRTAPIContracts.md
@@ -51,7 +51,7 @@ namespace Microsoft.Windows.System
     [contractversion(1)]
     apicontract EnvironmentManagerContract {}
 
-    [Contract(EnvironmentManagerContract, 1)]
+    [contract(EnvironmentManagerContract, 1)]
     runtimeclass EnvironmentManager
     {
         static EnvironmentManager GetForProcess();
@@ -108,7 +108,7 @@ The list of all contracts defined across Windows App SDK
 | Deployment         | windowsappsdk | DeploymentManagerContract       | Microsoft.Windows.ApplicationModel.WindowsAppRuntime |         |
 | DynamicDependency  | windowsappsdk | DynamicDependencyContract       | Microsoft.Windows.ApplicationModel.DynamicDependency |         |
 | EnvironmentManager | windowsappsdk | EnvironmentManagerContracct     | Microsoft.Windows.System                             |         |
-| MRTCore            | windowsappsdk | MrtContract                     | Microsoft.Windows.ApplicationModel.Resources         |         |
+| MRTCore            | windowsappsdk | MrtCoreContract                 | Microsoft.Windows.ApplicationModel.Resources         |         |
 | PowerNotifications | windowsappsdk | PowerNotificationsContract      | Microsoft.Windows.System.Power                       |         |
 | PushNotifications  | windowsappsdk | PushNotificationsContract       | Microsoft.Windows.PushNotifications                  |         |
 | WinUI              | winui         | HostingContract                 | Microsoft.UI.Xaml.Hosting                            |         |
@@ -117,6 +117,6 @@ The list of all contracts defined across Windows App SDK
 | WinUI              | winui         | XamlDirectContract              | Microsoft.UI.Xaml.Core.Direct                        |         |
 | ---                | ---           | WindowsAppSDKContract           | Microsoft.Foundation                                 |1,2,3    |
 
-<sup>1</sup> Only for use by IXP.<BR>
+<sup>1</sup> Only for use by InteractiveExperiences.<BR>
 <sup>2</sup> This contract is misnamed. It should have been `InteractiveExperiencesContract` in the `Windows.UI.Composition` namespace.<BR>
 <sup>3</sup> This contract is misversioned. It should have been `[contract(...,1)]` instead of `[contract(...,1.1)]`. The next contract version will be `[contract(...,2)]`.<BR>

--- a/specs/WinRT/WinRTAPIContracts.md
+++ b/specs/WinRT/WinRTAPIContracts.md
@@ -117,4 +117,4 @@ TODO:Start of the list. Needs review and undoubtedly correction and additions (e
 | WinUI              | winui         | WinUIContract                   | Microsoft.UI.Xaml                                    |          |
 | WinUI              | winui         | WinUIControlsContract           | Microsoft.UI.Xaml.Controls                           |          |
 | WinUI              | winui         | XamlDirectContract              | Microsoft.UI.Xaml.Core.Direct                        |          |
-| ---                | ---           | WindowsAppSDKContract           | Microsoft.Foundation                                 |Do not use|
+| ---                | ---           | WindowsAppSDKContract           | Microsoft.Foundation                                 |Misnomer. Should be called InteractiveExperiences in the Windows.UI.Composition namespace. Only for use by IXP.|

--- a/specs/WinRT/WinRTAPIContracts.md
+++ b/specs/WinRT/WinRTAPIContracts.md
@@ -100,8 +100,6 @@ additional information compared to the Windows App SDK version.
 # 6. All Contracts in Windows App SDK
 The list of all contracts defined across Windows App SDK
 
-TODO:Start of the list. Needs review and undoubtedly correction and additions (e.g. IXP)
-
 | Feature            | Repository    | Contract                        | Namespace                                            | Comment |
 |--------------------|---------------|---------------------------------|------------------------------------------------------|---------|
 | AccessControl      | windowsappsdk | AccessControlContract           | Microsoft.Windows.Security.AccessControl             |         |

--- a/specs/WinRT/WinRTAPIContracts.md
+++ b/specs/WinRT/WinRTAPIContracts.md
@@ -119,6 +119,6 @@ TODO:Start of the list. Needs review and undoubtedly correction and additions (e
 | WinUI              | winui         | XamlDirectContract              | Microsoft.UI.Xaml.Core.Direct                        |         |
 | ---                | ---           | WindowsAppSDKContract           | Microsoft.Foundation                                 |1,2,3    |
 
-<sup>1</sup> Only for use by IXP.
-<sup>2</sup> This contract is misnamed. It should be called `InteractiveExperiencesContract` in the `Windows.UI.Composition` namespace.
-<sup>3</sup> This contract is misversioned. It should have been `[contract(...,1)]` instead of `[contract(...,1.1)]`. The next contract version will be `[contract(...,2)]`.
+<sup>1</sup> Only for use by IXP.<BR>
+<sup>2</sup> This contract is misnamed. It should be called `InteractiveExperiencesContract` in the `Windows.UI.Composition` namespace.<BR>
+<sup>3</sup> This contract is misversioned. It should have been `[contract(...,1)]` instead of `[contract(...,1.1)]`. The next contract version will be `[contract(...,2)]`.<BR>


### PR DESCRIPTION
Added list of contacts acrocss WinAppSDK. NOTE: The list is meant to start the dialogue. There's undoubtedly corrections and additions needed.

Added TOC and section numbering. Minor formatting corrections

NOTE: This is a work-in-progress. Goal is to have a master list of the various contract names across features, then bring the list through API Review in 1 pass, then update code to match if/as necessary.