### PR TITLE
Making EM RS5+. Limiting the tracking capability to Windows11+ (Spec)

### DIFF
--- a/specs/AppLifecycle/EnvironmentVariables/AppLifecycle - Environment Variables (EV).md
+++ b/specs/AppLifecycle/EnvironmentVariables/AppLifecycle - Environment Variables (EV).md
@@ -11,9 +11,8 @@ that provide partially overlapping functionality, and with some gaps. This spec
 describes the Reunion support for environment variables.
 
 Important Note: The EV tracking feature relies on other platform features which are only
-available from Windows summer 2021 onwards. Therefore EV tracking is also 
-only available from Windows summer 2021 onwards. An app can check the 
-AreChangesTracked property to determine whether the current device supports the 
+available from Windows 21H1+ (i.e. version >=10.0.19043.0). An app can check the 
+IsChangeTrackingSupported property to determine whether the current device supports the 
 feature.
 
 
@@ -74,7 +73,7 @@ permissions section below).
   system-wide scope.
 - **static bool IsSupported { get; }** - readonly property that indicates whether this
   API is supported on the current device/OS version.
-- **bool AreChangesTracked{ get;}** - readonly property that indicates whether the EV changes will be tracked.
+- **bool IsChangeTrackingSupported { get;}** - readonly property that indicates whether the EV changes will be tracked.
 - **IMapView<string, string> GetEnvironmentVariables** - gets a collection of
   environment variables at the scope of the current EnvironmentManager.
 - **string GetEnvironmentVariable(string)** - gets the value of the specified
@@ -283,18 +282,11 @@ Setting a **User** or **System** variable will persist that variable beyond the
 life of the process in the user profile or system profile.
 
 Unpackaged apps can use the existing native Win32 Get/SetEnvironment and
-registry APIs. They can also use the managed System.Environment class, and
-specifically the methods GetEnvironmentVariable, GetEnvironmentVariables and
-SetEnvironmentVariable. We are introducing the new API so that non-fulltrust
-packaged apps can access some of the same functionality. Key existing behaviors
-are listed in the table below:
-
-| App Type       | API Type | Process Vars | User Vars   | Machine Vars |
-| -------------- | -------- | ------------ | ----------- | ------------ |
-| Unpackaged     | Native   | Read, Write  | Read, Write | Read, Write  |
-| Unpackaged     | Managed  | Read, Write  | Read, Write | Read, Write  |
-| Desktop Bridge | Native   | Read, Write  | Read, Write | Read, Write  |
-| Desktop Bridge | Managed  | Read, Write  | Read, Write | Read, Write  |
+registry APIs. Unpackaged .NET apps can use [System.Environment](https://docs.microsoft.com/en-us/dotnet/api/system.environment?view=net-6.0) class, and
+specifically the methods [GetEnvironmentVariable](https://docs.microsoft.com/en-us/dotnet/api/system.environment.getenvironmentvariable?view=net-6.0), 
+[GetEnvironmentVariables](https://docs.microsoft.com/en-us/dotnet/api/system.environment.getenvironmentvariables?view=net-6.0)
+and [SetEnvironmentVariable](https://docs.microsoft.com/en-us/dotnet/api/system.environment.setenvironmentvariable?view=net-6.0).
+We are introducing the new API so non-fulltrust apps can access the same functionality.
 
 Environment variables are stored in the registry here:
 
@@ -529,7 +521,7 @@ namespace Microsoft.Windows.System
         static EnvironmentManager GetForMachine();
         static bool IsSupported { get; }
         
-        bool AreChangesTracked {get; };
+        bool IsChangeTrackingSupported  {get; };
     
         IMapView<String, String> GetEnvironmentVariables();
         String GetEnvironmentVariable(String name);


### PR DESCRIPTION
I realized that the API used to manipulating environment variables can work down level. The restriction to EM was tracking the changes so they could be reverted when a package was removed.

I split up the changes. IsSupported always returns true. If the developer wants to know if the changes will be tracked, they can call the object method AreChangesTracked.

This PR has the spec change and is my formal request for an API review.