### PR TITLE
Make ResourceLoader use same context as default ResourceManager

### DIFF
--- a/dev/MRTCore/mrt/Microsoft.Windows.ApplicationModel.Resources/TestCommon/CommonTestCode.cs
+++ b/dev/MRTCore/mrt/Microsoft.Windows.ApplicationModel.Resources/TestCommon/CommonTestCode.cs
@@ -103,6 +103,16 @@ namespace CommonTestCode
             var filepath = ResourceLoader.GetDefaultResourceFilePath();
             Verify.AreNotEqual(filepath.IndexOf("resources.pri"), -1);
         }
+
+        public static void ReturnSameResultAsResourceManager()
+        {
+            var resourceLoader = new ResourceLoader("resources.pri.standalone");
+            var fromLoader = resourceLoader.GetString("IDS_WHATS_NEW_1710_2_EQUALIZER_TITLE");
+
+            var resourceManager = new ResourceManager("resources.pri.standalone");
+            var fromManager = resourceManager.MainResourceMap.GetValue("resources/IDS_WHATS_NEW_1710_2_EQUALIZER_TITLE").ValueAsString;
+            Verify.AreEqual(fromLoader, fromManager);
+        }
     }
 
     public class ResourceManagerTest

--- a/dev/MRTCore/mrt/Microsoft.Windows.ApplicationModel.Resources/UnpackagedTests/TestClass.cs
+++ b/dev/MRTCore/mrt/Microsoft.Windows.ApplicationModel.Resources/UnpackagedTests/TestClass.cs
@@ -364,6 +364,23 @@ namespace MrtCoreUnpackagedTests
         }
 
         [TestMethod]
+        public void ResourceLoader_ReturnSameResultAsResourceManager()
+        {
+            if (m_rs5)
+            {
+                // Test doesn't run before 19H1. Make it pass as skipped is treated as failure in Helix.
+                return;
+            }
+
+            if (m_exeFolder != m_assemblyFolder)
+            {
+                File.Copy(Path.Combine(m_assemblyFolder, "resources.pri.standalone"), Path.Combine(m_exeFolder, "resources.pri.standalone"));
+            }
+
+            CommonTestCode.ResourceLoaderTest.ReturnSameResultAsResourceManager();
+        }
+
+        [TestMethod]
         public void ResourceManager_ValueAsStringTest_StringResource_Succeeds()
         {
             if (m_rs5)

--- a/dev/MRTCore/mrt/Microsoft.Windows.ApplicationModel.Resources/UnpackagedTests/TestClass.cs
+++ b/dev/MRTCore/mrt/Microsoft.Windows.ApplicationModel.Resources/UnpackagedTests/TestClass.cs
@@ -16,96 +16,9 @@ namespace MrtCoreUnpackagedTests
     using WEX.TestExecution.Markup;
     using Microsoft.Windows.ApplicationModel.Resources;
 
-    #region Helper class for WinRT activation
-    internal class ActivationContext : IDisposable
-    {
-        private IntPtr m_cookie = (IntPtr)0;
-        private IntPtr m_ctx = (IntPtr)0;
-        private bool m_activated = false;
-
-        public ActivationContext()
-        {
-            Activate();
-        }
-
-        public void Activate()
-        {
-            if (!m_activated)
-            {
-                string assemblyPath = Assembly.GetExecutingAssembly().Location;
-                ActivateContext(Path.Combine(Path.GetDirectoryName(assemblyPath), "app.manifest"));
-                m_activated = true;
-            }
-        }
-
-        public void Dispose()
-        {
-            if (m_activated)
-            {
-                NativeMethods.DeactivateActCtx(0, m_cookie);
-                NativeMethods.ReleaseActCtx(m_ctx);
-                m_cookie = (IntPtr)0;
-                m_ctx = (IntPtr)0;
-                m_activated = false;
-            }
-        }
-
-        private void ActivateContext(string manifestPath)
-        {
-            var context = new NativeMethods.ACTCTX();
-            context.cbSize = (uint)Marshal.SizeOf(typeof(NativeMethods.ACTCTX));
-            context.lpSource = manifestPath;
-
-            m_ctx = NativeMethods.CreateActCtx(ref context);
-            if (m_ctx == (IntPtr)(-1))
-            {
-                throw new Win32Exception(Marshal.GetLastWin32Error());
-            }
-
-            if (!NativeMethods.ActivateActCtx(m_ctx, out m_cookie))
-            {
-                throw new Win32Exception(Marshal.GetLastWin32Error());
-            }
-        }
-    }
-
-    [SuppressUnmanagedCodeSecurity]
-    internal static class NativeMethods
-    {
-        [DllImport("kernel32.dll", SetLastError = true, EntryPoint = "CreateActCtxW")]
-        internal static extern IntPtr CreateActCtx(ref ACTCTX pActctx);
-
-        [DllImport("kernel32.dll", SetLastError = true)]
-        [return: MarshalAs(UnmanagedType.Bool)]
-        internal static extern bool ActivateActCtx(IntPtr hActCtx, out IntPtr lpCookie);
-
-        [DllImport("kernel32.dll", SetLastError = true)]
-        [return: MarshalAs(UnmanagedType.Bool)]
-        internal static extern bool DeactivateActCtx(int dwFlags, IntPtr ulCookie);
-
-        [DllImport("kernel32.dll")]
-        internal static extern void ReleaseActCtx(IntPtr hActCtx);
-
-        [StructLayout(LayoutKind.Sequential, CharSet = CharSet.Unicode)]
-        internal struct ACTCTX
-        {
-            public UInt32 cbSize;
-            public UInt32 dwFlags;
-            public string lpSource;
-            public UInt16 wProcessorArchitecture;
-            public UInt16 wLangId;
-            public string lpAssemblyDirectory;
-            public string lpResourceName;
-            public string lpApplicationName;
-            public IntPtr hModule;
-        }
-    }
-    #endregion
-
     [TestClass]
     public class TestClass
     {
-        private ActivationContext m_context = new ActivationContext();
         private static string m_assemblyFolder = Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location);
         private static string m_exeFolder = Path.GetDirectoryName(System.Diagnostics.Process.GetCurrentProcess().MainModule.FileName);
         private static bool m_rs5 = false;
@@ -148,6 +61,7 @@ namespace MrtCoreUnpackagedTests
         }
 
         [AssemblyInitialize]
