### PR TITLE
Remove [experimental] tags take 2

### DIFF
--- a/dev/AppNotifications/AppNotification.cpp
+++ b/dev/AppNotifications/AppNotification.cpp
@@ -9,8 +9,6 @@ namespace winrt::Microsoft::Windows::AppNotifications::implementation
 {
     AppNotification::AppNotification(hstring const& payload)
     {
-        THROW_HR_IF(E_NOTIMPL, !::Microsoft::Windows::AppNotifications::Feature_AppNotifications::IsEnabled());
-
         XmlDocument xmlDocument{};
 
         // We call LoadXml to verify the payload is xml

--- a/dev/AppNotifications/AppNotification.cpp
+++ b/dev/AppNotifications/AppNotification.cpp
@@ -1,7 +1,6 @@
 ﻿#include "pch.h"
 #include "AppNotification.h"
 #include "Microsoft.Windows.AppNotifications.AppNotification.g.cpp"
-#include <TerminalVelocityFeatures-AppNotifications.h>
 
 using namespace winrt::Windows::Data::Xml::Dom;
 

--- a/dev/AppNotifications/AppNotificationManager.cpp
+++ b/dev/AppNotifications/AppNotificationManager.cpp
@@ -19,7 +19,6 @@
 #include <winerror.h>
 #include <string_view>
 #include <winrt/Windows.Foundation.Collections.h>
-#include <TerminalVelocityFeatures-AppNotifications.h>
 #include <WindowsAppRuntime.SelfContained.h>
 
 using namespace std::literals;

--- a/dev/AppNotifications/AppNotificationProgressData.cpp
+++ b/dev/AppNotifications/AppNotificationProgressData.cpp
@@ -1,7 +1,6 @@
 ﻿#include "pch.h"
 #include "AppNotificationProgressData.h"
 #include "Microsoft.Windows.AppNotifications.AppNotificationProgressData.g.cpp"
-#include <TerminalVelocityFeatures-AppNotifications.h>
 
 namespace winrt::Microsoft::Windows::AppNotifications::implementation
 {

--- a/dev/AppNotifications/AppNotificationProgressData.cpp
+++ b/dev/AppNotifications/AppNotificationProgressData.cpp
@@ -7,8 +7,6 @@ namespace winrt::Microsoft::Windows::AppNotifications::implementation
 {
     AppNotificationProgressData::AppNotificationProgressData(uint32_t sequenceNumber)
     {
-        THROW_HR_IF(E_NOTIMPL, !::Microsoft::Windows::AppNotifications::Feature_AppNotifications::IsEnabled());
-
         THROW_HR_IF(E_INVALIDARG, sequenceNumber == 0); // The sequence number is always greater than 0
         m_sequenceNumber = sequenceNumber;
     }

--- a/dev/AppNotifications/AppNotifications.idl
+++ b/dev/AppNotifications/AppNotifications.idl
@@ -1,7 +1,5 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
-#include <TerminalVelocityFeatures-AppNotifications.h>
-
 import "..\AppLifecycle\AppLifecycle.idl";
 
 namespace Microsoft.Windows.AppNotifications

--- a/dev/AppNotifications/AppNotifications.idl
+++ b/dev/AppNotifications/AppNotifications.idl
@@ -11,7 +11,6 @@ namespace Microsoft.Windows.AppNotifications
     apicontract WindowsAppNotificationsContract {}
 
     // Event args for the Notification Activation
-    [feature(Feature_AppNotifications)]
     [contract(WindowsAppNotificationsContract, 1)]
     runtimeclass AppNotificationActivatedEventArgs
     {
@@ -23,7 +22,6 @@ namespace Microsoft.Windows.AppNotifications
     }
 
     // Notification Progress Data
-    [feature(Feature_AppNotifications)]
     [contract(WindowsAppNotificationsContract, 1)]
     runtimeclass AppNotificationProgressData
     {
@@ -49,7 +47,6 @@ namespace Microsoft.Windows.AppNotifications
     }
 
     // The Notification User Setting or Notification Group Policy Setting
-    [feature(Feature_AppNotifications)]
     [contract(WindowsAppNotificationsContract, 1)]
     enum AppNotificationSetting
     {
@@ -61,7 +58,6 @@ namespace Microsoft.Windows.AppNotifications
     };
 
     // The Result for a Notification Progress related operation
-    [feature(Feature_AppNotifications)]
     [contract(WindowsAppNotificationsContract, 1)]
     enum AppNotificationProgressResult
     {
@@ -70,7 +66,6 @@ namespace Microsoft.Windows.AppNotifications
     };
 
     // The Priority of the Notification UI associated with it's popup in the Action Centre
-    [feature(Feature_AppNotifications)]
     [contract(WindowsAppNotificationsContract, 1)]
     enum AppNotificationPriority
     {
@@ -78,7 +73,6 @@ namespace Microsoft.Windows.AppNotifications
         High, // The notification should be treated as high priority. For desktop PCs, this means during connected standby mode the incoming notification can turn on the screen for Surface-like devices if it doesn't have a closed lid detected.
     };
 
-    [feature(Feature_AppNotifications)]
     [contract(WindowsAppNotificationsContract, 1)]
     runtimeclass AppNotification
     {
@@ -115,7 +109,6 @@ namespace Microsoft.Windows.AppNotifications
     }
 
     // The manager class which encompasses all App Notification API Functionality
-    [feature(Feature_AppNotifications)]
     [contract(WindowsAppNotificationsContract, 1)]
     runtimeclass AppNotificationManager
     {

--- a/dev/PushNotifications/PushNotificationChannel.cpp
+++ b/dev/PushNotifications/PushNotificationChannel.cpp
@@ -24,8 +24,6 @@ namespace winrt::Microsoft::Windows::PushNotifications::implementation
 {
     PushNotificationChannel::PushNotificationChannel(struct ChannelDetails channelInfo)
     {
-        THROW_HR_IF(E_NOTIMPL, !::Microsoft::Windows::PushNotifications::Feature_PushNotifications::IsEnabled());
-
         std::swap(m_channelInfo, channelInfo);
     }
 

--- a/dev/PushNotifications/PushNotificationChannel.h
+++ b/dev/PushNotifications/PushNotificationChannel.h
@@ -3,9 +3,7 @@
 
 #pragma once
 #include "Microsoft.Windows.PushNotifications.PushNotificationChannel.g.h"
-
 #include "winrt/Windows.Networking.PushNotifications.h"
-#include <TerminalVelocityFeatures-PushNotifications.h>
 #include "externs.h"
 
 namespace winrt::Microsoft::Windows::PushNotifications::implementation

--- a/dev/PushNotifications/PushNotificationCreateChannelResult.cpp
+++ b/dev/PushNotifications/PushNotificationCreateChannelResult.cpp
@@ -3,7 +3,6 @@
 
 #include "pch.h"
 #include "PushNotificationCreateChannelResult.h"
-#include <TerminalVelocityFeatures-PushNotifications.h>
 #include "Microsoft.Windows.PushNotifications.PushNotificationCreateChannelResult.g.cpp"
 
 namespace winrt::Microsoft::Windows::PushNotifications::implementation

--- a/dev/PushNotifications/PushNotificationCreateChannelResult.cpp
+++ b/dev/PushNotifications/PushNotificationCreateChannelResult.cpp
@@ -13,7 +13,6 @@ namespace winrt::Microsoft::Windows::PushNotifications::implementation
         m_extendedError(extendedError),
         m_status(status)
     {
-        THROW_HR_IF(E_NOTIMPL, !::Microsoft::Windows::PushNotifications::Feature_PushNotifications::IsEnabled());
     }
 
     PushNotificationChannel PushNotificationCreateChannelResult::Channel()

--- a/dev/PushNotifications/PushNotificationManager.cpp
+++ b/dev/PushNotifications/PushNotificationManager.cpp
@@ -137,8 +137,6 @@ namespace winrt::Microsoft::Windows::PushNotifications::implementation
 
     winrt::Microsoft::Windows::PushNotifications::PushNotificationManager PushNotificationManager::Default()
     {
-        THROW_HR_IF(E_NOTIMPL, !::Microsoft::Windows::PushNotifications::Feature_PushNotifications::IsEnabled());
-
         static wil::srwlock lock;
 
         auto criticalSection{ lock.lock_exclusive() };
@@ -196,8 +194,6 @@ namespace winrt::Microsoft::Windows::PushNotifications::implementation
 
     winrt::IAsyncOperationWithProgress<winrt::Microsoft::Windows::PushNotifications::PushNotificationCreateChannelResult, winrt::Microsoft::Windows::PushNotifications::PushNotificationCreateChannelStatus> PushNotificationManager::CreateChannelAsync(const winrt::guid remoteId)
     {
-        THROW_HR_IF(E_NOTIMPL, !::Microsoft::Windows::PushNotifications::Feature_PushNotifications::IsEnabled());
-
         if (!IsSupported())
         {
             co_return winrt::make<PushNotificationCreateChannelResult>(

--- a/dev/PushNotifications/PushNotificationReceivedEventArgs.cpp
+++ b/dev/PushNotifications/PushNotificationReceivedEventArgs.cpp
@@ -31,28 +31,24 @@ namespace winrt::Microsoft::Windows::PushNotifications::implementation
         m_rawNotificationPayload(BuildPayload(backgroundTask.TriggerDetails().as<RawNotification>().ContentBytes())),
         m_unpackagedAppScenario(false)
     {
-        THROW_HR_IF(E_NOTIMPL, !::Microsoft::Windows::PushNotifications::Feature_PushNotifications::IsEnabled());
     }
 
     PushNotificationReceivedEventArgs::PushNotificationReceivedEventArgs(winrt::PushNotificationReceivedEventArgs const& args):
         m_rawNotificationPayload(BuildPayload(args.RawNotification().ContentBytes())),
         m_unpackagedAppScenario(false)
     {
-        THROW_HR_IF(E_NOTIMPL, !::Microsoft::Windows::PushNotifications::Feature_PushNotifications::IsEnabled());
     }
 
     PushNotificationReceivedEventArgs::PushNotificationReceivedEventArgs(byte* const& payload, ULONG const& length) :
         m_rawNotificationPayload(BuildPayload(payload, length)),
         m_unpackagedAppScenario(true)
     {
-        THROW_HR_IF(E_NOTIMPL, !::Microsoft::Windows::PushNotifications::Feature_PushNotifications::IsEnabled());
     }
 
     PushNotificationReceivedEventArgs::PushNotificationReceivedEventArgs(winrt::hstring const& payload) :
         m_rawNotificationPayload(BuildPayload(payload)),
         m_unpackagedAppScenario(true)
     {
-        THROW_HR_IF(E_NOTIMPL, !::Microsoft::Windows::PushNotifications::Feature_PushNotifications::IsEnabled());
     }
 
     std::vector<uint8_t> PushNotificationReceivedEventArgs::BuildPayload(winrt::Windows::Storage::Streams::IBuffer const& buffer)

--- a/dev/PushNotifications/PushNotificationReceivedEventArgs.cpp
+++ b/dev/PushNotifications/PushNotificationReceivedEventArgs.cpp
@@ -6,7 +6,6 @@
 #include <winrt/Windows.ApplicationModel.background.h>
 #include <winrt/Windows.Storage.Streams.h>
 #include <winrt/Windows.Networking.PushNotifications.h>
-#include <TerminalVelocityFeatures-PushNotifications.h>
 #include "PushNotificationReceivedEventArgs.h"
 #include "Microsoft.Windows.PushNotifications.PushNotificationReceivedEventArgs.g.cpp"
 #include <iostream>

--- a/dev/PushNotifications/PushNotifications.idl
+++ b/dev/PushNotifications/PushNotifications.idl
@@ -1,8 +1,6 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
-#include <TerminalVelocityFeatures-PushNotifications.h>
-
 namespace Microsoft.Windows.PushNotifications
 {
     // Event args for the Push payload.

--- a/dev/PushNotifications/PushNotifications.idl
+++ b/dev/PushNotifications/PushNotifications.idl
@@ -5,7 +5,6 @@
 
 namespace Microsoft.Windows.PushNotifications
 {
-    [feature(Feature_PushNotifications)]
     // Event args for the Push payload.
     runtimeclass PushNotificationReceivedEventArgs
     {
@@ -19,7 +18,6 @@ namespace Microsoft.Windows.PushNotifications
         event Windows.ApplicationModel.Background.BackgroundTaskCanceledEventHandler Canceled;
     };
 
-    [feature(Feature_PushNotifications)]
     enum PushNotificationChannelStatus
     {
         InProgress, // The request is in progress and there is no retry operation
@@ -29,7 +27,6 @@ namespace Microsoft.Windows.PushNotifications
     };
 
     // The PushNotificationChannel Progress result
-    [feature(Feature_PushNotifications)]
     struct PushNotificationCreateChannelStatus
     {
         // Either InProgress or InProgressRetry status
@@ -42,7 +39,6 @@ namespace Microsoft.Windows.PushNotifications
         UInt32 retryCount;
     };
 
-    [feature(Feature_PushNotifications)]
     runtimeclass PushNotificationChannel
     {
         // The Channel Uri for app to Post a notification to.
@@ -55,7 +51,6 @@ namespace Microsoft.Windows.PushNotifications
         void Close();
     }
 
-    [feature(Feature_PushNotifications)]
     runtimeclass PushNotificationCreateChannelResult
     {
         // The Push channel associated with the Result. Valid only if status is CompletedSuccess.
@@ -68,7 +63,6 @@ namespace Microsoft.Windows.PushNotifications
         PushNotificationChannelStatus Status { get; };
     };
 
-    [feature(Feature_PushNotifications)]
     runtimeclass PushNotificationManager
     {
         // Checks to see if the APIs are supported for the Desktop app


### PR DESCRIPTION
Turns out that activating APIs for preview and stable releases, requires more than just updating the terminal velocity xml files, it requires eradicating all references to the feature from the code. (feature_) from the IDL and gates from the code.

For reference: https://github.com/microsoft/WindowsAppSDK/pull/2224.