### PR TITLE
Introduce Register API to take in assets

### DIFF
--- a/dev/AppNotifications/AppNotificationManager.cpp
+++ b/dev/AppNotifications/AppNotificationManager.cpp
@@ -177,15 +177,14 @@ namespace winrt::Microsoft::Windows::AppNotifications::implementation
     {
         THROW_HR_IF_MSG(E_ILLEGAL_METHOD_CALL, AppModel::Identity::IsPackagedProcess(), "Not applicable for packaged applications");
 
-        THROW_HR_IF(E_INVALIDARG, (displayName != winrt::hstring{}) xor (iconUri != nullptr));
+        THROW_HR_IF(E_INVALIDARG, (displayName == winrt::hstring{}) || (iconUri == nullptr));
 
-        std::wstring iconFilePath{};
-        if (iconUri != nullptr)
-        {
-            iconFilePath = iconUri.Path();
-            iconFilePath = iconFilePath.substr(1, iconFilePath.size() - 1);
-            winrt::check_bool(std::filesystem::exists(std::filesystem::path{ iconFilePath }));
-        }
+        std::wstring iconFilePath{ iconUri.Path() };
+        iconFilePath = iconFilePath.substr(1, iconFilePath.size() - 1);
+        // Uri converts backward slashes to forward slashes
+        std::replace(iconFilePath.begin(), iconFilePath.end(), '/', '\\');
+
+        THROW_HR_IF_MSG(E_INVALIDARG, !IsIconFileExtensionSupported(std::filesystem::path{ iconFilePath }), "Icon not supported");
 
         RegisterHelper(displayName, iconFilePath);
     }

--- a/dev/AppNotifications/AppNotificationManager.h
+++ b/dev/AppNotifications/AppNotificationManager.h
@@ -18,6 +18,8 @@ namespace winrt::Microsoft::Windows::AppNotifications::implementation
 
         static winrt::Microsoft::Windows::AppNotifications::AppNotificationManager Default();
         static winrt::Windows::Foundation::IInspectable AppNotificationDeserialize(winrt::Windows::Foundation::Uri const& uri);
+        
+        void Register(hstring const& displayName, winrt::Windows::Foundation::Uri const& iconUri);
         void Register();
         void Unregister();
         void UnregisterAll();
@@ -45,6 +47,7 @@ namespace winrt::Microsoft::Windows::AppNotifications::implementation
         winrt::Windows::Foundation::IInspectable Deserialize(winrt::Windows::Foundation::Uri const& uri);
     private:
 
+        void RegisterHelper(hstring const& displayName, std::wstring const& iconFilePath);
         void UnregisterHelper();
 
         wil::unique_com_class_object_cookie m_notificationComActivatorRegistration;

--- a/dev/AppNotifications/AppNotificationUtility.cpp
+++ b/dev/AppNotifications/AppNotificationUtility.cpp
@@ -275,7 +275,7 @@ winrt::guid Microsoft::Windows::AppNotifications::Helpers::RegisterComActivatorG
 // 2. Based on the best app shortcut, using the FrameworkUdk.
 // 3. From the current process.
 // 4. Set a default DisplayName, but leave empty the icon file path so Shell can set a default icon.
-Microsoft::Windows::AppNotifications::ShellLocalization::AppNotificationAssets Microsoft::Windows::AppNotifications::Helpers::RegisterAssetsHelper(winrt::hstring const& displayName, std::wstring const& iconFilePath)
+Microsoft::Windows::AppNotifications::ShellLocalization::AppNotificationAssets Microsoft::Windows::AppNotifications::Helpers::GetAssetsHelper(winrt::hstring const& displayName, std::wstring const& iconFilePath)
 {
     Microsoft::Windows::AppNotifications::ShellLocalization::AppNotificationAssets assets{};
 
@@ -310,7 +310,7 @@ void Microsoft::Windows::AppNotifications::Helpers::RegisterAssets(std::wstring 
         &hKey,
         nullptr /* lpdwDisposition */));
 
