### PR TITLE
Fix issue where WinUI C# and C++ item templates are not appearing in WinUI projects

### DIFF
--- a/dev/VSIX/ItemTemplates/Desktop/CSharp/BlankWindow/WinUI.Desktop.Cs.BlankWindow.vstemplate
+++ b/dev/VSIX/ItemTemplates/Desktop/CSharp/BlankWindow/WinUI.Desktop.Cs.BlankWindow.vstemplate
@@ -8,7 +8,7 @@
     <ProjectType>CSharp</ProjectType>
     <TemplateID>WinUI.Desktop.Cs.BlankWindow</TemplateID>
     <TemplateGroupID>WinRT-Managed-UAP</TemplateGroupID>
-    <AppliesTo>CSharp + SharedAssetsProject</AppliesTo>
+    <AppliesTo>CSharp + WindowsAppSDK</AppliesTo>
     <NumberOfParentCategoriesToRollUp>2</NumberOfParentCategoriesToRollUp>
     <ShowByDefault>false</ShowByDefault>
     <TargetPlatformName>Windows</TargetPlatformName>

--- a/dev/VSIX/ItemTemplates/Desktop/CppWinRT/BlankWindow/WinUI.Desktop.CppWinRT.BlankWindow.vstemplate
+++ b/dev/VSIX/ItemTemplates/Desktop/CppWinRT/BlankWindow/WinUI.Desktop.CppWinRT.BlankWindow.vstemplate
@@ -7,6 +7,8 @@
     <Icon>WinUI.Desktop.CppWinRT.BlankWindow.ico</Icon>
     <ProjectType>VC</ProjectType>
     <TemplateID>WinUI.Desktop.CppWinRT.BlankWindow</TemplateID>
+    <TemplateGroupID>WinRT-Native-UAP</TemplateGroupID>
+    <AppliesTo>VisualC + WindowsAppSDK</AppliesTo>
     <NumberOfParentCategoriesToRollUp>2</NumberOfParentCategoriesToRollUp>
     <ShowByDefault>false</ShowByDefault>
     <TargetPlatformName>Windows</TargetPlatformName>

--- a/dev/VSIX/ItemTemplates/Neutral/CSharp/BlankPage/WinUI.Neutral.Cs.BlankPage.vstemplate
+++ b/dev/VSIX/ItemTemplates/Neutral/CSharp/BlankPage/WinUI.Neutral.Cs.BlankPage.vstemplate
@@ -8,7 +8,7 @@
     <ProjectType>CSharp</ProjectType>
     <TemplateID>WinUI.Neutral.Cs.BlankPage</TemplateID>
     <TemplateGroupID>WinRT-Managed-UAP</TemplateGroupID>
-    <AppliesTo>CSharp + SharedAssetsProject</AppliesTo>
+    <AppliesTo>CSharp + WindowsAppSDK</AppliesTo>
     <NumberOfParentCategoriesToRollUp>2</NumberOfParentCategoriesToRollUp>
     <ShowByDefault>false</ShowByDefault>
     <TargetPlatformName>Windows</TargetPlatformName>

--- a/dev/VSIX/ItemTemplates/Neutral/CSharp/ResourceDictionary/WinUI.Neutral.Cs.ResourceDictionary.vstemplate
+++ b/dev/VSIX/ItemTemplates/Neutral/CSharp/ResourceDictionary/WinUI.Neutral.Cs.ResourceDictionary.vstemplate
@@ -8,7 +8,7 @@
     <ProjectType>CSharp</ProjectType>
     <TemplateID>WinUI.Cs.Neutral.ResourceDictionary</TemplateID>
     <TemplateGroupID>WinRT-Managed-UAP</TemplateGroupID>
-    <AppliesTo>CSharp + SharedAssetsProject</AppliesTo>
+    <AppliesTo>CSharp + WindowsAppSDK</AppliesTo>
     <NumberOfParentCategoriesToRollUp>1</NumberOfParentCategoriesToRollUp>
     <ShowByDefault>false</ShowByDefault>
     <TargetPlatformName>Windows</TargetPlatformName>

--- a/dev/VSIX/ItemTemplates/Neutral/CSharp/Resw/WinUI.Neutral.Cs.Resw.vstemplate
+++ b/dev/VSIX/ItemTemplates/Neutral/CSharp/Resw/WinUI.Neutral.Cs.Resw.vstemplate
@@ -7,6 +7,8 @@
     <Icon>WinUI.Neutral.Cs.Resw.ico</Icon>
     <ProjectType>CSharp</ProjectType>
     <TemplateID>WinUI.Cs.Neutral.Resw</TemplateID>
