### PR TITLE
Add new DWrite color APIs.

### DIFF
--- a/specs/dwritecore/DWriteCore.md
+++ b/specs/dwritecore/DWriteCore.md
@@ -1756,9 +1756,9 @@ struct DWRITE_PAINT_COLOR
 
     /// <summary>
     /// Specifies the palette entry index if the color value comes from the font's color palette.
-    /// Otherwise, this member is UINT32_MAX.
+    /// Otherwise, this member is UINT16_MAX.
     /// </summary>
-    UINT32 paletteIndex;
+    UINT16 paletteEntryIndex;
 
     /// <summary>
     /// Specifies an alpha value multiplier in the range 0 to 1 that was used to compute the color

--- a/specs/dwritecore/DWriteCore.md
+++ b/specs/dwritecore/DWriteCore.md
@@ -1784,6 +1784,7 @@ struct DWRITE_PAINT_COLOR
 /// </summary>
 enum DWRITE_PAINT_COMPOSITE_MODE
 {
+    // Porter-Duff modes.
     DWRITE_COLOR_COMPOSITE_CLEAR,
     DWRITE_COLOR_COMPOSITE_SRC,
     DWRITE_COLOR_COMPOSITE_DEST,
@@ -1798,6 +1799,7 @@ enum DWRITE_PAINT_COMPOSITE_MODE
     DWRITE_COLOR_COMPOSITE_XOR,
     DWRITE_COLOR_COMPOSITE_PLUS,
 
+    // Separable color blend modes.
     DWRITE_COLOR_COMPOSITE_SCREEN,
     DWRITE_COLOR_COMPOSITE_OVERLAY,
     DWRITE_COLOR_COMPOSITE_DARKEN,
@@ -1810,6 +1812,7 @@ enum DWRITE_PAINT_COMPOSITE_MODE
     DWRITE_COLOR_COMPOSITE_EXCLUSION,
     DWRITE_COLOR_COMPOSITE_MULTIPLY,
 
+    // Non-separable color blend modes.
     DWRITE_COLOR_COMPOSITE_HSL_HUE,
     DWRITE_COLOR_COMPOSITE_HSL_SATURATION,
     DWRITE_COLOR_COMPOSITE_HSL_COLOR,
@@ -2065,12 +2068,14 @@ struct DWRITE_PAINT_ELEMENT
             float centerY;
 
             /// <summary>
-            /// Start of the angular range of the gradient, 180 degrees in counter-clockwise degrees per 1.0 of value.
+            /// Start of the angular range of the gradient, measured in counter-clockwise degrees
+            /// from the direction of the positive x axis.
             /// </summary>
             float startAngle;
 
             /// <summary>
-            /// End of the angular range of the gradient, 180 degrees in counter-clockwise degrees per 1.0 of value.
+            /// End of the angular range of the gradient, measured in counter-clockwise degrees
+            /// from the direction of the positive x axis.
             /// </summary>
             float endAngle;
         } sweepGradient;

