### PR TITLE
Copy DeploymentAgent executable to TestFwkPkg (#2467)

### DIFF
--- a/WindowsAppRuntime.sln
+++ b/WindowsAppRuntime.sln
@@ -68,6 +68,7 @@ EndProject
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "Microsoft.WindowsAppRuntime.Framework", "test\DynamicDependency\data\Microsoft.WindowsAppRuntime.Framework\Microsoft.WindowsAppRuntime.Framework.vcxproj", "{9C1A6C58-52D6-4514-9120-5C339C5DF4BE}"
 	ProjectSection(ProjectDependencies) = postProject
 		{BC5E5A3E-E733-4388-8B00-F8495DA7C778} = {BC5E5A3E-E733-4388-8B00-F8495DA7C778}
+		{4410D374-A90C-4ADF-8B15-AA2AAE2636BF} = {4410D374-A90C-4ADF-8B15-AA2AAE2636BF}
 	EndProjectSection
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "DynamicDependencyDataStore", "DynamicDependencyDataStore", "{441A3BB0-7FD2-4902-AEDB-A1C57B528C77}"

--- a/build/CopyFilesToStagingDir.ps1
+++ b/build/CopyFilesToStagingDir.ps1
@@ -118,6 +118,8 @@ PublishFile $FullBuildOutput\WindowsAppRuntime_DLL\Microsoft.WindowsAppRuntime.d
 PublishFile $FullBuildOutput\WindowsAppRuntime_DLL\Microsoft.WindowsAppRuntime.pdb $NugetDir\runtimes\win10-$Platform\native
 PublishFile $FullBuildOutput\RestartAgent\RestartAgent.exe $NugetDir\runtimes\win10-$Platform\native
 PublishFile $FullBuildOutput\RestartAgent\RestartAgent.pdb $NugetDir\runtimes\win10-$Platform\native
+PublishFile $FullBuildOutput\DeploymentAgent\DeploymentAgent.exe $NugetDir\runtimes\win10-$Platform\native
+PublishFile $FullBuildOutput\DeploymentAgent\DeploymentAgent.pdb $NugetDir\runtimes\win10-$Platform\native
 #
 # MSIX Main package
 PublishFile $FullBuildOutput\DynamicDependency.DataStore\DynamicDependency.DataStore.exe $NugetDir\runtimes\win10-$Platform\native

--- a/test/DynamicDependency/data/Microsoft.WindowsAppRuntime.Framework/Microsoft.WindowsAppRuntime.Framework.vcxproj
+++ b/test/DynamicDependency/data/Microsoft.WindowsAppRuntime.Framework/Microsoft.WindowsAppRuntime.Framework.vcxproj
@@ -77,8 +77,14 @@
     <MakeMsixInputsWithLocations Include="$(OutDir)..\RestartAgent\RestartAgent.exe">
       <TargetFile>RestartAgent.exe</TargetFile>
     </MakeMsixInputsWithLocations>
-    <MakeMsixInputsWithLocations Include="$(OutDir)..\RestartAgent\RestartAgent.exe">
+    <MakeMsixInputsWithLocations Include="$(OutDir)..\RestartAgent\RestartAgent.pdb">
       <TargetFile>RestartAgent.pdb</TargetFile>
+    </MakeMsixInputsWithLocations>
+    <MakeMsixInputsWithLocations Include="$(OutDir)..\DeploymentAgent\DeploymentAgent.exe">
+      <TargetFile>DeploymentAgent.exe</TargetFile>
+    </MakeMsixInputsWithLocations>
+    <MakeMsixInputsWithLocations Include="$(OutDir)..\DeploymentAgent\DeploymentAgent.pdb">
+      <TargetFile>DeploymentAgent.pdb</TargetFile>
     </MakeMsixInputsWithLocations>
     <MakeMsixInputs Include="$(OutDir)..\WindowsAppRuntime_DLL\Microsoft.WindowsAppRuntime.dll" />
     <MakeMsixInputs Include="$(OutDir)..\WindowsAppRuntime_DLL\Microsoft.WindowsAppRuntime.pdb" />


### PR DESCRIPTION
* Copy DeploymentAgent executable to TestFwkPkg

* Make DeploymentAgent a dependency to build Microsoft.Windows.Framework

Co-authored-by: Santosh Chintalapati <sachinta@ntdev.microsoft.com>