### PR TITLE
Deployment agent break away process creation fixes

### DIFF
--- a/dev/Deployment/DeploymentActivityContext.h
+++ b/dev/Deployment/DeploymentActivityContext.h
@@ -68,7 +68,7 @@ namespace WindowsAppRuntime::Deployment::Activity
             return m_deploymentErrorActivityId;
         }
 
-        WindowsAppRuntimeDeployment_TraceLogger::Initialize GetActivity() const
+        WindowsAppRuntimeDeployment_TraceLogger::Initialize& GetActivity()
         {
             return m_activity;
         }

--- a/dev/Deployment/DeploymentManager.cpp
+++ b/dev/Deployment/DeploymentManager.cpp
@@ -345,10 +345,6 @@ namespace winrt::Microsoft::Windows::ApplicationModel::WindowsAppRuntime::implem
         wil::unique_process_information processInfo;
         THROW_IF_WIN32_BOOL_FALSE(CreateProcess(nullptr, cmdLine.get(), nullptr, nullptr, TRUE, EXTENDED_STARTUPINFO_PRESENT, nullptr, nullptr, &info.StartupInfo, &processInfo));
 
-        // Transfer foreground rights to the new process before resuming it.
-        AllowSetForegroundWindow(processInfo.dwProcessId);
-        ResumeThread(processInfo.hThread);
-
         // This API is designed to only return to the caller on failure, otherwise block until process termination.
         // Wait for the agent to exit.  If the agent succeeds, it will terminate this process.  If the agent fails,
         // it can exit or crash.  This API will be able to detect the failure and return.

--- a/dev/Deployment/DeploymentManager.cpp
+++ b/dev/Deployment/DeploymentManager.cpp
@@ -343,7 +343,7 @@ namespace winrt::Microsoft::Windows::ApplicationModel::WindowsAppRuntime::implem
         info.lpAttributeList = attributeList;
 
         wil::unique_process_information processInfo;
-        THROW_IF_WIN32_BOOL_FALSE(CreateProcess(nullptr, cmdLine.get(), nullptr, nullptr, TRUE, EXTENDED_STARTUPINFO_PRESENT, nullptr, nullptr, &info.StartupInfo, &processInfo));
+        THROW_IF_WIN32_BOOL_FALSE(CreateProcess(nullptr, cmdLine.get(), nullptr, nullptr, FALSE, EXTENDED_STARTUPINFO_PRESENT, nullptr, nullptr, &info.StartupInfo, &processInfo));
 
         // This API is designed to only return to the caller on failure, otherwise block until process termination.
         // Wait for the agent to exit.  If the agent succeeds, it will terminate this process.  If the agent fails,

--- a/dev/Deployment/DeploymentManager.cpp
+++ b/dev/Deployment/DeploymentManager.cpp
@@ -343,8 +343,7 @@ namespace winrt::Microsoft::Windows::ApplicationModel::WindowsAppRuntime::implem
         info.lpAttributeList = attributeList;
 
         wil::unique_process_information processInfo;
-        THROW_IF_WIN32_BOOL_FALSE(CreateProcess(nullptr, cmdLine.get(), nullptr, nullptr, TRUE, CREATE_SUSPENDED | EXTENDED_STARTUPINFO_PRESENT, nullptr, nullptr,
-                                                &info.StartupInfo, &processInfo));
+        THROW_IF_WIN32_BOOL_FALSE(CreateProcess(nullptr, cmdLine.get(), nullptr, nullptr, TRUE, EXTENDED_STARTUPINFO_PRESENT, nullptr, nullptr, &info.StartupInfo, &processInfo));
 
         // Transfer foreground rights to the new process before resuming it.
         AllowSetForegroundWindow(processInfo.dwProcessId);

--- a/dev/Deployment/DeploymentManager.cpp
+++ b/dev/Deployment/DeploymentManager.cpp
@@ -332,10 +332,9 @@ namespace winrt::Microsoft::Windows::ApplicationModel::WindowsAppRuntime::implem
         THROW_IF_WIN32_BOOL_FALSE(InitializeProcThreadAttributeList(attributeList, attributeCount, 0, &attributeListSize));
         auto freeAttributeList{ wil::scope_exit([&] { DeleteProcThreadAttributeList(attributeList); }) };
 
