### PR TITLE
UndockedRegFreeWinRT self-contained and auto-initialization support

### DIFF
--- a/build/NuSpecs/Microsoft.WindowsAppSDK.UndockedRegFreeWinRTCommon.targets
+++ b/build/NuSpecs/Microsoft.WindowsAppSDK.UndockedRegFreeWinRTCommon.targets
@@ -7,4 +7,8 @@
         <WindowsAppSdkUndockedRegFreeWinRTInitialize>true</WindowsAppSdkUndockedRegFreeWinRTInitialize>
     </PropertyGroup>
 
+    <PropertyGroup Condition="'$(WindowsAppSdkUndockedRegFreeWinRTInitializeLoadLibrary)'=='' and '$(WindowsAppSdkUndockedRegFreeWinRTInitialize)'=='true'">
+        <WindowsAppSdkUndockedRegFreeWinRTInitializeLoadLibrary>true</WindowsAppSdkUndockedRegFreeWinRTInitializeLoadLibrary>
+    </PropertyGroup>
+
 </Project>

--- a/build/NuSpecs/WindowsAppSDK-Nuget-Native.UndockedRegFreeWinRT.targets
+++ b/build/NuSpecs/WindowsAppSDK-Nuget-Native.UndockedRegFreeWinRT.targets
@@ -1,9 +1,15 @@
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 
-    <Target Name="GenerateUndockedRegFreeWinRTCpp" BeforeTargets="ClCompile">
+    <Target Name="GenerateUndockedRegFreeWinRTCpp" BeforeTargets="ClCompile" Condition="'$(WindowsAppSdkUndockedRegFreeWinRTInitialize)' == 'true'">
         <ItemGroup>
+            <ClCompile>
+                <PreprocessorDefinitions>MICROSOFT_WINDOWSAPPSDK_UNDOCKEDREGFREEWINRT_AUTO_INITIALIZE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+                <PreprocessorDefinitions Condition="'$(WindowsAppSdkUndockedRegFreeWinRTInitializeLoadLibrary)' == 'true'">MICROSOFT_WINDOWSAPPSDK_UNDOCKEDREGFREEWINRT_AUTO_INITIALIZE_LOADLIBRARY;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+            </ClCompile>
             <ClCompile Include="$(MSBuildThisFileDirectory)..\..\include\UndockedRegFreeWinRT-AutoInitializer.cpp">
                 <PrecompiledHeader>NotUsing</PrecompiledHeader>
+                <PreprocessorDefinitions>MICROSOFT_WINDOWSAPPSDK_UNDOCKEDREGFREEWINRT_AUTO_INITIALIZE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+                <PreprocessorDefinitions Condition="'$(WindowsAppSdkUndockedRegFreeWinRTInitializeLoadLibrary)' == 'true'">MICROSOFT_WINDOWSAPPSDK_UNDOCKEDREGFREEWINRT_AUTO_INITIALIZE_LOADLIBRARY;%(PreprocessorDefinitions)</PreprocessorDefinitions>
             </ClCompile>
         </ItemGroup>
     </Target>

--- a/dev/UndockedRegFreeWinRT/UndockedRegFreeWinRT-AutoInitializer.cpp
+++ b/dev/UndockedRegFreeWinRT/UndockedRegFreeWinRT-AutoInitializer.cpp
@@ -2,24 +2,41 @@
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
 #include <Windows.h>
+#include <stdlib.h>
 
-// Do nothing. Just exist.
-//
-// This ensures the including PE file has an import reference
-// to the WindowsAppSDK runtime DLL and thus gets loaded when
+// Ensure the including PE file has an import reference to
+// the WindowsAppSDK runtime DLL and thus gets loaded when
 // the including PE file gets loaded.
 
 STDAPI UndockedRegFreeWinRT_EnsureIsLoaded();
 
-// NOTE: Disable optimizations to ensure this unreferenced symbol
-//       doesn't get 'optimized away'. We need the end compiled binary
-//       to import this symbol from the Windows App SDK runtime DLL.
-#pragma optimize("", off)
 namespace Microsoft::Windows::Foundation::UndockedRegFreeWinRT
 {
-static void EnsureIsLoaded()
-{
-    (void) UndockedRegFreeWinRT_EnsureIsLoaded();
+    struct AutoInitialize
+    {
+        AutoInitialize()
+        {
+            // Load the Windows App SDK runtime DLL. The only reason this could fail
+            // is if the loading application using WinAppSDK/SelfContained has a
+            // damaged self-contained configuration of the Windows App SDK's runtime.
+
+            // Define MICROSOFT_WINDOWSAPPSDK_UNDOCKEDREGFREEWINRT_AUTO_INITIALIZE_LOADLIBRARY
+            // if Microsoft.WindowsAppRuntime.dll is DelayLoad'd and thus we need
+            // to explicitly load the DLL at runtime. Otherwise we can implicitly
+            // link the library and get an import reference causing Windows to
+            // resolve our import at load-time.
+#if defined(MICROSOFT_WINDOWSAPPSDK_UNDOCKEDREGFREEWINRT_AUTO_INITIALIZE_LOADLIBRARY)
+            static HMODULE dll{ LoadLibraryExW(L"Microsoft.WindowsAppRuntime.dll", nullptr, 0) };
+            if (!dll)
+            {
+                const auto lastError{ GetLastError() };
+                DebugBreak();
+                exit(HRESULT_FROM_WIN32(lastError));
+            }
+#else
+            (void) UndockedRegFreeWinRT_EnsureIsLoaded();
+#endif
+        }
+    };
+    static AutoInitialize g_autoInitialize;
 }
-}
-#pragma optimize("", on)


### PR DESCRIPTION
Some refinements on the UndockedRegFreeWinRT self-contained and auto-initialization support

Testing here is a matter of modifying the nuget used by IntegrationTests in the Aggregator and then 'porting'/copying those changes from the local nuget to the actual source here. The Aggregator update is blocked until this makes it into the build

A couple of bits are less than elegant but work and can be refined later, when not so blocking/urgent.