### PR TITLE
Rename CsWinRT Dependency Variable for Windows SDK

### DIFF
--- a/dev/MRTCore/mrt/Microsoft.Windows.ApplicationModel.Resources/projection/Microsoft.Windows.ApplicationModel.Resources.Projection.csproj
+++ b/dev/MRTCore/mrt/Microsoft.Windows.ApplicationModel.Resources/projection/Microsoft.Windows.ApplicationModel.Resources.Projection.csproj
@@ -18,7 +18,7 @@
   <PropertyGroup>
     <CSWinRTIncludes>Microsoft.Windows.ApplicationModel.Resources</CSWinRTIncludes>
     <CSWinRTWindowsMetadata>10.0.17763.0</CSWinRTWindowsMetadata>
-    <WindowsSdkPackageVersion>10.0.17763.$(CsWinRTDependencyWindowsSdkPackagePackageVersion)</WindowsSdkPackageVersion>
+    <WindowsSdkPackageVersion>10.0.17763.$(CsWinRTDependencyWindowsSdkVersionSuffixPackageVersion)</WindowsSdkPackageVersion>
     <NoWarn>MSB3271</NoWarn>
   </PropertyGroup>
 

--- a/dev/Projections/CS/Microsoft.Windows.AppLifecycle/Microsoft.Windows.AppLifecycle.Projection.csproj
+++ b/dev/Projections/CS/Microsoft.Windows.AppLifecycle/Microsoft.Windows.AppLifecycle.Projection.csproj
@@ -21,7 +21,7 @@
   <PropertyGroup>
     <CSWinRTIncludes>Microsoft.Windows.AppLifecycle</CSWinRTIncludes>
     <CSWinRTWindowsMetadata>10.0.17763.0</CSWinRTWindowsMetadata>
-    <WindowsSdkPackageVersion>10.0.17763.$(CsWinRTDependencyWindowsSdkPackagePackageVersion)</WindowsSdkPackageVersion>
+    <WindowsSdkPackageVersion>10.0.17763.$(CsWinRTDependencyWindowsSdkVersionSuffixPackageVersion)</WindowsSdkPackageVersion>
   </PropertyGroup>
 
   <!-- Configure the release build binary to be as required by internal API scanning tools. -->

--- a/dev/Projections/CS/Microsoft.Windows.AppNotifications.Projection/Microsoft.Windows.AppNotifications.Projection.csproj
+++ b/dev/Projections/CS/Microsoft.Windows.AppNotifications.Projection/Microsoft.Windows.AppNotifications.Projection.csproj
@@ -21,7 +21,7 @@
   <PropertyGroup>
     <CSWinRTIncludes>Microsoft.Windows.AppNotifications</CSWinRTIncludes>
     <CSWinRTWindowsMetadata>10.0.17763.0</CSWinRTWindowsMetadata>
-    <WindowsSdkPackageVersion>10.0.17763.$(CsWinRTDependencyWindowsSdkPackagePackageVersion)</WindowsSdkPackageVersion>
+    <WindowsSdkPackageVersion>10.0.17763.$(CsWinRTDependencyWindowsSdkVersionSuffixPackageVersion)</WindowsSdkPackageVersion>
   </PropertyGroup>
 
   <!-- Configure the release build binary to be as required by internal API scanning tools. -->

--- a/dev/Projections/CS/Microsoft.Windows.ApplicationModel.DynamicDependency/Microsoft.Windows.ApplicationModel.DynamicDependency.Projection.csproj
+++ b/dev/Projections/CS/Microsoft.Windows.ApplicationModel.DynamicDependency/Microsoft.Windows.ApplicationModel.DynamicDependency.Projection.csproj
@@ -21,7 +21,7 @@
   <PropertyGroup>
     <CSWinRTIncludes>Microsoft.Windows.ApplicationModel.DynamicDependency</CSWinRTIncludes>
     <CSWinRTWindowsMetadata>10.0.17763.0</CSWinRTWindowsMetadata>
-    <WindowsSdkPackageVersion>10.0.17763.$(CsWinRTDependencyWindowsSdkPackagePackageVersion)</WindowsSdkPackageVersion>
+    <WindowsSdkPackageVersion>10.0.17763.$(CsWinRTDependencyWindowsSdkVersionSuffixPackageVersion)</WindowsSdkPackageVersion>
   </PropertyGroup>
 
   <!-- Configure the release build binary to be as required by internal API scanning tools. -->

--- a/dev/Projections/CS/Microsoft.Windows.ApplicationModel.WindowsAppRuntime/Microsoft.Windows.ApplicationModel.WindowsAppRuntime.Projection.csproj
+++ b/dev/Projections/CS/Microsoft.Windows.ApplicationModel.WindowsAppRuntime/Microsoft.Windows.ApplicationModel.WindowsAppRuntime.Projection.csproj
@@ -21,7 +21,7 @@
   <PropertyGroup>
     <CSWinRTIncludes>Microsoft.Windows.ApplicationModel.WindowsAppRuntime</CSWinRTIncludes>
     <CSWinRTWindowsMetadata>10.0.17763.0</CSWinRTWindowsMetadata>