-    Microsoft::Windows::AppNotifications::ShellLocalization::AppNotificationAssets assets{ RegisterAssetsHelper(displayName, iconFilePath) };
+    Microsoft::Windows::AppNotifications::ShellLocalization::AppNotificationAssets assets{ GetAssetsHelper(displayName, iconFilePath) };
 
     RegisterValue(hKey, L"DisplayName", reinterpret_cast<const BYTE*>(assets.displayName.c_str()), REG_EXPAND_SZ, assets.displayName.size() * sizeof(wchar_t));
 

--- a/dev/AppNotifications/AppNotificationUtility.h
+++ b/dev/AppNotifications/AppNotificationUtility.h
@@ -8,6 +8,7 @@
 #include <wil/resource.h>
 #include <AppNotificationActivatedEventArgs.h>
 #include <FrameworkUdk/toastnotificationsrt.h>
+#include <ShellLocalization.h>
 
 namespace Microsoft::Windows::AppNotifications::Helpers
 {
@@ -53,13 +54,15 @@ namespace Microsoft::Windows::AppNotifications::Helpers
 
     HRESULT GetActivatorGuid(std::wstring& activatorGuid) noexcept;
 
-    winrt::guid RegisterComActivatorGuidAndAssets();
+    winrt::guid RegisterComActivatorGuidAndAssets(winrt::hstring const& displayName, std::wstring const& iconFilePath);
 
-    void RegisterAssets(std::wstring const& appId, std::wstring const& clsid);
+    void RegisterAssets(std::wstring const& appId, std::wstring const& clsid, winrt::hstring const& displayName, std::wstring const& iconFilePath);
 
     wil::unique_cotaskmem_string ConvertUtf8StringToWideString(unsigned long length, const BYTE* utf8String);
 
     winrt::Microsoft::Windows::AppNotifications::AppNotification ToastNotificationFromToastProperties(ABI::Microsoft::Internal::ToastNotifications::INotificationProperties* properties);
 
     std::wstring GetDisplayNameBasedOnProcessName();
+
+    Microsoft::Windows::AppNotifications::ShellLocalization::AppNotificationAssets RegisterAssetsHelper(winrt::hstring const& displayName, std::wstring const& iconFilePath);
 }

--- a/dev/AppNotifications/AppNotificationUtility.h
+++ b/dev/AppNotifications/AppNotificationUtility.h
@@ -64,5 +64,5 @@ namespace Microsoft::Windows::AppNotifications::Helpers
 
     std::wstring GetDisplayNameBasedOnProcessName();
 
-    Microsoft::Windows::AppNotifications::ShellLocalization::AppNotificationAssets RegisterAssetsHelper(winrt::hstring const& displayName, std::wstring const& iconFilePath);
+    Microsoft::Windows::AppNotifications::ShellLocalization::AppNotificationAssets GetAssetsHelper(winrt::hstring const& displayName, std::wstring const& iconFilePath);
 }

--- a/dev/AppNotifications/AppNotifications.idl
+++ b/dev/AppNotifications/AppNotifications.idl
@@ -117,7 +117,7 @@ namespace Microsoft.Windows.AppNotifications
         // For Unpackaged apps, the caller process will be registered as the COM server. And assets like displayname and icon will be gleaned from Shell and registered as well.
         void Register();
 
-        // For Unpackaged apps only, the caller process will be registered as the COM server and assets registered.
+        // For Unpackaged apps only, the caller process will be registered as the COM server.
         void Register(String displayName, Windows.Foundation.Uri iconUri);
 
         // Unregisters the COM Service so that a subsequent activation will launch a new process

--- a/dev/AppNotifications/AppNotifications.idl
+++ b/dev/AppNotifications/AppNotifications.idl
@@ -117,6 +117,9 @@ namespace Microsoft.Windows.AppNotifications
         // For Unpackaged apps, the caller process will be registered as the COM server. And assets like displayname and icon will be gleaned from Shell and registered as well.
         void Register();
 
