### PR TITLE
UndockedRegFreeWinRT auto-initialization

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -26,7 +26,7 @@
   </PropertyGroup>
 
   <Target Name="DirectoryBuildPropsInfo">
-    <Message Condition="$(WindowsAppSDKBuildPipeline) == '1'" Importance="High" Text="Directory.Build.props detects WindowsAppSDKBuildPipeline=$(WindowsAppSDKBuildPipeline)"/>
+    <Message Condition="'$(WindowsAppSDKBuildPipeline)' == '1'" Importance="High" Text="Directory.Build.props detects WindowsAppSDKBuildPipeline=$(WindowsAppSDKBuildPipeline)"/>
 
     <Error Condition="!Exists('$(RepoTestCertificatePFX)')" Text="$(RepoTestCertificatePFX) not found. Run '$(RepoRoot)\tools\DevCheck.cmd' to generate the test certificate." />
     <Error Condition="!Exists('$(RepoTestCertificatePWD)')" Text="$(RepoTestCertificatePWD) not found. Run '$(RepoRoot)\tools\DevCheck.cmd' to generate the test certificate." />
@@ -65,4 +65,12 @@
     <RepoTestCertificatePassword>$([System.IO.File]::ReadAllText('$(RepoTestCertificatePWD)').TrimEnd())</RepoTestCertificatePassword>
     <RepoTestCertificatePasswordRedacted>...redacted...</RepoTestCertificatePasswordRedacted>
   </PropertyGroup>
+
+  <!-- 'Clean As We Go' to prevent build agents from running out of disk space -->
+  <PropertyGroup Condition="('$(WindowsAppSDKCleanIntermediateFiles)' == '') and ('$(WindowsAppSDKBuildPipeline)' == '1')">
+    <WindowsAppSDKCleanIntermediateFiles>true</WindowsAppSDKCleanIntermediateFiles>
+  </PropertyGroup>
+  <Target Name="CleanIntermediateFiles" AfterTargets="Build" Condition="'$(WindowsAppSDKCleanIntermediateFiles)' == 'true'">
+    <RemoveDir Directories="$(IntermediateOutputPath)" />
+  </Target>
 </Project>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -66,10 +66,7 @@
     <RepoTestCertificatePasswordRedacted>...redacted...</RepoTestCertificatePasswordRedacted>
   </PropertyGroup>
 
-  <!-- 'Clean As We Go' to prevent build agents from running out of disk space -->
-  <PropertyGroup Condition="('$(WindowsAppSDKCleanIntermediateFiles)' == '') and ('$(WindowsAppSDKBuildPipeline)' == '1')">
-    <WindowsAppSDKCleanIntermediateFiles>true</WindowsAppSDKCleanIntermediateFiles>
-  </PropertyGroup>
+  <!-- 'Clean As We Go' if necessary (specified). Prevents build agents from running out of disk space -->
   <Target Name="CleanIntermediateFiles" AfterTargets="Build" Condition="'$(WindowsAppSDKCleanIntermediateFiles)' == 'true'">
     <RemoveDir Directories="$(IntermediateOutputPath)" />
   </Target>

--- a/build/AzurePipelinesTemplates/WindowsAppSDK-BuildProject-Steps.yml
+++ b/build/AzurePipelinesTemplates/WindowsAppSDK-BuildProject-Steps.yml
@@ -2,6 +2,7 @@ parameters:
   solutionPath: ''
   nugetConfigPath: ''
   buildOutputDir: '$(Build.SourcesDirectory)\BuildOutput'
+  WindowsAppSDKCleanIntermediateFiles: 'true'
   artifactName: 'drop'
   channel: 'experimental'
   enableLicenseInstall: false