-    <WindowsSdkPackageVersion>10.0.17763.$(CsWinRTDependencyWindowsSdkPackagePackageVersion)</WindowsSdkPackageVersion>
+    <WindowsSdkPackageVersion>10.0.17763.$(CsWinRTDependencyWindowsSdkVersionSuffixPackageVersion)</WindowsSdkPackageVersion>
   </PropertyGroup>
 
   <!-- Configure the release build binary to be as required by internal API scanning tools. -->

--- a/dev/Projections/CS/Microsoft.Windows.PushNotifications.Projection/Microsoft.Windows.PushNotifications.Projection.csproj
+++ b/dev/Projections/CS/Microsoft.Windows.PushNotifications.Projection/Microsoft.Windows.PushNotifications.Projection.csproj
@@ -21,7 +21,7 @@
   <PropertyGroup>
     <CSWinRTIncludes>Microsoft.Windows.PushNotifications</CSWinRTIncludes>
     <CSWinRTWindowsMetadata>10.0.17763.0</CSWinRTWindowsMetadata>
-    <WindowsSdkPackageVersion>10.0.17763.$(CsWinRTDependencyWindowsSdkPackagePackageVersion)</WindowsSdkPackageVersion>
+    <WindowsSdkPackageVersion>10.0.17763.$(CsWinRTDependencyWindowsSdkVersionSuffixPackageVersion)</WindowsSdkPackageVersion>
   </PropertyGroup>
 
   <!-- Configure the release build binary to be as required by internal API scanning tools. -->

--- a/dev/Projections/CS/Microsoft.Windows.System.Power/Microsoft.Windows.System.Power.Projection.csproj
+++ b/dev/Projections/CS/Microsoft.Windows.System.Power/Microsoft.Windows.System.Power.Projection.csproj
@@ -21,7 +21,7 @@
   <PropertyGroup>
     <CSWinRTIncludes>Microsoft.Windows.System.Power</CSWinRTIncludes>
     <CSWinRTWindowsMetadata>10.0.17763.0</CSWinRTWindowsMetadata>
-    <WindowsSdkPackageVersion>10.0.17763.$(CsWinRTDependencyWindowsSdkPackagePackageVersion)</WindowsSdkPackageVersion>
+    <WindowsSdkPackageVersion>10.0.17763.$(CsWinRTDependencyWindowsSdkVersionSuffixPackageVersion)</WindowsSdkPackageVersion>
   </PropertyGroup>
 
   <!-- Configure the release build binary to be as required by internal API scanning tools. -->

--- a/dev/Projections/CS/Microsoft.Windows.System/Microsoft.Windows.System.Projection.csproj
+++ b/dev/Projections/CS/Microsoft.Windows.System/Microsoft.Windows.System.Projection.csproj
@@ -21,7 +21,7 @@
   <PropertyGroup>
     <CSWinRTIncludes>Microsoft.Windows.System</CSWinRTIncludes>
     <CSWinRTWindowsMetadata>10.0.17763.0</CSWinRTWindowsMetadata>
-    <WindowsSdkPackageVersion>10.0.17763.$(CsWinRTDependencyWindowsSdkPackagePackageVersion)</WindowsSdkPackageVersion>
+    <WindowsSdkPackageVersion>10.0.17763.$(CsWinRTDependencyWindowsSdkVersionSuffixPackageVersion)</WindowsSdkPackageVersion>
   </PropertyGroup>
 
   <!-- Configure the release build binary to be as required by internal API scanning tools. -->

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -19,7 +19,7 @@
       <Uri>https://github.com/microsoft/CsWinRT</Uri>
       <Sha>9b4a4df6144ac1f1642307046cc2468ce4664b0a</Sha>
     </Dependency>
-    <Dependency Name="CsWinRT.Dependency.WindowsSdkPackage" Version="24">
+    <Dependency Name="CsWinRT.Dependency.WindowsSdkVersionSuffix" Version="24">
       <Uri>https://github.com/microsoft/CsWinRT</Uri>
       <Sha>9b4a4df6144ac1f1642307046cc2468ce4664b0a</Sha>
     </Dependency>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -4,7 +4,7 @@
     <MicrosoftWindowsCsWinRTPackageVersion>1.6.1</MicrosoftWindowsCsWinRTPackageVersion>
     <CsWinRTDependencyDotNetCoreSdkPackageVersion>5.0.404</CsWinRTDependencyDotNetCoreSdkPackageVersion>
     <CsWinRTDependencyDotNetCoreRuntimePackageVersion>5.0.13</CsWinRTDependencyDotNetCoreRuntimePackageVersion>
-    <CsWinRTDependencyWindowsSdkPackagePackageVersion>24</CsWinRTDependencyWindowsSdkPackagePackageVersion>
+    <CsWinRTDependencyWindowsSdkVersionSuffixPackageVersion>24</CsWinRTDependencyWindowsSdkVersionSuffixPackageVersion>
     <!-- TODO: Fix DownloadDotNetCoreSdk.ps1 script so we don't need this property -->
     <CsWinRTDependencyDotNetCoreSdkLkgPackageVersion>$(CsWinRTDependencyDotNetCoreSdkPackageVersion)</CsWinRTDependencyDotNetCoreSdkLkgPackageVersion>
   </PropertyGroup>


### PR DESCRIPTION
In https://github.com/microsoft/WindowsAppSDK/pull/2015#discussion_r792928818 it was suggested we rename the variable to be more accurate. https://github.com/microsoft/CsWinRT/pull/1140 is the corresponding CsWinRT PR.