### PR TITLE
Remove C# auto-initialization check for reflection

### DIFF
--- a/dev/UndockedRegFreeWinRT/UndockedRegFreeWinRT-AutoInitializer.cs
+++ b/dev/UndockedRegFreeWinRT/UndockedRegFreeWinRT-AutoInitializer.cs
@@ -17,12 +17,6 @@ namespace Microsoft.Windows.Foundation.UndockedRegFreeWinRTCS
         [global::System.Runtime.CompilerServices.ModuleInitializer]
         internal static void AccessWindowsAppSDK()
         {
-            // Do nothing if we're being loaded for reflection (rather than execcution)
-            if (Assembly.GetEntryAssembly() != Assembly.GetExecutingAssembly())
-            {
-                return;
-            }
-
             // No error handling needed as the target function does nothing (just {return S_OK}).
             // It's the act of calling the function causing the DllImport to load the DLL that
             // matters. This provides the moral equivalent of a native DLL's Import Address

--- a/dev/UndockedRegFreeWinRT/catalog.cpp
+++ b/dev/UndockedRegFreeWinRT/catalog.cpp
@@ -85,8 +85,8 @@ HRESULT LoadManifestFromPath(std::wstring path)
         return COR_E_ARGUMENT;
     }
     std::wstring ext(path.substr(path.size() - 4, path.size()));
-    if ((CompareStringOrdinal(ext.c_str(), -1, L".exe.", -1, TRUE) == CSTR_EQUAL) ||
-        (CompareStringOrdinal(ext.c_str(), -1, L".dll.", -1, TRUE) == CSTR_EQUAL))
+    if ((CompareStringOrdinal(ext.c_str(), -1, L".exe", -1, TRUE) == CSTR_EQUAL) ||
+        (CompareStringOrdinal(ext.c_str(), -1, L".dll", -1, TRUE) == CSTR_EQUAL))
     {
         return LoadFromEmbeddedManifest(path.c_str());
     }
@@ -405,7 +405,7 @@ HRESULT WinRTGetMetadataFile(
     // will create an instance of the metadata reader to dispense metadata files.
     if (metaDataDispenser == nullptr)
     {
-        // Avoid using CoCreateInstance here, which will trigger a Feature-On-Demand (FOD) 
+        // Avoid using CoCreateInstance here, which will trigger a Feature-On-Demand (FOD)
         // installation request of .NET Framework 3.5 if it's not already installed. In the
         // mean time, Windows App SDK runtime doesn't need .NET Framework 3.5.
         RETURN_IF_FAILED(MetaDataGetDispenser(CLSID_CorMetaDataDispenser,

--- a/dev/WindowsAppRuntime_BootstrapDLL/MddBootstrapAutoInitializer.cs
+++ b/dev/WindowsAppRuntime_BootstrapDLL/MddBootstrapAutoInitializer.cs
@@ -26,12 +26,6 @@ namespace Microsoft.Windows.ApplicationModel.DynamicDependency.BootstrapCS
         [global::System.Runtime.CompilerServices.ModuleInitializer]
         internal static void AccessWindowsAppSDK()
         {
-            // Do nothing if we're being loaded for reflection (rather than execcution)
-            if (Assembly.GetEntryAssembly() != Assembly.GetExecutingAssembly())
-            {
-                return;
-            }
-
             uint majorMinorVersion = global::Microsoft.WindowsAppSDK.Release.MajorMinor;
             string versionTag = global::Microsoft.WindowsAppSDK.Release.VersionTag;
             var minVersion = new PackageVersion(global::Microsoft.WindowsAppSDK.Runtime.Version.UInt64);


### PR DESCRIPTION
Remove

```c#
if (Assembly.GetEntryAssembly() != Assembly.GetExecutingAssembly())
{
    return;
}
```
shortcircuit as it casts too wide a net right now. That catches loading for reflection AND for common test cases e.g.

```
te.exe foo.dll
```

as auto-initialization isn't restricted to exes (i.e. it gets compiled into foo.dll) and then Entry!=Executing.

Revert this for now and restore later when #2456 is addressed (by restricting auto-init by default to only compile into EXEs; require explicit opt-in to compile into DLLs)