@@ -117,7 +118,7 @@ steps:
       filePath: tools\TerminalVelocity\Generate-TerminalVelocityFeatures.ps1
       arguments: -Path $(Build.SourcesDirectory)\dev\common\TerminalVelocityFeatures-AppNotifications.xml -Channel ${{ parameters.channel }} -Language C++ -Namespace Microsoft.Windows.AppNotifications -Output $(Build.SourcesDirectory)\dev\common\TerminalVelocityFeatures-AppNotifications.h
       workingDirectory: '$(Build.SourcesDirectory)'
-      
+
   - task: powershell@2
     displayName: 'Create PushNotifications TerminalVelocity features'
     inputs:
@@ -172,7 +173,7 @@ steps:
       vsVersion: 16.0
       platform: '$(buildPlatform)'
       configuration: '$(buildConfiguration)'
-      msbuildArgs: '/restore /p:AppxSymbolPackageEnabled=false /binaryLogger:$(Build.SourcesDirectory)/${{ parameters.solutionPath }}.$(buildPlatform).$(buildConfiguration).binlog /p:WindowsAppSDKVersionBuild=$(builddate_yymm) /p:WindowsAppSDKVersionRevision=$(builddate_dd)$(buildrevision) /p:VCToolsInstallDir="$(VCToolsInstallDir)\" /p:PGOBuildMode=$(PGOBuildMode) /p:WindowsAppSDKBuildPipeline=1'
+      msbuildArgs: '/restore /p:AppxSymbolPackageEnabled=false /binaryLogger:$(Build.SourcesDirectory)/${{ parameters.solutionPath }}.$(buildPlatform).$(buildConfiguration).binlog /p:WindowsAppSDKVersionBuild=$(builddate_yymm) /p:WindowsAppSDKVersionRevision=$(builddate_dd)$(buildrevision) /p:VCToolsInstallDir="$(VCToolsInstallDir)\" /p:PGOBuildMode=$(PGOBuildMode) /p:WindowsAppSDKBuildPipeline=1 /p:WindowsAppSDKCleanIntermediateFiles=${{ parameters.WindowsAppSDKCleanIntermediateFiles }}'
 
   - task: powershell@2
     displayName: 'Install test certificate for MSIX test packages (DevCheck)'

--- a/build/AzurePipelinesTemplates/WindowsAppSDK-BuildSolution-Steps.yml
+++ b/build/AzurePipelinesTemplates/WindowsAppSDK-BuildSolution-Steps.yml
@@ -2,6 +2,7 @@ parameters:
   solutionPath: ''
   displayName: ''
   additionalMsBuildArgs: ''
+  WindowsAppSDKCleanIntermediateFiles: 'true'
 
 # Note, this template depends on these variables from parent yml:
 # $(buildConfiguration), $(buildPlatform)
@@ -22,7 +23,7 @@ steps:
     solution: ${{ parameters.solutionPath }}
     platform: $(buildPlatform)
     configuration: $(buildConfiguration)
-    msbuildArgs: /binaryLogger:$(Build.SourcesDirectory)\${{ parameters.displayName }}.$(buildConfiguration).$(buildPlatform).binlog /restore ${{ parameters.additionalMsBuildArgs }}
+    msbuildArgs: /binaryLogger:$(Build.SourcesDirectory)\${{ parameters.displayName }}.$(buildConfiguration).$(buildPlatform).binlog /restore ${{ parameters.additionalMsBuildArgs }} /p:WindowsAppSDKCleanIntermediateFiles=${{ parameters.WindowsAppSDKCleanIntermediateFiles }}
     logProjectEvents: false
 
 - task: PublishBuildArtifacts@1

--- a/build/AzurePipelinesTemplates/WindowsAppSDK-CreateNugetPackage-Job.yml
+++ b/build/AzurePipelinesTemplates/WindowsAppSDK-CreateNugetPackage-Job.yml
@@ -63,6 +63,9 @@ jobs:
         Copy-Item -Path "$targetsFilePath\Microsoft.WindowsAppSDK.Bootstrap.CS.targets" -Destination "$fullpackagePath\build\Microsoft.WindowsAppSDK.Bootstrap.CS.targets"
         Copy-Item -Path "$targetsFilePath\WindowsAppSDK-Nuget-Native.Bootstrap.targets" -Destination "$fullpackagePath\build\native\WindowsAppSDK-Nuget-Native.Bootstrap.targets"
         Copy-Item -Path "$targetsFilePath\Microsoft.WindowsAppSDK.BootstrapCommon.targets" -Destination "$fullpackagePath\build\Microsoft.WindowsAppSDK.BootstrapCommon.targets"
