### PR TITLE
Under a .NET SDK version check, bring back our (broken) default file inclusion solution for RESW and image files (applies to non-single project MSIX apps only).

### DIFF
--- a/build/NuSpecs/Microsoft.WindowsAppSDK.Foundation.props
+++ b/build/NuSpecs/Microsoft.WindowsAppSDK.Foundation.props
@@ -8,4 +8,10 @@
     <WindowsAppSdkFoundation>true</WindowsAppSdkFoundation>
   </PropertyGroup>
 
+  <!--
+    Ideally, this import would be done only if EnableCoreMrtTooling is true. That's impossible though because that
+    property cannot be defined beforehand.
+  -->
+  <Import Project="$(MSBuildThisFileDirectory)MrtCore.props" />
+
 </Project>

--- a/build/publish-mrt.yml
+++ b/build/publish-mrt.yml
@@ -105,6 +105,7 @@ steps:
   inputs:
     SourceFolder: '${{ parameters.MRTSourcesDirectory }}\packaging'
     Contents: |
+      MrtCore.props      
       MrtCore.PriGen.targets
       MrtCore.References.targets
       MrtCore.targets

--- a/dev/MRTCore/packaging/MrtCore.PriGen.targets
+++ b/dev/MRTCore/packaging/MrtCore.PriGen.targets
@@ -9,10 +9,9 @@
 
   <!--
     For .NET projects, we use the default file inclusion support that's built into the .NET SDK for the Windows App SDK. For that, we need to set these properties.
+    The support is only available in version 6.0.4 or higher.
   -->
-  <PropertyGroup Condition="'$(UsingMicrosoftNETSdk)' == 'true'">
-    <EnableDefaultContentItems Condition="'$(EnableDefaultContentItems)' == ''">true</EnableDefaultContentItems>
-    <EnableDefaultPRIResourceItems Condition="'$(EnableDefaultPRIResourceItems)' == ''">true</EnableDefaultPRIResourceItems>
+  <PropertyGroup Condition="'$(UsingMicrosoftNETSdk)' == 'true' and $([MSBuild]::VersionGreaterThanOrEquals($(TargetFrameworkVersion), '6.0.4'))">
     <EnableDefaultWindowsAppSdkContentItems Condition="'$(EnableDefaultWindowsAppSdkContentItems)' == ''">true</EnableDefaultWindowsAppSdkContentItems>
     <EnableDefaultWindowsAppSdkPRIResourceItems Condition="'$(EnableDefaultWindowsAppSdkPRIResourceItems)' == ''">true</EnableDefaultWindowsAppSdkPRIResourceItems>
   </PropertyGroup>

--- a/dev/MRTCore/packaging/MrtCore.PriGen.targets
+++ b/dev/MRTCore/packaging/MrtCore.PriGen.targets
@@ -9,9 +9,9 @@
 
   <!--
     For .NET projects, we use the default file inclusion support that's built into the .NET SDK for the Windows App SDK. For that, we need to set these properties.
-    The support is only available in version 6.0.4 or higher.
+    The support is only available in version 6.0.300 or higher.
   -->
-  <PropertyGroup Condition="'$(UsingMicrosoftNETSdk)' == 'true' and $([MSBuild]::VersionGreaterThanOrEquals($(TargetFrameworkVersion), '6.0.4'))">
+  <PropertyGroup Condition="'$(UsingMicrosoftNETSdk)' == 'true' and $([MSBuild]::VersionGreaterThanOrEquals($(NETCoreSdkVersion), '6.0.300'))">
     <EnableDefaultWindowsAppSdkContentItems Condition="'$(EnableDefaultWindowsAppSdkContentItems)' == ''">true</EnableDefaultWindowsAppSdkContentItems>
     <EnableDefaultWindowsAppSdkPRIResourceItems Condition="'$(EnableDefaultWindowsAppSdkPRIResourceItems)' == ''">true</EnableDefaultWindowsAppSdkPRIResourceItems>
   </PropertyGroup>

