### PR TITLE
Removing Silent Failures from Bootstrap Autoinitialization

### DIFF
--- a/dev/WindowsAppRuntime_BootstrapDLL/MddBootstrapAutoInitializer.cpp
+++ b/dev/WindowsAppRuntime_BootstrapDLL/MddBootstrapAutoInitializer.cpp
@@ -29,6 +29,12 @@ namespace Microsoft::Windows::ApplicationModel::DynamicDependency::Bootstrap
             const HRESULT hr{ ::MddBootstrapInitialize(c_majorMinorVersion, c_versionTag, c_minVersion) };
             if (FAILED(hr))
             {
+                if (IsDebuggerPresent()) {
+                    DebugBreak();
+                }
+                else {
+                    MessageBox(NULL,L"You need to run the Windows App Runtime Installer and its MSIX components", L"MddBootstrap", 0x00000010L);
+                }
                 exit(hr);
             }
         }

--- a/dev/WindowsAppRuntime_BootstrapDLL/MddBootstrapAutoInitializer.cs
+++ b/dev/WindowsAppRuntime_BootstrapDLL/MddBootstrapAutoInitializer.cs
@@ -5,6 +5,9 @@ namespace Microsoft.Windows.ApplicationModel.DynamicDependency.BootstrapCS
 {
     class AutoInitialize
     {
+        [global::System.Runtime.InteropServices.DllImport("user32.dll", CharSet = global::System.Runtime.InteropServices.CharSet.Unicode, SetLastError = true)]
+        private static extern int MessageBox(global::System.IntPtr hWnd, string lpText, string lpCaption, uint uType);
+
         [global::System.Runtime.CompilerServices.ModuleInitializer]
         internal static void AccessWindowsAppSDK()
         {
@@ -17,6 +20,14 @@ namespace Microsoft.Windows.ApplicationModel.DynamicDependency.BootstrapCS
             }
             catch (global::System.Exception e)
             {
+                if (global::System.Diagnostics.Debugger.IsAttached)
+                {
+                    global::System.Diagnostics.Debugger.Break();
+                }
+                else
+                {
+                    MessageBox(global::System.IntPtr.Zero, "You need to run the Windows App Runtime Installer and its MSIX components", "MddBootstrap", (uint)0x00000010L);
+                }
                 global::System.Environment.FailFast(e.Message);
             }
         }


### PR DESCRIPTION
The existing `MddBootstrapAutoInitializer.cs` and `MddBootstrapAutoInitializer.cpp` files would either `FailFast` or `exit` without giving any signal to the user. For example, if an unpackaged app's .exe was clicked without having the prerequisite Framework packages installed, it would fail silently and not let the user know why. This change adds a `MessageBox` that lets the user know that they may be missing the framework package. It will also create a debuggable moment if launched from Visual Studio.  