+        [TestProperty("ActivationContext", "app.manifest")]
         public static void ModuleSetup(TestContext testContext)
         {
             // Clean up any left over files just in case

--- a/dev/MRTCore/mrt/Microsoft.Windows.ApplicationModel.Resources/src/ResourceLoader.cpp
+++ b/dev/MRTCore/mrt/Microsoft.Windows.ApplicationModel.Resources/src/ResourceLoader.cpp
@@ -15,21 +15,28 @@ ResourceLoader::ResourceLoader()
 
     winrt::check_hresult(MrmCreateResourceManager(fileName.c_str(), &m_resourceManager));
     winrt::check_hresult(MrmGetChildResourceMap(m_resourceManager, nullptr, L"Resources", &m_currentResourceMap));
+    SetDefaultContext();
 }
 
 ResourceLoader::ResourceLoader(hstring const& fileName)
 {
     winrt::check_hresult(MrmCreateResourceManager(fileName.c_str(), &m_resourceManager));
     winrt::check_hresult(MrmGetChildResourceMap(m_resourceManager, nullptr, L"Resources", &m_currentResourceMap));
+    SetDefaultContext();
 }
 
 ResourceLoader::ResourceLoader(hstring const& fileName, hstring const& resourceMap)
 {
     winrt::check_hresult(MrmCreateResourceManager(fileName.c_str(), &m_resourceManager));
     winrt::check_hresult(MrmGetChildResourceMap(m_resourceManager, nullptr, resourceMap.c_str(), &m_currentResourceMap));
+    SetDefaultContext();
 }
 
