### PR TITLE
Notification Mitigations for 1.1-stable

### DIFF
--- a/dev/AppNotifications/AppNotificationManager.cpp
+++ b/dev/AppNotifications/AppNotificationManager.cpp
@@ -125,7 +125,7 @@ namespace winrt::Microsoft::Windows::AppNotifications::implementation
                     storedComActivatorGuid = RegisterComActivatorGuidAndAssets();
                 }
 
-                if (!WindowsAppRuntime::SelfContained::IsSelfContained())
+                if (!WindowsAppRuntime::SelfContained::IsSelfContained() && !PushNotificationHelpers::IsElevated())
                 {
                     auto notificationPlatform{ PushNotificationHelpers::GetNotificationPlatform() };
                     THROW_IF_FAILED(notificationPlatform->AddToastRegistrationMapping(m_processName.c_str(), m_appId.c_str()));
@@ -225,7 +225,7 @@ namespace winrt::Microsoft::Windows::AppNotifications::implementation
                 });
 
             // Remove any Registrations from the Long Running Process that are necessary for Cloud toasts
-            if (!PushNotificationHelpers::IsPackagedAppScenario() && !WindowsAppRuntime::SelfContained::IsSelfContained())
+            if (!PushNotificationHelpers::IsPackagedAppScenario() && !WindowsAppRuntime::SelfContained::IsSelfContained() && !PushNotificationHelpers::IsElevated())
             {
                 auto notificationPlatform{ PushNotificationHelpers::GetNotificationPlatform() };
                 THROW_IF_FAILED(notificationPlatform->RemoveToastRegistrationMapping(m_processName.c_str()));

--- a/dev/AppNotifications/AppNotificationUtility.cpp
+++ b/dev/AppNotifications/AppNotificationUtility.cpp
@@ -109,6 +109,68 @@ std::wstring Microsoft::Windows::AppNotifications::Helpers::RetrieveNotification
     }
 }
 
