### PR TITLE
Remove superfluous "Windows App SDK" platform tag

### DIFF
--- a/dev/VSIX/ProjectTemplates/Desktop/CSharp/ClassLibrary/WinUI.Desktop.Cs.ClassLibrary.vstemplate
+++ b/dev/VSIX/ProjectTemplates/Desktop/CSharp/ClassLibrary/WinUI.Desktop.Cs.ClassLibrary.vstemplate
@@ -21,7 +21,6 @@
     <LanguageTag>csharp</LanguageTag>
     <LanguageTag>XAML</LanguageTag>
     <PlatformTag>windows</PlatformTag>
-    <PlatformTag>Windows App SDK</PlatformTag>
     <ProjectTypeTag>desktop</ProjectTypeTag>
     <ProjectTypeTag>WinUI</ProjectTypeTag>
   </TemplateData>

--- a/dev/VSIX/ProjectTemplates/Desktop/CSharp/PackagedApp/BlankApp/WinUI.Desktop.Cs.BlankApp.vstemplate
+++ b/dev/VSIX/ProjectTemplates/Desktop/CSharp/PackagedApp/BlankApp/WinUI.Desktop.Cs.BlankApp.vstemplate
@@ -22,7 +22,6 @@
     <LanguageTag>csharp</LanguageTag>
     <LanguageTag>XAML</LanguageTag>
     <PlatformTag>windows</PlatformTag>
-    <PlatformTag>Windows App SDK</PlatformTag>
     <ProjectTypeTag>desktop</ProjectTypeTag>
     <ProjectTypeTag>WinUI</ProjectTypeTag>
   </TemplateData>

--- a/dev/VSIX/ProjectTemplates/Desktop/CSharp/PackagedApp/WapProj/WinUI.Desktop.Cs.WapProj.vstemplate
+++ b/dev/VSIX/ProjectTemplates/Desktop/CSharp/PackagedApp/WapProj/WinUI.Desktop.Cs.WapProj.vstemplate
@@ -20,7 +20,6 @@
     <LanguageTag>csharp</LanguageTag>
     <LanguageTag>XAML</LanguageTag>
     <PlatformTag>windows</PlatformTag>
-    <PlatformTag>Windows App SDK</PlatformTag>
     <ProjectTypeTag>desktop</ProjectTypeTag>
     <ProjectTypeTag>WinUI</ProjectTypeTag>
   </TemplateData>

--- a/dev/VSIX/ProjectTemplates/Desktop/CSharp/PackagedApp/WinUI.Desktop.Cs.PackagedApp.vstemplate
+++ b/dev/VSIX/ProjectTemplates/Desktop/CSharp/PackagedApp/WinUI.Desktop.Cs.PackagedApp.vstemplate
@@ -21,7 +21,6 @@
     <LanguageTag>csharp</LanguageTag>
     <LanguageTag>XAML</LanguageTag>
     <PlatformTag>windows</PlatformTag>
-    <PlatformTag>Windows App SDK</PlatformTag>
     <ProjectTypeTag>desktop</ProjectTypeTag>
     <ProjectTypeTag>WinUI</ProjectTypeTag>
   </TemplateData>

--- a/dev/VSIX/ProjectTemplates/Desktop/CSharp/SingleProjectPackagedApp/WinUI.Desktop.Cs.SingleProjectPackagedApp.vstemplate
+++ b/dev/VSIX/ProjectTemplates/Desktop/CSharp/SingleProjectPackagedApp/WinUI.Desktop.Cs.SingleProjectPackagedApp.vstemplate
@@ -21,7 +21,6 @@
     <LanguageTag>csharp</LanguageTag>
     <LanguageTag>XAML</LanguageTag>
     <PlatformTag>windows</PlatformTag>
-    <PlatformTag>Windows App SDK</PlatformTag>
     <ProjectTypeTag>desktop</ProjectTypeTag>
     <ProjectTypeTag>WinUI</ProjectTypeTag>
   </TemplateData>

--- a/dev/VSIX/ProjectTemplates/Desktop/CppWinRT/PackagedApp/BlankApp/WinUI.Desktop.CppWinRT.BlankApp.vstemplate
+++ b/dev/VSIX/ProjectTemplates/Desktop/CppWinRT/PackagedApp/BlankApp/WinUI.Desktop.CppWinRT.BlankApp.vstemplate
@@ -21,7 +21,6 @@
     <LanguageTag>cpp</LanguageTag>
     <LanguageTag>XAML</LanguageTag>
     <PlatformTag>windows</PlatformTag>
-    <PlatformTag>Windows App SDK</PlatformTag>
     <ProjectTypeTag>desktop</ProjectTypeTag>
     <ProjectTypeTag>WinUI</ProjectTypeTag>
   </TemplateData>

--- a/dev/VSIX/ProjectTemplates/Desktop/CppWinRT/PackagedApp/WapProj/WinUI.Desktop.CppWinRT.WapProj.vstemplate
+++ b/dev/VSIX/ProjectTemplates/Desktop/CppWinRT/PackagedApp/WapProj/WinUI.Desktop.CppWinRT.WapProj.vstemplate
@@ -20,7 +20,6 @@
     <LanguageTag>cpp</LanguageTag>
     <LanguageTag>XAML</LanguageTag>
     <PlatformTag>windows</PlatformTag>
-    <PlatformTag>Windows App SDK</PlatformTag>
     <ProjectTypeTag>desktop</ProjectTypeTag>
     <ProjectTypeTag>WinUI</ProjectTypeTag>
   </TemplateData>

