### PR TITLE
UrfwInitialize() didn't report if ExtRoLoadCatalog() returned error

### DIFF
--- a/dev/UndockedRegFreeWinRT/urfw.cpp
+++ b/dev/UndockedRegFreeWinRT/urfw.cpp
@@ -413,7 +413,7 @@ HRESULT UrfwInitialize() noexcept
     DetourAttach(&(PVOID&)TrueRoResolveNamespace, RoResolveNamespaceDetour);
     try
     {
-        ExtRoLoadCatalog();
+        RETURN_IF_FAILED(ExtRoLoadCatalog());
     }
     catch (...)
     {


### PR DESCRIPTION
UrfwInitialize() didn't report if ExtRoLoadCatalog() errored and returned a failing HRESULT (only trapped thrown exceptions, but the implementation does both)