### PR TITLE
Notification Mitigation - AppNotificationManager::IsSupported

### DIFF
--- a/dev/AppNotifications/AppNotificationManager.cpp
+++ b/dev/AppNotifications/AppNotificationManager.cpp
@@ -95,7 +95,7 @@ namespace winrt::Microsoft::Windows::AppNotifications::implementation
 
     bool AppNotificationManager::IsSupported()
     {
-        static bool isSupported{ !PushNotificationHelpers::IsElevated() };
+        static bool isSupported{ !Security::IntegrityLevel::IsElevated() };
         return isSupported;
     }
 
@@ -447,11 +447,6 @@ namespace winrt::Microsoft::Windows::AppNotifications::implementation
 
     winrt::Windows::Foundation::IAsyncOperation<winrt::Microsoft::Windows::AppNotifications::AppNotificationProgressResult> AppNotificationManager::UpdateAsync(winrt::Microsoft::Windows::AppNotifications::AppNotificationProgressData const data, hstring const tag)
     {
-        if (!IsSupported())
-        {
-            co_return winrt::AppNotificationProgressResult::Unsupported;
-        }
-
         co_return co_await UpdateAsync(data, tag, L"");
     }
 
@@ -629,7 +624,7 @@ namespace winrt::Microsoft::Windows::AppNotifications::implementation
     {
         if (!IsSupported())
         {
-            co_return nullptr;
+            co_return {};
         }
 
         HRESULT hr{ S_OK };

--- a/dev/AppNotifications/AppNotificationManager.cpp
+++ b/dev/AppNotifications/AppNotificationManager.cpp
@@ -93,8 +93,19 @@ namespace winrt::Microsoft::Windows::AppNotifications::implementation
         return m_activatedEventArgs;
     }
 
