### PR TITLE
Revert 'Use .NET SDK's default inclusion support for Windows App SDK and remove our own broken solution. (#2381)'

### DIFF
--- a/build/NuSpecs/Microsoft.WindowsAppSDK.Foundation.props
+++ b/build/NuSpecs/Microsoft.WindowsAppSDK.Foundation.props
@@ -8,4 +8,10 @@
     <WindowsAppSdkFoundation>true</WindowsAppSdkFoundation>
   </PropertyGroup>
 
+  <!--
+    Ideally, this import would be done only if EnableCoreMrtTooling is true. That's impossible though because that
+    property cannot be defined beforehand.
+  -->
+  <Import Project="$(MSBuildThisFileDirectory)MrtCore.props" />
+
 </Project>

--- a/build/publish-mrt.yml
+++ b/build/publish-mrt.yml
@@ -105,6 +105,7 @@ steps:
   inputs:
     SourceFolder: '${{ parameters.MRTSourcesDirectory }}\packaging'
     Contents: |
+      MrtCore.props      
       MrtCore.PriGen.targets
       MrtCore.References.targets
       MrtCore.targets

--- a/dev/MRTCore/packaging/MrtCore.PriGen.targets
+++ b/dev/MRTCore/packaging/MrtCore.PriGen.targets
@@ -7,16 +7,6 @@
     <TargetPlatformIdentifierAdjusted>UAP</TargetPlatformIdentifierAdjusted>
   </PropertyGroup>
 
-  <!--
-    For .NET projects, we use the default file inclusion support that's built into the .NET SDK for the Windows App SDK. For that, we need to set these properties.
-  -->
-  <PropertyGroup>
-    <EnableDefaultContentItems Condition="'$(EnableDefaultContentItems)' == ''">true</EnableDefaultContentItems>
-    <EnableDefaultPRIResourceItems Condition="'$(EnableDefaultPRIResourceItems)' == ''">true</EnableDefaultPRIResourceItems>
-    <EnableDefaultWindowsAppSdkContentItems Condition="'$(EnableDefaultWindowsAppSdkContentItems)' == ''">true</EnableDefaultWindowsAppSdkContentItems>
-    <EnableDefaultWindowsAppSdkPRIResourceItems Condition="'$(EnableDefaultWindowsAppSdkPRIResourceItems)' == ''">true</EnableDefaultWindowsAppSdkPRIResourceItems>
-  </PropertyGroup>
-
   <!-- The win32 project system adds all images in the project to the Image array in the project file.
        This MSBuild project file though (created originally for UWPs) requires images to be in the Content array. -->
   <ItemGroup>

--- a/dev/MRTCore/packaging/MrtCore.props
+++ b/dev/MRTCore/packaging/MrtCore.props
@@ -1,0 +1,37 @@
+<!--
+  Copyright (c) Microsoft Corporation. Licensed under the MIT License
+-->
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+
+  <PropertyGroup>
+    <_MrtCoreImageGlobs>**/*.png;**/*.bmp;**/*.jpg;**/*.dds;**/*.tif;**/*.tga;**/*.gif</_MrtCoreImageGlobs>
+  </PropertyGroup>
+
+  <!--
+    By default, add the .RESW files in the project to PRIResource and the image files in the project to Content.
+    That's needed for the strings in the .RESW files and the image files to be indexed during PRI generation.
+    The app dev can opt out a file by changing the Build Action file property to None in Visual Studio, which
+    will automatically modify the project file accordingly, or by manually modifying the CSPROJ file.
+
+    Yes, the properties used here, including EnableCoreMrtTooling, are defined in MSBuild files imported after
+    this file. This is correct though because ItemGroup definitions are evaluated in a later pass. See
+    https://docs.microsoft.com/en-us/visualstudio/msbuild/build-process-overview?view=vs-2019#evaluation-phase.
+
+    The implementation here is NOT exactly the same as the .NET SDK's implementation for default file inclusion
+    (https://docs.microsoft.com/en-us/dotnet/core/project-sdk/overview#default-includes-and-excludes). Specifically,
+    we don't remove the .RESW and image files from None here because None is populated in
+    Microsoft.NET.Sdk.DefaultItems.props, which is evaluated after this file. Removing them in a NuGet targets file,
+    which is evaluated after all props files and the project file, would have to be done as follows in order to respect
+    the app dev's potential opt-outs: <None Remove="@(Content)" /> and <None Remove="@(PRIResource)" />. That doesn't work
+    though due to a VS CPS bug: when an app dev changes the Build Action from PRIResource to None, an error message box
+    is displayed saying None is invalid because "the path is explicitly excluded from the project", referring to the
+    removal in the targets file. The change though removes the file from PRIResource (logic to do that is added to the
+    project file), so this error is invalid. Leaving the .RESW and image files in None doesn't confuse the VS UI though,
+    and the scenarios work, so this seems acceptable.
+  -->
+  <ItemGroup Condition="'$(TargetFrameworkIdentifier)'=='.NETCoreApp' and '$(EnableDefaultItems)'=='true' and '$(EnableCoreMrtTooling)'=='true'">
+    <Content Include="$(_MrtCoreImageGlobs)" Exclude="$(DefaultItemExcludes);$(DefaultExcludesInProjectFolder)" Condition="'$(EnableDefaultContentItems)'!='false'" />
+    <PRIResource Include="**/*.resw" Exclude="$(DefaultItemExcludes);$(DefaultExcludesInProjectFolder)" Condition="'$(EnableDefaultPRIResourceItems)'!='false'"/>
+  </ItemGroup>
+
+</Project>


### PR DESCRIPTION

This reverts commit 045d154c2e92e161e3775e3fec3f95aa5c215e7e.