+    <TemplateGroupID>WinRT-Managed-UAP</TemplateGroupID>
+    <AppliesTo>CSharp + WindowsAppSDK</AppliesTo>
     <NumberOfParentCategoriesToRollUp>1</NumberOfParentCategoriesToRollUp>
     <ShowByDefault>false</ShowByDefault>
     <TargetPlatformName>Windows</TargetPlatformName>

--- a/dev/VSIX/ItemTemplates/Neutral/CSharp/TemplatedControl/WinUI.Neutral.Cs.TemplatedControl.vstemplate
+++ b/dev/VSIX/ItemTemplates/Neutral/CSharp/TemplatedControl/WinUI.Neutral.Cs.TemplatedControl.vstemplate
@@ -8,7 +8,7 @@
     <ProjectType>CSharp</ProjectType>
     <TemplateID>WinUI.Neutral.UWP.TemplatedControl</TemplateID>
     <TemplateGroupID>WinRT-Managed-UAP</TemplateGroupID>
-    <AppliesTo>CSharp + SharedAssetsProject</AppliesTo>
+    <AppliesTo>CSharp + WindowsAppSDK</AppliesTo>
     <NumberOfParentCategoriesToRollUp>2</NumberOfParentCategoriesToRollUp>
     <ShowByDefault>false</ShowByDefault>
     <TargetPlatformName>Windows</TargetPlatformName>

--- a/dev/VSIX/ItemTemplates/Neutral/CSharp/UserControl/WinUI.Neutral.Cs.UserControl.vstemplate
+++ b/dev/VSIX/ItemTemplates/Neutral/CSharp/UserControl/WinUI.Neutral.Cs.UserControl.vstemplate
@@ -8,7 +8,7 @@
     <ProjectType>CSharp</ProjectType>
     <TemplateID>WinUI.Cs.Neutral.UserControl</TemplateID>
     <TemplateGroupID>WinRT-Managed-UAP</TemplateGroupID>
-    <AppliesTo>CSharp + SharedAssetsProject</AppliesTo>
+    <AppliesTo>CSharp + WindowsAppSDK</AppliesTo>
     <NumberOfParentCategoriesToRollUp>2</NumberOfParentCategoriesToRollUp>
     <ShowByDefault>false</ShowByDefault>
     <TargetPlatformName>Windows</TargetPlatformName>

--- a/dev/VSIX/ItemTemplates/Neutral/CppWinRT/BlankPage/WinUI.Neutral.CppWinRT.BlankPage.vstemplate
+++ b/dev/VSIX/ItemTemplates/Neutral/CppWinRT/BlankPage/WinUI.Neutral.CppWinRT.BlankPage.vstemplate
@@ -7,6 +7,8 @@
     <Icon>WinUI.Neutral.CppWinRT.BlankPage.ico</Icon>
     <ProjectType>VC</ProjectType>
     <TemplateID>WinUI.Neutral.CppWinRT.BlankPage</TemplateID>
+    <TemplateGroupID>WinRT-Native-UAP</TemplateGroupID>
+    <AppliesTo>VisualC + WindowsAppSDK</AppliesTo>
     <NumberOfParentCategoriesToRollUp>2</NumberOfParentCategoriesToRollUp>
     <ShowByDefault>false</ShowByDefault>
     <TargetPlatformName>Windows</TargetPlatformName>

--- a/dev/VSIX/ItemTemplates/Neutral/CppWinRT/ResourceDictionary/WinUI.Neutral.CppWinRT.ResourceDictionary.vstemplate
+++ b/dev/VSIX/ItemTemplates/Neutral/CppWinRT/ResourceDictionary/WinUI.Neutral.CppWinRT.ResourceDictionary.vstemplate
@@ -7,6 +7,8 @@
     <Icon>WinUI.Neutral.CppWinRT.ResourceDictionary.ico</Icon>
     <ProjectType>VC</ProjectType>
     <TemplateID>WinUI.Neutral.CppWinRT.ResourceDictionary</TemplateID>
+    <TemplateGroupID>WinRT-Native-UAP</TemplateGroupID>
+    <AppliesTo>VisualC + WindowsAppSDK</AppliesTo>
     <NumberOfParentCategoriesToRollUp>1</NumberOfParentCategoriesToRollUp>
     <ShowByDefault>false</ShowByDefault>
     <TargetPlatformName>Windows</TargetPlatformName>

--- a/dev/VSIX/ItemTemplates/Neutral/CppWinRT/Resw/WinUI.Neutral.CppWinRT.Resw.vstemplate
+++ b/dev/VSIX/ItemTemplates/Neutral/CppWinRT/Resw/WinUI.Neutral.CppWinRT.Resw.vstemplate
@@ -7,6 +7,8 @@
     <Icon>WinUI.Neutral.CppWinRT.Resw.ico</Icon>
     <ProjectType>VC</ProjectType>
     <TemplateID>WinUI.CppWinRT.Neutral.Resw</TemplateID>
