### PR TITLE
Remove Timestamp from VSIX version due to WinAppSDK NuGet Version Update

### DIFF
--- a/dev/VSIX/Extension/Directory.Build.targets
+++ b/dev/VSIX/Extension/Directory.Build.targets
@@ -20,6 +20,13 @@
   </PropertyGroup>
   <PropertyGroup Condition="'$(VSIXVersion)' == ''">
     <!-- Use 3-part Windows App SDK version, less any tagging suffix -->
+    <!-- 
+      WindowsAppSDK release versions now have a timestamp as part of the patch
+      and a revision count making very release versions unique. This avoids
+      version sequencing issues between experimental and stable/preview versions
+      that might otherwise have the same version number, since VSIX does not
+      support preview tags or other mechanisms to distinguish.
+    -->
     <VSIXVersion>$(WindowsAppSDKVersion)</VSIXVersion>
     <VSIXVersion Condition="$(VSIXVersion.Contains(&quot;-&quot;))">$(VSIXVersion.Substring(0, $(VSIXVersion.IndexOf("-"))))</VSIXVersion>
   </PropertyGroup>

--- a/dev/VSIX/Extension/Directory.Build.targets
+++ b/dev/VSIX/Extension/Directory.Build.targets
@@ -22,14 +22,6 @@
     <!-- Use 3-part Windows App SDK version, less any tagging suffix -->
     <VSIXVersion>$(WindowsAppSDKVersion)</VSIXVersion>
     <VSIXVersion Condition="$(VSIXVersion.Contains(&quot;-&quot;))">$(VSIXVersion.Substring(0, $(VSIXVersion.IndexOf("-"))))</VSIXVersion>
-    <!--
-      Add a timestamp as part 4 of the version for uniqueness, and to ensure newer builds are newer
-      versions. Note that the timestamp is also included in release builds. This avoids version
-      sequencing issues between experimental and stable/preview versions that might otherwise have the same
-      version number, since VSIX does not support preview tags or other mechanisms to distinguish.
-    -->
-    <TimeSpan>$([System.Math]::Floor($([System.DateTime]::UtcNow.Subtract($([System.DateTime]::Parse('2020-01-01T00:00Z'))).TotalSeconds)))</TimeSpan>
-    <VSIXVersion>$(VSIXVersion).$(TimeSpan)</VSIXVersion>
   </PropertyGroup>
 
   <Target Name="GetVSIXVersion" Outputs="$(VSIXVersion)" />


### PR DESCRIPTION
Adding a timestamp should not be necessary anymore because WinAppSDK Nuget Versions should be unique. 