+        // For Unpackaged apps only, the caller process will be registered as the COM server and assets registered.
+        void Register(String displayName, Windows.Foundation.Uri iconUri);
+
         // Unregisters the COM Service so that a subsequent activation will launch a new process
         void Unregister();
 

--- a/dev/AppNotifications/ShellLocalization.cpp
+++ b/dev/AppNotifications/ShellLocalization.cpp
@@ -167,9 +167,11 @@ void WriteHIconToPngFile(wil::unique_hicon const& hIcon, _In_ PCWSTR pszFileName
     THROW_IF_FAILED(spStreamOut->Commit(STGC_DANGEROUSLYCOMMITMERELYTODISKCACHE));
 }
 
-bool IsIconFileExtensionSupported(std::filesystem::path const& iconFilePath)
+bool Microsoft::Windows::AppNotifications::ShellLocalization::IsIconFileExtensionSupported(std::filesystem::path const& iconFilePath)
 {
     static PCWSTR c_supportedExtensions[]{ L".bmp", L".ico", L".jpg", L".png" };
+
+    winrt::check_bool(std::filesystem::exists(iconFilePath));
 
     const auto fileExtension{ iconFilePath.extension() };
     const auto extension{ fileExtension.c_str() };

--- a/dev/AppNotifications/ShellLocalization.cpp
+++ b/dev/AppNotifications/ShellLocalization.cpp
@@ -258,10 +258,7 @@ HRESULT Microsoft::Windows::AppNotifications::ShellLocalization::DeleteIconFromC
     std::path iconFilePath{ RetrieveLocalFolderPath() / (notificationAppId + c_pngExtension) };
 
     // If DeleteFile returned FALSE, then deletion failed and we should return the corresponding error code.
-    if (DeleteFile(iconFilePath.c_str()) == FALSE)
-    {
-        THROW_HR(HRESULT_FROM_WIN32(GetLastError()));
-    }
+    winrt::check_bool(DeleteFile(iconFilePath.c_str()) != FALSE);
 
     return S_OK;
 }

--- a/dev/AppNotifications/ShellLocalization.h
+++ b/dev/AppNotifications/ShellLocalization.h
@@ -4,6 +4,7 @@
 #pragma once
 
 #include "pch.h"
+#include <filesystem>
 
 // In this file we define methods that write/return Shell assets, like DisplayName and icon URI.
 
@@ -22,4 +23,6 @@ namespace Microsoft::Windows::AppNotifications::ShellLocalization
     HRESULT RetrieveAssetsFromShortcut(_Out_ Microsoft::Windows::AppNotifications::ShellLocalization::AppNotificationAssets& assets) noexcept;
 
     HRESULT DeleteIconFromCache() noexcept;
+
+    bool IsIconFileExtensionSupported(std::filesystem::path const& iconFilePath);
 }

--- a/dev/Common/Common.vcxitems.filters
+++ b/dev/Common/Common.vcxitems.filters
@@ -26,7 +26,7 @@
     <ClInclude Include="$(MSBuildThisFileDirectory)WindowsAppRuntime.SelfContained.h">
       <Filter>Header Files</Filter>
     </ClInclude>
-	<ClInclude Include="$(MSBuildThisFileDirectory)WindowsAppRuntime.VersionInfo.h">
+    <ClInclude Include="$(MSBuildThisFileDirectory)WindowsAppRuntime.VersionInfo.h">
       <Filter>Header Files</Filter>
     </ClInclude>
     <ClInclude Include="$(MSBuildThisFileDirectory)Security.IntegrityLevel.h">

--- a/dev/Common/Common.vcxitems.filters
+++ b/dev/Common/Common.vcxitems.filters
@@ -26,13 +26,13 @@
     <ClInclude Include="$(MSBuildThisFileDirectory)WindowsAppRuntime.SelfContained.h">
       <Filter>Header Files</Filter>
     </ClInclude>