+    <TemplateGroupID>WinRT-Native-UAP</TemplateGroupID>
+    <AppliesTo>VisualC + WindowsAppSDK</AppliesTo>
     <NumberOfParentCategoriesToRollUp>1</NumberOfParentCategoriesToRollUp>
     <ShowByDefault>false</ShowByDefault>
     <TargetPlatformName>Windows</TargetPlatformName>

--- a/dev/VSIX/ItemTemplates/Neutral/CppWinRT/TemplatedControl/WinUI.Neutral.CppWinRT.TemplatedControl.vstemplate
+++ b/dev/VSIX/ItemTemplates/Neutral/CppWinRT/TemplatedControl/WinUI.Neutral.CppWinRT.TemplatedControl.vstemplate
@@ -7,6 +7,8 @@
     <Icon>WinUI.Neutral.CppWinRT.TemplatedControl.ico</Icon>
     <ProjectType>VC</ProjectType>
     <TemplateID>WinUI.Neutral.CppWinRT.TemplatedControl</TemplateID>
+    <TemplateGroupID>WinRT-Native-UAP</TemplateGroupID>
+    <AppliesTo>VisualC + WindowsAppSDK</AppliesTo>
     <NumberOfParentCategoriesToRollUp>2</NumberOfParentCategoriesToRollUp>
     <ShowByDefault>false</ShowByDefault>
     <TargetPlatformName>Windows</TargetPlatformName>

--- a/dev/VSIX/ItemTemplates/Neutral/CppWinRT/UserControl/WinUI.Neutral.CppWinRT.UserControl.vstemplate
+++ b/dev/VSIX/ItemTemplates/Neutral/CppWinRT/UserControl/WinUI.Neutral.CppWinRT.UserControl.vstemplate
@@ -7,6 +7,8 @@
     <Icon>WinUI.Neutral.CppWinRT.UserControl.ico</Icon>
     <ProjectType>VC</ProjectType>
     <TemplateID>WinUI.Neutral.CppWinRT.UserControl</TemplateID>
+    <TemplateGroupID>WinRT-Native-UAP</TemplateGroupID>
+    <AppliesTo>VisualC + WindowsAppSDK</AppliesTo>
     <NumberOfParentCategoriesToRollUp>2</NumberOfParentCategoriesToRollUp>
     <ShowByDefault>false</ShowByDefault>
     <TargetPlatformName>Windows</TargetPlatformName>


### PR DESCRIPTION
## Problem
In a [previous PR](https://github.com/microsoft/WindowsAppSDK/pull/2289), I attempted to prevent the WinUI C# templates from appearing in projects unrelated to WinUI. To do so, I set the [ShowByDefault](https://docs.microsoft.com/en-us/visualstudio/extensibility/showbydefault-visual-studio-templates?view=vs-2022) property to `false`. When this property is `false`, the decision to show/hide the item templates falls to the [AppliesTo](https://docs.microsoft.com/en-us/visualstudio/extensibility/appliesto-element-visual-studio-templates?view=vs-2022) and [TemplateGroupID](https://docs.microsoft.com/en-us/visualstudio/extensibility/templategroupid-element-visual-studio-templates?view=vs-2022) properties.

The C# templates currently hold the value `CSharp + SharedAssetsProject`. However, an examination of the capabilities for a WinUI project reveals that `SharedAssetsProject` is no longer present:
![image](https://user-images.githubusercontent.com/59936622/172943854-a7d108ed-453e-4849-844e-170489d4fca7.png)

The C++ templates currently hold no value for `AppliesTo` and `TemplateGroupID`.

## Solution
For the C# templates, we can adjust the value for `AppliesTo` to be `CSharp + WindowsAppSdk`.

For the C++ templates, we can add the property `AppliesTo` with value `VisualC + WindowsAppSdk`. We can also add the property `TemplateGroupID` with value `WinRT-Native-UAP`, which comes from this table ([link](https://docs.microsoft.com/en-us/visualstudio/extensibility/templategroupid-element-visual-studio-templates?view=vs-2022)):

![image](https://user-images.githubusercontent.com/59936622/172949107-b4be14fc-33d1-466c-9227-2d9db61c1643.png)

## C#
![image](https://user-images.githubusercontent.com/59936622/172935775-e1120116-95bc-4f97-8034-53175686e3a3.png)

## C++
![image](https://user-images.githubusercontent.com/59936622/172939101-6b791b67-d51d-4ca0-acd5-6014474f03ca.png)

## Work Item
https://github.com/microsoft/microsoft-ui-xaml/issues/7148