### PR TITLE
Deleting SetDisplayNameAndIcon from test and demo apps

### DIFF
--- a/test/TestApps/PushNotificationsDemoApp/main.cpp
+++ b/test/TestApps/PushNotificationsDemoApp/main.cpp
@@ -87,33 +87,6 @@ winrt::PushNotificationChannel RequestChannel()
     return result;
 }
 
-// This function is intended to be called in the unpackaged scenario.
-void SetDisplayNameAndIcon() noexcept try
-{
-    // Not mandatory, but it's highly recommended to specify AppUserModelId
-    THROW_IF_FAILED(SetCurrentProcessExplicitAppUserModelID(L"TestPushAppId"));
-
-    // Icon is mandatory
-    winrt::com_ptr<IPropertyStore> propertyStore;
-    wil::unique_hwnd hWindow{ GetConsoleWindow() };
-
-    THROW_IF_FAILED(SHGetPropertyStoreForWindow(hWindow.get(), IID_PPV_ARGS(&propertyStore)));
-
-    wil::unique_prop_variant propVariantIcon;
-    wil::unique_cotaskmem_string sth = wil::make_unique_string<wil::unique_cotaskmem_string>(LR"(%SystemRoot%\system32\@WLOGO_96x96.png)");
-    propVariantIcon.pwszVal = sth.release();
-    propVariantIcon.vt = VT_LPWSTR;
-    THROW_IF_FAILED(propertyStore->SetValue(PKEY_AppUserModel_RelaunchIconResource, propVariantIcon));
-
-    // App name is not mandatory, but it's highly recommended to specify it
-    wil::unique_prop_variant propVariantAppName;
-    wil::unique_cotaskmem_string prodName = wil::make_unique_string<wil::unique_cotaskmem_string>(L"The Push Notification Demo App");
-    propVariantAppName.pwszVal = prodName.release();
-    propVariantAppName.vt = VT_LPWSTR;
-    THROW_IF_FAILED(propertyStore->SetValue(PKEY_AppUserModel_RelaunchDisplayNameResource, propVariantAppName));
-}
-CATCH_LOG()
-
 int main()
 {
     if (!Test::AppModel::IsPackagedProcess())
@@ -127,7 +100,8 @@ int main()
         const PACKAGE_VERSION minVersion{};
         RETURN_IF_FAILED(MddBootstrapInitialize(c_Version_MajorMinor, nullptr, minVersion));
 
-        SetDisplayNameAndIcon();
+        // Not mandatory, but it's highly recommended to specify AppUserModelId
+        THROW_IF_FAILED(SetCurrentProcessExplicitAppUserModelID(L"PushTestAppId"));
     }
 
     // Register Push Event for Foreground

--- a/test/TestApps/ToastNotificationsTestApp/main.cpp
+++ b/test/TestApps/ToastNotificationsTestApp/main.cpp
@@ -257,7 +257,6 @@ bool VerifyExplicitAppId_Unpackaged()
     winrt::AppNotificationManager::Default().Unregister();
     try
     {
-        THROW_IF_FAILED(SetCurrentProcessExplicitAppUserModelID(L"TestAppId"));
         winrt::AppNotificationManager::Default().Register();
         winrt::AppNotificationManager::Default().Unregister();
     }
@@ -304,7 +303,6 @@ bool VerifyUnregisterAll_Unpackaged()
     winrt::AppNotificationManager::Default().UnregisterAll();
     try
     {
-        THROW_IF_FAILED(SetCurrentProcessExplicitAppUserModelID(L"TestAppId"));
         winrt::AppNotificationManager::Default().Register();
         winrt::AppNotificationManager::Default().UnregisterAll();
     }
@@ -1375,33 +1373,6 @@ bool runUnitTest(std::string unitTest)
     return it->second();
 }
 
-// This function is intended to be called in the unpackaged scenario.
-void SetDisplayNameAndIcon() noexcept try
-{
-    // Not mandatory, but it's highly recommended to specify AppUserModelId
-    THROW_IF_FAILED(SetCurrentProcessExplicitAppUserModelID(L"TestAppId"));
-
-    // Icon is mandatory
-    winrt::com_ptr<IPropertyStore> propertyStore;
-    wil::unique_hwnd hWindow{ GetConsoleWindow() };
-
-    THROW_IF_FAILED(SHGetPropertyStoreForWindow(hWindow.get(), IID_PPV_ARGS(&propertyStore)));
-
-    wil::unique_prop_variant propVariantIcon;
-    wil::unique_cotaskmem_string sth = wil::make_unique_string<wil::unique_cotaskmem_string>(LR"(%SystemRoot%\system32\@WLOGO_96x96.png)");
-    propVariantIcon.pwszVal = sth.release();
-    propVariantIcon.vt = VT_LPWSTR;
-    THROW_IF_FAILED(propertyStore->SetValue(PKEY_AppUserModel_RelaunchIconResource, propVariantIcon));
-
-    // App name is not mandatory, but it's highly recommended to specify it
-    wil::unique_prop_variant propVariantAppName;
-    wil::unique_cotaskmem_string prodName = wil::make_unique_string<wil::unique_cotaskmem_string>(L"The Toast Demo App");
-    propVariantAppName.pwszVal = prodName.release();
-    propVariantAppName.vt = VT_LPWSTR;
-    THROW_IF_FAILED(propertyStore->SetValue(PKEY_AppUserModel_RelaunchDisplayNameResource, propVariantAppName));
-}
-CATCH_LOG()
-
 int main() try
 {
     bool testResult = false;
@@ -1413,7 +1384,8 @@ int main() try
 
     if (!Test::AppModel::IsPackagedProcess())
     {
-        SetDisplayNameAndIcon();
+        // Not mandatory, but it's highly recommended to specify AppUserModelId
+        THROW_IF_FAILED(SetCurrentProcessExplicitAppUserModelID(L"TaefTestAppId"));
     }
 
     winrt::AppNotificationManager::Default().Register();


### PR DESCRIPTION
During AppNotification registration for unpackaged apps, we don't retrieve icon/displayName from window anymore. Hence, in this PR we remove the sample code used to set icon and display name using Shell APIs.