### PR TITLE
Detoured GetCurrentPackageInfo3() should route to the OS any PackageInfoType value it doesn't handle

### DIFF
--- a/dev/DynamicDependency/API/MddDetourPackageGraph.cpp
+++ b/dev/DynamicDependency/API/MddDetourPackageGraph.cpp
@@ -225,3 +225,15 @@ LONG MddGetPackageInfo1Or2(
         return ::GetPackageInfo(packageInfoReference, flags, bufferLength, buffer, count);
     }
 }
+
+HRESULT MddTrueGetCurrentPackageInfo3(
+    UINT32 flags,
+    PackageInfoType packageInfoType,
+    UINT32* bufferLength,
+    void* buffer,
+    UINT32* count)
+{
+    // Passthru to the original (not-Detoured) Windows API
+    RETURN_IF_FAILED(TrueGetCurrentPackageInfo3(flags, packageInfoType, bufferLength, buffer, count));
+    return S_OK;
+}

--- a/dev/DynamicDependency/API/MddDetourPackageGraph.h
+++ b/dev/DynamicDependency/API/MddDetourPackageGraph.h
@@ -1,8 +1,10 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
 #if !defined(MDDDETOURPACKAGEGRAPH_H)
 #define MDDDETOURPACKAGEGRAPH_H
+
+#include "appmodel_msixdynamicdependency.h"
 
 HRESULT WINAPI MddDetourPackageGraphInitialize() noexcept;
 
@@ -20,6 +22,13 @@ LONG MddGetPackageInfo1Or2(
     PackagePathType packagePathType,
     UINT32* bufferLength,
     BYTE* buffer,
+    UINT32* count);
+
+HRESULT MddTrueGetCurrentPackageInfo3(
+    UINT32 flags,
+    PackageInfoType packageInfoType,
+    UINT32* bufferLength,
+    void* buffer,
     UINT32* count);
 
 #endif // MDDDETOURPACKAGEGRAPH_H


### PR DESCRIPTION
If `GetCurrentPackageInfo3()` is called with any `PackageInfoType` value it doesn't handle (but Windows does) we return an error instead of giving the OS a crack at it.

Changed to pass unknown enum values down to Windows instead of prematurely rejecting them.