### PR TITLE
Notification Mitigation - AppNotificationManager::IsSupported

### DIFF
--- a/dev/AppNotifications/AppNotificationManager.h
+++ b/dev/AppNotifications/AppNotificationManager.h
@@ -21,6 +21,7 @@ namespace winrt::Microsoft::Windows::AppNotifications::implementation
         void Register();
         void Unregister();
         void UnregisterAll();
+        static bool IsSupported();
         winrt::event_token NotificationInvoked(winrt::Windows::Foundation::TypedEventHandler<winrt::Microsoft::Windows::AppNotifications::AppNotificationManager, winrt::Microsoft::Windows::AppNotifications::AppNotificationActivatedEventArgs> const& handler);
         void NotificationInvoked(winrt::event_token const& token) noexcept;
         void Show(winrt::Microsoft::Windows::AppNotifications::AppNotification const& notification);

--- a/dev/AppNotifications/AppNotifications.idl
+++ b/dev/AppNotifications/AppNotifications.idl
@@ -52,6 +52,7 @@ namespace Microsoft.Windows.AppNotifications
         DisabledForUser, // Notification is blocked by a user defined Global Setting
         DisabledByGroupPolicy, // Notification is blocked by Group Policy
         DisabledByManifest, // Notification is blocked by a setting in the manifest. Only for packaged applications.
+        Unsupported, // The current operation was called when AppNotifications are not supported
     };
 
     // The Result for a Notification Progress related operation
@@ -60,6 +61,7 @@ namespace Microsoft.Windows.AppNotifications
     {
         Succeeded, // The progress operation succeeded
         AppNotificationNotFound, // The progress operation failed to find a Notification to process updates
+        Unsupported, // The current operation was called when AppNotifications are not supported
     };
 
     // The Priority of the Notification UI associated with it's popup in the Action Centre
@@ -109,6 +111,10 @@ namespace Microsoft.Windows.AppNotifications
     [contract(AppNotificationsContract, 1)]
     runtimeclass AppNotificationManager
     {
+        // Checks to see if the APIs are supported for the Desktop app
+        // Certain scenarios are unsupported by AppNotifications
+        static Boolean IsSupported();
+
         // Gets a Default instance of a AppNotificationManager
         static AppNotificationManager Default{ get; };
 

--- a/dev/PushNotifications/PushNotificationManager.cpp
+++ b/dev/PushNotifications/PushNotificationManager.cpp
@@ -130,7 +130,7 @@ namespace winrt::Microsoft::Windows::PushNotifications::implementation
     bool PushNotificationManager::IsSupported()
     {
         // Only scenarios that use the Background Infrastructure component of the OS support Push in the SelfContained case
-        static bool isSupported{ !WindowsAppRuntime::SelfContained::IsSelfContained() || PushNotificationHelpers::IsPackagedAppScenario() };
+        static bool isSupported{ (!WindowsAppRuntime::SelfContained::IsSelfContained() || PushNotificationHelpers::IsPackagedAppScenario()) && !PushNotificationHelpers::IsElevated() };
         return isSupported;
 
     }

--- a/dev/PushNotifications/PushNotificationManager.cpp
+++ b/dev/PushNotifications/PushNotificationManager.cpp
@@ -129,7 +129,8 @@ namespace winrt::Microsoft::Windows::PushNotifications::implementation
 
     bool PushNotificationManager::IsSupported()
     {
-        // Only scenarios that use the Background Infrastructure component of the OS support Push in the SelfContained case
+        // PackagedAppScenario always works. UnpackagedAppScenario does not when it is self contained
+        // or is elevated because the process cannot use the PushNotificationsLongRunningProcess.
         static bool isSupported{ PushNotificationHelpers::IsPackagedAppScenario() || !(WindowsAppRuntime::SelfContained::IsSelfContained() || PushNotificationHelpers::IsElevated()) };
         return isSupported;
 

--- a/dev/PushNotifications/PushNotificationManager.cpp
+++ b/dev/PushNotifications/PushNotificationManager.cpp
@@ -130,7 +130,7 @@ namespace winrt::Microsoft::Windows::PushNotifications::implementation
     bool PushNotificationManager::IsSupported()
     {
         // Only scenarios that use the Background Infrastructure component of the OS support Push in the SelfContained case
-        static bool isSupported{ (!WindowsAppRuntime::SelfContained::IsSelfContained() || PushNotificationHelpers::IsPackagedAppScenario()) && !PushNotificationHelpers::IsElevated() };
+        static bool isSupported{ PushNotificationHelpers::IsPackagedAppScenario() || !(WindowsAppRuntime::SelfContained::IsSelfContained() || PushNotificationHelpers::IsElevated()) };
         return isSupported;
 
     }

--- a/dev/PushNotifications/PushNotificationUtility.h
+++ b/dev/PushNotifications/PushNotificationUtility.h
@@ -150,7 +150,9 @@ namespace winrt::Microsoft::Windows::PushNotifications::Helpers
 
         auto tokenLabel{ wil::get_token_information<TOKEN_MANDATORY_LABEL>(processToken.get()) };
         DWORD subAuthority = static_cast<DWORD>(*GetSidSubAuthorityCount(tokenLabel->Label.Sid) - 1);
-        return *GetSidSubAuthority(tokenLabel->Label.Sid, subAuthority) >= SECURITY_MANDATORY_HIGH_RID;
+
+        // HIGH_RID means the process is elevated
+        return *GetSidSubAuthority(tokenLabel->Label.Sid, subAuthority) == SECURITY_MANDATORY_HIGH_RID;
     }
 
     inline HRESULT GetPackageFullName(wil::unique_cotaskmem_string& packagedFullName) noexcept try

--- a/dev/PushNotifications/PushNotificationUtility.h
+++ b/dev/PushNotifications/PushNotificationUtility.h
@@ -143,6 +143,16 @@ namespace winrt::Microsoft::Windows::PushNotifications::Helpers
         return AppModel::Identity::IsPackagedProcess() && IsBackgroundTaskBuilderAvailable();
     }
 