+        Copy-Item -Path "$targetsFilePath\Microsoft.WindowsAppSDK.UndockedRegFreeWinRT.CS.targets" -Destination "$fullpackagePath\build\Microsoft.WindowsAppSDK.UndockedRegFreeWinRT.CS.targets"
+        Copy-Item -Path "$targetsFilePath\WindowsAppSDK-Nuget-Native.UndockedRegFreeWinRT.targets" -Destination "$fullpackagePath\build\native\WindowsAppSDK-Nuget-Native.UndockedRegFreeWinRT.targets"
+        Copy-Item -Path "$targetsFilePath\Microsoft.WindowsAppSDK.UndockedRegFreeWinRTCommon.targets" -Destination "$fullpackagePath\build\Microsoft.WindowsAppSDK.UndockedRegFreeWinRTCommon.targets"
 
         Copy-Item -Path "$targetsFilePath\AppxManifest.xml" -Destination "$fullpackagePath\AppxManifest.xml"
         $manifestPath = $fullpackagePath+'\manifests';

--- a/build/CopyFilesToStagingDir.ps1
+++ b/build/CopyFilesToStagingDir.ps1
@@ -88,7 +88,7 @@ PublishFile $FullBuildOutput\Microsoft.Windows.AppLifecycle.Projection\Microsoft
 PublishFile $FullBuildOutput\Microsoft.Windows.AppLifecycle.Projection\Microsoft.Windows.AppLifecycle.Projection.pdb $NugetDir\lib\net5.0-windows10.0.17763.0
 PublishFile $FullBuildOutput\Microsoft.Windows.AppNotifications.Projection\Microsoft.Windows.AppNotifications.Projection.dll $NugetDir\lib\net5.0-windows10.0.17763.0
 PublishFile $FullBuildOutput\Microsoft.Windows.AppNotifications.Projection\Microsoft.Windows.AppNotifications.Projection.pdb $NugetDir\lib\net5.0-windows10.0.17763.0
-PublishFile $FullBuildOutput\Microsoft.Windows.PushNotifications.Projection\Microsoft.Windows.PushNotifications.Projection.dll $NugetDir\lib\net5.0-windows10.0.17763.0 
+PublishFile $FullBuildOutput\Microsoft.Windows.PushNotifications.Projection\Microsoft.Windows.PushNotifications.Projection.dll $NugetDir\lib\net5.0-windows10.0.17763.0
 PublishFile $FullBuildOutput\Microsoft.Windows.PushNotifications.Projection\Microsoft.Windows.PushNotifications.Projection.pdb $NugetDir\lib\net5.0-windows10.0.17763.0
 PublishFile $FullBuildOutput\Microsoft.Windows.System.Projection\Microsoft.Windows.System.Projection.dll $NugetDir\lib\net5.0-windows10.0.17763.0
 PublishFile $FullBuildOutput\Microsoft.Windows.System.Projection\Microsoft.Windows.System.Projection.pdb $NugetDir\lib\net5.0-windows10.0.17763.0
@@ -155,9 +155,13 @@ PublishFile $FullBuildOutput\WindowsAppRuntime_DLL\StrippedWinMD\Microsoft.Windo
 PublishFile $FullBuildOutput\WindowsAppRuntime_DLL\StrippedWinMD\Microsoft.Windows.System.winmd $NugetDir\lib\uap10.0
 PublishFile $FullBuildOutput\WindowsAppRuntime_DLL\StrippedWinMD\Microsoft.Windows.System.Power.winmd $NugetDir\lib\uap10.0
 #