+    bool AppNotificationManager::IsSupported()
+    {
+        static bool isSupported{ !PushNotificationHelpers::IsElevated() };
+        return isSupported;
+    }
+
     void AppNotificationManager::Register()
     {
+        if (!IsSupported())
+        {
+            return;
+        }
+
         HRESULT hr{ S_OK };
 
         auto logTelemetry{ wil::scope_exit([&]() {
@@ -175,6 +186,11 @@ namespace winrt::Microsoft::Windows::AppNotifications::implementation
 
     void AppNotificationManager::Unregister()
     {
+        if (!IsSupported())
+        {
+            return;
+        }
+
         HRESULT hr{ S_OK };
 
         auto logTelemetry{ wil::scope_exit([&]() {
@@ -203,6 +219,11 @@ namespace winrt::Microsoft::Windows::AppNotifications::implementation
 
     void AppNotificationManager::UnregisterAll()
     {
+        if (!IsSupported())
+        {
+            return;
+        }
+
         HRESULT hr{ S_OK };
 
         auto logTelemetry{ wil::scope_exit([&]() {
@@ -256,6 +277,11 @@ namespace winrt::Microsoft::Windows::AppNotifications::implementation
 
     winrt::event_token AppNotificationManager::NotificationInvoked(winrt::Windows::Foundation::TypedEventHandler<winrt::Microsoft::Windows::AppNotifications::AppNotificationManager, winrt::Microsoft::Windows::AppNotifications::AppNotificationActivatedEventArgs> const& handler)
     {
+        if (!IsSupported())
+        {
+            return winrt::event_token{};
+        }
+
         auto lock{ m_lock.lock_exclusive() };
         THROW_HR_IF_MSG(HRESULT_FROM_WIN32(ERROR_NOT_FOUND), m_notificationComActivatorRegistration, "Must register event handlers before calling Register()");
         return m_notificationHandlers.add(handler);
@@ -263,6 +289,11 @@ namespace winrt::Microsoft::Windows::AppNotifications::implementation
 
     void AppNotificationManager::NotificationInvoked(winrt::event_token const& token) noexcept
     {
+        if (!IsSupported())
+        {
+            return;
+        }
+
         auto lock{ m_lock.lock_exclusive() };
         m_notificationHandlers.remove(token);
     }
@@ -335,6 +366,11 @@ namespace winrt::Microsoft::Windows::AppNotifications::implementation
 
     void AppNotificationManager::Show(winrt::Microsoft::Windows::AppNotifications::AppNotification const& notification)
     {
+        if (!IsSupported())
+        {
+            return;
+        }
+
         THROW_HR_IF(WPN_E_NOTIFICATION_POSTED, notification.Id() != 0);
 
         HRESULT hr{ S_OK };
@@ -366,6 +402,11 @@ namespace winrt::Microsoft::Windows::AppNotifications::implementation
 
     winrt::Windows::Foundation::IAsyncOperation<winrt::Microsoft::Windows::AppNotifications::AppNotificationProgressResult> AppNotificationManager::UpdateAsync(winrt::Microsoft::Windows::AppNotifications::AppNotificationProgressData const data, hstring const tag, hstring const group)
     {
+        if (!IsSupported())
+        {
+            co_return winrt::AppNotificationProgressResult::Unsupported;
+        }
+
         THROW_HR_IF_MSG(E_INVALIDARG, tag == winrt::hstring(L""), "Update operation isn't guaranteed to find a specific notification to replace correctly.");
         THROW_HR_IF_MSG(E_INVALIDARG, data.SequenceNumber() == 0, "Sequence Number for Updates should be greater than 0!");
 
@@ -406,11 +447,21 @@ namespace winrt::Microsoft::Windows::AppNotifications::implementation
 
     winrt::Windows::Foundation::IAsyncOperation<winrt::Microsoft::Windows::AppNotifications::AppNotificationProgressResult> AppNotificationManager::UpdateAsync(winrt::Microsoft::Windows::AppNotifications::AppNotificationProgressData const data, hstring const tag)
     {
+        if (!IsSupported())
+        {
+            co_return winrt::AppNotificationProgressResult::Unsupported;
+        }
+
         co_return co_await UpdateAsync(data, tag, L"");
     }
 
     winrt::Microsoft::Windows::AppNotifications::AppNotificationSetting AppNotificationManager::Setting()
     {
+        if (!IsSupported())
+        {
+            return AppNotificationSetting::Unsupported;
+        }
+
         HRESULT hr{ S_OK };
 
         auto logTelemetry{ wil::scope_exit([&]() {
@@ -432,6 +483,11 @@ namespace winrt::Microsoft::Windows::AppNotifications::implementation
 
     winrt::Windows::Foundation::IAsyncAction AppNotificationManager::RemoveByIdAsync(uint32_t notificationId)
     {
+        if (!IsSupported())
+        {
+            return;
+        }
+
         THROW_HR_IF(E_INVALIDARG, notificationId == 0);
 
         HRESULT hr{ S_OK };
@@ -456,6 +512,11 @@ namespace winrt::Microsoft::Windows::AppNotifications::implementation
 
     winrt::Windows::Foundation::IAsyncAction AppNotificationManager::RemoveByTagAsync(hstring const tag)
     {
+        if (!IsSupported())
+        {
+            return;
+        }
+
         THROW_HR_IF(E_INVALIDARG, tag == winrt::hstring(L""));
 
         HRESULT hr{ S_OK };
@@ -480,6 +541,11 @@ namespace winrt::Microsoft::Windows::AppNotifications::implementation
 
     winrt::Windows::Foundation::IAsyncAction AppNotificationManager::RemoveByTagAndGroupAsync(hstring const tag, hstring const group)
     {
+        if (!IsSupported())
+        {
+            return;
+        }
+
         THROW_HR_IF(E_INVALIDARG, tag == winrt::hstring(L""));
         THROW_HR_IF(E_INVALIDARG, group == winrt::hstring(L""));
 
@@ -505,6 +571,11 @@ namespace winrt::Microsoft::Windows::AppNotifications::implementation
 
     winrt::Windows::Foundation::IAsyncAction AppNotificationManager::RemoveByGroupAsync(hstring const group)
     {
+        if (!IsSupported())
+        {
+            return;
+        }
+
         THROW_HR_IF(E_INVALIDARG, group == winrt::hstring(L""));
 
         HRESULT hr{ S_OK };
@@ -529,6 +600,11 @@ namespace winrt::Microsoft::Windows::AppNotifications::implementation
 
     winrt::Windows::Foundation::IAsyncAction AppNotificationManager::RemoveAllAsync()
     {
+        if (!IsSupported())
+        {
+            return;
+        }
+
         HRESULT hr{ S_OK };
 
         auto strong = get_strong();
@@ -551,6 +627,11 @@ namespace winrt::Microsoft::Windows::AppNotifications::implementation
 
     winrt::Windows::Foundation::IAsyncOperation<winrt::Windows::Foundation::Collections::IVector<winrt::Microsoft::Windows::AppNotifications::AppNotification>> AppNotificationManager::GetAllAsync()
     {
+        if (!IsSupported())
+        {
+            co_return nullptr;
+        }
+
         HRESULT hr{ S_OK };
 
         auto strong = get_strong();

--- a/dev/AppNotifications/AppNotificationManager.h
+++ b/dev/AppNotifications/AppNotificationManager.h
@@ -21,6 +21,7 @@ namespace winrt::Microsoft::Windows::AppNotifications::implementation
         void Register();
         void Unregister();
         void UnregisterAll();
+        static bool IsSupported();
         winrt::event_token NotificationInvoked(winrt::Windows::Foundation::TypedEventHandler<winrt::Microsoft::Windows::AppNotifications::AppNotificationManager, winrt::Microsoft::Windows::AppNotifications::AppNotificationActivatedEventArgs> const& handler);
         void NotificationInvoked(winrt::event_token const& token) noexcept;
         void Show(winrt::Microsoft::Windows::AppNotifications::AppNotification const& notification);

--- a/dev/AppNotifications/AppNotifications.idl
+++ b/dev/AppNotifications/AppNotifications.idl
@@ -52,6 +52,7 @@ namespace Microsoft.Windows.AppNotifications
         DisabledForUser, // Notification is blocked by a user defined Global Setting
         DisabledByGroupPolicy, // Notification is blocked by Group Policy
         DisabledByManifest, // Notification is blocked by a setting in the manifest. Only for packaged applications.
+        Unsupported, // The current operation was called when AppNotifications are not supported
     };
 
     // The Result for a Notification Progress related operation
@@ -60,6 +61,7 @@ namespace Microsoft.Windows.AppNotifications
     {
         Succeeded, // The progress operation succeeded
         AppNotificationNotFound, // The progress operation failed to find a Notification to process updates
+        Unsupported, // The current operation was called when AppNotifications are not supported
     };
 
     // The Priority of the Notification UI associated with it's popup in the Action Centre
@@ -109,6 +111,10 @@ namespace Microsoft.Windows.AppNotifications
     [contract(AppNotificationsContract, 1)]
     runtimeclass AppNotificationManager
     {
+        // Checks to see if the APIs are supported for the Desktop app
+        // Certain scenarios are unsupported by AppNotifications
+        static Boolean IsSupported();
+
         // Gets a Default instance of a AppNotificationManager
         static AppNotificationManager Default{ get; };
 

--- a/dev/PushNotifications/PushNotificationManager.cpp
+++ b/dev/PushNotifications/PushNotificationManager.cpp
@@ -21,6 +21,7 @@
 #include "PushNotificationUtility.h"
 #include "AppNotificationUtility.h"
 #include "PushNotificationReceivedEventArgs.h"
+#include <security.integritylevel.h>
 
 using namespace std::literals;
 using namespace Microsoft::Windows::AppNotifications::Helpers;
@@ -131,7 +132,7 @@ namespace winrt::Microsoft::Windows::PushNotifications::implementation
     {
         // Elevated processes are not supported by PushNotifications. UnpackagedAppScenario is not supported when it is self contained
         // because the PushNotificationsLongRunningProcess is unavailable due to missing the Singleton package.
-        static bool isSupported{ !PushNotificationHelpers::IsElevated() && (PushNotificationHelpers::IsPackagedAppScenario() || !WindowsAppRuntime::SelfContained::IsSelfContained()) };
+        static bool isSupported{ !Security::IntegrityLevel::IsElevated() && (PushNotificationHelpers::IsPackagedAppScenario() || !WindowsAppRuntime::SelfContained::IsSelfContained()) };
         return isSupported;
 
     }

--- a/dev/PushNotifications/PushNotificationManager.cpp
+++ b/dev/PushNotifications/PushNotificationManager.cpp
@@ -129,8 +129,9 @@ namespace winrt::Microsoft::Windows::PushNotifications::implementation
 
     bool PushNotificationManager::IsSupported()
     {
-        // Only scenarios that use the Background Infrastructure component of the OS support Push in the SelfContained case
-        static bool isSupported{ !WindowsAppRuntime::SelfContained::IsSelfContained() || PushNotificationHelpers::IsPackagedAppScenario() };
+        // PackagedAppScenario always works. UnpackagedAppScenario does not when it is self contained
+        // or is elevated because the process cannot use the PushNotificationsLongRunningProcess.
+        static bool isSupported{ PushNotificationHelpers::IsPackagedAppScenario() || !(WindowsAppRuntime::SelfContained::IsSelfContained() || PushNotificationHelpers::IsElevated()) };
         return isSupported;
 
     }

--- a/dev/PushNotifications/PushNotificationManager.cpp
+++ b/dev/PushNotifications/PushNotificationManager.cpp
@@ -129,9 +129,9 @@ namespace winrt::Microsoft::Windows::PushNotifications::implementation
 
     bool PushNotificationManager::IsSupported()
     {
-        // PackagedAppScenario always works. UnpackagedAppScenario does not when it is self contained
-        // or is elevated because the process cannot use the PushNotificationsLongRunningProcess.
-        static bool isSupported{ PushNotificationHelpers::IsPackagedAppScenario() || !(WindowsAppRuntime::SelfContained::IsSelfContained() || PushNotificationHelpers::IsElevated()) };
+        // Elevated processes are not supported by PushNotifications. UnpackagedAppScenario is not supported when it is self contained
+        // because the PushNotificationsLongRunningProcess is unavailable due to missing the Singleton package.
+        static bool isSupported{ !PushNotificationHelpers::IsElevated() && (PushNotificationHelpers::IsPackagedAppScenario() || !WindowsAppRuntime::SelfContained::IsSelfContained()) };
         return isSupported;
 
     }

--- a/dev/PushNotifications/PushNotificationUtility.h
+++ b/dev/PushNotifications/PushNotificationUtility.h
@@ -143,11 +143,8 @@ namespace winrt::Microsoft::Windows::PushNotifications::Helpers
         wil::unique_handle processToken;
         THROW_IF_WIN32_BOOL_FALSE(OpenProcessToken(GetCurrentProcess(), MAXIMUM_ALLOWED, &processToken));
 
-        auto tokenLabel{ wil::get_token_information<TOKEN_MANDATORY_LABEL>(processToken.get()) };
-        DWORD subAuthority = static_cast<DWORD>(*GetSidSubAuthorityCount(tokenLabel->Label.Sid) - 1);
-
-        // HIGH_RID means the process is elevated
-        return *GetSidSubAuthority(tokenLabel->Label.Sid, subAuthority) == SECURITY_MANDATORY_HIGH_RID;
+        auto elevationToken{ wil::get_token_information<TOKEN_ELEVATION>(processToken.get()) };
+        return elevationToken.TokenIsElevated;
     }
 
     inline bool IsPackagedAppScenario()

--- a/dev/PushNotifications/PushNotificationUtility.h
+++ b/dev/PushNotifications/PushNotificationUtility.h
@@ -138,6 +138,18 @@ namespace winrt::Microsoft::Windows::PushNotifications::Helpers
         return hasSetTaskEntrypoint;
     }
 
+    inline bool IsElevated()
+    {
+        wil::unique_handle processToken;
+        THROW_IF_WIN32_BOOL_FALSE(OpenProcessToken(GetCurrentProcess(), MAXIMUM_ALLOWED, &processToken));
+
+        auto tokenLabel{ wil::get_token_information<TOKEN_MANDATORY_LABEL>(processToken.get()) };
+        DWORD subAuthority = static_cast<DWORD>(*GetSidSubAuthorityCount(tokenLabel->Label.Sid) - 1);
+
+        // HIGH_RID means the process is elevated
+        return *GetSidSubAuthority(tokenLabel->Label.Sid, subAuthority) == SECURITY_MANDATORY_HIGH_RID;
+    }
+
     inline bool IsPackagedAppScenario()
     {
         return AppModel::Identity::IsPackagedProcess() && IsBackgroundTaskBuilderAvailable();

--- a/dev/PushNotifications/PushNotificationUtility.h
+++ b/dev/PushNotifications/PushNotificationUtility.h
@@ -138,15 +138,6 @@ namespace winrt::Microsoft::Windows::PushNotifications::Helpers
         return hasSetTaskEntrypoint;
     }
 
-    inline bool IsElevated()
-    {
-        wil::unique_handle processToken;
-        THROW_IF_WIN32_BOOL_FALSE(OpenProcessToken(GetCurrentProcess(), MAXIMUM_ALLOWED, &processToken));
-
-        auto elevationToken{ wil::get_token_information<TOKEN_ELEVATION>(processToken.get()) };
-        return elevationToken.TokenIsElevated;
-    }
-
     inline bool IsPackagedAppScenario()
     {
         return AppModel::Identity::IsPackagedProcess() && IsBackgroundTaskBuilderAvailable();

--- a/test/TestApps/ToastNotificationsDemoApp/main.cpp
+++ b/test/TestApps/ToastNotificationsDemoApp/main.cpp
@@ -209,6 +209,9 @@ int main()
         std::wcout << std::endl;
     }
 
+    std::wcout << L"Requesting PushNotificationChannel...\n\n";
+    winrt::PushNotificationChannel channel{ RequestChannel() };
+
     std::wcout << L"Post a Toast..." << std::endl;
     PostToastHelper(L"Tag", L"Group");
     std::wcout << L"Done.\n\n";

--- a/test/TestApps/ToastNotificationsDemoApp/main.cpp
+++ b/test/TestApps/ToastNotificationsDemoApp/main.cpp
@@ -98,7 +98,8 @@ std::wstring GetEnumString(winrt::AppNotificationSetting const& setting)
         { winrt::AppNotificationSetting::DisabledForApplication, L"DisabledForApplication" },
         { winrt::AppNotificationSetting::DisabledForUser, L"DisabledForUser"},
         { winrt::AppNotificationSetting::DisabledByGroupPolicy, L"DisabledByGroupPolicy"},
-        { winrt::AppNotificationSetting::DisabledByManifest, L"DisabledByManifest"}
+        { winrt::AppNotificationSetting::DisabledByManifest, L"DisabledByManifest"},
+        { winrt::AppNotificationSetting::Unsupported, L"Unsupported"}
     };
     return enumMapping[setting];
 }
@@ -207,9 +208,6 @@ int main()
         }
         std::wcout << std::endl;
     }
-
-    std::wcout << L"Requesting PushNotificationChannel...\n\n";
-    winrt::PushNotificationChannel channel{ RequestChannel() };
 
     std::wcout << L"Post a Toast..." << std::endl;
     PostToastHelper(L"Tag", L"Group");


### PR DESCRIPTION
Branch was based on stable 1.1 branch which led to unnecessary files being merged to main. Previous PR was closed here: https://github.com/microsoft/WindowsAppSDK/pull/2505

Issue:
In elevated scenarios, PushNotifications do not work for both unpackaged + packaged applications and the IsSupported API doesn't include this limitation. Also for AppNotifications, there is no IsSupported API. Elevated scenarios are currently not supported for AppNotifications so we are added an IsElevated check to this newly added IsSupported API.

Fix:
Added IsElevated check to the Push/AppNotification IsSupported API.

Verified:
Changes were tested by manually running scenarios of unpackaged/packaged + non-elevated/elevated and confirming correct behavior of Push/AppNotification APIs.