+	<ClInclude Include="$(MSBuildThisFileDirectory)WindowsAppRuntime.VersionInfo.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
     <ClInclude Include="$(MSBuildThisFileDirectory)Security.IntegrityLevel.h">
       <Filter>Header Files</Filter>
     </ClInclude>
     <ClInclude Include="$(MSBuildThisFileDirectory)Microsoft.Foundation.String.h">
-      <Filter>Header Files</Filter>
-    </ClInclude>
-    <ClInclude Include="$(MSBuildThisFileDirectory)WindowsAppRuntime.VersionInfo.h">
       <Filter>Header Files</Filter>
     </ClInclude>
   </ItemGroup>

--- a/dev/Common/Common.vcxitems.filters
+++ b/dev/Common/Common.vcxitems.filters
@@ -26,13 +26,13 @@
     <ClInclude Include="$(MSBuildThisFileDirectory)WindowsAppRuntime.SelfContained.h">
       <Filter>Header Files</Filter>
     </ClInclude>
-    <ClInclude Include="$(MSBuildThisFileDirectory)WindowsAppRuntime.VersionInfo.h">
-      <Filter>Header Files</Filter>
-    </ClInclude>
     <ClInclude Include="$(MSBuildThisFileDirectory)Security.IntegrityLevel.h">
       <Filter>Header Files</Filter>
     </ClInclude>
     <ClInclude Include="$(MSBuildThisFileDirectory)Microsoft.Foundation.String.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="$(MSBuildThisFileDirectory)WindowsAppRuntime.VersionInfo.h">
       <Filter>Header Files</Filter>
     </ClInclude>
   </ItemGroup>

--- a/specs/AppNotifications/AppNotifications-spec.md
+++ b/specs/AppNotifications/AppNotifications-spec.md
@@ -141,12 +141,12 @@ int main()
 
 ## Registering for App Notifications using assets
 
-For Unpackaged applications, the developer calls into Register API with DisplayName and Icon.
-WinAppSDK will register and display them when an App Notification is received. The developer
-should provide both the assets or not provide them at all. If assets are not provided WinAppSDK
-will determine appropriate DisplayName and Icon. Icon provided by the developer should
-be valid and reside on the local machine only. For Packaged applications, this API is not
-applicable and will throw an exception.
+For Unpackaged applications, the developer can opt to call into Register API with DisplayName and Icon.
+WinAppSDK will register the application and display these assets when an App Notification is received.
+The developer should provide both the assets or not provide them at all. If assets are not provided WinAppSDK
+will determine appropriate DisplayName and Icon. Icon provided by the developer should be a valid supported
+format like png, bmp, ico or jpg and should reside on the local machine only. For Packaged applications,
+this API is not applicable and will throw an exception.
 
 ```cpp
 int main()

--- a/specs/AppNotifications/AppNotifications-spec.md
+++ b/specs/AppNotifications/AppNotifications-spec.md
@@ -139,6 +139,29 @@ int main()
 }
 ```
 
+## Registering for App Notifications using assets
+
+For Unpackaged applications, the developer calls into Register API with DisplayName and Icon.
+WinAppSDK will register and display them when an App Notification is received. The developer
+should provide both the assets or not provide them at all. If assets are not provided WinAppSDK
+will determine appropriate DisplayName and Icon. Icon provided by the developer should
+be valid and reside on the local machine only. For Packaged applications, this API is not
+applicable and will throw an exception.
+
+```cpp
+int main()
+{
+    auto manager = winrt::AppNotificationManager::Default();
+    manager.Register(L"AppNotifications", winrt::Windows::Foundation::Uri {L"<Path to Icon>"});
+
+    // other app init and then message loop here
+
+    // Call Unregister() before exiting main so that subsequent invocations will launch a new process
+    manager.Unregister();
+    return 0;
+}
+```
+
 ## Displaying an App Notification
 
 To display a Notification, an app needs to define a payload in xml. In the example below, the