-# Bootstrap Static Helper Files
-PublishFile $FullBuildOutput\WindowsAppRuntime_BootstrapDLL\MddBootstrapAutoInitializer.cs $NugetDir\include
+# Bootstrap Auto-Initializer Files
 PublishFile $FullBuildOutput\WindowsAppRuntime_BootstrapDLL\MddBootstrapAutoInitializer.cpp $NugetDir\include
+PublishFile $FullBuildOutput\WindowsAppRuntime_BootstrapDLL\MddBootstrapAutoInitializer.cs $NugetDir\include
+#
+# UndockedRegFreeWinRT (URFW) Auto-Initializer Files
+PublishFile $FullBuildOutput\WindowsAppRuntime_DLL\UndockedRegFreeWinRT-AutoInitializer.cpp $NugetDir\include
+PublishFile $FullBuildOutput\WindowsAppRuntime_DLL\UndockedRegFreeWinRT-AutoInitializer.cs $NugetDir\include
 #
 # Build overrides
 PublishFile $OverrideDir\DynamicDependency-Override.json $NugetDir\runtimes\win10-$Platform\native

--- a/build/NuSpecs/Microsoft.WindowsAppSDK.Foundation.targets
+++ b/build/NuSpecs/Microsoft.WindowsAppSDK.Foundation.targets
@@ -1,7 +1,13 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <!-- Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT License. See LICENSE in the project root for license information. -->
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+
   <Import Project="$(MSBuildThisFileDirectory)MrtCore.targets" />
+
   <Import Project="$(MSBuildThisFileDirectory)Microsoft.WindowsAppSDK.BootstrapCommon.targets" />
   <Import Project="$(MSBuildThisFileDirectory)Microsoft.WindowsAppSDK.Bootstrap.CS.targets" Condition="'$(WindowsAppSdkBootstrapInitialize)' == 'true'"/>
+
+  <Import Project="$(MSBuildThisFileDirectory)Microsoft.WindowsAppSDK.UndockedRegFreeWinRTCommon.targets" />
+  <Import Project="$(MSBuildThisFileDirectory)Microsoft.WindowsAppSDK.UndockedRegFreeWinRT.CS.targets" Condition="'$(WindowsAppSdkUndockedRegFreeWinRTInitialize)' == 'true'"/>
+
 </Project>

--- a/build/NuSpecs/Microsoft.WindowsAppSDK.UndockedRegFreeWinRT.CS.targets
+++ b/build/NuSpecs/Microsoft.WindowsAppSDK.UndockedRegFreeWinRT.CS.targets
@@ -1,0 +1,9 @@
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+
+    <Target Name="GenerateUndockedRegFreeWinRTCS" BeforeTargets="BeforeCompile">
+        <ItemGroup>
+            <Compile Include="$(MSBuildThisFileDirectory)..\include\MddUndockedRegFreeWinRT-AutoInitializer.cs" />
+        </ItemGroup>
+    </Target>
+
+</Project>

--- a/build/NuSpecs/Microsoft.WindowsAppSDK.UndockedRegFreeWinRTCommon.targets
+++ b/build/NuSpecs/Microsoft.WindowsAppSDK.UndockedRegFreeWinRTCommon.targets
@@ -1,0 +1,10 @@
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+
+    <!-- Targets file common to both managed and native projects that helps enable access to Undocked RegFree WinRT-->
+
+    <PropertyGroup Condition="'$(WindowsAppSdkUndockedRegFreeWinRTInitialize)'=='' and '$(WindowsAppSDKSelfContained)'=='true'">
+        <!--Allows GenerateUndockedRegFreeWinRTCS/GenerateUndockedRegFreeWinRTCpp to run-->
+        <WindowsAppSdkUndockedRegFreeWinRTInitialize>true</WindowsAppSdkUndockedRegFreeWinRTInitialize>
+    </PropertyGroup>
+
+</Project>

