### PR TITLE
Refactor Register API in AppNotifications

### DIFF
--- a/dev/AppNotifications/AppNotificationManager.cpp
+++ b/dev/AppNotifications/AppNotificationManager.cpp
@@ -93,6 +93,59 @@ namespace winrt::Microsoft::Windows::AppNotifications::implementation
         return m_activatedEventArgs;
     }
 
+    void AppNotificationManager::RegisterUnpackagedHelper()
+    {
+        THROW_IF_FAILED(PushNotifications_RegisterFullTrustApplication(m_appId.c_str(), GUID_NULL));
+
+        // Future work: glean off the assets from process/shortcuts/default and pass it to the below API
+        winrt::guid storedComActivatorGuid{ RegisterComActivatorGuidAndAssets() };
+
+        if (!WindowsAppRuntime::SelfContained::IsSelfContained())
+        {
+            auto notificationPlatform{ PushNotificationHelpers::GetNotificationPlatform() };
+            THROW_IF_FAILED(notificationPlatform->AddToastRegistrationMapping(m_processName.c_str(), m_appId.c_str()));
+        }
+
+        RegisterNotificationCallback(storedComActivatorGuid);
+    }
+
+    void AppNotificationManager::RegisterPackagedHelper()
+    {
+        if (!PushNotificationHelpers::IsPackagedAppScenario() && !WindowsAppRuntime::SelfContained::IsSelfContained())
+        {
+            auto notificationPlatform{ PushNotificationHelpers::GetNotificationPlatform() };
+            THROW_IF_FAILED(notificationPlatform->AddToastRegistrationMapping(m_processName.c_str(), m_appId.c_str()));
+        }
+
+        winrt::guid registeredClsid{ PushNotificationHelpers::GetComRegistrationFromRegistry(expectedAppServerArgs.data()) };
+        RegisterNotificationCallback(registeredClsid);
+    }
+
+    void AppNotificationManager::RegisterNotificationCallback(winrt::guid const& comActivatorGuid)
+    {
+        // Create event handle before COM Registration otherwise if a notification arrives will lead to race condition
+        m_waitHandleForArgs.create();
+
+        {
+            auto lock{ m_lock.lock_exclusive() };
+            THROW_HR_IF_MSG(E_INVALIDARG, m_notificationComActivatorRegistration, "Already Registered for App Notifications!");
+
+            // Check if the caller has registered event handlers, if so the REGCLS_MULTIPLEUSE flag will cause COM to ensure that all activators
+            // are routed inproc, otherwise with REGCLS_SINGLEUSE COM will launch a new process of the Win32 app for each invocation.
+            auto activationFlag{ m_notificationHandlers ? REGCLS_MULTIPLEUSE : REGCLS_SINGLEUSE };
+
+            // Register an INotificationActivationCallback to receive background activations from AppNotification.
+            // Also, STA threads that call CoRegisterClassObject need to use the REGCLS_AGILE flag so that the object is
+            // associated with the neutral apartment. This allows other threads to activate the STA registered thread.
+            THROW_IF_FAILED(::CoRegisterClassObject(
+                comActivatorGuid,
+                winrt::make<AppNotificationManagerFactory>().get(),
+                CLSCTX_LOCAL_SERVER,
+                activationFlag | REGCLS_AGILE,
+                &m_notificationComActivatorRegistration));
+        }
+    }
+
     void AppNotificationManager::Register()
     {
         HRESULT hr{ S_OK };
@@ -115,50 +168,7 @@ namespace winrt::Microsoft::Windows::AppNotifications::implementation
                 m_registering = false;
             }) };
 