-        // Desktop Bridge applications by default have their child processes break away from the parent process.
-        // In order to recreate the calling process' environment correctly, we must prevent child breakaway semantics
-        // when calling the agent. Additionally the agent must do the same when restarting the caller.
-        DWORD policy{ PROCESS_CREATION_DESKTOP_APP_BREAKAWAY_OVERRIDE };
+        // The process being created will create any child processes outside of the desktop app runtime environment.
+        // This behavior is the default for processes for which no policy has been set.
+        DWORD policy{ PROCESS_CREATION_DESKTOP_APP_BREAKAWAY_ENABLE_PROCESS_TREE };
         THROW_IF_WIN32_BOOL_FALSE(UpdateProcThreadAttribute(attributeList, 0, PROC_THREAD_ATTRIBUTE_DESKTOP_APP_POLICY, &policy, sizeof(policy), nullptr, nullptr));
 
         STARTUPINFOEX info{};

--- a/dev/Deployment/DeploymentManager.cpp
+++ b/dev/Deployment/DeploymentManager.cpp
@@ -332,8 +332,9 @@ namespace winrt::Microsoft::Windows::ApplicationModel::WindowsAppRuntime::implem
         THROW_IF_WIN32_BOOL_FALSE(InitializeProcThreadAttributeList(attributeList, attributeCount, 0, &attributeListSize));
         auto freeAttributeList{ wil::scope_exit([&] { DeleteProcThreadAttributeList(attributeList); }) };
 
+        // https://docs.microsoft.com/en-us/windows/win32/api/processthreadsapi/nf-processthreadsapi-updateprocthreadattribute
         // The process being created will create any child processes outside of the desktop app runtime environment.
-        // This behavior is the default for processes for which no policy has been set.
+        // This behavior is the default for processes for which no policy has been set
         DWORD policy{ PROCESS_CREATION_DESKTOP_APP_BREAKAWAY_ENABLE_PROCESS_TREE };
         THROW_IF_WIN32_BOOL_FALSE(UpdateProcThreadAttribute(attributeList, 0, PROC_THREAD_ATTRIBUTE_DESKTOP_APP_POLICY, &policy, sizeof(policy), nullptr, nullptr));
 

--- a/dev/WindowsAppRuntime_BootstrapDLL/MddBootstrapActivity.h
+++ b/dev/WindowsAppRuntime_BootstrapDLL/MddBootstrapActivity.h
@@ -67,12 +67,12 @@ namespace WindowsAppRuntime::MddBootstrap::Activity
             return m_initializationPackageFullName;
         }
 
-        WindowsAppRuntimeBootstrap_TraceLogger::Initialize GetInitializeActivity()
+        WindowsAppRuntimeBootstrap_TraceLogger::Initialize& GetInitializeActivity()
         {
             return m_bootstrapInitializeActivity;
         }
 
-        WindowsAppRuntimeBootstrap_TraceLogger::Shutdown GetShutdownActivity()
+        WindowsAppRuntimeBootstrap_TraceLogger::Shutdown& GetShutdownActivity()
         {
             return m_bootstrapShutdownActivity;
         }


### PR DESCRIPTION
Main problem is that CreateProcess is called with PROCESS_CREATION_DESKTOP_APP_BREAKAWAY_OVERRIDE instead of PROCESS_CREATION_DESKTOP_APP_BREAKAWAY_ENABLE_PROCESS_TREE which have opposite affects. The latter is what we need to create a breakaway process outside desktop app runtime environment.

Along with it, updated CreateProcess to start DeploymentAgent.exe in running mode and not in suspend mode (+ xfer foreground rights + resume it) as that's not required.

And telemetry is also reporting failure incorrectly even in case of success due to GetActivity method returning a copy of tracelogger activity object which is short lived instead of a reference to it -this is also fixed.