### PR TITLE
MddBootstrap.h -- Add stdint.h

### DIFF
--- a/dev/WindowsAppRuntime_BootstrapDLL/MddBootstrap.h
+++ b/dev/WindowsAppRuntime_BootstrapDLL/MddBootstrap.h
@@ -81,6 +81,7 @@ STDAPI_(void) MddBootstrapShutdown() noexcept;
 #if defined(WINDOWSAPPSDK_RELEASE_MAJORMINOR) && defined(WINDOWSAPPSDK_RELEASE_VERSION_TAG_W) && defined(WINDOWSAPPSDK_RUNTIME_VERSION_UINT64)
 
 #include <memory>
+#include <stdint.h>
 
 namespace Microsoft::Windows::ApplicationModel
 {


### PR DESCRIPTION
The Bootstrapper's C++ API in MddBootstrap.h uses modern C++ types like uint32_t. Depending on your code and order of #include's you could get undefined errors because stdint.h wasn't included before MddBootstrap.h. This is uncommon as most folks use the Bootstrap auto-initializer and even those who explicitly use this often add the header after other things that do bring in stdint.h. This ensures zero problem even for the rare birds who might hit it.

The workaround if you hit the problem today is to add stdint.h before MddBootstrap.h e.g.

```c++
#include <stdint.h>
#include <MddBootstrap.h>
```

https://task.ms/39766902