--- a/dev/MRTCore/packaging/MrtCore.props
+++ b/dev/MRTCore/packaging/MrtCore.props
@@ -1,0 +1,31 @@
+<!--
+  Copyright (c) Microsoft Corporation. Licensed under the MIT License
+-->
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+
+  <PropertyGroup>
+    <_MrtCoreImageGlobs>**/*.png;**/*.bmp;**/*.jpg;**/*.dds;**/*.tif;**/*.tga;**/*.gif</_MrtCoreImageGlobs>
+  </PropertyGroup>
+
+  <!--
+    For .NET apps, by default, add the .RESW files in the project to PRIResource and the image files in the project to Content.
+    That's needed for the strings in the .RESW files and the image files to be indexed during PRI generation.
+    The app dev can opt out a file by changing the Build Action file property to None in Visual Studio, which
+    will automatically modify the project file accordingly, or by manually modifying the CSPROJ file.
+
+    Yes, the properties used here, including EnableCoreMrtTooling, are defined in MSBuild files imported after
+    this file. This is correct though because ItemGroup definitions are evaluated in a later pass. See
+    https://docs.microsoft.com/en-us/visualstudio/msbuild/build-process-overview?view=vs-2019#evaluation-phase.
+
+    NOTE:
+    This solution is broken. See issue https://github.com/microsoft/WindowsAppSDK/issues/1674. A correct solution
+    now exists in the .NET SDK but is available only in version 6.0.4 or higher. So, continue to use this broken
+    solution if we're using an older version. For the .NET SDK feature request with info on why this is
+    insufficient, see https://github.com/dotnet/sdk/issues/24093.
+  -->
+  <ItemGroup Condition="'$(TargetFrameworkIdentifier)'=='.NETCoreApp' and $([MSBuild]::VersionLessThan($(TargetFrameworkVersion), '6.0.4')) and '$(EnableDefaultItems)'=='true' and '$(EnableCoreMrtTooling)'=='true'">
+    <Content Include="$(_MrtCoreImageGlobs)" Exclude="$(DefaultItemExcludes);$(DefaultExcludesInProjectFolder)" Condition="'$(EnableDefaultContentItems)'!='false'" />
+    <PRIResource Include="**/*.resw" Exclude="$(DefaultItemExcludes);$(DefaultExcludesInProjectFolder)" Condition="'$(EnableDefaultPRIResourceItems)'!='false'"/>
+  </ItemGroup>
+
+</Project>

--- a/dev/MRTCore/packaging/MrtCore.props
+++ b/dev/MRTCore/packaging/MrtCore.props
@@ -19,11 +19,11 @@
 
     NOTE:
     This solution is broken. See issue https://github.com/microsoft/WindowsAppSDK/issues/1674. A correct solution
-    now exists in the .NET SDK but is available only in version 6.0.4 or higher. So, continue to use this broken
+    now exists in the .NET SDK but is available only in version 6.0.300 or higher. So, continue to use this broken
     solution if we're using an older version. For the .NET SDK feature request with info on why this is
     insufficient, see https://github.com/dotnet/sdk/issues/24093.
   -->
-  <ItemGroup Condition="'$(TargetFrameworkIdentifier)'=='.NETCoreApp' and $([MSBuild]::VersionLessThan($(TargetFrameworkVersion), '6.0.4')) and '$(EnableDefaultItems)'=='true' and '$(EnableCoreMrtTooling)'=='true'">
+  <ItemGroup Condition="'$(TargetFrameworkIdentifier)'=='.NETCoreApp' and $([MSBuild]::VersionLessThan($(NETCoreSdkVersion), '6.0.300')) and '$(EnableDefaultItems)'=='true' and '$(EnableCoreMrtTooling)'=='true'">
     <Content Include="$(_MrtCoreImageGlobs)" Exclude="$(DefaultItemExcludes);$(DefaultExcludesInProjectFolder)" Condition="'$(EnableDefaultContentItems)'!='false'" />
     <PRIResource Include="**/*.resw" Exclude="$(DefaultItemExcludes);$(DefaultExcludesInProjectFolder)" Condition="'$(EnableDefaultPRIResourceItems)'!='false'"/>
   </ItemGroup>


### PR DESCRIPTION
Under a .NET SDK version check, bring back our (broken) default file inclusion solution for RESW and image files (applies to non-single project MSIX apps only).

Reason for change: we don't break apps on upgrade. If they use a sufficiently recent .NET SDK version, they'll get the improvement. Otherwise, they'll get the existing behavior.

**How verified**
In a WinUI with WAP app:
1. If version is less than threshold, do we use the old, WASDK solution? Yes.
2. If version is equal to the threshold, do we use the .NET SDK solution? Yes.
3. If there are duplicate images in Content, do we error? No.
4. If the version is 6.0.2xx, does the comparison still work? Does that evaluate as less than 6.0.300? Yes.