### PR TITLE
Return the payload if it was processed already.

### DIFF
--- a/dev/AppNotifications/AppNotificationManager.cpp
+++ b/dev/AppNotifications/AppNotificationManager.cpp
@@ -81,6 +81,12 @@ namespace winrt::Microsoft::Windows::AppNotifications::implementation
 
     winrt::Windows::Foundation::IInspectable AppNotificationManager::Deserialize(winrt::Windows::Foundation::Uri const& /* uri */)
     {
+        // Return the args if they are available.
+        if (m_activatedEventArgs)
+        {
+            return m_activatedEventArgs;
+        }
+
         THROW_HR_IF(HRESULT_FROM_WIN32(ERROR_TIMEOUT), !m_waitHandleForArgs.wait(c_receiveArgsTimeoutInMSec));
         return m_activatedEventArgs;
     }

--- a/dev/PushNotifications/PushNotificationManager.cpp
+++ b/dev/PushNotifications/PushNotificationManager.cpp
@@ -164,6 +164,12 @@ namespace winrt::Microsoft::Windows::PushNotifications::implementation
 
     winrt::Windows::Foundation::IInspectable PushNotificationManager::Deserialize(winrt::Windows::Foundation::Uri const& uri)
     {
+        // Return the args if they are available.
+        if (m_backgroundTaskArgs)
+        {
+            return m_backgroundTaskArgs;
+        }
+
         winrt::Microsoft::Windows::PushNotifications::PushNotificationReceivedEventArgs eventArgs{ nullptr };
 
         // All packaged processes are triggered through COM via Long Running Process or the Background Infra OS component
@@ -183,6 +189,7 @@ namespace winrt::Microsoft::Windows::PushNotifications::implementation
                     // Convert escaped components to its normal content from the conversion done in the Long Running Process (see NotificationListener.cpp)
                     auto payloadAsWstring = winrt::Windows::Foundation::Uri::UnescapeComponent(pair.Value());
                     eventArgs = winrt::make<winrt::Microsoft::Windows::PushNotifications::implementation::PushNotificationReceivedEventArgs>(payloadAsWstring);
+                    m_backgroundTaskArgs = eventArgs;
                 }
             }
 


### PR DESCRIPTION
No need to wait for the payload if it has already been delivered. Push/AppNotificationManager no longer throw E_TIMEOUT if you call GetActivatedEventArgs twice.