### PR TITLE
Add PRIResource build action to WPF projects.

### DIFF
--- a/dev/MRTCore/packaging/MrtCore.PriGen.targets
+++ b/dev/MRTCore/packaging/MrtCore.PriGen.targets
@@ -22,6 +22,15 @@
     <DefaultLanguage Condition="'$(DefaultLanguage)' == ''">en-US</DefaultLanguage>
   </PropertyGroup>
 
+  <!--
+    PRIResource is not by default in the list of Build Actions for WPF apps. So add it!
+    If we don't add it, our attempt to by default include RESW files in PRIResource will
+    fail (VS will inject MSBuild code in the project file to undo that include).
+  -->
+  <ItemGroup>
+    <AvailableItemName Include="PRIResource" Condition="'$(UseWPF)' == 'true'"/>
+  </ItemGroup>
+
   <PropertyGroup>
     <MSBuildAllProjects>$(MSBuildAllProjects);$(MSBuildThisFileFullPath)</MSBuildAllProjects>
   </PropertyGroup>

--- a/dev/MRTCore/packaging/MrtCore.PriGen.targets
+++ b/dev/MRTCore/packaging/MrtCore.PriGen.targets
@@ -25,10 +25,12 @@
   <!--
     PRIResource is not by default in the list of Build Actions for WPF apps. So add it!
     If we don't add it, our attempt to by default include RESW files in PRIResource will
-    fail (VS will inject MSBuild code in the project file to undo that include).
+    fail (VS will inject MSBuild code in the project file to undo that include). We don't
+    restrict this to WPF projects because there is no harm in including the item in other
+    project types.
   -->
   <ItemGroup>
-    <AvailableItemName Include="PRIResource" Condition="'$(UseWPF)' == 'true'"/>
+    <AvailableItemName Include="PRIResource"/>
   </ItemGroup>
 
   <PropertyGroup>


### PR DESCRIPTION
Please see issue https://github.com/microsoft/WindowsAppSDK/issues/2324 for a description.

I confirmed that for both .NET 5 and .NET 6 WPF projects created in VS 2022, the property is automatically added and set to true.

Note: We don't restrict this to WPF projects because there is no harm in including the item in other project types.

Thanks to @drewnoakes for the help.

**How verified**
1. Use the .NET SDK change https://github.com/dotnet/sdk/pull/24139 (the change isn't merged yet, so you can do this manually by copying over the text in the change to the existing .NET 6 installation).
2. Create a WPF project targeting .NET 6.0. Add a WAP project to it to make it packaged (you'll need to make the WAP project the startup project and add a project reference to the WPF project).
3. Install the Windows App SDK NuGet package in the WPF project.
4. Modify the NuGet install to use this change.
5. Add a pre-existing RESW file to the project via the VS UI. Is the Build Action correct? Yes. Were there project file modifications? Nope.

I verified that nothing is broken by doing this include in non-WPF apps. For that, I did the same as above with a WinForms packaged app, with some additional verification:
1. Does the app build? Yes.
2. Were there dupe resw files in the resources.resfiles file? Nope.
3. Were there dupe strings in the PRI file? Nope.