--- a/specs/dwritecore/DWriteCore.md
+++ b/specs/dwritecore/DWriteCore.md
@@ -1690,7 +1690,7 @@ void DumpPaintElement(std::ostream& out, Indent indent, IDWritePaintReader* read
     {
         DWRITE_MATRIX const& paint = element.paint.transform;
         out << indent << "DWRITE_PAINT_TYPE_TRANSFORM:\n"
-            << indent << PropName{ "transform" } << paint
+            << indent << PropName{ "transform" } << paint << '\n'
             << indent << PropName{ "child" } << '\n';
         WriteChildren(1);
         break;

--- a/specs/dwritecore/DWriteCore.md
+++ b/specs/dwritecore/DWriteCore.md
@@ -16,14 +16,14 @@ For an application that already uses DirectWrite, switching to DWriteCore requir
 In return, the application gets the benefits of Windows App SDK, namely, access to the newest APIs
 and functionality regardless of what version of Windows your customer is running.
 
-# Background
+## Background
 
 The DWriteCore API is the same as the existing public DirectWrite API, with a few additions. These
 additions should eventually be incorporated into the in-box DirectWrite as well, so it is
 appropriate to think of the DWriteCore API as just the latest version of the DirectWrite API. This
 document focuses primarily on the additions.
 
-## API Versioning
+### API Versioning
 
 The DirectWrite API has grown over time, and many APIs have multiple versions: IDWriteFactory,
 IDWriteFactory1, IDWriteFactory2, etc. Prior to Windows 10, each new version got a new header file.
@@ -57,7 +57,7 @@ dwrite.h). The dwrite_core.h simply defines the DWRITE_CORE preprocessor symbol 
 dwrite_3.h. In this way, an application that includes dwrite_core.h has access to all DirectWrite
 APIs regardless of the NTDDI_VERSION.
 
-## Cross-Platform Considerations
+### Cross-Platform Considerations
 
 DWriteCore runs on non-Windows platforms in addition to the down-level Windows versions targetted by
 Windows App SDK. In order to compile cross-platform, it is necessary to have definitions of Windows
@@ -75,7 +75,7 @@ This is outside the scope of the API itself, but is mentioned here because other
 libraries will have to solve the same problem, and if each library solves the problem in its own
 way, we may end up with interoperability issues.
 
-# Description
+## Description
 
 New APIs introduced by DWriteCore include:
 
@@ -86,7 +86,7 @@ New APIs introduced by DWriteCore include:
 -   New methods for selecting fonts from a font set
 -   A new factory method to release unreferenced fonts
 
-# Factory Creation
+## Factory Creation
 
 The new `DWRITE_FACTORY_TYPE_ISOLATED2` enumerator complements the existing factory types. It is
 similar to `DWRITE_FACTORY_TYPE_ISOLATED`, but is more locked down in two ways. First, it only
@@ -97,7 +97,7 @@ implementation to efficiently construct the system font collection without depen
 cross-process or persistent cache. An example use case for the new factory type would be a web
 browser rendering process with very limited permissions.
 
-# Text Rendering
+## Text Rendering
 
 A _bitmap render target_ (`IDWriteBitmapRenderTarget`) is an API object that encapsulates a system
 memory bitmap and enables rendering glyphs to the bitmap. On Windows, the object encapsulates a GDI
@@ -106,7 +106,7 @@ platforms, there is no GDI DC, and the bitmap is just a system memory array. DWr
 new version of the bitmap render target interface that an application can use to access the bitmap
 data without going through GDI.
 
-# Font Selection
+## Font Selection
 
 The new `IDWriteFontSet4` interface exposes new methods for selecting fonts from a font set. The new
 methods make it possible to transition to the _typographic font family model_ while maintaining
@@ -131,7 +131,7 @@ The following sections compare the older font family models with the typographic
 explain compatibility challenges posed by changing font family models, and finally explains how
 those challenges can be overcome by using the `IDWriteFontSet4` methods.
 
-## RBIZ Font Family Model
+### RBIZ Font Family Model
 
 The de facto font family model used in the GDI application ecosystem is sometimes called the
 "four-font model" or "RBIZ" model. Each font family in this model typically has at most four fonts.
@@ -176,7 +176,7 @@ converting to and from the RBIZ model, such as `IDWriteGdiInterop::CreateFontFro
 calling its `GetInformationalStrings` method and specifying
 `DWRITE_INFORMATIONAL_STRING_WIN32_FAMILY_NAMES`.
 
-## Weight-Stretch-Style Font Family Model
+### Weight-Stretch-Style Font Family Model
 
 The weight-stretch-style font family model is the original font family model used by DirectWrite
 before the typographic font family model was introduced. It is also known as weight-width-slope
@@ -206,7 +206,7 @@ Nevertheless, the weight-stretch-style model is not open-ended. If two fonts hav
 stretch, and style but differ in some other way (e.g., optical size), they cannot be included in the
 same WWS font family. This brings us to the typographic font family model.
 
-## Typographic Font Family Model
+### Typographic Font Family Model
 
 Unlike its predecessors, the typographic font family model is open-ended. It supports any number of
 axes of variation within a font family.
@@ -238,7 +238,7 @@ to the user to specify the right WWS family name for a given font size. With the
 family model, the user can simply choose "Sitka", and the application can automatically set the
 "opsz" axis value based on the font size.
 
-## Typographic Font Selection and Variable Fonts
+### Typographic Font Selection and Variable Fonts
 
 The concept of axes of variation is often associated with variable fonts, but it also applies to
 static fonts. The OpenType
@@ -293,7 +293,7 @@ In the above example, the matching fonts are arbitrary variable font instances. 
 instance of Sitka with weight 475. In contrast, the weight-stretch-style matching algorithm only
 returns named instances.
 
-## Font Matching Order
+### Font Matching Order
 
 There are different overloaded `GetMatchingFonts` methods for the weight-stretch-style font family
 model and the typographic font family model. In both cases, the output is a list of matching fonts
@@ -363,7 +363,7 @@ in the typographic model are decomposed into an "ital" axis (0..1) and a "slnt" 
 chosen multipliers for these two axes give equivalent results to the legacy algorithm if we assume a
 default 20-degree slant for oblique fonts.
 
-## Typographic Font Selection and Optical Size
+### Typographic Font Selection and Optical Size
 
 An application using the typographic font family model can implement optical sizing by specifying an
 `opsz` axis value as a font selection parameter. For example, a word processing application could
@@ -381,7 +381,7 @@ static fonts have different, non-overlapping `opsz` axis ranges. (These are decl
 font selection purposes, but they are not variable axes.) Specifying `opsz` as a font selection
 parameter enables the correct static font for the optical size to be selected.
 
-## Typographic Font Selection Advantages and Compatibility Issues
+### Typographic Font Selection Advantages and Compatibility Issues
 
 The typographic font selection model has several advantages over earlier models, but in its pure
 form it has some potential compatibility issues. This section describes the advantages and
@@ -436,7 +436,7 @@ fonts predate OpenType 1.8, so their only design axes are those derived from wei
 style. For each weight, this font family has two fonts with identical axis values, so it is not
 possible to unambiguously select a font in this family using axis values alone.
 
-## Hybrid Font Selection Algorithm
+### Hybrid Font Selection Algorithm
 
 The font selection APIs described in the next section use a hybrid font selection algorithm that
 preserves the advantages of typographic font selection while mitigating its compatibilty issues.
@@ -487,7 +487,7 @@ by the method will only include font axes that were not specified explicitly. Th
 specified explicitly by the document (or application) take precedence over axis values derived from
 weight, stretch, style, and font size.
 
-## Hybrid Font Selection APIs
+### Hybrid Font Selection APIs
 
 The hybrid font selection model is implemented by the following `IDWriteFontSet4` methods:
 
@@ -510,9 +510,189 @@ The following other DirectWrite APIs also use the hybrid font selection algorith
 -   `IDWriteTextLayout` if the typographic font family model is enabled by calling
     `IDWriteTextLayout4::SetFontAxisValues` or `IDWriteTextLayout4::SetAutomaticFontAxes`
 
-# Examples
+## Color Font Support
 
-## Creating an isolated factory
+By default, a glyph has a shape but no intrinsic color. Both DirectWrite and Direct2D have
+`DrawGlyphRun` methods that render glyph runs by filling the glyph shapes with a specified text
+color. For convenience, we will refer to this as _monochrome_ glyph rendering. All fonts have
+monochrome glyphs, but a color font also has color representations of some glyphs. To render glyphs
+in color, an application must use different glyph rendering APIs instead of calling the monochrome
+`DrawGlyphRun` method.
+
+Note that color font support does not affect text layout it at all. The text layout always produces
+monochrome glyph runs. Color is enabled at the glyph rendering level by substituting color
+representations for the monochrome glyphs.
+
+The easiest way to enable color is to call the `DrawGlyphRunWithColor` method instead of calling
+`DrawGyphRun`. Direct2D exposes this method through the `ID2D1DeviceContext7` interface. DirectWrite
+exposes this method through the `IDWriteBitmapRenderTarget3` interface.
+
+At a lower level, enabling color involves translating the monochrome _base glyph run_ to a sequence
+of _color glyph runs_. Each color glyph run must then be rendered using the appropriate method,
+depending on its _glyph image format_. The translation is performed by the factory object's
+`TranslateColorGlyphRun` method. It and related APIs are described in the following sections.
+
+### Using TranslateColorGlyphRun
+
+The `TranslateColorGlyphRun` factory method translates a monochrome _base glyph run_ into a sequence
+of _color glyph runs_. There are multiple ways of representiong color glyphs, known as _glyph image
+formats_ and identified by the `DWRITE_GLYPH_IMAGE_FORMATS` enumeration. When calling
+`TranslateColorGlyphRun`, the client specifies the combination of glyph image formats it supports.
+The `TranslateColorGlyphRun` returns a _glyph run enumerator_ object
+(`IDWriteColorGlyphRunEnumerator1` interface), which the client uses to iterate over the sequence of
+color glyph runs, represented by the `DWRITE_COLOR_GLYPH_RUN1` structure. Each color glyph run has a
+glyph image format. The client branches on the color run's glyph image format to determine how to
+render the color run.
+
+If the base glyph run does not have color glyphs in any of the requested glyph image formats, the
+`TranslateColorGlyphRun` method returns `DWRITE_E_NOCOLOR`, in which case the client should render
+the base glyph run as a monochrome glyph run.
+
+The glyph image formats fall into four general categories:
+
+-   Layers of solid-color glyphs (`DWRITE_GLYPH_IMAGE_FORMATS_COLR`)
+-   Color bitmaps embedded in the font (`DWRITE_GLYPH_IMAGE_FORMATS_PNG`,
+    `DWRITE_GLYPH_IMAGE_FORMATS_JPEG`, `DWRITE_GLYPH_IMAGE_FORMATS_TIFF`, and
+    `DWRITE_GLYPH_IMAGE_FORMATS_PREMULTIPLIED_B8G8R8A8`)
+-   Vector graphics encoded as SVG in the font (`DWRITE_GLYPH_IMAGE_FORMATS_SVG`)
+-   Vector graphics as a tree of "paint" elements (`DWRITE_GLYPH_IMAGE_FORMATS_COLR_PAINT_TREE`)
+
+The following subsections describe each of these approaches.
+
+### Layers of solid color glyphs
+
+The `DWRITE_GLYPH_IMAGE_FORMATS_COLR` value specifies a color format that supports version 0 of the
+OpenType COLR table. In this format, a color glyph is rendered by drawing multiple monochrome glyphs
+on top of each other, each in a specified color.
+
+The calling pattern used with this image format is different than with all other glyph image
+formats. That's because what gets rendered at the end of the day is just a series of ordinary,
+monochrome glyph runs -- just with different glyph IDs and different colors than were specified to
+begin with. Because the enumerated color glyph runs are rendered as ordinary monochrome glyph runs,
+their glyph image formats are either `DWRITE_GLYPH_IMAGE_FORMATS_TRUETYPE` or
+`DWRITE_GLYPH_IMAGE_FORMATS_CFF`.
+
+For example, suppose the base glyph run specifies a smiley face glyph. If we rendered the base glyph
+run using `DrawGlyphRun`, the visual result would be a monochrome representation of a smiley face
+(the base glyph ID). Thd COLR table in the font maps this base glyph ID to an array of _layer
+records_, each of which specifies a _replacement glyph ID_ and an index into a font-defined color
+palette. The `IDWriteColorGlyphRunEnumerator` object returned by `TranslateColorGlyphRun` enumerates
+one color glyph run for each of those layer records. Each color glyph run has a position, a single
+glyph ID (the replacement glyph ID for the layer), and a color (derived from the palette entry
+index). The client draws the enumerated color glyph runs in the specified colors at the specified
+coordinates to produce the desired visual result. In the smiley face example, this might comprise a
+filled-circle glyph rendered in yellow followed by an eyes-and-mouth glyph rendered in black.
+
+### Color bitmaps embedded in the font
+
+The `DWRITE_GLYPH_IMAGE_FORMATS` enumeration includes values for several bitmap formats: PNG, JPEG,
+TIFF, and premultiplied BGRA32 format. A font may represent color glyphs by embedding bitmaps in any
+of these formats in the font. A font may include bitmaps or multiple sizes to support different font
+sizes and DPI scales, though this comes at an obvious cost in terms of file size.
+
+If the client requests bitmap image formats then `TranslateColorGlyphRun` checks if the font has
+color bitmaps for the specified input glyphs in the specified formats. If so, then the enumerated
+color glyph runs specify the base glyph IDs and the matching image format. Note that there are no
+replacement glyph IDs in this case, like there are with `DWRITE_GLYPH_IMAGE_FORMATS_COLR`. However,
+the base glyph run may still be split into multiple color runs if different input glyphs have color
+bitmaps in different image formats, or some glyphs have color representations and others are
+monochrome only.
+
+A client using Direct2D can render the enumerated color glyph runs in these formats by calling the
+`ID2DDeviceContext3::DrawColorBitmapGlyphRun` method.
+
+A lower-level client can call the `IDWriteFontFace3::GetGlyphImageData` to get the raw bitmap data
+for each glyph in the returned image format. The client is then responsible for decoding and
+rendering the bitmaps itself. Direct2D's internal implementation of `DrawColorBitmapGlyphRun` calls
+`GetGlyphImageData` to get the bitmaps for each glyph.
+
+### Vector graphics encoded as SVG in the font
+
+The `DWRITE_GLYPH_IMAGE_FORMATS_SVG` value specifies a glyph image format in which color glyphs are
+represented as vector graphics in SVG (Scaled Vector Graphics) format embedded in the font. The
+embedded SVG may be stored with gzip compression.
+
+The calling pattern used with SVG is similar to that with the bitmap formats, and unlike the calling
+pattern for `DWRITE_GLYPH_IMAGE_FORMATS_COLR`. If the client requests SVG format, and specified
+glyph IDs have SVG representations, then the enumerated color glyph runs specify the base glyph IDs
+and the SVG image format.
+
+A client using Direct2D can render enumerated color glyph runs in this format by calling the
+`ID2DDeviceContext3::DrawSvgGlyphRun` method.
+
+A lower-level client can call the `IDWriteFontFace3::GetGlyphImageData` to get the raw SVG data for
+each glyph. The client is then responsible for parsing and rendering the SVG itself. Direct2D's
+internal implementation of `DrawSvgGlyphRun` calls `GetGlyphImageData` to get the SVG data for each
+glyph.
+
+### Vector graphics as a tree of "paint" elements
+
+In version 1 of the OpenType COLR table, color glyphs are represented by a tree of _paint elements_.
+There are different types of paint elements for geometries (represented as glyphs), transforms,
+solid and gradient fills, and composition. The `DWRITE_GLYPH_IMAGE_FORMATS_COLR` format only
+supports layering solid-color glyphs on top of each other, so a different glyph image format is
+required to support COLR version 1 and greater: `DWRITE_GLYPH_IMAGE_FORMATS_COLR_PAINT_TREE`. When
+using this glyph image format, the client must also specify the maximum _paint feature level_
+(`DWRITE_PAINT_FEATURE_LEVEL`) it supports. This enables future versions of the COLR table to be
+supported without having to define additional glyph image formats.
+
+The calling pattern used with this glyph image format is similar to that used with SVG. If the
+client requests the COLR-paint format and the specified glyph IDs have COLR representations, then
+the enumerated color glyph runs specify the base glyph IDs and the COLR-paint image format.
+
+A client using Direct2D can render enumerated color glyph runs in this format by calling the
+`ID2DDeviceContext7::DrawPaintGlyphRun` method. A client using DirectWrite's bitmap render target
+API can call `IDWriteBitmapRenderTarget3::DrawPaintGlyphRun`.
+
+A lower-level client can use the color paint APIs described in the next section to get the tree of
+paint elements for each glyph and render it. Direct2D's and DirectWrite's implementations of
+`DrawPaintGlyphRun` internally use these lower-level APIs.
+
+### Color paint APIs
+
+A glyph in the `DWRITE_GLYPH_IMAGE_FORMATS_COLR_PAINT_TREE` image format is represented as a tree of
+_paint elements_. (The OpenType COLR table spec describes a directed acyclic graph of paint records,
+but the subgraph for a specific glyph is always a tree.) A client can use a _paint reader_ object
+(`IDWritePaintReader` interface) to read the tree of paint elements for a glyph.
+
+Each paint element has a _paint type_ (`DWRITE_PAINT_TYPE` enumeration). There are different paint
+types for graphical elements such as geometries (represented as glyphs), transforms, and solid and
+gradient fills. Paint reader methods return information about a paint element by filling in a
+`DWRITE_PAINT_ELEMENT` structure, which comprises a paint type and a union.
+
+Additional paint types may be added in future versions of the COLR specification. To allow for this,
+a client must specify the maximum _paint feature level_ (`DWRITE_PAINT_FEATURE_LEVEL`) it supports
+when creating a paint reader object or calling `TranslateColorGlyphRun`. Only paint elements of
+types supported by the specified feature level are returned by paint reader methods. In addition,
+methods that take an output parameter of type `DWRITE_PAINT_ELEMENT` also take a size parameter,
+since the structure size may change when additional paint types are defined.
+
+The algorithm for rendering a color glyph is to recursively render the paint elements, each
+according to its type. The following paint types are defined:
+
+| Paint Type                          | Rendering Action                                                                         |
+| ----------------------------------- | ---------------------------------------------------------------------------------------- |
+| `DWRITE_PAINT_TYPE_NONE`            | No action                                                                                |
+| `DWRITE_PAINT_TYPE_LAYERS`          | Render the child paint elements in bottom-up order.                                      |
+| `DWRITE_PAINT_TYPE_SOLID_GLYPH`     | Fill the specified glyph shape with the specified color.                                 |
+| `DWRITE_PAINT_TYPE_SOLID`           | Fill the current clip with the specified color.                                          |
+| `DWRITE_PAINT_TYPE_LINEAR_GRADIENT` | Fill the current clip with the specified gradient.                                       |
+| `DWRITE_PAINT_TYPE_RADIAL_GRADIENT` | Fill the current clip with the specified gradient.                                       |
+| `DWRITE_PAINT_TYPE_SWEEP_GRADIENT`  | Fill the current clip with the specified gradient.                                       |
+| `DWRITE_PAINT_TYPE_GLYPH`           | Fill the specified glyph shape with child paint element.                                 |
+| `DWRITE_PAINT_TYPE_COLOR_GLYPH`     | Render the child paint element.                                                          |
+| `DWRITE_PAINT_TYPE_TRANSFORM`       | Render the child paint element with the specified transform.                             |
+| `DWRITE_PAINT_TYPE_COMPOSITE`       | Render the two child paint elements and compose them using the specified composite mode. |
+
+For more information about paint types, see the
+[OpenType COLR Table](https://docs.microsoft.com/en-us/typography/opentype/spec/colr) specification.
+Note that some paint types in the DirectWrite API correspond to multiple paint formats in the COLR
+table. This is because the API hides some complexities, such as differences in how some paint
+elements are encoded in variable vs. non-variable fonts.
+
+## Examples
+
+### Creating an isolated factory
 
 An application calls the `DWriteCoreCreateFactory` function to create a factory object, which is the
 entry-point to all other DirectWrite APIs. An application can specify the new
@@ -533,7 +713,7 @@ HRESULT hr = DWriteCoreCreateFactory(
     );
 ```
 
-## Drawing glyphs to a system memory bitmap
+### Drawing glyphs to a system memory bitmap
 
 An application creates a bitmap render target by calling
 [`IDWriteGdiInterop::CreateBitmapRenderTarget`](https://docs.microsoft.com/windows/win32/api/dwrite/nf-dwrite-idwritegdiinterop-createbitmaprendertarget).
@@ -587,7 +767,7 @@ DWRITE_BITMAP_DATA_BGRA32 TextRenderer::GetBitmapData(_In_ IDWriteBitmapRenderTa
 }
 ```
 
-## Using Font Selection APIs
+### Using Font Selection APIs
 
 This section shows a complete console application that demonstrates the
 `IDWriteFontSet4::GetMatchingFonts` and `IDWriteFontSet4::ConvertWeightStretchStyleToFontAxisValues`
@@ -1050,9 +1230,185 @@ int __cdecl wmain(int argc, WCHAR** argv)
 }
 ```
 
-# API Details
+### Rendering Color Glyph Runs
 
-## DWRITE_FACTORY_TYPE Enumeration
+In most cases, the simplest way to render glyph runs with color is to use either Direct2D's or
+DirectWrite's `DrawGlyphRunWithColor` method.
+
+The following example shows a lower-level approach, in which the client calls
+`TranslateColorGlyphRun` to translate the base glyph run into a sequence of color glyph runs, each
+of which must then be rendered in accordance with its glyph image format. This example assumes the
+client using DirectWrite along with Direct2D.
+
+```c++
+HRESULT DrawGlyphRunWithColor(
+    IDWriteFactory8* dwriteFactory,
+    ID2D1DeviceContext7* deviceContext,
+    DWRITE_GLYPH_RUN const& glyphRun,
+    D2D_POINT_2F baselineOrigin,
+    UINT32 colorPaletteIndex,
+    ID2D1Brush* foregroundBrush
+)
+{
+    // Get the current world transform for the device context.
+    D2D1_MATRIX_3X2_F transform;
+    deviceContext->GetTransform(&transform);
+
+    // Multiply the world transform by the DPI scale to get a world and DPI transform.
+    float dpiX, dpiY;
+    deviceContext->GetDpi(&dpiX, &dpiY);
+    transform = transform * D2D1::Matrix3x2F::Scale(dpiX / 96, dpiY / 96);
+
+    // Combination of image formats we support.
+    constexpr DWRITE_GLYPH_IMAGE_FORMATS desiredGlyphImageFormats =
+        DWRITE_GLYPH_IMAGE_FORMATS_TRUETYPE |
+        DWRITE_GLYPH_IMAGE_FORMATS_CFF |
+        DWRITE_GLYPH_IMAGE_FORMATS_COLR |
+        DWRITE_GLYPH_IMAGE_FORMATS_SVG |
+        DWRITE_GLYPH_IMAGE_FORMATS_PNG |
+        DWRITE_GLYPH_IMAGE_FORMATS_JPEG |
+        DWRITE_GLYPH_IMAGE_FORMATS_TIFF |
+        DWRITE_GLYPH_IMAGE_FORMATS_PREMULTIPLIED_B8G8R8A8 |
+        DWRITE_GLYPH_IMAGE_FORMATS_COLR_PAINT_TREE;
+
+    // Color glyph runs of type DWRITE_GLYPH_IMAGE_FORMATS_COLR_PAINT_TREE will be
+    // rendered using D2D's DrawPaintGlyphRun, so get the paint feature level from D2D.
+    DWRITE_PAINT_FEATURE_LEVEL paintFeatureLevel = deviceContext->GetColorPaintFeatureLevel();
+
+    // Call TranslateColorGlyphRun to translate the monochrome "base" glyph run
+    // into a sequence of color glyph runs.
+    wil::com_ptr<IDWriteColorGlyphRunEnumerator1> colorRunEnumerator;
+
+    HRESULT hr = dwriteFactory->TranslateColorGlyphRun(
+        baselineOrigin,
+        &glyphRun,
+        /*glyphRunDescription*/ nullptr,
+        desiredGlyphImageFormats,
+        paintFeatureLevel,
+        DWRITE_MEASURING_MODE_NATURAL,
+        reinterpret_cast<DWRITE_MATRIX const*>(&transform),
+        colorPaletteIndex,
+        &colorRunEnumerator
+    );
+
+    // Handle DWRITE_E_NOCOLOR, which is returned if the base glyph run does not
+    // have any color glyphs in the desired glyph image formats. In this case,
+    // just render the base glyph run as a monochrome glyph run.
+    if (hr == DWRITE_E_NOCOLOR)
+    {
+        deviceContext->DrawGlyphRun(
+            baselineOrigin,
+            &glyphRun,
+            foregroundBrush,
+            DWRITE_MEASURING_MODE_NATURAL
+        );
+        return S_OK;
+    }
+
+    // Any other error returned by TranslateColorGyphRun is a failure.
+    RETURN_IF_FAILED(hr);
+
+    // Solid color brush to be lazily created if needed.
+    wil::com_ptr<ID2D1SolidColorBrush> solidBrush;
+
+    // Use the returned enumerator object to iterate over the color glyph runs.
+    for (;;)
+    {
+        // Advanced to the first or next run.
+        BOOL haveRun;
+        RETURN_IF_FAILED(colorRunEnumerator->MoveNext(&haveRun));
+        if (!haveRun)
+            break;
+
+        // Get a pointer to the color glyph run structure.
+        DWRITE_COLOR_GLYPH_RUN1 const* colorGlyphRun;
+        RETURN_IF_FAILED(colorRunEnumerator->GetCurrentRun(&colorGlyphRun));
+
+        // Determine the brush to use for this color glyph run.
+        ID2D1Brush* runBrush;
+        if (colorGlyphRun->paletteIndex == 0xFFFF)
+        {
+            // Special palette index meaning use the text foreground brush.
+            runBrush = foregroundBrush;
+        }
+        else
+        {
+            // Use the specified color from the font's color palette.
+            if (solidBrush == nullptr)
+            {
+                // Lazily create the solid color brush with the specified color.
+                RETURN_IF_FAILED(deviceContext->CreateSolidColorBrush(colorGlyphRun->runColor, &solidBrush));
+            }
+            else
+            {
+                // We already created the brush, so just set its color.
+                solidBrush->SetColor(colorGlyphRun->runColor);
+            }
+
+            // use the solid color brush as the current run's brush.
+            runBrush = solidBrush.get();
+        }
+
+        // Branch depending on the run's glyph image format.
+        switch (colorGlyphRun->glyphImageFormat)
+        {
+        case DWRITE_GLYPH_IMAGE_FORMATS_NONE:
+            // do nothing
+            break;
+
+        case DWRITE_GLYPH_IMAGE_FORMATS_PNG:
+        case DWRITE_GLYPH_IMAGE_FORMATS_JPEG:
+        case DWRITE_GLYPH_IMAGE_FORMATS_TIFF:
+        case DWRITE_GLYPH_IMAGE_FORMATS_PREMULTIPLIED_B8G8R8A8:
+            deviceContext->DrawColorBitmapGlyphRun(
+                colorGlyphRun->glyphImageFormat,
+                baselineOrigin,
+                &colorGlyphRun->glyphRun,
+                colorGlyphRun->measuringMode,
+                D2D1_COLOR_BITMAP_GLYPH_SNAP_OPTION_DEFAULT
+            );
+            break;
+
+        case DWRITE_GLYPH_IMAGE_FORMATS_SVG:
+            deviceContext->DrawSvgGlyphRun(
+                baselineOrigin,
+                &colorGlyphRun->glyphRun,
+                runBrush,
+                /*SVG style*/ nullptr,
+                colorPaletteIndex,
+                colorGlyphRun->measuringMode
+            );
+            break;
+
+        case DWRITE_GLYPH_IMAGE_FORMATS_COLR_PAINT_TREE:
+            deviceContext->DrawPaintGlyphRun(
+                baselineOrigin,
+                &colorGlyphRun->glyphRun,
+                runBrush,
+                colorPaletteIndex,
+                colorGlyphRun->measuringMode
+            );
+            break;
+
+        default:
+            deviceContext->DrawGlyphRun(
+                baselineOrigin,
+                &colorGlyphRun->glyphRun,
+                colorGlyphRun->glyphRunDescription,
+                runBrush,
+                colorGlyphRun->measuringMode
+            );
+            break;
+        }
+    }
+
+    return S_OK;
+}
+```
+
+## API Details
+
+### DWRITE_FACTORY_TYPE Enumeration
 
 ```c++
 /// <summary>
@@ -1094,7 +1450,7 @@ enum DWRITE_FACTORY_TYPE
 };
 ```
 
-## DWriteCoreCreateFactory Function
+### DWriteCoreCreateFactory Function
 
 ```c++
 /// <summary>
@@ -1117,7 +1473,7 @@ EXTERN_C HRESULT DWRITE_EXPORT DWriteCoreCreateFactory(
 );
 ```
 
-## DWRITE_BITMAP_DATA_BGRA32 Structure
+### DWRITE_BITMAP_DATA_BGRA32 Structure
 
 ```c++
 /// <summary>
@@ -1132,7 +1488,7 @@ struct DWRITE_BITMAP_DATA_BGRA32
 };
 ```
 
-## IDWriteBitmapRenderTarget2 Interface
+### IDWriteBitmapRenderTarget2 Interface
 
 ```c++
 /// <summary>
@@ -1149,7 +1505,7 @@ DWRITE_BEGIN_INTERFACE(IDWriteBitmapRenderTarget2, "C553A742-FC01-44DA-A66E-B8B9
 };
 ```
 
-## IDWriteFontSet4 Interface
+### IDWriteFontSet4 Interface
 
 ```c++
 DWRITE_BEGIN_INTERFACE(IDWriteFontSet4, "EEC175FC-BEA9-4C86-8B53-CCBDD7DF0C82") : IDWriteFontSet3
@@ -1214,7 +1570,7 @@ DWRITE_BEGIN_INTERFACE(IDWriteFontSet4, "EEC175FC-BEA9-4C86-8B53-CCBDD7DF0C82") 
 };
 ```
 
-## IDWriteFactory7 Interface
+### IDWriteFactory7 Interface
 
 ```c++
 DWRITE_BEGIN_INTERFACE(IDWriteFactory8, "202D44F0-84AC-4D6F-B8D0-704B27675CAA") : IDWriteFactory7
@@ -1232,6 +1588,904 @@ DWRITE_BEGIN_INTERFACE(IDWriteFactory8, "202D44F0-84AC-4D6F-B8D0-704B27675CAA") 
     /// factories or other processes.
     /// </remarks>
     STDMETHOD_(void, ReleaseUnreferencedFonts)(
+        ) PURE;
+};
+```
+
+### DWRITE_GLYPH_IMAGE_FORMATS Enumeration
+
+This enumeration defines formats that may be used to represent color glyphs in a font.
+
+```c++
+/// <summary>
+/// Fonts may contain multiple drawable data formats for glyphs. These flags specify which formats
+/// are supported in the font, either at a font-wide level or per glyph, and the app may use them
+/// to tell DWrite which formats to return when splitting a color glyph run.
+/// </summary>
+enum DWRITE_GLYPH_IMAGE_FORMATS
+{
+    /// <summary>
+    /// Indicates no data is available for this glyph.
+    /// </summary>
+    DWRITE_GLYPH_IMAGE_FORMATS_NONE = 0x00000000,
+
+    /// <summary>
+    /// The glyph has TrueType outlines.
+    /// </summary>
+    DWRITE_GLYPH_IMAGE_FORMATS_TRUETYPE = 0x00000001,
+
+    /// <summary>
+    /// The glyph has CFF outlines.
+    /// </summary>
+    DWRITE_GLYPH_IMAGE_FORMATS_CFF = 0x00000002,
+
+    /// <summary>
+    /// The glyph has multilayered COLR data.
+    /// </summary>
+    DWRITE_GLYPH_IMAGE_FORMATS_COLR = 0x00000004,
+
+    /// <summary>
+    /// The glyph has SVG outlines as standard XML.
+    /// </summary>
+    /// <remarks>
+    /// Fonts may store the content gzip'd rather than plain text,
+    /// indicated by the first two bytes as gzip header {0x1F 0x8B}.
+    /// </remarks>
+    DWRITE_GLYPH_IMAGE_FORMATS_SVG = 0x00000008,
+
+    /// <summary>
+    /// The glyph has PNG image data, with standard PNG IHDR.
+    /// </summary>
+    DWRITE_GLYPH_IMAGE_FORMATS_PNG = 0x00000010,
+
+    /// <summary>
+    /// The glyph has JPEG image data, with standard JIFF SOI header.
+    /// </summary>
+    DWRITE_GLYPH_IMAGE_FORMATS_JPEG = 0x00000020,
+
+    /// <summary>
+    /// The glyph has TIFF image data.
+    /// </summary>
+    DWRITE_GLYPH_IMAGE_FORMATS_TIFF = 0x00000040,
+
+    /// <summary>
+    /// The glyph has raw 32-bit premultiplied BGRA data.
+    /// </summary>
+    DWRITE_GLYPH_IMAGE_FORMATS_PREMULTIPLIED_B8G8R8A8 = 0x00000080,
+
+    /// <summary>
+    /// The glyph is represented by a tree of paint elements in the
+    /// font's COLR table.
+    /// </summary>
+    DWRITE_GLYPH_IMAGE_FORMATS_COLR_PAINT_TREE = 0x00000100,
+};
+
+#define DWRITE_GLYPH_IMAGE_FORMATS_COLR_PAINT_TREE_DEFINED
+```
+
+The above enumeration is defined in `dcommon.h`, which is not a lifted header file.
+
+The `DWRITE_GLYPH_IMAGE_FORMATS_COLR_PAINT_TREE_DEFINED` symbol exists so lifted `dwrite_3.h` can
+conditionally define `DWRITE_GLYPH_IMAGE_FORMATS_COLR_PAINT_TREE` as a macro if it is not already
+defined in the included version of `dcommon.h`. This is accomplished as follows in `dwrite_3.h`:
+
+```c++
+/// <summary>
+/// DWRITE_GLYPH_IMAGE_FORMATS_COLR_PAINT_TREE image format represents a color glyph that can be
+/// rendered by drawing paint elements returned by IDWritePaintReader.
+/// </summary>
+#ifndef DWRITE_GLYPH_IMAGE_FORMATS_COLR_PAINT_TREE_DEFINED
+#define DWRITE_GLYPH_IMAGE_FORMATS_COLR_PAINT_TREE_DEFINED
+#define DWRITE_GLYPH_IMAGE_FORMATS_COLR_PAINT_TREE static_cast<DWRITE_GLYPH_IMAGE_FORMATS>(0x00000100)
+#endif
+```
+
+### DWRITE_PAINT_FEATURE_LEVEL Enumeration
+
+```c++
+/// <summary>
+/// Defines known feature level for use with the IDWritePaintReader interface and
+/// related APIs. A feature level represents a level of functionality. For example, it
+/// determines what DWRITE_PAINT_TYPE values might be returned.
+/// </summary>
+/// <remarks>
+/// See the DWRITE_PAINT_TYPE enumration for which paint types are required for each
+/// feature level.
+/// </remarks>
+enum DWRITE_PAINT_FEATURE_LEVEL
+{
+    /// <summary>
+    /// No paint API support.
+    /// </summary>
+    DWRITE_PAINT_FEATURE_LEVEL_NONE = 0,
+
+    /// <summary>
+    /// Specifies a level of functionality corresponding to OpenType COLR version 0.
+    /// </summary>
+    DWRITE_PAINT_FEATURE_LEVEL_COLR_V0 = 1,
+
+    /// <summary>
+    /// Specifies a level of functionality corresponding to OpenType COLR version 1.
+    /// </summary>
+    DWRITE_PAINT_FEATURE_LEVEL_COLR_V1 = 2
+};
+```
+
+### DWRITE_PAINT_ATTRIBUTES Enumeration
+
+```c++
+/// <summary>
+/// Combination of flags specifying attributes of a color glyph or of specific color values in
+/// a color glyph.
+/// </summary>
+enum DWRITE_PAINT_ATTRIBUTES
+{
+    DWRITE_PAINT_ATTRIBUTES_NONE = 0,
+
+    /// <summary>
+    /// Specifies that the color value (or any color value in the glyph) comes from the font's
+    /// color palette. This means the appearance may depend on the current palette index, which
+    /// may be important to clients that cache color glyphs.
+    /// </summary>
+    DWRITE_PAINT_ATTRIBUTES_USES_PALETTE = 0x01,
+
+    /// <summary>
+    /// Specifies that the color value (or any color value in the glyph) comes from the client-specified
+    /// text color. This means the appearance may depend on the text color, which may be important to
+    /// clients that cache color glyphs.
+    /// </summary>
+    DWRITE_PAINT_ATTRIBUTES_USES_TEXT_COLOR = 0x02
+};
+#ifdef DEFINE_ENUM_FLAG_OPERATORS
+DEFINE_ENUM_FLAG_OPERATORS(DWRITE_PAINT_ATTRIBUTES)
+#endif
+```
+
+### DWRITE_PAINT_COLOR Structure
+
+```c++
+/// <summary>
+/// Represents a color in a color glyph.
+/// </summary>
+struct DWRITE_PAINT_COLOR
+{
+    /// <summary>
+    /// Color value.
+    /// </summary>
+    DWRITE_COLOR_F value;
+
+    /// <summary>
+    /// Specifies the palette entry index if the color value comes from the font's color palette.
+    /// Otherwise, this member is UINT32_MAX.
+    /// </summary>
+    UINT32 paletteIndex;
+
+    /// <summary>
+    /// Specifies an alpha value multiplier in the range 0 to 1 that was used to compute the color
+    /// value. Color glyph descriptions may include alpha values to be multiplied with the alpha
+    /// values of palette entries.
+    /// </summary>
+    float alphaMultiplier;
+
+    /// <summary>
+    /// Flags specifying whether the color value comes from the font's color palette or from the
+    /// client-specified text color.
+    /// </summary>
+    DWRITE_PAINT_ATTRIBUTES colorAttributes;
+};
+```
+
+### DWRITE_PAINT_COMPOSITE_MODE Enumeration
+
+```c++
+/// <summary>
+/// Specifies a composite mode for combining source and destination paint elements in a
+/// color glyph. These are taken from the W3C Compositing and Blending Level 1 specification.
+/// </summary>
+enum DWRITE_PAINT_COMPOSITE_MODE
+{
+    DWRITE_COLOR_COMPOSITE_CLEAR,
+    DWRITE_COLOR_COMPOSITE_SRC,
+    DWRITE_COLOR_COMPOSITE_DEST,
+    DWRITE_COLOR_COMPOSITE_SRC_OVER,
+    DWRITE_COLOR_COMPOSITE_DEST_OVER,
+    DWRITE_COLOR_COMPOSITE_SRC_IN,
+    DWRITE_COLOR_COMPOSITE_DEST_IN,
+    DWRITE_COLOR_COMPOSITE_SRC_OUT,
+    DWRITE_COLOR_COMPOSITE_DEST_OUT,
+    DWRITE_COLOR_COMPOSITE_SRC_ATOP,
+    DWRITE_COLOR_COMPOSITE_DEST_ATOP,
+    DWRITE_COLOR_COMPOSITE_XOR,
+    DWRITE_COLOR_COMPOSITE_PLUS,
+
+    DWRITE_COLOR_COMPOSITE_SCREEN,
+    DWRITE_COLOR_COMPOSITE_OVERLAY,
+    DWRITE_COLOR_COMPOSITE_DARKEN,
+    DWRITE_COLOR_COMPOSITE_LIGHTEN,
+    DWRITE_COLOR_COMPOSITE_COLOR_DODGE,
+    DWRITE_COLOR_COMPOSITE_COLOR_BURN,
+    DWRITE_COLOR_COMPOSITE_HARD_LIGHT,
+    DWRITE_COLOR_COMPOSITE_SOFT_LIGHT,
+    DWRITE_COLOR_COMPOSITE_DIFFERENCE,
+    DWRITE_COLOR_COMPOSITE_EXCLUSION,
+    DWRITE_COLOR_COMPOSITE_MULTIPLY,
+
+    DWRITE_COLOR_COMPOSITE_HSL_HUE,
+    DWRITE_COLOR_COMPOSITE_HSL_SATURATION,
+    DWRITE_COLOR_COMPOSITE_HSL_COLOR,
+    DWRITE_COLOR_COMPOSITE_HSL_LUMINOSITY
+};
+```
+
+### DWRITE_PAINT_TYPE Enumeration
+
+```c++
+/// <summary>
+/// Identifies a type of paint element in a color glyph. A color glyph's visual representation
+/// is defined by a tree of paint elements. A paint element's properties are specified by a
+/// DWRITE_PAINT_ELEMENT structure, which combines a paint type an a union.
+/// </summary>
+/// <remarks>
+/// For more information about each paint type, see DWRITE_PAINT_ELEMENT.
+/// </remarks>
+enum DWRITE_PAINT_TYPE
+{
+    // The following paint types may be returned for color feature levels greater than
+    // or equal to DWRITE_PAINT_FEATURE_LEVEL_COLR_V0.
+    DWRITE_PAINT_TYPE_NONE,
+    DWRITE_PAINT_TYPE_LAYERS,
+    DWRITE_PAINT_TYPE_SOLID_GLYPH,
+
+    // The following paint types may be returned for color feature levels greater than
+    // or equal to DWRITE_PAINT_FEATURE_LEVEL_COLR_V1.
+    DWRITE_PAINT_TYPE_SOLID,
+    DWRITE_PAINT_TYPE_LINEAR_GRADIENT,
+    DWRITE_PAINT_TYPE_RADIAL_GRADIENT,
+    DWRITE_PAINT_TYPE_SWEEP_GRADIENT,
+    DWRITE_PAINT_TYPE_GLYPH,
+    DWRITE_PAINT_TYPE_COLOR_GLYPH,
+    DWRITE_PAINT_TYPE_TRANSFORM,
+    DWRITE_PAINT_TYPE_COMPOSITE
+};
+```
+
+### DWRITE_PAINT_ELEMENT Structure
+
+```c++
+/// <summary>
+/// Specifies properties of a paint element, which is one node in a visual tree associated
+/// with a color glyph. This is passed as an output parameter to various IDWritePaintReader
+/// methods.
+/// </summary>
+/// <remarks>
+/// For a detailed description of how paint elements should be rendered, see the OpenType COLR
+/// table specification. Comments below reference the COLR paint record formats associated with
+/// each paint type.
+/// </remarks>
+struct DWRITE_PAINT_ELEMENT
+{
+    /// <summary>
+    /// Specifies the paint type, and thus which member of the union is valid.
+    /// </summary>
+    DWRITE_PAINT_TYPE paintType;
+
+    /// <summary>
+    /// Specifies type-specific properties of the paint element.
+    /// </summary>
+    union PAINT_UNION
+    {
+        /// <summary>
+        /// Valid for paint elements of type DWRITE_PAINT_TYPE_LAYERS.
+        /// Contains one or more child paint elements to be drawn in bottom-up order.
+        /// </summary>
+        /// <remarks>
+        /// This corresponds to a PaintColrLayers record in the OpenType COLR table.
+        /// Or it may correspond to a BaseGlyph record defined by COLR version 0.
+        /// </remarks>
+        struct PAINT_LAYERS
+        {
+            /// <summary>
+            /// Number of child paint elements in bottom-up order. Use the IDWritePaintReader
+            /// interface's MoveFirstChild and MoveNextSibling methods to retrieve the child paint
+            /// elements. Use the MoveParent method to return to the parent element.
+            /// </summary>
+            UINT32 childCount;
+        } layers;
+
+        /// <summary>
+        /// Valid for paint elements of type DWRITE_PAINT_TYPE_SOLID_GLYPH.
+        /// Specifies a glyph with a solid color fill.
+        /// This paint element has no child elements.
+        /// </summary>
+        /// <remarks>
+        /// This corresponds to a combination of two paint records in the OpenType COLR table:
+        /// a PaintGlyph record, which references either a PaintSolid or PaintVarSolid record.
+        /// Or it may correspond to a Layer record defined by COLR version 0.
+        /// </remarks>
+        struct PAINT_SOLID_GLYPH
+        {
+            /// <summary>
+            /// Glyph index defining the shape to be filled.
+            /// </summary>
+            UINT32 glyphIndex;
+
+            /// <summary>
+            /// Glyph color used to fill the glyph shape.
+            /// </summary>
+            DWRITE_PAINT_COLOR color;
+        } solidGlyph;
+
+        /// <summary>
+        /// Valid for paint elements of type DWRITE_PAINT_TYPE_SOLID.
+        /// Specifies a solid color used to fill the current shape or clip.
+        /// This paint element has no child elements.
+        /// </summary>
+        /// <remarks>
+        /// This corresponds to a PaintSolid or PaintVarSolid record in the OpenType COLR table.
+        /// </remarks>
+        typedef DWRITE_PAINT_COLOR PAINT_SOLID;
+        PAINT_SOLID solid;
+
+        /// <summary>
+        /// Valid for paint elements of type DWRITE_PAINT_TYPE_LINEAR_GRADIENT.
+        /// Specifies a linear gradient used to fill the current shape or clip.
+        /// This paint element has no child elements.
+        /// </summary>
+        /// <remarks>
+        /// This corresponds to a PaintLinearGradient or PaintVarLinearGradient record in the OpenType
+        /// COLR table.
+        /// </remarks>
+        struct PAINT_LINEAR_GRADIENT
+        {
+            /// <summary>
+            /// D2D1_EXTEND_MODE value speciying how colors outside the interval are defined.
+            /// </summary>
+            UINT32 extendMode;
+
+            /// <summary>
+            /// Number of gradient stops. Use the IDWritePaintReader::GetGradientStops method to
+            /// get the gradient stops.
+            /// </summary>
+            UINT32 gradientStopCount;
+
+            /// <summary>
+            /// X coordinate of the start point of the color line.
+            /// </summary>
+            float x0;
+
+            /// <summary>
+            /// Y coordinate of the start point of the color line.
+            /// </summary>
+            float y0;
+
+            /// <summary>
+            /// X coordinate of the end point of the color line.
+            /// </summary>
+            float x1;
+
+            /// <summary>
+            /// Y coordinate of the end point of the color line.
+            /// </summary>
+            float y1;
+
+            /// <summary>
+            /// X coordinate of the rotation point of the color line.
+            /// </summary>
+            float x2;
+
+            /// <summary>
+            /// Y coordinate of the rotation point of the color line.
+            /// </summary>
+            float y2;
+        } linearGradient;
+
+        /// <summary>
+        /// Valid for paint elements of type DWRITE_PAINT_TYPE_RADIAL_GRADIENT.
+        /// Specifies a radial gradient used to fill the current shape or clip.
+        /// This paint element has no child elements.
+        /// </summary>
+        /// <remarks>
+        /// This corresponds to a PaintRadialGradient or PaintVarRadialGradient record in the OpenType
+        /// COLR table.
+        /// </remarks>
+        struct PAINT_RADIAL_GRADIENT
+        {
+            /// <summary>
+            /// D2D1_EXTEND_MODE value speciying how colors outside the interval are defined.
+            /// </summary>
+            UINT32 extendMode;
+
+            /// <summary>
+            /// Number of gradient stops. Use the IDWritePaintReader::GetGradientStops method to
+            /// get the gradient stops.
+            /// </summary>
+            UINT32 gradientStopCount;
+
+            /// <summary>
+            /// Center X coordinate of the start circle.
+            /// </summary>
+            float x0;
+
+            /// <summary>
+            /// Center Y coordinate of the start circle.
+            /// </summary>
+            float y0;
+
+            /// <summary>
+            /// Radius of the start circle.
+            /// </summary>
+            float radius0;
+
+            /// <summary>
+            /// Center X coordinate of the end circle.
+            /// </summary>
+            float x1;
+
+            /// <summary>
+            /// Center Y coordinate of the end circle.
+            /// </summary>
+            float y1;
+
+            /// <summary>
+            /// Radius of the end circle.
+            /// </summary>
+            float radius1;
+        } radialGradient;
+
+        /// <summary>
+        /// Valid for paint elements of type DWRITE_PAINT_TYPE_SWEEPL_GRADIENT.
+        /// Specifies a sweep gradient used to fill the current shape or clip.
+        /// This paint element has no child elements.
+        /// </summary>
+        /// <remarks>
+        /// This corresponds to a PaintSweepGradient or PaintVarSweepGradient record in the OpenType
+        /// COLR table.
+        /// </remarks>
+        struct PAINT_SWEEP_GRADIENT
+        {
+            /// <summary>
+            /// D2D1_EXTEND_MODE value speciying how colors outside the interval are defined.
+            /// </summary>
+            UINT32 extendMode;
+
+            /// <summary>
+            /// Number of gradient stops. Use the IDWritePaintReader::GetGradientStops method to
+            /// get the gradient stops.
+            /// </summary>
+            UINT32 gradientStopCount;
+
+            /// <summary>
+            /// Center X coordinate.
+            /// </summary>
+            float centerX;
+
+            /// <summary>
+            /// Center Y coordinate.
+            /// </summary>
+            float centerY;
+
+            /// <summary>
+            /// Start of the angular range of the gradient, 180 degrees in counter-clockwise degrees per 1.0 of value.
+            /// </summary>
+            float startAngle;
+
+            /// <summary>
+            /// End of the angular range of the gradient, 180 degrees in counter-clockwise degrees per 1.0 of value.
+            /// </summary>
+            float endAngle;
+        } sweepGradient;
+
+        /// <summary>
+        /// Valid for paint elements of type DWRITE_PAINT_TYPE_GLYPH.
+        /// Specifies a glyph shape to be filled or, equivalently, a clip region.
+        /// This paint element has one child element.
+        /// </summary>
+        /// <remarks>
+        /// The child paint element defines how the glyph shape is filled. The child element can be a single paint
+        /// element, such as a linear gradient. Or the child element can be the root of a visual tree to be rendered
+        /// with the glyph shape as a clip region.
+        /// This corresponds to a PaintGlyph record in the OpenType COLR table.
+        /// </remarks>
+        struct PAINT_GLYPH
+        {
+            /// <summary>
+            /// Glyph index of the glyph that defines the shape to be filled.
+            /// </summary>
+            UINT32 glyphIndex;
+        } glyph;
+
+        /// <summary>
+        /// Valid for paint elements of type DWRITE_PAINT_TYPE_COLOR_GLYPH.
+        /// Specifies another color glyph, used as a reusable component.
+        /// This paint element has one child element, which is the root paint element of the specified color glyph.
+        /// </summary>
+        /// <remarks>
+        /// This corresponds to a PaintColorGlyph record in the OpenType COLR table.
+        /// </remarks>
+        struct PAINT_COLOR_GLYPH
+        {
+            /// <summary>
+            /// Glyph index of the referenced color glyph.
+            /// </summary>
+            UINT32 glyphIndex;
+
+            /// <summary>
+            /// Clip box of the referenced color glyph, in ems. This is an empty rectangle of the color glyph does
+            /// not specify a clip box. If it is not an empty rect, the client is required to clip the child content
+            /// to this box.
+            /// </summary>
+            D2D_RECT_F clipBox;
+        } colorGlyph;
+
+        /// <summary>
+        /// Valid for paint elements of type DWRITE_PAINT_TYPE_TRANSFORM.
+        /// Specifies an affine transform to be applied to child content.
+        /// This paint element has one child element, which is the transformed content.
+        /// </summary>
+        /// <remarks>
+        /// This corresponds to paint formats 12 through 31 in the OpenType COLR table.
+        /// </remarks>
+        typedef DWRITE_MATRIX PAINT_TRANSFORM;
+        PAINT_TRANSFORM transform;
+
+        /// <summary>
+        /// Valid for paint elements of type DWRITE_PAINT_TYPE_COMPOSITE.
+        /// Combines the two child paint elements using the specified compositing or blending mode.
+        /// This paint element has two child elements. The first child is the paint source. The
+        /// second child is the paint destination (or backdrop).
+        /// </summary>
+        /// <remarks>
+        /// This corresponds to a PaintComposite record in the OpenType COLR table.
+        /// </remarks>
+        struct PAINT_COMPOSITE
+        {
+            /// <summary>
+            /// Specifies the compositing or blending mode.
+            /// </summary>
+            DWRITE_PAINT_COMPOSITE_MODE mode;
+        } composite;
+    } paint;
+};
+```
+
+### IDWritePaintReader Interface
+
+```c++
+/// <summary>
+/// Interface used to read color glyph data for a specific font. A color glyph is
+/// represented as a visual tree of paint elements.
+/// </summary>
+DWRITE_BEGIN_INTERFACE(IDWritePaintReader, "8128E912-3B97-42A5-AB6C-24AAD3A86E54") : IUnknown
+{
+    /// <summary>
+    /// Sets the current glyph and positions the reader on the root paint element of the
+    /// selected glyph's visual tree.
+    /// </summary>
+    /// <param name="glyphIndex">Glyph index to get the color glyph representation for.</param>
+    /// <param name="paintElement">Receives information about the root paint element of the
+    /// glyph's visual tree.</param>
+    /// <param name="structSize">Size of the DWRITE_PAINT_ELEMENT structure, in bytes.</param>
+    /// <param name="clipBox">Receives a precomputed glyph box (in ems) for the specified glyph,
+    /// if one is specified by the font. Otherwise, the glyph box is set to an empty rectangle
+    /// (all zeros). If a non-empty clip box is specified, the client must clip the color
+    /// glyph's representation to the specified box.</param>
+    /// <param name="glyphAttributes">Receives optional paint attributes for the glyph.</param>
+    /// <returns>
+    /// Standard HRESULT error code.
+    /// </returns>
+    /// <remarks>
+    /// If the specified glyph index is not a color glyph, the method succeeds, but the paintType
+    /// member of the DWRITE_PAINT_ELEMENT structure is set to DWRITE_PAINT_TYPE_NONE. In this
+    /// case, the application should draw the input glyph as a non-color glyph.
+    /// </remarks>
+    STDMETHOD(SetCurrentGlyph)(
+        UINT32 glyphIndex,
+        _Out_writes_bytes_(structSize) DWRITE_PAINT_ELEMENT* paintElement,
+        UINT32 structSize,
+        _Out_ D2D_RECT_F* clipBox,
+        _Out_opt_ DWRITE_PAINT_ATTRIBUTES* glyphAttributes = nullptr
+        ) PURE;
+
+    // Inline overload of SetCurrentGlyph, in which structSize is implied.
+    HRESULT SetCurrentGlyph(
+        UINT32 glyphIndex,
+        _Out_writes_bytes_(structSize) DWRITE_PAINT_ELEMENT* paintElement,
+        _Out_ D2D_RECT_F* clipBox,
+        _Out_opt_ DWRITE_PAINT_ATTRIBUTES* glyphAttributes = nullptr
+        )
+    {
+        return SetCurrentGlyph(
+            glyphIndex,
+            paintElement,
+            sizeof(DWRITE_PAINT_ELEMENT),
+            clipBox,
+            glyphAttributes
+            );
+    }
+
+    /// <summary>
+    /// Sets the client-defined text color. The default value is transparent black. Changing the text color
+    /// can affect the appearance of a glyph if its definition uses the current text color. If this is the
+    /// case, the SetCurrentGlyph method returns the DWRITE_PAINT_ATTRIBUTES_USES_TEXT_COLOR flag via the
+    /// glyphAttributes output parameter.
+    /// </summary>
+    /// <param name="textColor">Specifies the text color.</param>
+    /// <returns>
+    /// Standard HRESULT error code.
+    /// </returns>
+    STDMETHOD(SetTextColor)(
+        DWRITE_COLOR_F const& textColor
+        ) PURE;
+
+    /// <summary>
+    /// Sets the current color palette index. The default value is zero. Changing the palette index can affect
+    /// the appearance of a glyph if its definition references colors in the color palette. If this is the case,
+    /// the SetCurrentGlyph method returns the DWRITE_PAINT_ATTRIBUTES_USES_PALETTE flag via the glyphAttributes
+    /// output parameter.
+    /// </summary>
+    /// <param name="textColor">Specifies the color palette index.</param>
+    /// <returns>
+    /// Standard HRESULT error code.
+    /// </returns>
+    STDMETHOD(SetColorPaletteIndex)(
+        UINT32 colorPaletteIndex
+        ) PURE;
+
+    /// <summary>
+    /// Sets a custom color palette with client-defined palette entries instead of using a font-defined color
+    /// palette. Changing the color palette can affect the appearance of a glyph if its definition references
+    /// colors in the color palette. If this is the case, the SetCurrentGlyph method returns the
+    /// DWRITE_PAINT_ATTRIBUTES_USES_PALETTE flag via the glyphAttributes output parameter.
+    /// </summary>
+    /// <param name="paletteEntries">Array of palette entries for the client-defined color palette.</param>
+    /// <param name="paletteEntryCount">Size of the paletteEntries array. This must equal the font's palette
+    /// entry count as returned by IDWriteFontFace2::GetPaletteEntryCount.</param>
+    /// <returns>
+    /// Standard HRESULT error code.
+    /// </returns>
+    STDMETHOD(SetCustomColorPalette)(
+        _In_reads_(paletteEntryCount) DWRITE_COLOR_F const* paletteEntries,
+        UINT32 paletteEntryCount
+        ) PURE;
+
+    /// <summary>
+    /// Sets the current position in the visual tree to the first child of the current paint element, and returns
+    /// the newly-selected element's properties via the paintElement output parameter.
+    /// </summary>
+    /// <param name="paintElement">Receives the properties of the newly-selected element.</param>
+    /// <param name="structSize">Size of the DWRITE_PAINT_ELEMENT structure, in bytes.</param>
+    /// <returns>
+    /// Standard HRESULT error code. The return value is E_INVALIDARG if the current paint element doesn't have
+    /// any children.
+    /// </returns>
+    /// <remarks>
+    /// Whether a paint element has children (and how many) can be determined a priori from its paint type and
+    /// properties. For more information, see DWRITE_PAINT_ELEMENT.
+    /// </remarks>
+    STDMETHOD(MoveToFirstChild)(
+        _Out_writes_bytes_(structSize) DWRITE_PAINT_ELEMENT* paintElement,
+        UINT32 structSize = sizeof(DWRITE_PAINT_ELEMENT)
+        ) PURE;
+
+    /// <summary>
+    /// Sets the current position in the visual tree to the next sibling of the current paint element, and returns
+    /// the newly-selected element's properties via the paintElement output parameter.
+    /// </summary>
+    /// <param name="paintElement">Receives the properties of the newly-selected element.</param>
+    /// <param name="structSize">Size of the DWRITE_PAINT_ELEMENT structure, in bytes.</param>
+    /// <returns>
+    /// Standard HRESULT error code. The return value is E_INVALIDARG if the current paint element doesn't have
+    /// a next sibling.
+    /// </returns>
+    /// <remarks>
+    /// Whether a paint element has children (and how many) can be determined a priori from its paint type and
+    /// properties. For more information, see DWRITE_PAINT_ELEMENT.
+    /// </remarks>
+    STDMETHOD(MoveToNextSibling)(
+        _Out_writes_bytes_(structSize) DWRITE_PAINT_ELEMENT* paintElement,
+        UINT32 structSize = sizeof(DWRITE_PAINT_ELEMENT)
+        ) PURE;
+
+    /// <summary>
+    /// Sets the current position in the visual tree to the parent of the current paint element.
+    /// </summary>
+    /// <returns>
+    /// Standard HRESULT error code. The return value is E_INVALIDARG if the current paint element is the root
+    /// element of the visual tree.
+    /// </returns>
+    STDMETHOD(MoveToParent)() PURE;
+
+    /// <summary>
+    /// Returns gradient stops of the current paint element.
+    /// </summary>
+    /// <param name="firstGradientStopIndex">Index of the first gradient stop to get.</param>
+    /// <param name="gradientStopCount">Number of gradient stops to get.</param>
+    /// <param name="gradientStops">Receives the gradient stops.</param>
+    /// <returns>Standard HRESULT error code.</returns>
+    STDMETHOD(GetGradientStops)(
+        UINT32 firstGradientStopIndex,
+        UINT32 gradientStopCount,
+        _Out_writes_(gradientStopCount) D2D1_GRADIENT_STOP* gradientStops
+        ) PURE;
+
+    /// <summary>
+    /// Returns color information about each gradient stop, such as palette indices.
+    /// </summary>
+    /// <param name="firstGradientStopIndex">Index of the first gradient stop to get.</param>
+    /// <param name="gradientStopCount">Number of gradient stops to get.</param>
+    /// <param name="gradientStopColors">Receives the gradient stop colors.</param>
+    /// <returns>Standard HRESULT error code.</returns>
+    STDMETHOD(GetGradientStopColors)(
+        UINT32 firstGradientStopIndex,
+        UINT32 gradientStopCount,
+        _Out_writes_(gradientStopCount) DWRITE_PAINT_COLOR* gradientStopColors
+        ) PURE;
+};
+```
+
+### IDWriteFontFace7 Interface
+
+```c++
+DWRITE_BEGIN_INTERFACE(IDWriteFontFace7, "3945B85B-BC95-40F7-B72C-8B73BFC7E13B") : IDWriteFontFace6
+{
+    /// <summary>
+    /// Returns the maximum paint feature level supported for the specified glyph image format.
+    /// Possible values are specified by the DWRITE_PAINT_FEATURE_LEVEL enumeration,
+    /// but additional feature levels may be added over time.
+    /// </summary>
+    /// <param name="glyphImageFormat">Glyph image format to get the paint feature level for.
+    /// The return value is zero if the image format is not supported by the IDWritePaintReader API,
+    /// or if the font doesn't contain image data in that format.</param>
+    STDMETHOD_(DWRITE_PAINT_FEATURE_LEVEL, GetPaintFeatureLevel)(
+        DWRITE_GLYPH_IMAGE_FORMATS glyphImageFormat
+        ) PURE;
+
+    /// <summary>
+    /// Creates a paint reader object, which can be used to retrieve vector graphic information
+    /// for color glyphs in the font.
+    /// </summary>
+    /// <param name="glyphImageFormat">Specifies the type of glyph data the reader will obtain. The only
+    /// glyph image format currently supported by this method is DWRITE_GLYPH_IMAGE_FORMATS_COLR_PAINT_TREE.</param>
+    /// <param name="paintFeatureLevel">Specifies the maximum paint feature level supported by the client.
+    /// This affects the types of paint elements that may be returned by the paint reader.</param>
+    /// <param name="paintReader">Receives a pointer to the newly-created object.</param>
+    /// <returns>Standard HRESULT error code.</returns>
+    STDMETHOD(CreatePaintReader)(
+        DWRITE_GLYPH_IMAGE_FORMATS glyphImageFormat,
+        DWRITE_PAINT_FEATURE_LEVEL paintFeatureLevel,
+        _COM_Outptr_ IDWritePaintReader** paintReader
+        ) PURE;
+};
+```
+
+### IDWriteFactory8 Interface
+
+The `IDWriteFactory8` interface adds a new version of `TranslateColorGlyphRun`. The new method adds
+a new _paintFeatureLevel_ parameter, but is otherwise identical to
+`IDWriteFactory4::TranslateColorGlyphRun`.
+
+```c++
+DWRITE_BEGIN_INTERFACE(IDWriteFactory8, "EE0A7FB5-DEF4-4C23-A454-C9C7DC878398") : IDWriteFactory7
+{
+    /// <summary>
+    /// Translates a glyph run to a sequence of color glyph runs, which can be
+    /// rendered to produce a color representation of the original "base" run.
+    /// </summary>
+    /// <param name="baselineOriginX">Horizontal and vertical origin of the base glyph run in
+    /// pre-transform coordinates.</param>
+    /// <param name="glyphRun">Pointer to the original "base" glyph run.</param>
+    /// <param name="glyphRunDescription">Optional glyph run description.</param>
+    /// <param name="desiredGlyphImageFormats">Which data formats TranslateColorGlyphRun
+    /// should split the runs into.</param>
+    /// <param name="paintFeatureLevel">Paint feature level supported by the caller. Used
+    /// when desiredGlyphImageFormats includes DWRITE_GLYPH_IMAGE_FORMATS_COLR_PAINT_TREE. See
+    /// DWRITE_PAINT_FEATURE_LEVEL for more information.</param>
+    /// <param name="measuringMode">Measuring mode, needed to compute the origins
+    /// of each glyph.</param>
+    /// <param name="worldToDeviceTransform">Matrix converting from the client's
+    /// coordinate space to device coordinates (pixels), i.e., the world transform
+    /// multiplied by any DPI scaling.</param>
+    /// <param name="colorPaletteIndex">Zero-based index of the color palette to use.
+    /// Valid indices are less than the number of palettes in the font, as returned
+    /// by IDWriteFontFace2::GetColorPaletteCount.</param>
+    /// <param name="colorEnumerator">If the function succeeds, receives a pointer
+    /// to an enumerator object that can be used to obtain the color glyph runs.
+    /// If the base run has no color glyphs, then the output pointer is NULL
+    /// and the method returns DWRITE_E_NOCOLOR.</param>
+    /// <returns>
+    /// Returns DWRITE_E_NOCOLOR if the font has no color information, the glyph run
+    /// does not contain any color glyphs, or the specified color palette index
+    /// is out of range. In this case, the client should render the original glyph
+    /// run. Otherwise, returns a standard HRESULT error code.
+    /// </returns>
+    /// <remarks>
+    /// The old IDWriteFactory2::TranslateColorGlyphRun is equivalent to passing
+    /// DWRITE_GLYPH_IMAGE_FORMATS_TRUETYPE|CFF|COLR.
+    /// </remarks>
+    STDMETHOD(TranslateColorGlyphRun)(
+        D2D1_POINT_2F baselineOrigin,
+        _In_ DWRITE_GLYPH_RUN const* glyphRun,
+        _In_opt_ DWRITE_GLYPH_RUN_DESCRIPTION const* glyphRunDescription,
+        DWRITE_GLYPH_IMAGE_FORMATS desiredGlyphImageFormats,
+        DWRITE_PAINT_FEATURE_LEVEL paintFeatureLevel,
+        DWRITE_MEASURING_MODE measuringMode,
+        _In_opt_ DWRITE_MATRIX const* worldAndDpiTransform,
+        UINT32 colorPaletteIndex,
+        _COM_Outptr_ IDWriteColorGlyphRunEnumerator1** colorEnumerator
+        ) PURE;
+};
+```
+
+### IDWriteBitmapRenderTarget3 Interface
+
+```c++
+/// <summary>
+/// Encapsulates a bitmap which can be used for rendering glyphs.
+/// </summary>
+DWRITE_BEGIN_INTERFACE(IDWriteBitmapRenderTarget3, "AEEC37DB-C337-40F1-8E2A-9A41B167B238") : IDWriteBitmapRenderTarget2
+{
+    /// <summary>
+    /// Returns the paint feature level supported by this render target.
+    /// A client can pass the return value of this method to IDWriteFactory8::TranslateColorGlyphRun.
+    /// </summary>
+    STDMETHOD_(DWRITE_PAINT_FEATURE_LEVEL, GetPaintFeatureLevel)() PURE;
+
+    /// <summary>
+    /// Draws a glyph run in a "paint" image format returned by IDWriteColorGlyphRunEnumerator1.
+    /// </summary>
+    /// <param name="baselineOriginX">X-coordinate of the baseline.</param>
+    /// <param name="baselineOriginY">Y-coordinate of the baseline.</param>
+    /// <param name="measuringMode">Specifies measuring mode for positioning glyphs in the run.</param>
+    /// <param name="glyphRun">The glyph run to draw.</param>
+    /// <param name="glyphImageFormat">The image format of the color glyph run, as returned by
+    /// IDWriteColorGlyphRunEnumerator1. This must be one of the "paint" image formats.</param>
+    /// <param name="textColor">Foreground color of the text, used in cases where a color glyph
+    /// uses the text color.</param>
+    /// <param name="colorPaletteIndex">Zero-based index of the font-defined color palette to use.</param>
+    /// <param name="blackBoxRect">Optional rectangle that receives the bounding box (in pixels not DIPs) of all the pixels affected by
+    /// drawing the glyph run. The black box rectangle may extend beyond the dimensions of the bitmap.</param>
+    /// <returns>
+    /// Standard HRESULT error code.
+    /// </returns>
+    STDMETHOD(DrawPaintGlyphRun)(
+        FLOAT baselineOriginX,
+        FLOAT baselineOriginY,
+        DWRITE_MEASURING_MODE measuringMode,
+        _In_ DWRITE_GLYPH_RUN const* glyphRun,
+        DWRITE_GLYPH_IMAGE_FORMATS glyphImageFormat,
+        COLORREF textColor,
+        UINT32 colorPaletteIndex = 0,
+        _Out_opt_ RECT* blackBoxRect = NULL
+        ) PURE;
+
+    /// <summary>
+    /// Draws a glyph run, using color representations of glyphs if available in the font.
+    /// </summary>
+    /// <param name="baselineOriginX">X-coordinate of the baseline.</param>
+    /// <param name="baselineOriginY">Y-coordinate of the baseline.</param>
+    /// <param name="measuringMode">Specifies measuring mode for positioning glyphs in the run.</param>
+    /// <param name="glyphRun">The glyph run to draw.</param>
+    /// <param name="renderingParams">Object that controls rendering behavior.</param>
+    /// <param name="textColor">Foreground color of the text.</param>
+    /// <param name="colorPaletteIndex">Zero-based index of the font-defined color palette to use.</param>
+    /// <param name="blackBoxRect">Optional rectangle that receives the bounding box (in pixels not DIPs) of all the pixels affected by
+    /// drawing the glyph run. The black box rectangle may extend beyond the dimensions of the bitmap.</param>
+    /// <returns>
+    /// Standard HRESULT error code.
+    /// </returns>
+    /// <remarks>
+    /// This method internally calls TranslateColorGlyphRun and then automatically calls the appropriate
+    /// lower-level methods to render monochrome or color glyph runs.
+    /// </remarks>
+    STDMETHOD(DrawGlyphRunWithColor)(
+        FLOAT baselineOriginX,
+        FLOAT baselineOriginY,
+        DWRITE_MEASURING_MODE measuringMode,
+        _In_ DWRITE_GLYPH_RUN const* glyphRun,
+        _In_ IDWriteRenderingParams* renderingParams,
+        COLORREF textColor,
+        UINT32 colorPaletteIndex = 0,
+        _Out_opt_ RECT* blackBoxRect = NULL
         ) PURE;
 };
 ```

--- a/specs/dwritecore/DWriteCore.md
+++ b/specs/dwritecore/DWriteCore.md
@@ -2197,13 +2197,15 @@ DEFINE_ENUM_FLAG_OPERATORS(DWRITE_PAINT_ATTRIBUTES)
 struct DWRITE_PAINT_COLOR
 {
     /// <summary>
-    /// Color value.
+    /// Color value (not premultiplied). See the colorAttributes member for information about how
+    /// the color is determined.
     /// </summary>
     DWRITE_COLOR_F value;
 
     /// <summary>
-    /// Specifies the palette entry index if the color value comes from the font's color palette.
-    /// Otherwise, this member is DWRITE_NO_PALETTE_INDEX (0xFFFF).
+    /// If the colorAttributes member is DWRITE_PAINT_ATTRIBUTES_USES_PALETTE, this member is
+    /// the index of a palette entry in the selected color palette. Otherwise, this member is
+    /// DWRITE_NO_PALETTE_INDEX (0xFFFF).
     /// </summary>
     UINT16 paletteEntryIndex;
 
@@ -2215,8 +2217,14 @@ struct DWRITE_PAINT_COLOR
     float alphaMultiplier;
 
     /// <summary>
-    /// Flags specifying whether the color value comes from the font's color palette or from the
-    /// client-specified text color.
+    /// Specifies how the color value is determined. If this member is 
+    /// DWRITE_PAINT_ATTRIBUTES_USES_PALETTE, the color value is determined by getting the color at
+    /// paletteEntryIndex in the current color palette. The color's alpha value is then multiplied
+    /// by alphaMultiplier. If a font has multiple color palettes, a client can set the current color
+    /// palette using the IDWritePaintReader::SetColorPaletteIndex method. A client that uses a custom
+    /// palette can use the paletteEntryIndex and alphaMultiplier methods to compute the color. If this
+    /// member is DWRITE_PAINT_ATTRIBUTES_USES_TEXT_COLOR, the color value is equal to the text 
+    /// foreground color, which can be set using the IDWritePaintReader::SetTextColor method.
     /// </summary>
     DWRITE_PAINT_ATTRIBUTES colorAttributes;
 };


### PR DESCRIPTION
This change updates the DWriteCore API specification to include new color font APIs, which will be added to both system DWrite and DWriteCore.

The new color font APIs are needed to support new capabilities in version 1 of the OpenType COLR table, including gradients, transforms, and composition modes. The relevant chapter of the OpenType spec is here: https://docs.microsoft.com/en-us/typography/opentype/spec/colr

Note: Much of the new overview material is describing existing APIs.