### PR TITLE
[Ask mode approved] [Cherry-pick] Fix IsSelfContained() to lookup framework packagefamilyname at runtime

### DIFF
--- a/dev/Common/Common.vcxitems
+++ b/dev/Common/Common.vcxitems
@@ -16,6 +16,7 @@
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="$(MSBuildThisFileDirectory)WindowsAppRuntime.SelfContained.cpp" />
+    <ClCompile Include="$(MSBuildThisFileDirectory)WindowsAppRuntime.VersionInfo.cpp" />
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="$(MSBuildThisFileDirectory)AppModel.Identity.h" />
@@ -25,5 +26,6 @@
     <ClInclude Include="$(MSBuildThisFileDirectory)Microsoft.Utf8.h" />
     <ClInclude Include="$(MSBuildThisFileDirectory)Security.IntegrityLevel.h" />
     <ClInclude Include="$(MSBuildThisFileDirectory)WindowsAppRuntime.SelfContained.h" />
+    <ClInclude Include="$(MSBuildThisFileDirectory)WindowsAppRuntime.VersionInfo.h" />
   </ItemGroup>
 </Project>

--- a/dev/Common/Common.vcxitems.filters
+++ b/dev/Common/Common.vcxitems.filters
@@ -26,6 +26,9 @@
     <ClInclude Include="$(MSBuildThisFileDirectory)WindowsAppRuntime.SelfContained.h">
       <Filter>Header Files</Filter>
     </ClInclude>
+    <ClInclude Include="$(MSBuildThisFileDirectory)WindowsAppRuntime.VersionInfo.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
     <ClInclude Include="$(MSBuildThisFileDirectory)Security.IntegrityLevel.h">
       <Filter>Header Files</Filter>
     </ClInclude>
@@ -35,6 +38,9 @@
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="$(MSBuildThisFileDirectory)WindowsAppRuntime.SelfContained.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="$(MSBuildThisFileDirectory)WindowsAppRuntime.VersionInfo.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
   </ItemGroup>

--- a/dev/Common/WindowsAppRuntime.SelfContained.cpp
+++ b/dev/Common/WindowsAppRuntime.SelfContained.cpp
@@ -3,17 +3,10 @@
 
 #include "pch.h"
 
-#if __has_include(<WindowsAppRuntime-VersionInfo.h>)
-#   include <WindowsAppRuntime-VersionInfo.h>
-#   define WINDOWSAPPRUNTIME_SELFCONTAINED_EXPECTED_PACKAGEFAMILYNAME   WINDOWSAPPSDK_RUNTIME_PACKAGE_FRAMEWORK_PACKAGEFAMILYNAME_W
-#else
-#   define WINDOWSAPPRUNTIME_SELFCONTAINED_EXPECTED_PACKAGEFAMILYNAME   nullptr
-#endif
 #include <AppModel.PackageGraph.h>
 
+#include "WindowsAppRuntime.VersionInfo.h"
 #include "WindowsAppRuntime.SelfContained.h"
-
-static std::wstring g_test_frameworkPackageFamilyName;
 
 STDAPI WindowsAppRuntime_IsSelfContained(
     BOOL* isSelfContained) noexcept try