-            winrt::guid storedComActivatorGuid{ GUID_NULL };
-            if (!PushNotificationHelpers::IsPackagedAppScenario())
-            {
-                if (!AppModel::Identity::IsPackagedProcess())
-                {
-                    THROW_IF_FAILED(PushNotifications_RegisterFullTrustApplication(m_appId.c_str(), GUID_NULL));
-
-                    storedComActivatorGuid = RegisterComActivatorGuidAndAssets();
-                }
-
-                if (!WindowsAppRuntime::SelfContained::IsSelfContained())
-                {
-                    auto notificationPlatform{ PushNotificationHelpers::GetNotificationPlatform() };
-                    THROW_IF_FAILED(notificationPlatform->AddToastRegistrationMapping(m_processName.c_str(), m_appId.c_str()));
-                }
-            }
-
-            winrt::guid registeredClsid{ GUID_NULL };
-            if (AppModel::Identity::IsPackagedProcess())
-            {
-                registeredClsid = PushNotificationHelpers::GetComRegistrationFromRegistry(expectedAppServerArgs.data());
-            }
-
-            // Create event handle before COM Registration otherwise if a notification arrives will lead to race condition
-            m_waitHandleForArgs.create();
-
-            {
-                auto lock{ m_lock.lock_exclusive() };
-                THROW_HR_IF_MSG(E_INVALIDARG, m_notificationComActivatorRegistration, "Already Registered for App Notifications!");
-
-                // Check if the caller has registered event handlers, if so the REGCLS_MULTIPLEUSE flag will cause COM to ensure that all activators
-                // are routed inproc, otherwise with REGCLS_SINGLEUSE COM will launch a new process of the Win32 app for each invocation.
-                auto activationFlag{ m_notificationHandlers ? REGCLS_MULTIPLEUSE : REGCLS_SINGLEUSE };
-
-                // Register an INotificationActivationCallback to receive background activations from AppNotification.
-                // Also, STA threads that call CoRegisterClassObject need to use the REGCLS_AGILE flag so that the object is
-                // associated with the neutral apartment. This allows other threads to activate the STA registered thread.
-                THROW_IF_FAILED(::CoRegisterClassObject(
-                    AppModel::Identity::IsPackagedProcess() ? registeredClsid : storedComActivatorGuid,
-                    winrt::make<AppNotificationManagerFactory>().get(),
-                    CLSCTX_LOCAL_SERVER,
-                    activationFlag | REGCLS_AGILE,
-                    &m_notificationComActivatorRegistration));
-            }
+            AppModel::Identity::IsPackagedProcess() ? RegisterPackagedHelper() : RegisterUnpackagedHelper();
         }
         catch (...)
         {

--- a/dev/AppNotifications/AppNotificationManager.h
+++ b/dev/AppNotifications/AppNotificationManager.h
@@ -45,7 +45,7 @@ namespace winrt::Microsoft::Windows::AppNotifications::implementation
         winrt::Windows::Foundation::IInspectable Deserialize(winrt::Windows::Foundation::Uri const& uri);
     private:
 
-        void RegisterUnpackagedHelper();
+        void RegisterUnpackagedHelper(std::wstring const& displayName, std::wstring const& iconFilePath);
         void RegisterPackagedHelper();
         void RegisterNotificationCallback(winrt::guid const& comActivatorGuid);
 

--- a/dev/AppNotifications/AppNotificationManager.h
+++ b/dev/AppNotifications/AppNotificationManager.h
@@ -45,6 +45,10 @@ namespace winrt::Microsoft::Windows::AppNotifications::implementation
         winrt::Windows::Foundation::IInspectable Deserialize(winrt::Windows::Foundation::Uri const& uri);
     private:
 
+        void RegisterUnpackagedHelper();
+        void RegisterPackagedHelper();
+        void RegisterNotificationCallback(winrt::guid const& comActivatorGuid);
+
         void UnregisterHelper();
 
         wil::unique_com_class_object_cookie m_notificationComActivatorRegistration;

--- a/dev/AppNotifications/AppNotificationUtility.cpp
+++ b/dev/AppNotifications/AppNotificationUtility.cpp
@@ -38,6 +38,8 @@ namespace ToastABI
     using namespace ::ABI::Microsoft::Internal::ToastNotifications;
 }
 
+using namespace Microsoft::Windows::AppNotifications::ShellLocalization;
+
 std::wstring Microsoft::Windows::AppNotifications::Helpers::RetrieveUnpackagedNotificationAppId()
 {
     wil::unique_cotaskmem_string appId;
@@ -241,7 +243,7 @@ std::wstring Microsoft::Windows::AppNotifications::Helpers::GetDisplayNameBasedO
     return displayName;
 }
 
-winrt::guid Microsoft::Windows::AppNotifications::Helpers::RegisterComActivatorGuidAndAssets()
+winrt::guid Microsoft::Windows::AppNotifications::Helpers::RegisterComActivatorGuidAndAssets(std::wstring const& displayName, std::wstring const& iconFilePath)
 {
     std::wstring registeredGuid;
     auto hr = GetActivatorGuid(registeredGuid);
@@ -258,20 +260,36 @@ winrt::guid Microsoft::Windows::AppNotifications::Helpers::RegisterComActivatorG
         RegisterComServer(comActivatorGuidString);
 
         registeredGuid = comActivatorGuidString.get();
+        std::wstring notificationAppId{ Microsoft::Windows::AppNotifications::Helpers::RetrieveNotificationAppId() };
+        RegisterAssets(notificationAppId, registeredGuid, displayName, iconFilePath);
     }
     else
     {
         THROW_IF_FAILED(hr);
     }
 
-    std::wstring notificationAppId{ Microsoft::Windows::AppNotifications::Helpers::RetrieveNotificationAppId() };
-    RegisterAssets(notificationAppId, registeredGuid);
-
     // Remove braces around the guid string
     return winrt::guid(registeredGuid.substr(1, registeredGuid.size() - 2));
 }
 