+    inline bool IsElevated()
+    {
+        wil::unique_handle processToken;
+        THROW_IF_WIN32_BOOL_FALSE(OpenProcessToken(GetCurrentProcess(), MAXIMUM_ALLOWED, &processToken));
+
+        auto tokenLabel{ wil::get_token_information<TOKEN_MANDATORY_LABEL>(processToken.get()) };
+        DWORD subAuthority = static_cast<DWORD>(*GetSidSubAuthorityCount(tokenLabel->Label.Sid) - 1);
+        return *GetSidSubAuthority(tokenLabel->Label.Sid, subAuthority) >= SECURITY_MANDATORY_HIGH_RID;
+    }
+
     inline HRESULT GetPackageFullName(wil::unique_cotaskmem_string& packagedFullName) noexcept try
     {
         WCHAR packageFullName[PACKAGE_FULL_NAME_MAX_LENGTH + 1]{};

--- a/test/TestApps/ToastNotificationsDemoApp/main.cpp
+++ b/test/TestApps/ToastNotificationsDemoApp/main.cpp
@@ -98,7 +98,8 @@ std::wstring GetEnumString(winrt::AppNotificationSetting const& setting)
         { winrt::AppNotificationSetting::DisabledForApplication, L"DisabledForApplication" },
         { winrt::AppNotificationSetting::DisabledForUser, L"DisabledForUser"},
         { winrt::AppNotificationSetting::DisabledByGroupPolicy, L"DisabledByGroupPolicy"},
-        { winrt::AppNotificationSetting::DisabledByManifest, L"DisabledByManifest"}
+        { winrt::AppNotificationSetting::DisabledByManifest, L"DisabledByManifest"},
+        { winrt::AppNotificationSetting::Unsupported, L"Unsupported"}
     };
     return enumMapping[setting];
 }
@@ -207,9 +208,6 @@ int main()
         }
         std::wcout << std::endl;
     }
-
-    std::wcout << L"Requesting PushNotificationChannel...\n\n";
-    winrt::PushNotificationChannel channel{ RequestChannel() };
 
     std::wcout << L"Post a Toast..." << std::endl;
     PostToastHelper(L"Tag", L"Group");


### PR DESCRIPTION
Issue:
In elevated scenarios, PushNotifications do not work for both unpackaged + packaged applications and the IsSupported API doesn't include this limitation. Also for AppNotifications, there is no IsSupported API. Elevated scenarios are currently not supported for AppNotifications so we are added an IsElevated check to this newly added IsSupported API.

Fix:
Added IsElevated check to the PushNotification/AppNotification IsSupported API.

Verified:
Changes were tested by manually running scenarios of unpackaged/packaged + non-elevated/elevated and confirming correct behavior of AppNotification APIs.