### PR TITLE
Update WindowsAppSDK-RunHelixTests-Job.yml

### DIFF
--- a/build/AzurePipelinesTemplates/WindowsAppSDK-RunHelixTests-Job.yml
+++ b/build/AzurePipelinesTemplates/WindowsAppSDK-RunHelixTests-Job.yml
@@ -30,8 +30,8 @@ jobs:
 
     # The target queues to run the tests on.
     # Note: %3b is the escape sequence for ';' which is used as the delimiter
-    helixTargetQueuesOpen: 'Windows.10.Amd64.ClientRS5.Open.reunion%3bWindows.10.Amd64.Client20h2.Open.reunion%3bwindows.10.amd64.client21h1.open.reunion'
-    helixTargetQueuesClosed: 'windows.10.amd64.client20h2.reunion%3bwindows.10.amd64.clientrs5.reunion%3bwindows.10.amd64.client21h1.reunion'
+    helixTargetQueuesOpen: 'Windows.10.Amd64.ClientRS5.Open.reunion%3bWindows.10.Amd64.Client20h2.Open.reunion%3bwindows.10.amd64.client21h1.open.reunion%3bwindows.11.amd64.client.open.reunion'
+    helixTargetQueuesClosed: 'windows.10.amd64.client20h2.reunion%3bwindows.10.amd64.clientrs5.reunion%3bwindows.10.amd64.client21h1.reunion%3bWindows.11.Amd64.client.Reunion'
 
     # When a test fails, it is re-run 10 times. This variable specifies how many times out of 10 it is required to pass
     rerunPassesRequiredToAvoidFailure: 8


### PR DESCRIPTION
Appended windows.11.amd64.client.open.reunion to helixTargetQueuesOpen and Windows.11.Amd64.client.Reunion to helixTargetQueuesClosed.

The corresponding change on the Internal repo successfully added the Win11 image to the test matrix:

Starting Azure Pipelines Test Run windows.10.amd64.client20h2.reunion
Starting Azure Pipelines Test Run windows.10.amd64.clientrs5.reunion 
Starting Azure Pipelines Test Run windows.10.amd64.client21h1.reunion 
Starting Azure Pipelines Test Run Windows.11.Amd64.Client.Reunion            <<<<