--- a/build/NuSpecs/WindowsAppSDK-Nuget-Native.UndockedRegFreeWinRT.targets
+++ b/build/NuSpecs/WindowsAppSDK-Nuget-Native.UndockedRegFreeWinRT.targets
@@ -1,0 +1,9 @@
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+
+    <Target Name="GenerateUndockedRegFreeWinRTCpp" BeforeTargets="ClCompile">
+        <ItemGroup>
+            <ClCompile Include="$(MSBuildThisFileDirectory)..\..\include\MddUndockedRegFreeWinRT-AutoInitializer.cpp" />
+        </ItemGroup>
+    </Target>
+
+</Project>

--- a/build/NuSpecs/WindowsAppSDK-Nuget-Native.targets
+++ b/build/NuSpecs/WindowsAppSDK-Nuget-Native.targets
@@ -64,4 +64,7 @@
   <Import Project="$(MSBuildThisFileDirectory)..\Microsoft.WindowsAppSDK.BootstrapCommon.targets" />
   <Import Project="$(MSBuildThisFileDirectory)WindowsAppSDK-Nuget-Native.Bootstrap.targets" Condition="'$(WindowsAppSdkBootstrapInitialize)' == 'true'"/>
 
+  <Import Project="$(MSBuildThisFileDirectory)..\Microsoft.WindowsAppSDK.UndockedRegFreeWinRTCommon.targets" />
+  <Import Project="$(MSBuildThisFileDirectory)WindowsAppSDK-Nuget-Native.UndockedRegFreeWinRT.targets" Condition="'$(WindowsAppSdkUndockedRegFreeWinRTInitialize)' == 'true'"/>
+
 </Project>

--- a/dev/UndockedRegFreeWinRT/UndockedRegFreeWinRT-AutoInitializer.cpp
+++ b/dev/UndockedRegFreeWinRT/UndockedRegFreeWinRT-AutoInitializer.cpp
@@ -1,0 +1,25 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+#include <Windows.h>
+
+// Do nothing. Just exist.
+//
+// This ensures the including PE file has an import reference
+// to the WindowsAppSDK runtime DLL and thus gets loaded when
+// the including PE file gets loaded.
+
+STDAPI UndockedRegFreeWinRT_EnsureIsLoaded();
+
+// NOTE: Disable optimizations to ensure this unreferenced symbol
+//       doesn't get 'optimized away'. We need the end compiled binary
+//       to import this symbol from the Windows App SDK runtime DLL.
+#pragma optimize("", off)
+namespace Microsoft::Windows::Foundation::UndockedRegFreeWinRT
+{
+static void EnsureIsLoaded()
+{
+    (void) UndockedRegFreeWinRT_EnsureIsLoaded();
+}
+}
+#pragma optimize("", on)

--- a/dev/UndockedRegFreeWinRT/UndockedRegFreeWinRT-AutoInitializer.cs
+++ b/dev/UndockedRegFreeWinRT/UndockedRegFreeWinRT-AutoInitializer.cs
@@ -16,11 +16,11 @@ namespace Microsoft.Windows.Foundation.UndockedRegFreeWinRTCS
         [global::System.Runtime.CompilerServices.ModuleInitializer]
         internal static void AccessWindowsAppSDK()
         {
-            int hr = NativeMethods.UndockedRegFreeWinRT_EnsureIsLoaded();
-            if (hr < 0)
-            {
-                global::System.Environment.Exit(hr);
-            }
+            // No error handling needed as the target function does nothing (just {return S_OK}).
+            // It's the act of calling the function causing the DllImport to load the DLL that
+            // matters. This provides the moral equivalent of a native DLL's Import Address
+            // Table (IAT) have an entry that's resolved when this module is loaded.
+            NativeMethods.UndockedRegFreeWinRT_EnsureIsLoaded();
         }
     }
 }