@@ -25,12 +18,10 @@ STDAPI WindowsAppRuntime_IsSelfContained(
     const PACKAGE_INFO* packageInfo{};
     wil::unique_cotaskmem_ptr<BYTE[]> buffer;
     RETURN_IF_FAILED(::AppModel::PackageGraph::GetCurrentPackageGraph(flags, packageInfoCount, packageInfo, buffer));
-    PCWSTR c_frameworkPackageFamilyName{ !g_test_frameworkPackageFamilyName.empty() ?
-                                            g_test_frameworkPackageFamilyName.c_str() :
-                                            WINDOWSAPPRUNTIME_SELFCONTAINED_EXPECTED_PACKAGEFAMILYNAME };
+    const auto frameworkPackageFamilyName{ ::WindowsAppRuntime::VersionInfo::GetPackageFamilyName() };
     for (uint32_t index=0; index < packageInfoCount; ++index)
     {
-        if (CompareStringOrdinal(packageInfo[index].packageFamilyName, -1, c_frameworkPackageFamilyName, -1, TRUE) == CSTR_EQUAL)
+        if (CompareStringOrdinal(packageInfo[index].packageFamilyName, -1, frameworkPackageFamilyName.c_str(), -1, TRUE) == CSTR_EQUAL)
         {
             // Found the Windows App SDK framework package in the package graph. Not self-contained!
             return S_OK;
@@ -39,23 +30,6 @@ STDAPI WindowsAppRuntime_IsSelfContained(
 
     // Didn't find the Windows App SDK framework package in the package graph. We're self-contained!
     *isSelfContained = TRUE;
-    return S_OK;
-}
-CATCH_RETURN();
-
-STDAPI WindowsAppRuntime_SelfContainedTestInitialize(
-    PCWSTR frameworkPackageFamilyName) noexcept try
-{
-    if (!frameworkPackageFamilyName || (*frameworkPackageFamilyName == L'0'))
-    {
-        // Shutdown test support
-        g_test_frameworkPackageFamilyName.clear();
-    }
-    else
-    {
-        // Initialize test support
-        g_test_frameworkPackageFamilyName = frameworkPackageFamilyName;
-    }
     return S_OK;
 }
 CATCH_RETURN();

--- a/dev/Common/WindowsAppRuntime.SelfContained.h
+++ b/dev/Common/WindowsAppRuntime.SelfContained.h
@@ -10,45 +10,15 @@
 STDAPI WindowsAppRuntime_IsSelfContained(
     BOOL* isSelfContained) noexcept;
 
-/// Initialize SelfContained's test support. This will constrain package enumeration
-/// and matching for test purposes.
-///
-/// @param frameworkPackageFamilyName only match framework packages with this family name.
-///                                   If nullptr test support is disabled.
-///
-/// @note Not for product use. This is for test purposes only to verify the implementation.
-STDAPI WindowsAppRuntime_SelfContainedTestInitialize(
-    PCWSTR frameworkPackageFamilyName) noexcept;
-
 #if defined(__cplusplus)
-/// Return true if Windows App SDK in use by the current process is deployed Self-Contained.
 namespace WindowsAppRuntime::SelfContained
 {
+/// Return true if Windows App SDK in use by the current process is deployed Self-Contained.
 inline bool IsSelfContained()
 {
     BOOL isSelfContained{};
     THROW_IF_FAILED(WindowsAppRuntime_IsSelfContained(&isSelfContained));
     return !!isSelfContained;
-}
-
-/// Initialize SelfContained's test support. This will constrain package enumeration
-/// and matching for test purposes.
-///
-/// @param frameworkPackageFamilyName only match framework packages with this family name
-///
-/// @note Not for product use. This is for test purposes only to verify the implementation.
-inline void TestInitialize(
-    _In_ PCWSTR frameworkPackageFamilyName)
-{
-    THROW_IF_FAILED(WindowsAppRuntime_SelfContainedTestInitialize(frameworkPackageFamilyName));
-}
-
-/// Shutdown SelfContained's test support.
-///
-/// @note Not for product use. This is for test purposes only to verify the implementation.
-inline void TestShutdown()
-{
-    WindowsAppRuntime_SelfContainedTestInitialize(nullptr);
 }
 }
 #endif // defined(__cplusplus)

--- a/dev/Common/WindowsAppRuntime.VersionInfo.cpp
+++ b/dev/Common/WindowsAppRuntime.VersionInfo.cpp
@@ -1,0 +1,83 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+#include "pch.h"
+
+#include <Microsoft.Utf8.h>
+
+#include "WindowsAppRuntime.VersionInfo.h"
+
+static std::wstring g_test_frameworkPackageFamilyName;
+
+namespace Microsoft::WindowsAppRuntime::VersionInfo
+{
+class RuntimeInformation
+{
+public:
+    static const std::wstring& GetFrameworkPackageFamilyName()
+    {
+        if (!g_test_frameworkPackageFamilyName.empty())
+        {
+            return g_test_frameworkPackageFamilyName;
+        }
+
+        const uint32_t c_frameworkPackageFamilyNameResourceId{ 10002 };
+        static std::wstring frameworkPackageFamilyName{ LoadStringWFromResource(c_frameworkPackageFamilyNameResourceId) };
+        return frameworkPackageFamilyName;
+    }
+
+private:
+    static std::wstring LoadStringWFromResource(uint32_t id)
+    {
+        const auto string{ LoadStringAFromResource(id) };
+        return ::Microsoft::Utf8::ToUtf16<std::wstring>(string.c_str());
+    }
+
+    static std::string LoadStringAFromResource(uint32_t id)
+    {
+        static wil::unique_hmodule module{ LoadResourceModule() };
+
+        const uint32_t c_ResourceMaxLength{ 1024 };
+        char resourceValue[c_ResourceMaxLength]{};
+        const auto resourceValueLength{ ::LoadStringA(module.get(), id, resourceValue, ARRAYSIZE(resourceValue)) };
+        THROW_LAST_ERROR_IF_MSG(resourceValueLength == 0, "Failed to load resource string. id: %u", id);
+        return resourceValue;
+    }
+
+    static wil::unique_hmodule LoadResourceModule()
+    {
+        const PCWSTR c_resourceDllName{ L"Microsoft.WindowsAppRuntime.Insights.Resource.dll" };
+        wil::unique_hmodule resourceDllHandle(::LoadLibraryW(c_resourceDllName));
+        THROW_LAST_ERROR_IF_NULL_MSG(resourceDllHandle, "Unable to load resource dll. %ls", c_resourceDllName);
+        return resourceDllHandle;
+    }
+};
+}
+
+STDAPI WindowsAppRuntime_VersionInfo_MSIX_Framework_PackageFamilyName_Get(
+    PCWSTR* packageFamilyName) noexcept try
+{
+    *packageFamilyName = nullptr;
+    const auto& frameworkPackageFamilyName{ ::Microsoft::WindowsAppRuntime::VersionInfo::RuntimeInformation::GetFrameworkPackageFamilyName() };
+    *packageFamilyName = frameworkPackageFamilyName.c_str();
+    RETURN_HR_IF_MSG(E_UNEXPECTED, frameworkPackageFamilyName.empty(), "WindowsAppSDK framework PackageFamilyName resource not valid (\"\")");
+    return S_OK;
+}
+CATCH_RETURN();
+
+STDAPI WindowsAppRuntime_VersionInfo_TestInitialize(
+    PCWSTR frameworkPackageFamilyName) noexcept try
+{
+    if (!frameworkPackageFamilyName || (*frameworkPackageFamilyName == L'0'))
+    {
+        // Shutdown test support
+        g_test_frameworkPackageFamilyName.clear();
+    }
+    else
+    {
+        // Initialize test support
+        g_test_frameworkPackageFamilyName = frameworkPackageFamilyName;
+    }
+    return S_OK;
+}
+CATCH_RETURN();

--- a/dev/Common/WindowsAppRuntime.VersionInfo.h
+++ b/dev/Common/WindowsAppRuntime.VersionInfo.h
@@ -1,0 +1,56 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+#ifndef __MICROSFT_WINDOWSAPPRUNTIME_VERSIONINFO_H
+#define __MICROSFT_WINDOWSAPPRUNTIME_VERSIONINFO_H
+
+/// Determine if Windows App SDK in use by the current process is deployed Self-Contained (vs deployed as MSIX packages)
+///
+/// @param packageFamilyName framework's package family name.
+STDAPI WindowsAppRuntime_VersionInfo_MSIX_Framework_PackageFamilyName_Get(
+    PCWSTR* packageFamilyName) noexcept;
+
+/// Initialize SelfContained's test support. This will constrain package enumeration
+/// and matching for test purposes.
+///
+/// @param frameworkPackageFamilyName only match framework packages with this family name.
+///                                   If nullptr test support is disabled.
+///
+/// @note Not for product use. This is for test purposes only to verify the implementation.
+STDAPI WindowsAppRuntime_VersionInfo_TestInitialize(
+    PCWSTR frameworkPackageFamilyName) noexcept;
+
+#if defined(__cplusplus)
+namespace WindowsAppRuntime::VersionInfo
+{
+/// Return the Windows App SDK framework's package family name.
+inline std::wstring GetPackageFamilyName()
+{
+    PCWSTR packageFamilyName{};
+    THROW_IF_FAILED(WindowsAppRuntime_VersionInfo_MSIX_Framework_PackageFamilyName_Get(&packageFamilyName));
+    return std::wstring{ packageFamilyName };
+}
+
+/// Initialize VersionInfo's test support. This will constrain package enumeration
+/// and matching for test purposes.
+///
+/// @param frameworkPackageFamilyName only match framework packages with this family name
+///
+/// @note Not for product use. This is for test purposes only to verify the implementation.
+inline void TestInitialize(
+    _In_ PCWSTR frameworkPackageFamilyName)
+{
+    THROW_IF_FAILED(WindowsAppRuntime_VersionInfo_TestInitialize(frameworkPackageFamilyName));
+}
+
+/// Shutdown VersionInfo's test support.
+///
+/// @note Not for product use. This is for test purposes only to verify the implementation.
+inline void TestShutdown()
+{
+    WindowsAppRuntime_VersionInfo_TestInitialize(nullptr);
+}
+}
+#endif // defined(__cplusplus)
+
+#endif // __MICROSFT_WINDOWSAPPRUNTIME_VERSIONINFO_H

--- a/dev/WindowsAppRuntime_DLL/WindowsAppRuntime.def
+++ b/dev/WindowsAppRuntime_DLL/WindowsAppRuntime.def
@@ -20,4 +20,6 @@ EXPORTS
     GetSecurityDescriptorForAppContainerNames
 
     WindowsAppRuntime_IsSelfContained
-    WindowsAppRuntime_SelfContainedTestInitialize
+
+    WindowsAppRuntime_VersionInfo_MSIX_Framework_PackageFamilyName_Get
+    WindowsAppRuntime_VersionInfo_TestInitialize

--- a/docs/Coding-Guidelines/SelfContained.md
+++ b/docs/Coding-Guidelines/SelfContained.md
@@ -8,18 +8,18 @@ See the [Self-Contained spec](https://github.com/microsoft/WindowsAppSDK/pull/12
 
 ## How to detect if Windows App SDK is deployed Self-Contained?
 
-If necessary, use `Microsoft::WindowsAppSDK::SelfContained::IsSelfContained()` to detect if the
+If necessary, use `WindowsAppRuntime::SelfContained::IsSelfContained()` to detect if the
 current process is using WindowsAppSDK deployed via SelfContained (vs MSIX).
 
 **NOTE:** The implementation assumes Windows App SDK is in use. Failure to detect
 WindowsAppSDK/MSIX is thus assumed to be WindowsAppSDK/SelfContained.
 
 ```c++
-#include <Microsoft.WindowsAppSDK.SelfContained.h>
+#include <WindowsAppRuntime.SelfContained.h>
 
 void JustDoIt()
 {
-    if (::Microsoft::WindowsAppSDK::SelfContained::IsSelfContained())
+    if (::WindowsAppRuntime::SelfContained::IsSelfContained())
     {
         printf("WindowsAppSDK/SelfContained");
     }
@@ -33,14 +33,15 @@ void JustDoIt()
 ### Unit and Functional Testing
 
 Unit and Functional Tests using alternative test packages (not Integration Tests using the real
-MSIX packages) need to call `::WindowsAppRuntime::SelfContained::TestInitialize()` with a nonexistent
+MSIX packages) need to call `::WindowsAppRuntime::VersionInfo::TestInitialize()` with a nonexistent
 alternative (test) framework package family name **BEFORE** calling `IsSelfContained()` to simulate
 running in a self-contained deployment.
 
 ```c++
 #include "pch.h"
 
-#include <Microsoft.WindowsAppSDK.SelfContained.h>
+#include <WindowsAppRuntime.SelfContained.h>
+#include <WindowsAppRuntime.VersionInfo.h>
 
 namespace TB = ::Test::Bootstrap;
 namespace TP = ::Test::Packages;
@@ -59,14 +60,14 @@ namespace Test::MyFeature
         {
             ::TB::SetupPackages();
             ::TB::SetupBootstrap();
-            const auto c_doesNotExistPackageFamilyName{ L"Test.SelfContained.PackageFamilyName.DoesNotExist_1234567890abc" };
-            ::WindowsAppRuntime::SelfContained::TestInitialize(c_doesNotExistPackageFamilyName);
+            const auto c_testFrameworkPackageFamilyName{ L"Test.Framework.PackageFamilyName_1234567890abc" };
+            ::WindowsAppRuntime::VersionInfo::TestInitialize(c_testFrameworkPackageFamilyName);
             return true;
         }
 
         TEST_CLASS_CLEANUP(ClassCleanup)
         {
-            ::WindowsAppRuntime::SelfContained::TestShutdown();
+            ::WindowsAppRuntime::VersionInfo::TestShutdown();
             ::TB::CleanupBootstrap();
             ::TB::CleanupPackages();
             return true;
@@ -82,12 +83,12 @@ namespace Test::MyFeature
 Alternatively, replace
 
 ```
-::WindowsAppRuntime::SelfContained::TestInitialize(c_doesNotExistPackageFamilyName);
+::WindowsAppRuntime::VersionInfo::TestInitialize(c_testFrameworkPackageFamilyName);
 ```
 
 with
 ```
-::WindowsAppRuntime::SelfContained::TestInitialize(::TP::WindowsAppRuntimeFramework::c_PackageFamilyName);
+::WindowsAppRuntime::VersionInfo::TestInitialize(::TP::WindowsAppRuntimeFramework::c_PackageFamilyName);
 ```
 
 to simulate running in a non-self-contained environment (i.e. Windows App SDK via MSIX packages).

--- a/test/Common/Test_SelfContained.cpp
+++ b/test/Common/Test_SelfContained.cpp
@@ -33,11 +33,11 @@ namespace Test::Common
         {
             ::TB::SetupBootstrap();
             auto cleanup = wil::scope_exit([&] {
-                ::WindowsAppRuntime::SelfContained::TestShutdown();
+                ::WindowsAppRuntime::VersionInfo::TestShutdown();
                 ::TB::CleanupBootstrap();
             });
             const auto c_doesNotExistPackageFamilyName{ L"Test.PackageFamilyName.DoesNotExist_1234567890abc" };
-            ::WindowsAppRuntime::SelfContained::TestInitialize(c_doesNotExistPackageFamilyName);
+            ::WindowsAppRuntime::VersionInfo::TestInitialize(c_doesNotExistPackageFamilyName);
 
             VERIFY_IS_TRUE(::WindowsAppRuntime::SelfContained::IsSelfContained());
         }
@@ -47,10 +47,10 @@ namespace Test::Common
             {
                 ::TB::SetupBootstrap();
                 auto cleanup = wil::scope_exit([&]{
-                    ::WindowsAppRuntime::SelfContained::TestShutdown();
+                    ::WindowsAppRuntime::VersionInfo::TestShutdown();
                     ::TB::CleanupBootstrap();
                 });
-                ::WindowsAppRuntime::SelfContained::TestInitialize(::TP::WindowsAppRuntimeFramework::c_PackageFamilyName);
+                WindowsAppRuntime::VersionInfo::TestInitialize(::TP::WindowsAppRuntimeFramework::c_PackageFamilyName);
 
                 VERIFY_IS_FALSE(::WindowsAppRuntime::SelfContained::IsSelfContained());
             }
@@ -60,16 +60,16 @@ namespace Test::Common
         {
             ::TB::SetupBootstrap();
             auto cleanup = wil::scope_exit([&] {
-                ::WindowsAppRuntime::SelfContained::TestShutdown();
+                ::WindowsAppRuntime::VersionInfo::TestShutdown();
                 ::TB::CleanupBootstrap();
             });
             const auto c_doesNotExistPackageFamilyName{ L"Test.PackageFamilyName.DoesNotExist_1234567890abc" };
-            ::WindowsAppRuntime::SelfContained::TestInitialize(c_doesNotExistPackageFamilyName);
+            WindowsAppRuntime::VersionInfo::TestInitialize(c_doesNotExistPackageFamilyName);
             VERIFY_IS_TRUE(::WindowsAppRuntime::SelfContained::IsSelfContained());
 
-            ::WindowsAppRuntime::SelfContained::TestInitialize(::TP::WindowsAppRuntimeFramework::c_PackageFamilyName);
+            WindowsAppRuntime::VersionInfo::TestInitialize(::TP::WindowsAppRuntimeFramework::c_PackageFamilyName);
             VERIFY_IS_FALSE(::WindowsAppRuntime::SelfContained::IsSelfContained());
-            ::WindowsAppRuntime::SelfContained::TestInitialize(c_doesNotExistPackageFamilyName);
+            WindowsAppRuntime::VersionInfo::TestInitialize(c_doesNotExistPackageFamilyName);
 
             VERIFY_IS_TRUE(::WindowsAppRuntime::SelfContained::IsSelfContained());
         }

--- a/test/Common/pch.h
+++ b/test/Common/pch.h
@@ -36,6 +36,7 @@
 
 #include <Microsoft.Utf8.h>
 #include <WindowsAppRuntime.SelfContained.h>
+#include <WindowsAppRuntime.VersionInfo.h>
 
 #include <WindowsAppRuntime.Test.AppModel.h>
 #include <WindowsAppRuntime.Test.Package.h>

--- a/test/PushNotificationTests/BaseTestSuite.cpp
+++ b/test/PushNotificationTests/BaseTestSuite.cpp
@@ -27,7 +27,7 @@ void BaseTestSuite::ClassSetup()
 
     if (!isSelfContained)
     {
-        ::WindowsAppRuntime::SelfContained::TestInitialize(::Test::Bootstrap::TP::WindowsAppRuntimeFramework::c_PackageFamilyName);
+        ::WindowsAppRuntime::VersionInfo::TestInitialize(::Test::Bootstrap::TP::WindowsAppRuntimeFramework::c_PackageFamilyName);
     }
 }
 

--- a/test/PushNotificationTests/pch.h
+++ b/test/PushNotificationTests/pch.h
@@ -41,6 +41,7 @@
 
 #include <winrt/Microsoft.Windows.PushNotifications.h>
 #include <WindowsAppRuntime.SelfContained.h>
+#include <WindowsAppRuntime.VersionInfo.h>
 
 #define VERIFY_THROWS_HR(expression, hr)        \
             VERIFY_THROWS_SPECIFIC(expression,          \

--- a/test/TestApps/PushNotificationsTestApp/main.cpp
+++ b/test/TestApps/PushNotificationsTestApp/main.cpp
@@ -268,7 +268,7 @@ std::map<std::string, bool(*)()> const& GetSwitchMapping()
         { "ChannelRequestUsingNullRemoteId",  &ChannelRequestUsingNullRemoteId },
         { "ChannelRequestUsingRemoteId", &ChannelRequestUsingRemoteId },
         { "MultipleChannelClose", &MultipleChannelClose},
-        
+
         { "BackgroundActivationTest", &BackgroundActivationTest},
 
         { "VerifyRegisterandUnregister", &VerifyRegisterandUnregister},
@@ -319,15 +319,15 @@ int main() try
 
 
     // Test hook to ensure that the app is not self-contained
-    ::WindowsAppRuntime::SelfContained::TestInitialize(::Test::Bootstrap::TP::WindowsAppRuntimeFramework::c_PackageFamilyName);
+    WindowsAppRuntime::VersionInfo::TestInitialize(::Test::Bootstrap::TP::WindowsAppRuntimeFramework::c_PackageFamilyName);
 
     auto scope_exit = wil::scope_exit([&] {
-        ::WindowsAppRuntime::SelfContained::TestShutdown();
+        ::WindowsAppRuntime::VersionInfo::TestShutdown();
         ::Test::Bootstrap::CleanupBootstrap();
         });
 
     PushNotificationManager::Default().Register();
-    
+
     auto args = AppInstance::GetCurrent().GetActivatedEventArgs();
     auto kind = args.Kind();
 

--- a/test/TestApps/PushNotificationsTestApp/pch.h
+++ b/test/TestApps/PushNotificationsTestApp/pch.h
@@ -18,3 +18,4 @@
 
 #include <WindowsAppRuntime.Test.Bootstrap.h>
 #include <WindowsAppRuntime.SelfContained.h>
+#include <WindowsAppRuntime.VersionInfo.h>


### PR DESCRIPTION
Cherry-pick of #2411 

* Added Microsoft::WindowsAppRuntime::VersionInfo::RuntimeInformation as a (partial) runtime-equivalent WindowsAppSDK-VersionInfo.h to workaround the chicken-egg problem where we need to know the versioninfo now but it's nto defined until higher in the build tree (the Aggregator pipeline at the top)

* Replaced WindowsAppRuntime_SelfContainedTestInitialize with WindowsAppRuntime_VersionInfo_TestInitialize as we moved the functionality down a level

* Removed dead code

* Update docs for IsSelfContained

* Update test to match SelfContained/VersionInfo::TestInitialize change

* Add missing #include