### PR TITLE
Fix URFW auto-init reference to EnsureIsLoaded()

### DIFF
--- a/dev/UndockedRegFreeWinRT/UndockedRegFreeWinRT-AutoInitializer.cpp
+++ b/dev/UndockedRegFreeWinRT/UndockedRegFreeWinRT-AutoInitializer.cpp
@@ -8,7 +8,7 @@
 // the WindowsAppSDK runtime DLL and thus gets loaded when
 // the including PE file gets loaded.
 
-STDAPI UndockedRegFreeWinRT_EnsureIsLoaded();
+STDAPI WindowsAppRuntime_EnsureIsLoaded();
 
 namespace Microsoft::Windows::Foundation::UndockedRegFreeWinRT
 {
@@ -34,7 +34,7 @@ namespace Microsoft::Windows::Foundation::UndockedRegFreeWinRT
                 exit(HRESULT_FROM_WIN32(lastError));
             }
 #else
-            (void) UndockedRegFreeWinRT_EnsureIsLoaded();
+            (void) WindowsAppRuntime_EnsureIsLoaded();
 #endif
         }
     };

--- a/dev/UndockedRegFreeWinRT/UndockedRegFreeWinRT-AutoInitializer.cs
+++ b/dev/UndockedRegFreeWinRT/UndockedRegFreeWinRT-AutoInitializer.cs
@@ -9,7 +9,7 @@ namespace Microsoft.Windows.Foundation.UndockedRegFreeWinRTCS
     internal static class NativeMethods
     {
         [DllImport("Microsoft.WindowsAppRuntime.dll", CharSet = CharSet.Unicode, ExactSpelling = true)]
-        internal static extern int UndockedRegFreeWinRT_EnsureIsLoaded();
+        internal static extern int WindowsAppRuntime_EnsureIsLoaded();
     }
 
     class AutoInitialize
@@ -21,7 +21,7 @@ namespace Microsoft.Windows.Foundation.UndockedRegFreeWinRTCS
             // It's the act of calling the function causing the DllImport to load the DLL that
             // matters. This provides the moral equivalent of a native DLL's Import Address
             // Table (IAT) have an entry that's resolved when this module is loaded.
-            NativeMethods.UndockedRegFreeWinRT_EnsureIsLoaded();
+            NativeMethods.WindowsAppRuntime_EnsureIsLoaded();
         }
     }
 }


### PR DESCRIPTION
URFW auto-initializers were incorrectly referencing `UndockedRegFreeWinRT_EnsureIsLoaded()` when it should have been `WindowsAppRuntime_EnsureIsLoaded()`. This was usually harmless to the C++ auto-init but fatal to C# :-(