@@ -450,6 +473,9 @@ namespace Microsoft.Windows.AppNotifications
         // For Packaged apps, the COM server is defined in the manifest. The Process calling Register() and the process defined as the COM server are required to be the same.
         // For Unpackaged apps, the caller process will be registered as the COM server. And assets like displayname and icon will be gleaned from Shell and registered as well.
         void Register();
+
+        // For Unpackaged apps only, the caller process will be registered as the COM server.
+        void Register(String displayName, Windows.Foundation.Uri iconUri);
 
         // Unregisters the COM Service so that a subsequent activation will launch a new process
         void Unregister();

--- a/test/TestApps/ToastNotificationsTestApp/main.cpp
+++ b/test/TestApps/ToastNotificationsTestApp/main.cpp
@@ -550,10 +550,10 @@ bool VerifyShowToast_Unpackaged()
 	// Registration happens in main()
     auto toastNotificationManager = winrt::AppNotificationManager::Default();
 
-    /*auto scope_exit = wil::scope_exit(
+    auto scope_exit = wil::scope_exit(
         [&] {
             toastNotificationManager.UnregisterAll();
-        }); */
+        });
 
     EnsureNoActiveToasts();
 
@@ -1372,7 +1372,7 @@ bool VerifyRegisterWithNullDisplayNameAndNullIconFail_Unpackaged()
     }
     catch (...)
     {
-        return false;
+        return winrt::to_hresult() == E_INVALIDARG;
     }
 
     return true;

--- a/test/TestApps/ToastNotificationsTestApp/main.cpp
+++ b/test/TestApps/ToastNotificationsTestApp/main.cpp
@@ -550,10 +550,10 @@ bool VerifyShowToast_Unpackaged()
 	// Registration happens in main()
     auto toastNotificationManager = winrt::AppNotificationManager::Default();
 
-    auto scope_exit = wil::scope_exit(
+    /*auto scope_exit = wil::scope_exit(
         [&] {
             toastNotificationManager.UnregisterAll();
-        });
+        }); */
 
     EnsureNoActiveToasts();
 
@@ -1322,6 +1322,171 @@ bool VerifyIconPathExists_Unpackaged()
     return true;
 }
 
