### PR TITLE
[MRT Core] Set properties to get default file inclusion only if we're in a .NET project.

### DIFF
--- a/dev/MRTCore/packaging/MrtCore.PriGen.targets
+++ b/dev/MRTCore/packaging/MrtCore.PriGen.targets
@@ -10,7 +10,7 @@
   <!--
     For .NET projects, we use the default file inclusion support that's built into the .NET SDK for the Windows App SDK. For that, we need to set these properties.
   -->
-  <PropertyGroup>
+  <PropertyGroup Condition="'$(UsingMicrosoftNETSdk)' == 'true'">
     <EnableDefaultContentItems Condition="'$(EnableDefaultContentItems)' == ''">true</EnableDefaultContentItems>
     <EnableDefaultPRIResourceItems Condition="'$(EnableDefaultPRIResourceItems)' == ''">true</EnableDefaultPRIResourceItems>
     <EnableDefaultWindowsAppSdkContentItems Condition="'$(EnableDefaultWindowsAppSdkContentItems)' == ''">true</EnableDefaultWindowsAppSdkContentItems>


### PR DESCRIPTION
There is no risk in not doing this, but it's still the right thing to do. I say there is no risk because the properties aren't referenced in native projects.

**How verified**
- WinUI app (WAP based) C# app: properties were set.
- WinUI app (WAP based) C++ app: properties were not set.