-ResourceLoader::~ResourceLoader() { MrmDestroyResourceManager(m_resourceManager); }
+ResourceLoader::~ResourceLoader()
+{
+    m_defaultContext = nullptr;
+    MrmDestroyResourceManager(m_resourceManager);
+}
 
 hstring ResourceLoader::GetDefaultResourceFilePath()
 {
@@ -42,7 +49,8 @@ hstring ResourceLoader::GetDefaultResourceFilePath()
 hstring ResourceLoader::GetString(hstring const& resourceId)
 {
     wchar_t* resourceString;
-    winrt::check_hresult(MrmLoadStringResource(m_resourceManager, nullptr, m_currentResourceMap, resourceId.c_str(), &resourceString));
+    auto contextHandle = m_defaultContext.as<Resources::implementation::ResourceContext>()->GetContextHandle();
+    winrt::check_hresult(MrmLoadStringResource(m_resourceManager, contextHandle, m_currentResourceMap, resourceId.c_str(), &resourceString));
 
     string_resoure_ptr resourceContainer(resourceString);
     return winrt::to_hstring(resourceContainer.get());
@@ -51,9 +59,18 @@ hstring ResourceLoader::GetString(hstring const& resourceId)
 hstring ResourceLoader::GetStringForUri(winrt::Windows::Foundation::Uri const& resourceUri)
 {
     wchar_t* resourceString;
-    winrt::check_hresult(MrmLoadStringResourceFromResourceUri(m_resourceManager, nullptr, resourceUri.ToString().c_str(), &resourceString));
+    auto contextHandle = m_defaultContext.as<Resources::implementation::ResourceContext>()->GetContextHandle();
+    winrt::check_hresult(MrmLoadStringResourceFromResourceUri(m_resourceManager, contextHandle, resourceUri.ToString().c_str(), &resourceString));
 
     string_resoure_ptr resourceContainer(resourceString);
     return winrt::to_hstring(resourceContainer.get());
+}
+
+void ResourceLoader::SetDefaultContext()
+{
+    MrmContextHandle contextHandle = nullptr;
+    winrt::check_hresult(MrmCreateResourceContext(m_resourceManager, &contextHandle));
+    m_defaultContext = winrt::make<ResourceContext>(contextHandle);
+    m_defaultContext.as<Resources::implementation::ResourceContext>()->Apply();
 }
 } // namespace winrt::Microsoft::Windows::ApplicationModel::Resources::implementation

--- a/dev/MRTCore/mrt/Microsoft.Windows.ApplicationModel.Resources/src/ResourceLoader.h
+++ b/dev/MRTCore/mrt/Microsoft.Windows.ApplicationModel.Resources/src/ResourceLoader.h
@@ -3,6 +3,9 @@
 
 #pragma once
 #include "ResourceLoader.g.h"
+#include "ResourceContext.h"
+
+using namespace winrt::Microsoft::Windows::ApplicationModel::Resources;
 
 namespace winrt::Microsoft::Windows::ApplicationModel::Resources::implementation
 {
@@ -20,9 +23,11 @@ struct ResourceLoader : ResourceLoaderT<ResourceLoader>
 
 private:
     ~ResourceLoader();
+    void SetDefaultContext();
 
     MrmManagerHandle m_resourceManager = nullptr;
     MrmMapHandle m_currentResourceMap = nullptr;
+    Resources::ResourceContext m_defaultContext {nullptr};
 };
 
 } // namespace winrt::Microsoft::Windows::ApplicationModel::Resources::implementation

--- a/dev/MRTCore/mrt/Microsoft.Windows.ApplicationModel.Resources/unittests/UnitTest.cs
+++ b/dev/MRTCore/mrt/Microsoft.Windows.ApplicationModel.Resources/unittests/UnitTest.cs
@@ -39,6 +39,12 @@ namespace ManagedTest
         {
             CommonTestCode.ResourceLoaderTest.GetDefaultResourceFilePathTest();
         }
+
+        [TestMethod]
+        public void ReturnSameResultAsResourceManager()
+        {
+            CommonTestCode.ResourceLoaderTest.ReturnSameResultAsResourceManager();
+        }
     }
 
     [TestClass]


### PR DESCRIPTION
Previously ResourceManager by default uses user preferred language, but ResourceLoader uses windows display language. Now make ResourceLoader also use user preferred language.