+void Microsoft::Windows::AppNotifications::Helpers::RegisterForElevatedActivation(wil::unique_cotaskmem_string const& clsid)
+{
+    std::wstring clsidSubkey{ c_clsIdPath };
+    clsidSubkey.append(clsid.get());
+
+    wil::unique_hkey hKeyElevatedClsid;
+    // Create CLSID entry in HKLM
+    // Software\Classes\CLSID\{comActivatorGuidString}
+    THROW_IF_WIN32_ERROR(RegCreateKeyEx(
+        HKEY_LOCAL_MACHINE,
+        clsidSubkey.c_str(),
+        0,
+        nullptr /* lpClass */,
+        REG_OPTION_NON_VOLATILE,
+        KEY_ALL_ACCESS,
+        nullptr /* lpSecurityAttributes */,
+        &hKeyElevatedClsid,
+        nullptr /* lpdwDisposition */));
+
+    RegisterValue(hKeyElevatedClsid, L"AppId", reinterpret_cast<const BYTE*>(clsid.get()), REG_SZ, (wcslen(clsid.get()) * sizeof(wchar_t)));
+
+    // Create LocalServer32 entry for the elevated process in HKLM
+    // Software\Classes\CLSID\{comActivatorGuidString}\LocalServer32
+    clsidSubkey.append(LR"(\LocalServer32)");
+
+    wil::unique_hkey hKeyElevatedServer;
+    THROW_IF_WIN32_ERROR(RegCreateKeyEx(
+        HKEY_LOCAL_MACHINE,
+        clsidSubkey.c_str(),
+        0,
+        nullptr /* lpClass */,
+        REG_OPTION_NON_VOLATILE,
+        KEY_ALL_ACCESS,
+        nullptr /* lpSecurityAttributes */,
+        &hKeyElevatedServer,
+        nullptr /* lpdwDisposition */));
+
+    std::wstring comRegistrationExeString{ c_quote + GetCurrentProcessPath() + c_quote + c_notificationActivatedArgument };
+    RegisterValue(hKeyElevatedServer, nullptr, reinterpret_cast<const BYTE*>(comRegistrationExeString.c_str()), REG_SZ, (comRegistrationExeString.size() * sizeof(wchar_t)));
+
+    // Create an AppId entry for the elevated process
+    // Software\Classes\AppId\{comActivatorGuidString}
+    std::wstring appIdSubkey{ c_elevatedClientPath };
+    appIdSubkey.append(clsid.get());
+
+    wil::unique_hkey hKeyElevatedAppId;
+    THROW_IF_WIN32_ERROR(RegCreateKeyEx(
+        HKEY_LOCAL_MACHINE,
+        appIdSubkey.c_str(),
+        0,
+        nullptr /* lpClass */,
+        REG_OPTION_NON_VOLATILE,
+        KEY_ALL_ACCESS,
+        nullptr /* lpSecurityAttributes */,
+        &hKeyElevatedAppId,
+        nullptr /* lpdwDisposition */));
+
+    // This tells COM to match any client, so Action Center will activate our elevated process.
+    // More info: https://docs.microsoft.com/windows/win32/com/runas
+    RegisterValue(hKeyElevatedAppId, L"RunAs", reinterpret_cast<const BYTE*>(c_interactiveUser), REG_SZ, (wcslen(c_interactiveUser) * sizeof(wchar_t)));
+}
+
 void Microsoft::Windows::AppNotifications::Helpers::RegisterComServer(wil::unique_cotaskmem_string const& clsid)
 {
     wil::unique_hkey hKey;
@@ -131,6 +193,10 @@ void Microsoft::Windows::AppNotifications::Helpers::RegisterComServer(wil::uniqu
     std::wstring comRegistrationExeString{ c_quote + GetCurrentProcessPath() + c_quote + c_notificationActivatedArgument };
 
     RegisterValue(hKey, nullptr, reinterpret_cast<const BYTE*>(comRegistrationExeString.c_str()), REG_SZ, (comRegistrationExeString.size() * sizeof(wchar_t)));
+    if (PushNotificationHelpers::IsElevated())
+    {
+        RegisterForElevatedActivation(clsid);
+    }
 }
 
 void Microsoft::Windows::AppNotifications::Helpers::UnRegisterComServer(std::wstring const& clsid)
@@ -153,6 +219,30 @@ void Microsoft::Windows::AppNotifications::Helpers::UnRegisterComServer(std::wst
         clsidPath.c_str(),
         KEY_ALL_ACCESS,
         0));
+
+    if (PushNotificationHelpers::IsElevated())
+    {
+        THROW_IF_WIN32_ERROR(RegDeleteKeyEx(
+            HKEY_LOCAL_MACHINE,
+            subKey.c_str(),
+            KEY_ALL_ACCESS,
+            0));
+
+        THROW_IF_WIN32_ERROR(RegDeleteKeyEx(
+            HKEY_LOCAL_MACHINE,
+            clsidPath.c_str(),
+            KEY_ALL_ACCESS,
+            0));
+
+        //subKey: Software\Classes\AppId\{comActivatorGuidString}
+        std::wstring appIdsubKey{ c_elevatedClientPath + clsid };
+        // Need to delete AppId key
+        THROW_IF_WIN32_ERROR(RegDeleteKeyEx(
+            HKEY_LOCAL_MACHINE,
+            appIdsubKey.c_str(),
+            KEY_ALL_ACCESS,
+            0));
+    }
 }
 
 void Microsoft::Windows::AppNotifications::Helpers::UnRegisterNotificationAppIdentifierFromRegistry()

