### PR TITLE
Fix `Package.appxmanifest` not appearing in Solution Explorer when creating a new C++ project

### DIFF
--- a/dev/VSIX/ProjectTemplates/Desktop/CppWinRT/SingleProjectPackagedApp/ProjectTemplate.vcxproj
+++ b/dev/VSIX/ProjectTemplates/Desktop/CppWinRT/SingleProjectPackagedApp/ProjectTemplate.vcxproj
@@ -96,6 +96,11 @@
       <OptimizeReferences>true</OptimizeReferences>
     </Link>
   </ItemDefinitionGroup>
+  <ItemGroup Condition="'$(WindowsPackageType)'!='None' and Exists('Package.appxmanifest')">
+    <AppxManifest Include="Package.appxmanifest">
+      <SubType>Designer</SubType>
+    </AppxManifest>
+  </ItemGroup>
   <ItemGroup>
     <Manifest Include="app.manifest" />
   </ItemGroup>


### PR DESCRIPTION
Fixes [Bug 38465376: Package.appxmanifest is missing from Blank App, Packaged (C++) single project template solution](http://task.ms/38465376).

When creating a new C++ app using the `Blank App, Packaged (WinUI 3 in Desktop)` project template, the included `Package.appxmanifest` file doesn't appear in Solution Explorer until after the project has been reloaded, even though it is automatically included in the project by the WinAppSdk `.targets`.

Apparently `Package.appxmanifest` needs to be explicitly included via the .vcxproj rather than an imported .targets file (even if both inclusions are using the same MSBuild condition!) in order for it to appear in Solution Explorer immediately after creating a new project.

Just VS C++ doing VS C++ things. ¯\\\_(ツ)_/¯