### PR TITLE
Fix SelfContained always returning true

### DIFF
--- a/dev/Common/WindowsAppRuntime.SelfContained.cpp
+++ b/dev/Common/WindowsAppRuntime.SelfContained.cpp
@@ -3,8 +3,8 @@
 
 #include "pch.h"
 
-#if __has_include(<WindowsAppRuntime-VersionInfo.h>)
-#   include <WindowsAppRuntime-VersionInfo.h>
+#if __has_include(<WindowsAppSDK-VersionInfo.h>)
+#   include <WindowsAppSDK-VersionInfo.h>
 #   define WINDOWSAPPRUNTIME_SELFCONTAINED_EXPECTED_PACKAGEFAMILYNAME   WINDOWSAPPSDK_RUNTIME_PACKAGE_FRAMEWORK_PACKAGEFAMILYNAME_W
 #else
 #   define WINDOWSAPPRUNTIME_SELFCONTAINED_EXPECTED_PACKAGEFAMILYNAME   nullptr


### PR DESCRIPTION
The IsSelfContained check uses a generated header file from azure pipelines to retrieve the expected framework package family name. After debugging, it was found that the expected package family name was always nullptr. 

This PR fixes the version info header file:
WindowsAppRuntime-VersionInfo.h -> WindowsAppSDK-VersionInfo.h