+bool VerifyRegisterWithNullDisplayNameFail_Unpackaged()
+{
+    // Register is already called in main with an explicit appusermodelId
+    winrt::AppNotificationManager::Default().UnregisterAll();
+    try
+    {
+        winrt::AppNotificationManager::Default().Register(winrt::hstring{}, winrt::Uri{ LR"(C:\Windows\System32\WindowsSecurityIcon.png)" });
+
+
+        winrt::AppNotificationManager::Default().UnregisterAll();
+    }
+    catch (...)
+    {
+        return winrt::to_hresult() == E_INVALIDARG;
+    }
+
+    return false;
+}
+
+bool VerifyRegisterWithNullIconFail_Unpackaged()
+{
+    // Register is already called in main with an explicit appusermodelId
+    winrt::AppNotificationManager::Default().UnregisterAll();
+    try
+    {
+        winrt::AppNotificationManager::Default().Register(L"ToastNotificationApp", nullptr);
+
+        winrt::AppNotificationManager::Default().UnregisterAll();
+    }
+    catch (...)
+    {
+        return winrt::to_hresult() == E_INVALIDARG;
+    }
+
+    return false;
+}
+
+bool VerifyRegisterWithNullDisplayNameAndNullIconFail_Unpackaged()
+{
+    // Register is already called in main with an explicit appusermodelId
+    winrt::AppNotificationManager::Default().UnregisterAll();
+    try
+    {
+        winrt::AppNotificationManager::Default().Register(winrt::hstring{}, nullptr);
+
+
+        winrt::AppNotificationManager::Default().UnregisterAll();
+    }
+    catch (...)
+    {
+        return false;
+    }
+
+    return true;
+}
+
+bool VerifyRegisterWithDisplayNameAndIcon_Unpackaged()
+{
+    // Register is already called in main with an explicit appusermodelId
+    winrt::AppNotificationManager::Default().UnregisterAll();
+    try
+    {
+        winrt::AppNotificationManager::Default().Register(L"ToastNotificationApp", winrt::Uri{ LR"(C:\Windows\System32\WindowsSecurityIcon.png)" });
+
+        winrt::AppNotificationManager::Default().UnregisterAll();
+    }
+    catch (...)
+    {
+        return false;
+    }
+
+    return true;
+}
+
+bool VerifyRegisterWithDisplayNameAndInvalidIconPathFail_Unpackaged()
+{
+    // Register is already called in main with an explicit appusermodelId
+    winrt::AppNotificationManager::Default().UnregisterAll();
+    try
+    {
+        winrt::AppNotificationManager::Default().Register(L"ToastNotificationApp", winrt::Uri{ LR"(C:\InvalidPath\)" });
+
+        winrt::AppNotificationManager::Default().UnregisterAll();
+    }
+    catch (...)
+    {
+        return winrt::to_hresult() == HRESULT_FROM_WIN32(ERROR_FILE_NOT_FOUND);
+    }
+
+    return false;
+}
+
+bool VerifyRegisterWithEmptyDisplayNameFail_Unpackaged()
+{
+    // Register is already called in main with an explicit appusermodelId
+    winrt::AppNotificationManager::Default().UnregisterAll();
+    try
+    {
+        // hstring treats L"" as assigning nullptr
+        winrt::AppNotificationManager::Default().Register(L"", winrt::Uri{ LR"(C:\Windows\System32\WindowsSecurityIcon.png)" });
+
+        winrt::AppNotificationManager::Default().UnregisterAll();
+    }
+    catch (...)
+    {
+        return winrt::to_hresult() == E_INVALIDARG;
+    }
+
+    return false;
+}
+
+bool VerifyRegisterWithEmptyIconFail_Unpackaged()
+{
+    // Register is already called in main with an explicit appusermodelId
+    winrt::AppNotificationManager::Default().UnregisterAll();
+    try
+    {
+        winrt::AppNotificationManager::Default().Register(L"ToastNotifications", winrt::Uri{ L"" });
+
+        winrt::AppNotificationManager::Default().UnregisterAll();
+    }
+    catch (...)
+    {
+        return winrt::to_hresult() == E_POINTER;
+    }
+
+    return false;
+}
+
+bool VerifyRegisterWithEmptyDisplayNameAndEmptyIconFail_Unpackaged()
+{
+    // Register is already called in main with an explicit appusermodelId
+    winrt::AppNotificationManager::Default().UnregisterAll();
+    try
+    {
+        winrt::AppNotificationManager::Default().Register(L"", winrt::Uri{ L"" });
+
+        winrt::AppNotificationManager::Default().UnregisterAll();
+    }
+    catch (...)
+    {
+        return winrt::to_hresult() == E_POINTER;
+    }
+
+    return false;
+}
+
+bool VerifyRegisterWithAssetsFail()
+{
+    // Register is already called in main with an explicit appusermodelId
+    winrt::AppNotificationManager::Default().UnregisterAll();
+    try
+    {
+        winrt::AppNotificationManager::Default().Register(L"ToastNotificationApp", winrt::Uri{ LR"(C:\InvalidPath\)" });
+
+        winrt::AppNotificationManager::Default().UnregisterAll();
+    }
+    catch (...)
+    {
+        return winrt::to_hresult() == E_ILLEGAL_METHOD_CALL;
+    }
+
+    return false;
+}
+
 std::map<std::string, bool(*)()> const& GetSwitchMapping()
 {
     static std::map<std::string, bool(*)()> switchMapping = {
@@ -1380,6 +1545,15 @@ std::map<std::string, bool(*)()> const& GetSwitchMapping()
         { "VerifyToastProgressDataSequence0Fail", &VerifyToastProgressDataSequence0Fail },
         { "VerifyToastUpdateZeroSequenceFail_Unpackaged", &VerifyToastUpdateZeroSequenceFail_Unpackaged },
         { "VerifyIconPathExists_Unpackaged", &VerifyIconPathExists_Unpackaged},
+        { "VerifyRegisterWithNullDisplayNameFail_Unpackaged", &VerifyRegisterWithNullDisplayNameFail_Unpackaged},
+        { "VerifyRegisterWithNullIconFail_Unpackaged", &VerifyRegisterWithNullIconFail_Unpackaged},
+        { "VerifyRegisterWithNullDisplayNameAndNullIconFail_Unpackaged", &VerifyRegisterWithNullDisplayNameAndNullIconFail_Unpackaged},
+        { "VerifyRegisterWithDisplayNameAndIcon_Unpackaged", &VerifyRegisterWithDisplayNameAndIcon_Unpackaged},
+        { "VerifyRegisterWithDisplayNameAndInvalidIconPathFail_Unpackaged", &VerifyRegisterWithDisplayNameAndInvalidIconPathFail_Unpackaged},
+        { "VerifyRegisterWithEmptyDisplayNameFail_Unpackaged", &VerifyRegisterWithEmptyDisplayNameFail_Unpackaged},
+        { "VerifyRegisterWithEmptyIconFail_Unpackaged", &VerifyRegisterWithEmptyIconFail_Unpackaged},
+        { "VerifyRegisterWithEmptyDisplayNameAndEmptyIconFail_Unpackaged", &VerifyRegisterWithEmptyDisplayNameAndEmptyIconFail_Unpackaged},
+        { "VerifyRegisterWithAssetsFail", &VerifyRegisterWithAssetsFail},
       };
 
     return switchMapping;

--- a/test/TestApps/ToastNotificationsTestApp/main.cpp
+++ b/test/TestApps/ToastNotificationsTestApp/main.cpp
@@ -1347,7 +1347,7 @@ bool VerifyRegisterWithNullIconFail_Unpackaged()
     winrt::AppNotificationManager::Default().UnregisterAll();
     try
     {
-        winrt::AppNotificationManager::Default().Register(L"ToastNotificationApp", nullptr);
+        winrt::AppNotificationManager::Default().Register(L"AppNotificationApp", nullptr);
 
         winrt::AppNotificationManager::Default().UnregisterAll();
     }
@@ -1384,7 +1384,7 @@ bool VerifyRegisterWithDisplayNameAndIcon_Unpackaged()
     winrt::AppNotificationManager::Default().UnregisterAll();
     try
     {
-        winrt::AppNotificationManager::Default().Register(L"ToastNotificationApp", winrt::Uri{ LR"(C:\Windows\System32\WindowsSecurityIcon.png)" });
+        winrt::AppNotificationManager::Default().Register(L"AppNotificationApp", winrt::Uri{ LR"(C:\Windows\System32\WindowsSecurityIcon.png)" });
 
         winrt::AppNotificationManager::Default().UnregisterAll();
     }
@@ -1402,7 +1402,7 @@ bool VerifyRegisterWithDisplayNameAndInvalidIconPathFail_Unpackaged()
     winrt::AppNotificationManager::Default().UnregisterAll();
     try
     {
-        winrt::AppNotificationManager::Default().Register(L"ToastNotificationApp", winrt::Uri{ LR"(C:\InvalidPath\)" });
+        winrt::AppNotificationManager::Default().Register(L"AppNotificationApp", winrt::Uri{ LR"(C:\InvalidPath\)" });
 
         winrt::AppNotificationManager::Default().UnregisterAll();
     }
@@ -1439,7 +1439,7 @@ bool VerifyRegisterWithEmptyIconFail_Unpackaged()
     winrt::AppNotificationManager::Default().UnregisterAll();
     try
     {
-        winrt::AppNotificationManager::Default().Register(L"ToastNotifications", winrt::Uri{ L"" });
+        winrt::AppNotificationManager::Default().Register(L"AppNotificationApp", winrt::Uri{ L"" });
 
         winrt::AppNotificationManager::Default().UnregisterAll();
     }
@@ -1475,7 +1475,7 @@ bool VerifyRegisterWithAssetsFail()
     winrt::AppNotificationManager::Default().UnregisterAll();
     try
     {
-        winrt::AppNotificationManager::Default().Register(L"ToastNotificationApp", winrt::Uri{ LR"(C:\InvalidPath\)" });
+        winrt::AppNotificationManager::Default().Register(L"AppNotificationApp", winrt::Uri{ LR"(C:\InvalidPath\)" });
 
         winrt::AppNotificationManager::Default().UnregisterAll();
     }

--- a/test/ToastNotificationTests/APITests.cpp
+++ b/test/ToastNotificationTests/APITests.cpp
@@ -583,5 +583,50 @@ namespace Test::ToastNotifications
         {
             RunTestUnpackaged(L"VerifyIconPathExists_Unpackaged", testWaitTime());
         }
+
+        TEST_METHOD(VerifyRegisterWithNullDisplayNameFail_Unpackaged)
+        {
+            RunTestUnpackaged(L"VerifyRegisterWithNullDisplayNameFail_Unpackaged", testWaitTime());
+        }
+
+        TEST_METHOD(VerifyRegisterWithNullIconFail_Unpackaged)
+        {
+            RunTestUnpackaged(L"VerifyRegisterWithNullIconFail_Unpackaged", testWaitTime());
+        }
+
+        TEST_METHOD(VerifyRegisterWithNullDisplayNameAndNullIconFail_Unpackaged)
+        {
+            RunTestUnpackaged(L"VerifyRegisterWithNullDisplayNameAndNullIconFail_Unpackaged", testWaitTime());
+        }
+
+        TEST_METHOD(VerifyRegisterWithDisplayNameAndIcon_Unpackaged)
+        {
+            RunTestUnpackaged(L"VerifyRegisterWithDisplayNameAndIcon_Unpackaged", testWaitTime());
+        }
+
+        TEST_METHOD(VerifyRegisterWithDisplayNameAndInvalidIconPathFail_Unpackaged)
+        {
+            RunTestUnpackaged(L"VerifyRegisterWithDisplayNameAndInvalidIconPathFail_Unpackaged", testWaitTime());
+        }
+
+        TEST_METHOD(VerifyRegisterWithEmptyDisplayNameFail_Unpackaged)
+        {
+            RunTestUnpackaged(L"VerifyRegisterWithEmptyDisplayNameFail_Unpackaged", testWaitTime());
+        }
+
+        TEST_METHOD(VerifyRegisterWithEmptyIconFail_Unpackaged)
+        {
+            RunTestUnpackaged(L"VerifyRegisterWithEmptyIconFail_Unpackaged", testWaitTime());
+        }
+
+        TEST_METHOD(VerifyRegisterWithEmptyDisplayNameAndEmptyIconFail_Unpackaged)
+        {
+            RunTestUnpackaged(L"VerifyRegisterWithEmptyDisplayNameAndEmptyIconFail_Unpackaged", testWaitTime());
+        }
+
+        TEST_METHOD(VerifyRegisterWithAssetsFail)
+        {
+            RunTest(L"VerifyRegisterWithAssetsFail", testWaitTime());
+        }
     };
 }


### PR DESCRIPTION
Description: Allow developers to input DisplayName and Icon of their choice to be registered with AppNotificationManager so that these assets can show up when AppNotifications are posted or received.

Validation: Introduced unittests and validated them.