### PR TITLE
Updating reference to pick up license installation fix.

### DIFF
--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Dependencies>
   <ProductDependencies>
-    <Dependency Name="Microsoft.WindowsAppSDK.AppLicensingInternal.TransportPackage" Version="1.0.0-preview1.20211111.12">
+    <Dependency Name="Microsoft.WindowsAppSDK.AppLicensingInternal.TransportPackage" Version="1.1.0-stable.20220518.4">
       <Uri>https://dev.azure.com/microsoft/ProjectReunion/_git/ProjectReunionClosed</Uri>
-      <Sha>a3b6cd2d041c342d4a5ac2ed0c90c30e9ed08f15</Sha>
+      <Sha>0f4add1a10caa92e635919b81a678d2f1bcf229b</Sha>
     </Dependency>
   </ProductDependencies>
   <ToolsetDependencies>


### PR DESCRIPTION
This change picks up final stable license changes for installing licenses via the bootstrapper (initialization API) for the 1.1 stable release.