### PR TITLE
Fix warning C4018 on x86

### DIFF
--- a/dev/AppNotifications/AppNotificationUtility.h
+++ b/dev/AppNotifications/AppNotificationUtility.h
@@ -20,7 +20,7 @@ namespace Microsoft::Windows::AppNotifications::Helpers
 
     inline std::wstring ConvertPathToKey(std::wstring path)
     {
-        for (int i = 0; i < path.length(); i++)
+        for (size_t i = 0; i < path.length(); i++)
         {
             if (path[i] == '\\')
             {


### PR DESCRIPTION
Fix warning C4018: '<': signed/unsigned mismatch in dev\AppNotifications\AppNotificationUtility.h for x86 platform.