--- a/dev/UndockedRegFreeWinRT/UndockedRegFreeWinRT-AutoInitializer.cs
+++ b/dev/UndockedRegFreeWinRT/UndockedRegFreeWinRT-AutoInitializer.cs
@@ -16,6 +16,12 @@ namespace Microsoft.Windows.Foundation.UndockedRegFreeWinRTCS
         [global::System.Runtime.CompilerServices.ModuleInitializer]
         internal static void AccessWindowsAppSDK()
         {
+            // Do nothing if we're being loaded for reflection (rather than execcution)
+            if (Assembly.GetEntryAssembly() != Assembly.GetExecutingAssembly())
+            {
+                return;
+            }
+
             // No error handling needed as the target function does nothing (just {return S_OK}).
             // It's the act of calling the function causing the DllImport to load the DLL that
             // matters. This provides the moral equivalent of a native DLL's Import Address

--- a/dev/UndockedRegFreeWinRT/UndockedRegFreeWinRT-AutoInitializer.cs
+++ b/dev/UndockedRegFreeWinRT/UndockedRegFreeWinRT-AutoInitializer.cs
@@ -1,0 +1,26 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using System.Runtime.InteropServices;
+
+namespace Microsoft.Windows.Foundation.UndockedRegFreeWinRTCS
+{
+    internal static class NativeMethods
+    {
+        [DllImport("Microsoft.WindowsAppRuntime.dll", CharSet = CharSet.Unicode, ExactSpelling = true)]
+        internal static extern int UndockedRegFreeWinRT_EnsureIsLoaded();
+    }
+
+    class AutoInitialize
+    {
+        [global::System.Runtime.CompilerServices.ModuleInitializer]
+        internal static void AccessWindowsAppSDK()
+        {
+            int hr = NativeMethods.UndockedRegFreeWinRT_EnsureIsLoaded();
+            if (hr < 0)
+            {
+                global::System.Environment.Exit(hr);
+            }
+        }
+    }
+}

--- a/dev/UndockedRegFreeWinRT/UndockedRegFreeWinRT-AutoInitializer.cs
+++ b/dev/UndockedRegFreeWinRT/UndockedRegFreeWinRT-AutoInitializer.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
+using System.Reflection;
 using System.Runtime.InteropServices;
 
 namespace Microsoft.Windows.Foundation.UndockedRegFreeWinRTCS

--- a/dev/UndockedRegFreeWinRT/UndockedRegFreeWinRT.vcxitems
+++ b/dev/UndockedRegFreeWinRT/UndockedRegFreeWinRT.vcxitems
@@ -23,4 +23,8 @@
     <ClInclude Include="$(MSBuildThisFileDirectory)typeresolution.h" />
     <ClInclude Include="$(MSBuildThisFileDirectory)urfw.h" />
   </ItemGroup>
+  <ItemGroup>
+    <PublicHeaders Include="$(MSBuildThisFileDirectory)UndockedRegFreeWinRT-AutoInitializer.cpp" />
+    <PublicHeaders Include="$(MSBuildThisFileDirectory)UndockedRegFreeWinRT-AutoInitializer.cs" />
+  </ItemGroup>
 </Project>

--- a/dev/UndockedRegFreeWinRT/urfw.cpp
+++ b/dev/UndockedRegFreeWinRT/urfw.cpp
@@ -16,8 +16,6 @@
 
 #include <../Detours/detours.h>
 
-#define WIN1019H1_BLDNUM 18362
-
 // Ensure that metadata resolution functions are imported so they can be detoured
 extern "C"
 {

--- a/dev/WindowsAppRuntime_BootstrapDLL/MddBootstrapActivity.cpp
+++ b/dev/WindowsAppRuntime_BootstrapDLL/MddBootstrapActivity.cpp
@@ -63,7 +63,7 @@ uint32_t WindowsAppRuntime::MddBootstrap::Activity::Context::DecrementInitializa
     return m_initializationCount;
 }
 
-const WindowsAppRuntime::MddBootstrap::Activity::IntegrityFlags& WindowsAppRuntime::MddBootstrap::Activity::Context::GetIntegrityFlags(HANDLE token)
+const WindowsAppRuntime::MddBootstrap::Activity::IntegrityFlags WindowsAppRuntime::MddBootstrap::Activity::Context::GetIntegrityFlags(HANDLE token)
 {
     WindowsAppRuntime::MddBootstrap::Activity::IntegrityFlags flags{};
     const auto integrityLevel{ Security::IntegrityLevel::GetIntegrityLevel(token) };

--- a/dev/WindowsAppRuntime_BootstrapDLL/MddBootstrapActivity.h
+++ b/dev/WindowsAppRuntime_BootstrapDLL/MddBootstrapActivity.h
@@ -49,7 +49,7 @@ namespace WindowsAppRuntime::MddBootstrap::Activity
     public:
         static WindowsAppRuntime::MddBootstrap::Activity::Context& Get();
 
-        static const WindowsAppRuntime::MddBootstrap::Activity::IntegrityFlags& GetIntegrityFlags(HANDLE token = nullptr);
+        static const WindowsAppRuntime::MddBootstrap::Activity::IntegrityFlags GetIntegrityFlags(HANDLE token = nullptr);
 
         const MddBootstrapAPI& GetMddBootstrapAPI() const
         {

--- a/dev/WindowsAppRuntime_BootstrapDLL/MddBootstrapAutoInitializer.cs
+++ b/dev/WindowsAppRuntime_BootstrapDLL/MddBootstrapAutoInitializer.cs
@@ -16,6 +16,9 @@
 #endif
 #endif
 
+using System.Reflection;
+using System.Runtime.InteropServices;
+
 namespace Microsoft.Windows.ApplicationModel.DynamicDependency.BootstrapCS
 {
     class AutoInitialize

--- a/dev/WindowsAppRuntime_BootstrapDLL/MddBootstrapAutoInitializer.cs
+++ b/dev/WindowsAppRuntime_BootstrapDLL/MddBootstrapAutoInitializer.cs
@@ -23,6 +23,12 @@ namespace Microsoft.Windows.ApplicationModel.DynamicDependency.BootstrapCS
         [global::System.Runtime.CompilerServices.ModuleInitializer]
         internal static void AccessWindowsAppSDK()
         {
+            // Do nothing if we're being loaded for reflection (rather than execcution)
+            if (Assembly.GetEntryAssembly() != Assembly.GetExecutingAssembly())
+            {
+                return;
+            }
+
             uint majorMinorVersion = global::Microsoft.WindowsAppSDK.Release.MajorMinor;
             string versionTag = global::Microsoft.WindowsAppSDK.Release.VersionTag;
             var minVersion = new PackageVersion(global::Microsoft.WindowsAppSDK.Runtime.Version.UInt64);

--- a/dev/WindowsAppRuntime_DLL/WindowsAppRuntime.def
+++ b/dev/WindowsAppRuntime_DLL/WindowsAppRuntime.def
@@ -23,3 +23,5 @@ EXPORTS
 
     WindowsAppRuntime_VersionInfo_MSIX_Framework_PackageFamilyName_Get
     WindowsAppRuntime_VersionInfo_TestInitialize
+
+    WindowsAppRuntime_EnsureIsLoaded

--- a/dev/WindowsAppRuntime_DLL/WindowsAppRuntime_DLL.vcxproj
+++ b/dev/WindowsAppRuntime_DLL/WindowsAppRuntime_DLL.vcxproj
@@ -376,6 +376,7 @@
   <ItemGroup>
     <ClCompile Include="dllmain.cpp" />
     <ClCompile Include="COMExports.cpp" />
+    <ClCompile Include="WindowsAppRuntime_EnsureIsLoaded.cpp" />
     <ClCompile Include="pch.cpp">
       <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">Create</PrecompiledHeader>
       <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|ARM'">Create</PrecompiledHeader>

--- a/dev/WindowsAppRuntime_DLL/WindowsAppRuntime_DLL.vcxproj.filters
+++ b/dev/WindowsAppRuntime_DLL/WindowsAppRuntime_DLL.vcxproj.filters
@@ -32,6 +32,9 @@
     <ClCompile Include="COMExports.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="WindowsAppRuntime_EnsureIsLoaded.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <None Include="packages.config" />

--- a/dev/WindowsAppRuntime_DLL/WindowsAppRuntime_EnsureInitialization.cpp
+++ b/dev/WindowsAppRuntime_DLL/WindowsAppRuntime_EnsureInitialization.cpp
@@ -1,0 +1,11 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+#include "pch.h"
+
+
+// Do nothing. Just exist so consumers can import a reference to ensure the DLL is loaded
+STDAPI WindowsAppRuntime_EnsureIsLoaded()
+{
+    return S_OK;
+}

--- a/dev/WindowsAppRuntime_DLL/WindowsAppRuntime_EnsureIsLoaded.cpp
+++ b/dev/WindowsAppRuntime_DLL/WindowsAppRuntime_EnsureIsLoaded.cpp
@@ -3,7 +3,6 @@
 
 #include "pch.h"
 
-
 // Do nothing. Just exist so consumers can import a reference to ensure the DLL is loaded
 STDAPI WindowsAppRuntime_EnsureIsLoaded()
 {

--- a/dev/WindowsAppRuntime_MSIXInstallFromPath/main.cpp
+++ b/dev/WindowsAppRuntime_MSIXInstallFromPath/main.cpp
@@ -184,7 +184,7 @@ void AddPackageIfNecessary(PCWSTR path, const std::wstring& filename, const std:
     wprintf(L"Path: %s\n", path);
     wprintf(L"Filename: %s\n", filename.c_str());
     wprintf(L"PackageFullName: %s\n", packageFullName.c_str());
-    wprintf(L"forceDeployment:%s\n", forceDeployment ?  "true" : "false");
+    wprintf(L"forceDeployment:%s\n", forceDeployment ?  L"true" : L"false");
 
     if (!NeedToRegisterPackage(packageFullName))
     {
@@ -194,8 +194,8 @@ void AddPackageIfNecessary(PCWSTR path, const std::wstring& filename, const std:
     auto hr{ AddPackage(path, filename, forceDeployment) };
     if (FAILED(hr))
     {
-        wprintf(L"AddPackage(): 0x%X Path:%ls Filename:%ls PackageFullName:%ls forceDeployment:%s", hr, path, filename.c_str(), packageFullName.c_str(), forceDeployment ? "true" : "false");
-        THROW_HR_MSG(hr, "Path:%ls Filename:%ls PackageFullName:%ls forceDeployment:%s", path, filename.c_str(), packageFullName.c_str(), forceDeployment ? "true" : "false");
+        wprintf(L"AddPackage(): 0x%X Path:%s Filename:%s PackageFullName:%s forceDeployment:%s", hr, path, filename.c_str(), packageFullName.c_str(), forceDeployment ? L"true" : L"false");
+        THROW_HR_MSG(hr, "Path:%ls Filename:%ls PackageFullName:%ls forceDeployment:%ls", path, filename.c_str(), packageFullName.c_str(), forceDeployment ? L"true" : L"false");
     }
 }
 


### PR DESCRIPTION
Enable UndockedRegFreeWinRT automagic initialization, when using WinAppSDK/SelfContained.

NOTE: This is similar to Bootstrapper automagic initialization, when an unpackaged app is using WinAppSDK/MSIX.

You can disable (opt-out) this auto-initialization by defining the project property `<WindowsAppSdkUndockedRegFreeWinRTInitialize>false</WindowsAppSdkUndockedRegFreeWinRTInitialize>`.

If undefined (the default) this is enabled with `<WindowsAppSDKSelfContained>` is `true`

https://task.ms/38121572