-void Microsoft::Windows::AppNotifications::Helpers::RegisterAssets(std::wstring const& appId, std::wstring const& clsid)
+// Try the following techniques to retrieve display name and icon:
+// 1. Based on the best app shortcut, using the FrameworkUdk.
+// 2. From the current process.
+// 3. Set a default DisplayName, but leave empty the icon file path so Shell can set a default icon.
+AppNotificationAssets  Microsoft::Windows::AppNotifications::Helpers::GetAssetsHelper()
+{
+    AppNotificationAssets assets{};
+
+    if (FAILED(Microsoft::Windows::AppNotifications::ShellLocalization::RetrieveAssetsFromShortcut(assets)) &&
+        FAILED(Microsoft::Windows::AppNotifications::ShellLocalization::RetrieveAssetsFromProcess(assets)))
+    {
+        assets.displayName = GetDisplayNameBasedOnProcessName();
+    }
+
+    return assets;
+}
+
+void Microsoft::Windows::AppNotifications::Helpers::RegisterAssets(std::wstring const& appId, std::wstring const& clsid, std::wstring const& displayName, std::wstring const& iconFilePath)
 {
     wil::unique_hkey hKey;
     // subKey: \Software\Classes\AppUserModelId\{AppGUID}
@@ -288,24 +306,12 @@ void Microsoft::Windows::AppNotifications::Helpers::RegisterAssets(std::wstring 
         &hKey,
         nullptr /* lpdwDisposition */));
 
-    // Try the following techniques to retrieve display name and icon:
-    // 1. Based on the best app shortcut, using the FrameworkUdk.
-    // 2. From the current process.
-    // 3. Set a default DisplayName, but leave empty the icon file path so Shell can set a default icon.
-    Microsoft::Windows::AppNotifications::ShellLocalization::AppNotificationAssets assets{};
-
-    if (FAILED(Microsoft::Windows::AppNotifications::ShellLocalization::RetrieveAssetsFromShortcut(assets)) &&
-        FAILED(Microsoft::Windows::AppNotifications::ShellLocalization::RetrieveAssetsFromProcess(assets)))
-    {
-        assets.displayName = GetDisplayNameBasedOnProcessName();
-    }
-
-    RegisterValue(hKey, L"DisplayName", reinterpret_cast<const BYTE*>(assets.displayName.c_str()), REG_EXPAND_SZ, assets.displayName.size() * sizeof(wchar_t));
+    RegisterValue(hKey, L"DisplayName", reinterpret_cast<const BYTE*>(displayName.c_str()), REG_EXPAND_SZ, displayName.size() * sizeof(wchar_t));
 
     // If no icon is specified in the Registry, the OS will render a default icon for App Notifications.
-    if (!assets.iconFilePath.empty())
+    if (!iconFilePath.empty())
     {
-        RegisterValue(hKey, L"IconUri", reinterpret_cast<const BYTE*>(assets.iconFilePath.c_str()), REG_EXPAND_SZ, assets.iconFilePath.size() * sizeof(wchar_t));
+        RegisterValue(hKey, L"IconFilePath", reinterpret_cast<const BYTE*>(iconFilePath.c_str()), REG_EXPAND_SZ, iconFilePath.size() * sizeof(wchar_t));
     }
     else // clean any Icon URI from previous registrations
     {

--- a/dev/AppNotifications/AppNotificationUtility.h
+++ b/dev/AppNotifications/AppNotificationUtility.h
@@ -8,6 +8,7 @@
 #include <wil/resource.h>
 #include <AppNotificationActivatedEventArgs.h>
 #include <FrameworkUdk/toastnotificationsrt.h>
+#include <ShellLocalization.h>
 
 namespace Microsoft::Windows::AppNotifications::Helpers
 {
@@ -53,13 +54,15 @@ namespace Microsoft::Windows::AppNotifications::Helpers
 
     HRESULT GetActivatorGuid(std::wstring& activatorGuid) noexcept;
 
-    winrt::guid RegisterComActivatorGuidAndAssets();
+    winrt::guid RegisterComActivatorGuidAndAssets(std::wstring const& displayName, std::wstring const& iconFilePath);
 
-    void RegisterAssets(std::wstring const& appId, std::wstring const& clsid);
+    void RegisterAssets(std::wstring const& appId, std::wstring const& clsid, std::wstring const& displayName, std::wstring const& iconFilePath);
 
     wil::unique_cotaskmem_string ConvertUtf8StringToWideString(unsigned long length, const BYTE* utf8String);
 
     winrt::Microsoft::Windows::AppNotifications::AppNotification ToastNotificationFromToastProperties(ABI::Microsoft::Internal::ToastNotifications::INotificationProperties* properties);
 
     std::wstring GetDisplayNameBasedOnProcessName();
+
+    Microsoft::Windows::AppNotifications::ShellLocalization::AppNotificationAssets GetAssetsHelper();
 }


### PR DESCRIPTION
Description: Refactoring the existing implementation to be able to do specialized operation depending on the Application type. This makes it easy to even introduce overloaded Register API that takes in assets to directly call into appropriate helpers to assist in registration process.