--- a/dev/AppNotifications/AppNotificationUtility.h
+++ b/dev/AppNotifications/AppNotificationUtility.h
@@ -13,8 +13,10 @@ namespace Microsoft::Windows::AppNotifications::Helpers
 {
     const PCWSTR c_appIdentifierPath{ LR"(Software\Classes\AppUserModelId\)" };
     const PCWSTR c_clsIdPath{ LR"(Software\Classes\CLSID\)" };
+    const PCWSTR c_elevatedClientPath{ LR"(Software\Classes\AppID\)" };
     const PCWSTR c_quote{ LR"(")" };
     const PCWSTR c_notificationActivatedArgument{ L" ----AppNotificationActivated:" };
+    const PCWSTR c_interactiveUser{ L"Interactive User" };
 
     inline const int GUID_LENGTH = 39; // GUID + '{' + '}' + '/0'
 
@@ -44,6 +46,8 @@ namespace Microsoft::Windows::AppNotifications::Helpers
     std::wstring RetrieveUnpackagedNotificationAppId();
 
     std::wstring RetrieveNotificationAppId();
+
+    void RegisterForElevatedActivation(wil::unique_cotaskmem_string const& clsid);
 
     void RegisterComServer(wil::unique_cotaskmem_string const& clsid);
 

--- a/dev/PushNotifications/PushNotificationManager.cpp
+++ b/dev/PushNotifications/PushNotificationManager.cpp
@@ -130,7 +130,7 @@ namespace winrt::Microsoft::Windows::PushNotifications::implementation
     bool PushNotificationManager::IsSupported()
     {
         // Only scenarios that use the Background Infrastructure component of the OS support Push in the SelfContained case
-        static bool isSupported{ !WindowsAppRuntime::SelfContained::IsSelfContained() || PushNotificationHelpers::IsPackagedAppScenario() };
+        static bool isSupported{ (!WindowsAppRuntime::SelfContained::IsSelfContained() || PushNotificationHelpers::IsPackagedAppScenario()) && !PushNotificationHelpers::IsElevated() };
         return isSupported;
 
     }

--- a/dev/PushNotifications/PushNotificationUtility.h
+++ b/dev/PushNotifications/PushNotificationUtility.h
@@ -143,6 +143,16 @@ namespace winrt::Microsoft::Windows::PushNotifications::Helpers
         return AppModel::Identity::IsPackagedProcess() && IsBackgroundTaskBuilderAvailable();
     }
 
+    inline bool IsElevated()
+    {
+        wil::unique_handle processToken;
+        THROW_IF_WIN32_BOOL_FALSE(OpenProcessToken(GetCurrentProcess(), MAXIMUM_ALLOWED, &processToken));
+
+        auto tokenLabel{ wil::get_token_information<TOKEN_MANDATORY_LABEL>(processToken.get()) };
+        DWORD subAuthority = static_cast<DWORD>(*GetSidSubAuthorityCount(tokenLabel->Label.Sid) - 1);
+        return *GetSidSubAuthority(tokenLabel->Label.Sid, subAuthority) >= SECURITY_MANDATORY_HIGH_RID;
+    }
+
     inline HRESULT GetPackageFullName(wil::unique_cotaskmem_string& packagedFullName) noexcept try
     {
         WCHAR packageFullName[PACKAGE_FULL_NAME_MAX_LENGTH + 1]{};

--- a/test/TestApps/ToastNotificationsDemoApp/main.cpp
+++ b/test/TestApps/ToastNotificationsDemoApp/main.cpp
@@ -208,9 +208,6 @@ int main()
         std::wcout << std::endl;
     }
 
-    std::wcout << L"Requesting PushNotificationChannel...\n\n";
-    winrt::PushNotificationChannel channel{ RequestChannel() };
-
     std::wcout << L"Post a Toast..." << std::endl;
     PostToastHelper(L"Tag", L"Group");
     std::wcout << L"Done.\n\n";
@@ -219,7 +216,7 @@ int main()
     std::cin.ignore();
 
     // Call Unregister so that COM can launch a new process for ToastInvokes after we terminate this process.
-    appNotificationManager.Unregister();
+    appNotificationManager.UnregisterAll();
     if (!isPackaged)
     {
         MddBootstrapShutdown();


### PR DESCRIPTION
Issue:
- In elevated scenarios, PushNotifications do not work for both unpackaged + packaged applications and the IsSupported API doesn't include this limitation.
- In elevated scenarios, AppNotification activations do not work for unpackaged applications.

Fix:
- Added IsElevated check to the PushNotification IsSupported API.
- Register COM server and AppID entries in HKLM in the registry

Verified:
Changes were tested by manually running scenarios of unpackaged/packaged + non-elevated/elevated and confirming correct behavior.