--- a/dev/VSIX/ProjectTemplates/Desktop/CppWinRT/PackagedApp/WinUI.Desktop.CppWinRT.PackagedApp.vstemplate
+++ b/dev/VSIX/ProjectTemplates/Desktop/CppWinRT/PackagedApp/WinUI.Desktop.CppWinRT.PackagedApp.vstemplate
@@ -20,7 +20,6 @@
     <LanguageTag>cpp</LanguageTag>
     <LanguageTag>XAML</LanguageTag>
     <PlatformTag>windows</PlatformTag>
-    <PlatformTag>Windows App SDK</PlatformTag>
     <ProjectTypeTag>desktop</ProjectTypeTag>
     <ProjectTypeTag>WinUI</ProjectTypeTag>
   </TemplateData>

--- a/dev/VSIX/ProjectTemplates/Desktop/CppWinRT/SingleProjectPackagedApp/WinUI.Desktop.CppWinRT.SingleProjectPackagedApp.vstemplate
+++ b/dev/VSIX/ProjectTemplates/Desktop/CppWinRT/SingleProjectPackagedApp/WinUI.Desktop.CppWinRT.SingleProjectPackagedApp.vstemplate
@@ -20,7 +20,6 @@
     <LanguageTag>cpp</LanguageTag>
     <LanguageTag>XAML</LanguageTag>
     <PlatformTag>windows</PlatformTag>
-    <PlatformTag>Windows App SDK</PlatformTag>
     <ProjectTypeTag>desktop</ProjectTypeTag>
     <ProjectTypeTag>WinUI</ProjectTypeTag>
   </TemplateData>

--- a/dev/VSIX/ProjectTemplates/Neutral/CppWinRT/RuntimeComponent/WinUI.Neutral.CppWinRT.RuntimeComponent.vstemplate
+++ b/dev/VSIX/ProjectTemplates/Neutral/CppWinRT/RuntimeComponent/WinUI.Neutral.CppWinRT.RuntimeComponent.vstemplate
@@ -20,7 +20,6 @@
     <LanguageTag>cpp</LanguageTag>
     <LanguageTag>XAML</LanguageTag>
     <PlatformTag>windows</PlatformTag>
-    <PlatformTag>Windows App SDK</PlatformTag>
     <ProjectTypeTag>desktop</ProjectTypeTag>
     <ProjectTypeTag>uwp</ProjectTypeTag>
     <ProjectTypeTag>WinUI</ProjectTypeTag>

--- a/dev/VSIX/ProjectTemplates/UWP/CSharp/BlankApp/WinUI.UWP.Cs.BlankApp.vstemplate
+++ b/dev/VSIX/ProjectTemplates/UWP/CSharp/BlankApp/WinUI.UWP.Cs.BlankApp.vstemplate
@@ -21,7 +21,6 @@
     <LanguageTag>csharp</LanguageTag>
     <LanguageTag>XAML</LanguageTag>
     <PlatformTag>windows</PlatformTag>
-    <PlatformTag>Windows App SDK</PlatformTag>
     <ProjectTypeTag>uwp</ProjectTypeTag>
     <ProjectTypeTag>WinUI</ProjectTypeTag>
   </TemplateData>

--- a/dev/VSIX/ProjectTemplates/UWP/CSharp/ClassLibrary/WinUI.UWP.Cs.ClassLibrary.vstemplate
+++ b/dev/VSIX/ProjectTemplates/UWP/CSharp/ClassLibrary/WinUI.UWP.Cs.ClassLibrary.vstemplate
@@ -21,7 +21,6 @@
     <LanguageTag>csharp</LanguageTag>
     <LanguageTag>XAML</LanguageTag>
     <PlatformTag>windows</PlatformTag>
-    <PlatformTag>Windows App SDK</PlatformTag>
     <ProjectTypeTag>uwp</ProjectTypeTag>
     <ProjectTypeTag>WinUI</ProjectTypeTag>
   </TemplateData>

--- a/dev/VSIX/ProjectTemplates/UWP/CSharp/RuntimeComponent/WinUI.UWP.Cs.RuntimeComponent.vstemplate
+++ b/dev/VSIX/ProjectTemplates/UWP/CSharp/RuntimeComponent/WinUI.UWP.Cs.RuntimeComponent.vstemplate
@@ -21,7 +21,6 @@
     <LanguageTag>csharp</LanguageTag>
     <LanguageTag>XAML</LanguageTag>
     <PlatformTag>windows</PlatformTag>
-    <PlatformTag>Windows App SDK</PlatformTag>
     <ProjectTypeTag>uwp</ProjectTypeTag>
     <ProjectTypeTag>WinUI</ProjectTypeTag>
   </TemplateData>

--- a/dev/VSIX/ProjectTemplates/UWP/CppWinRT/BlankApp/WinUI.UWP.CppWinRT.BlankApp.vstemplate
+++ b/dev/VSIX/ProjectTemplates/UWP/CppWinRT/BlankApp/WinUI.UWP.CppWinRT.BlankApp.vstemplate
@@ -20,7 +20,6 @@
     <LanguageTag>cpp</LanguageTag>
     <LanguageTag>XAML</LanguageTag>
     <PlatformTag>windows</PlatformTag>
-    <PlatformTag>Windows App SDK</PlatformTag>
     <ProjectTypeTag>uwp</ProjectTypeTag>
     <ProjectTypeTag>WinUI</ProjectTypeTag>
   </TemplateData>


### PR DESCRIPTION
This fixes #1665 by removing the spurious "Windows App SDK" platform tag.