### PR TITLE
39817966: [WinAppSDK 1.1] Unpackaged + self-contained Blank Project crashes at startup

### DIFF
--- a/dev/UndockedRegFreeWinRT/catalog.cpp
+++ b/dev/UndockedRegFreeWinRT/catalog.cpp
@@ -188,11 +188,12 @@ HRESULT ParseFileTag(IXmlReader* xmlReader)
     HRESULT hr = S_OK;
     XmlNodeType nodeType;
     PCWSTR localName = nullptr;
-    PCWSTR fileName = nullptr;
+    PCWSTR value = nullptr;
     hr = xmlReader->MoveToAttributeByName(L"name", nullptr);
     RETURN_HR_IF(HRESULT_FROM_WIN32(ERROR_SXS_MANIFEST_PARSE_ERROR), hr != S_OK);
-    RETURN_IF_FAILED(xmlReader->GetValue(&fileName, nullptr));
-    RETURN_HR_IF(HRESULT_FROM_WIN32(ERROR_SXS_MANIFEST_PARSE_ERROR), fileName == nullptr || !fileName[0]);
+    RETURN_IF_FAILED(xmlReader->GetValue(&value, nullptr));
+    std::wstring fileName{ !value ? L"" : value };
+    RETURN_HR_IF(HRESULT_FROM_WIN32(ERROR_SXS_MANIFEST_PARSE_ERROR), fileName.empty());
     auto locale = _create_locale(LC_ALL, "C");
     while (S_OK == xmlReader->Read(&nodeType))
     {
@@ -201,7 +202,7 @@ HRESULT ParseFileTag(IXmlReader* xmlReader)
             RETURN_IF_FAILED(xmlReader->GetLocalName(&localName, nullptr));
             if (localName != nullptr && _wcsicmp_l(localName, L"activatableClass", locale) == 0)
             {
-                RETURN_IF_FAILED(ParseActivatableClassTag(xmlReader, fileName));
+                RETURN_IF_FAILED(ParseActivatableClassTag(xmlReader, fileName.c_str()));
             }
         }
         else if (nodeType == XmlNodeType_EndElement)


### PR DESCRIPTION
Undocked RegFree WinRT had a long-standing bug in ParseFileTag() where it retrieved the filename via `xmlReader->GetValue()` into a raw pointer and then used it AFTER calling `xmlReader->Read()`. That's a no-no -- GetValue returns a raw pointer to the current-context; you need to deep-copy if if you want to use it after you change the parser's current-context (e.g. by calling Read), as per https://docs.microsoft.com/en-us/previous-versions/windows/desktop/ms752870(v=vs.85)

>Note

>
>The pointer returned by GetValue is only valid until you move the reader to another node. When you move the reader to another node, XmlLite may reuse the memory referenced by the pointer. Therefore, you should not use the pointer after calling one of the following methods: [Read](https://docs.microsoft.com/en-us/previous-versions/windows/desktop/ms752878(v=vs.85)), [MoveToNextAttribute](https://docs.microsoft.com/en-us/previous-versions/windows/desktop/ms752820(v=vs.85)), [MoveToFirstAttribute](https://docs.microsoft.com/en-us/previous-versions/windows/desktop/ms753122(v=vs.85)), [MoveToAttributeByName](https://docs.microsoft.com/en-us/previous-versions/windows/desktop/ms752880(v=vs.85)), or [MoveToElement](https://docs.microsoft.com/en-us/previous-versions/windows/desktop/ms752884(v=vs.85)). Although they do not move the reader, the following two methods will also make the pointer invalid: [SetInput](https://docs.microsoft.com/en-us/previous-versions/windows/desktop/ms752891(v=vs.85)) and IUnknown::Release. If you want to preserve the value that was returned in ppwszValue, you should make a deep copy.

The key phrase: `When you move the reader to another node, XmlLite may reuse the memory referenced by the pointer. Therefore, you should not use the pointer after calling one of the following methods:...`

This could coincidentally work if you had small RegFreeWinRT info in your manifest, but that was pure luck of memory layout.

This issue exists in URFW from before we forked copy. URFW should be likewise fixed, tracked per [RegFreeWinRT support has bug in string handling that leads to failed DLL lookup #776](https://github.com/microsoft/xlang/issues/776)