### PR TITLE
v1.1 SDK throws an access violation from MddBootstrapInitialize's logging code if no matching packages are installed #2592 (#2608) - 1.1-servicing

### DIFF
--- a/WindowsAppRuntime.sln
+++ b/WindowsAppRuntime.sln
@@ -375,7 +375,6 @@ Global
 		dev\AppLifecycle\AppLifecycle.vcxitems*{e3a522a3-6635-4a42-bded-1af46a15f63c}*SharedItemsImports = 9
 		test\inc\inc.vcxitems*{e5659a29-fe68-417b-9bc5-613073dd54df}*SharedItemsImports = 4
 		test\inc\inc.vcxitems*{e977b1bd-00dc-4085-a105-e0a18e0183d7}*SharedItemsImports = 4
-		dev\Common\Common.vcxitems*{f76b776e-86f5-48c5-8fc7-d2795ecc9746}*SharedItemsImports = 4
 	EndGlobalSection
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU

--- a/dev/Common/WindowsAppRuntime.SelfContained.cpp
+++ b/dev/Common/WindowsAppRuntime.SelfContained.cpp
@@ -18,7 +18,7 @@ STDAPI WindowsAppRuntime_IsSelfContained(
     const PACKAGE_INFO* packageInfo{};
     wil::unique_cotaskmem_ptr<BYTE[]> buffer;
     RETURN_IF_FAILED(::AppModel::PackageGraph::GetCurrentPackageGraph(flags, packageInfoCount, packageInfo, buffer));
-    const auto frameworkPackageFamilyName{ ::WindowsAppRuntime::VersionInfo::GetPackageFamilyName() };
+    const auto frameworkPackageFamilyName{ ::WindowsAppRuntime::VersionInfo::Framework::GetPackageFamilyName() };
     for (uint32_t index=0; index < packageInfoCount; ++index)
     {
         if (CompareStringOrdinal(packageInfo[index].packageFamilyName, -1, frameworkPackageFamilyName.c_str(), -1, TRUE) == CSTR_EQUAL)

--- a/dev/Common/WindowsAppRuntime.VersionInfo.h
+++ b/dev/Common/WindowsAppRuntime.VersionInfo.h
@@ -10,18 +10,29 @@
 STDAPI WindowsAppRuntime_VersionInfo_MSIX_Framework_PackageFamilyName_Get(
     PCWSTR* packageFamilyName) noexcept;
 
+/// Determine if Windows App SDK in use by the current process is deployed Self-Contained (vs deployed as MSIX packages)
+///
+/// @param packageFamilyName main's package family name.
+STDAPI WindowsAppRuntime_VersionInfo_MSIX_Main_PackageFamilyName_Get(
+    PCWSTR* packageFamilyName) noexcept;
+
 /// Initialize SelfContained's test support. This will constrain package enumeration
 /// and matching for test purposes.
 ///
 /// @param frameworkPackageFamilyName only match framework packages with this family name.
 ///                                   If nullptr test support is disabled.
+/// @param mainPackageFamilyName only match main packages with this family name.
+///                              If nullptr test support is disabled.
 ///
 /// @note Not for product use. This is for test purposes only to verify the implementation.
 STDAPI WindowsAppRuntime_VersionInfo_TestInitialize(
-    PCWSTR frameworkPackageFamilyName) noexcept;
+    PCWSTR frameworkPackageFamilyName,
+    PCWSTR mainPackageFamilyName) noexcept;
 
 #if defined(__cplusplus)
 namespace WindowsAppRuntime::VersionInfo
+{
+namespace Framework
 {
 /// Return the Windows App SDK framework's package family name.
 inline std::wstring GetPackageFamilyName()
@@ -30,17 +41,31 @@ inline std::wstring GetPackageFamilyName()
     THROW_IF_FAILED(WindowsAppRuntime_VersionInfo_MSIX_Framework_PackageFamilyName_Get(&packageFamilyName));
     return std::wstring{ packageFamilyName };
 }
+}
+
+namespace Main
+{
+/// Return the Windows App SDK main's package family name.
+inline std::wstring GetPackageFamilyName()
+{
+    PCWSTR packageFamilyName{};
+    THROW_IF_FAILED(WindowsAppRuntime_VersionInfo_MSIX_Main_PackageFamilyName_Get(&packageFamilyName));
+    return std::wstring{ packageFamilyName };
+}
+}
 
 /// Initialize VersionInfo's test support. This will constrain package enumeration
 /// and matching for test purposes.
 ///
 /// @param frameworkPackageFamilyName only match framework packages with this family name
+/// @param mainPackageFamilyName only match main packages with this family name
 ///
 /// @note Not for product use. This is for test purposes only to verify the implementation.
 inline void TestInitialize(
-    _In_ PCWSTR frameworkPackageFamilyName)
+    _In_ PCWSTR frameworkPackageFamilyName,
+    _In_ PCWSTR mainPackageFamilyName)
 {
-    THROW_IF_FAILED(WindowsAppRuntime_VersionInfo_TestInitialize(frameworkPackageFamilyName));
+    THROW_IF_FAILED(WindowsAppRuntime_VersionInfo_TestInitialize(frameworkPackageFamilyName, mainPackageFamilyName));
 }
 
 /// Shutdown VersionInfo's test support.
@@ -48,7 +73,7 @@ inline void TestInitialize(
 /// @note Not for product use. This is for test purposes only to verify the implementation.
 inline void TestShutdown()
 {
-    WindowsAppRuntime_VersionInfo_TestInitialize(nullptr);
+    WindowsAppRuntime_VersionInfo_TestInitialize(nullptr, nullptr);
 }
 }
 #endif // defined(__cplusplus)

--- a/dev/DynamicDependency/API/MsixDynamicDependency.h
+++ b/dev/DynamicDependency/API/MsixDynamicDependency.h
@@ -11,6 +11,9 @@
 /// MSIX Dynamic Dependency HRESULT: Windows App Runtime is not in the package graph.
 #define MDD_E_WINDOWSAPPRUNTIME_NOT_IN_PACKAGE_GRAPH    _HRESULT_TYPEDEF_(0x80040001L)
 
+/// MSIX Dynamic Dependency HRESULT: Data Store not found (Windows App Runtime's Main package not registered?)
+#define MDD_E_WINDOWSAPPRUNTIME_DATASTORE_NOT_FOUND     _HRESULT_TYPEDEF_(0x80040002L)
+
 /// MSIX Dynamic Dependency: Bootstrap initialization is scanning for an applicable DynamicDependencyLifetimeManager (DDLM) package
 #define MDD_E_BOOTSTRAP_INITIALIZE_SCAN_FOR_DDLM        _HRESULT_TYPEDEF_(0x80040010L)
 

--- a/dev/DynamicDependency/API/pch.h
+++ b/dev/DynamicDependency/API/pch.h
@@ -42,3 +42,4 @@
 #include <appmodel.packagegraph.h>
 #include <microsoft.utf8.h>
 #include <security.integritylevel.h>
+#include <windowsappruntime.versioninfo.h>

--- a/dev/WindowsAppRuntime_BootstrapDLL/MddBootstrapActivity.cpp
+++ b/dev/WindowsAppRuntime_BootstrapDLL/MddBootstrapActivity.cpp
@@ -46,21 +46,19 @@ void WindowsAppRuntime::MddBootstrap::Activity::Context::SetLastFailure(const wi
     }
 }
 
-uint32_t WindowsAppRuntime::MddBootstrap::Activity::Context::DecrementInitializationCount()
+void WindowsAppRuntime::MddBootstrap::Activity::Context::DecrementInitializationCount()
 {
-    const auto initializationCount{ m_initializationCount.load() };
-
-    if (initializationCount > 1)
+    const uint32_t initializationCount{ m_initializationCount.load() };
+    if (initializationCount == 0)
     {
-        // Multiply initialized. Just decrement our count
-        return --m_initializationCount;
+        // Not initialized
+        SetInitializationPackageFullName(nullptr);
     }
-    else if (initializationCount == 0)
+    else
     {
-        // Not initialized.
-        SetInitializationPackageFullName(PWSTR{});
+        // Initialized (at least once). Decrement our count
+        --m_initializationCount;
     }
-    return m_initializationCount;
 }
 
 const WindowsAppRuntime::MddBootstrap::Activity::IntegrityFlags WindowsAppRuntime::MddBootstrap::Activity::Context::GetIntegrityFlags(HANDLE token)

--- a/dev/WindowsAppRuntime_BootstrapDLL/MddBootstrapActivity.h
+++ b/dev/WindowsAppRuntime_BootstrapDLL/MddBootstrapActivity.h
@@ -107,7 +107,7 @@ namespace WindowsAppRuntime::MddBootstrap::Activity
             return ++m_initializationCount;
         }
 
-        uint32_t DecrementInitializationCount();
+        void DecrementInitializationCount();
 
         void SetLastFailure(const wil::FailureInfo& failure);
 

--- a/dev/WindowsAppRuntime_BootstrapDLL/MddBootstrapTest.h
+++ b/dev/WindowsAppRuntime_BootstrapDLL/MddBootstrapTest.h
@@ -9,10 +9,14 @@
 ///
 /// @param ddlmPackageNamePrefix only match DDLM packages with Name starting with this value
 /// @param ddlmPackagePublisherId only match DDLM packages with this PublisherId
+/// @param frameworkPackageNamePrefix framework package Name prefix (the 'Microsoft.WindowsAppRuntime' in 'Microsoft.WindowsAppRuntime.1.2-preview3')
+/// @param mainPackageNamePrefix main package Name prefix (the 'MicrosoftCorporationII.WinAppRuntime' in 'MicrosoftCorporationII.WinAppRuntime.1.2-preview3')
 ///
 /// @note Not for product use. This is only test purposes only to verify the implementation.
 STDAPI MddBootstrapTestInitialize(
     _In_ PCWSTR ddlmPackageNamePrefix,
-    _In_ PCWSTR ddlPackagePublisherId) noexcept;
+    _In_ PCWSTR ddlPackagePublisherId,
+    _In_ PCWSTR frameworkPackageNamePrefix,
+    _In_ PCWSTR mainPackageNamePrefix) noexcept;
 
 #endif // MDDBOOTSTRAPTEST_H

--- a/dev/WindowsAppRuntime_BootstrapDLL/MddBootstrapTracelogging.cpp
+++ b/dev/WindowsAppRuntime_BootstrapDLL/MddBootstrapTracelogging.cpp
@@ -6,22 +6,18 @@
 #include "pch.h"
 
 void MddBootstrap_StopActivity(
-    const std::string failureType,
     const bool isActivityRunning,
-    const GUID *activityId,
-    const WindowsAppRuntime::MddBootstrap::Activity::Context& activityContext,
+    WindowsAppRuntime::MddBootstrap::Activity::Context& activityContext,
     const wil::FailureInfo& failure)
 {
-    MddBootstrap_WriteEventWithActivity(*failureType.c_str(), activityId);
-
     if (isActivityRunning)
     {
         PWSTR initializationFrameworkPackageFullName{};
-        auto initializationCount{ WindowsAppRuntime::MddBootstrap::Activity::Context::Get().GetInitializeData(initializationFrameworkPackageFullName) };
+        auto initializationCount{ activityContext.GetInitializeData(initializationFrameworkPackageFullName) };
 
         if (activityContext.GetMddBootstrapAPI() == WindowsAppRuntime::MddBootstrap::Activity::MddBootstrapAPI::Initialize)
         {
-            WindowsAppRuntime::MddBootstrap::Activity::Context::Get().GetInitializeActivity().StopWithResult(
+            activityContext.GetInitializeActivity().StopWithResult(
                 failure.hr,
                 static_cast<UINT32>(initializationCount),
                 static_cast<UINT32>(WindowsAppRuntime::MddBootstrap::Activity::Context::GetIntegrityFlags()),
@@ -34,7 +30,7 @@ void MddBootstrap_StopActivity(
         }
         else if (activityContext.GetMddBootstrapAPI() == WindowsAppRuntime::MddBootstrap::Activity::MddBootstrapAPI::Shutdown)
         {
-            WindowsAppRuntime::MddBootstrap::Activity::Context::Get().GetShutdownActivity().StopWithResult(
+            activityContext.GetShutdownActivity().StopWithResult(
                 failure.hr,
                 static_cast<UINT32>(initializationCount),
                 static_cast<UINT32>(activityContext.GetLastFailure().type),
@@ -52,48 +48,46 @@ bool __stdcall wilResultLoggingThreadCallback(const wil::FailureInfo& failure) n
 {
     if (WindowsAppRuntimeBootstrap_TraceLogger::IsEnabled())
     {
-        auto IsActivityRunning = []()
+        auto& activityContext{ WindowsAppRuntime::MddBootstrap::Activity::Context::Get() };
+
+        auto IsActivityRunning = [&activityContext]()
         {
-            if (WindowsAppRuntime::MddBootstrap::Activity::Context::Get().GetMddBootstrapAPI() ==
-                WindowsAppRuntime::MddBootstrap::Activity::MddBootstrapAPI::Initialize)
+            if (activityContext.GetMddBootstrapAPI() == WindowsAppRuntime::MddBootstrap::Activity::MddBootstrapAPI::Initialize)
             {
-                return WindowsAppRuntime::MddBootstrap::Activity::Context::Get().GetInitializeActivity().IsRunning();
+                return activityContext.GetInitializeActivity().IsRunning();
             }
-            else if (WindowsAppRuntime::MddBootstrap::Activity::Context::Get().GetMddBootstrapAPI() ==
-                WindowsAppRuntime::MddBootstrap::Activity::MddBootstrapAPI::Shutdown)
+            else if (activityContext.GetMddBootstrapAPI() == WindowsAppRuntime::MddBootstrap::Activity::MddBootstrapAPI::Shutdown)
             {
-                return WindowsAppRuntime::MddBootstrap::Activity::Context::Get().GetShutdownActivity().IsRunning();
+                return activityContext.GetShutdownActivity().IsRunning();
             }
             return false;
         };
 
         auto isActivityRunning = IsActivityRunning();
 
-        auto GetActivityId = [isActivityRunning]()
+        auto GetActivityId = [&activityContext, isActivityRunning]()
         {
-            if (WindowsAppRuntime::MddBootstrap::Activity::Context::Get().GetMddBootstrapAPI() ==
-                WindowsAppRuntime::MddBootstrap::Activity::MddBootstrapAPI::Initialize)
+            if (activityContext.GetMddBootstrapAPI() == WindowsAppRuntime::MddBootstrap::Activity::MddBootstrapAPI::Initialize)
             {
                 if (isActivityRunning)
                 {
-                    return WindowsAppRuntime::MddBootstrap::Activity::Context::Get().GetInitializeActivity().Id();
+                    return activityContext.GetInitializeActivity().Id();
                 }
                 else
                 {
-                    return WindowsAppRuntime::MddBootstrap::Activity::Context::Get().GetSavedInitializeActivityId();
+                    return activityContext.GetSavedInitializeActivityId();
                 }
             }
-            else if (WindowsAppRuntime::MddBootstrap::Activity::Context::Get().GetMddBootstrapAPI() ==
-                WindowsAppRuntime::MddBootstrap::Activity::MddBootstrapAPI::Shutdown)
+            else if (activityContext.GetMddBootstrapAPI() == WindowsAppRuntime::MddBootstrap::Activity::MddBootstrapAPI::Shutdown)
             {
                 if (isActivityRunning)
                 {
-                    return WindowsAppRuntime::MddBootstrap::Activity::Context::Get().GetShutdownActivity().Id();
+                    return activityContext.GetShutdownActivity().Id();
 
                 }
                 else
                 {
-                    return WindowsAppRuntime::MddBootstrap::Activity::Context::Get().GetSavedShutdownActivityId();
+                    return activityContext.GetSavedShutdownActivityId();
                 }
             }
             return static_cast<const GUID*>(nullptr);
@@ -108,49 +102,50 @@ bool __stdcall wilResultLoggingThreadCallback(const wil::FailureInfo& failure) n
         else if (failure.type == wil::FailureType::Exception)
         {
             // Bootstrap shutdown API is a best effort API. Hence, don't stop bootstrap activity on an Exception
-            if (WindowsAppRuntime::MddBootstrap::Activity::Context::Get().GetMddBootstrapAPI() ==
-                WindowsAppRuntime::MddBootstrap::Activity::MddBootstrapAPI::Shutdown)
+            if (activityContext.GetMddBootstrapAPI() == WindowsAppRuntime::MddBootstrap::Activity::MddBootstrapAPI::Shutdown)
             {
                 MddBootstrap_WriteEventWithActivity("Exception", activityId);
             }
             else
             {
-                MddBootstrap_StopActivity("Exception", isActivityRunning, activityId, WindowsAppRuntime::MddBootstrap::Activity::Context::Get(), failure);
+                MddBootstrap_WriteEventWithActivity("Exception", activityId);
+                MddBootstrap_StopActivity(isActivityRunning, activityContext, failure);
             }
         }
         else if (failure.type == wil::FailureType::FailFast)
         {
-            MddBootstrap_StopActivity("FailFast", isActivityRunning, activityId, WindowsAppRuntime::MddBootstrap::Activity::Context::Get(), failure);
+            MddBootstrap_WriteEventWithActivity("FailFast", activityId);
+            MddBootstrap_StopActivity(isActivityRunning, activityContext, failure);
         }
         else if (failure.type == wil::FailureType::Return)
         {
             // For the RETURN_ macro that returns from the Bootstrap API, WindowsAppRuntime::MddBootstrap::Activity::Context::
             // m_stopActivityForWilReturnHR need to be set to indicate to this callback that the activity should be stopped.
             // When it is set, stop the activity.
-            if (WindowsAppRuntime::MddBootstrap::Activity::Context::Get().ShouldStopActivityForWilReturnHR())
+            if (activityContext.ShouldStopActivityForWilReturnHR())
             {
-                MddBootstrap_StopActivity("Return", isActivityRunning, activityId, WindowsAppRuntime::MddBootstrap::Activity::Context::Get(), failure);
-                WindowsAppRuntime::MddBootstrap::Activity::Context::Get().StopActivityForWilReturnHR(false);
+                MddBootstrap_WriteEventWithActivity("Return", activityId);
+                MddBootstrap_StopActivity(isActivityRunning, activityContext, failure);
+                activityContext.StopActivityForWilReturnHR(false);
             }
             else
             {
                 MddBootstrap_WriteEventWithActivity("Return", activityId);
-                WindowsAppRuntime::MddBootstrap::Activity::Context::Get().SetLastFailure(failure);
+                activityContext.SetLastFailure(failure);
             }
         }
     }
-    // Returning true indicates to wil that the error is reported in Telemetry by this callback.
+
+    // Returning true indicates to wil that the error is reported in Telemetry by this callback
     return true;
 }
 
 GUID& GetLifetimeActivityId() noexcept
 {
-    static GUID lifetimeActivityId{};
-
-    if (IsEqualGUID(lifetimeActivityId, GUID_NULL))
+    static GUID s_lifetimeActivityId{};
+    if (IsEqualGUID(s_lifetimeActivityId, GUID{}))
     {
-        std::ignore = CoCreateGuid(&lifetimeActivityId);
+        std::ignore = CoCreateGuid(&s_lifetimeActivityId);
     }
-
-    return lifetimeActivityId;
+    return s_lifetimeActivityId;
 }

--- a/dev/WindowsAppRuntime_BootstrapDLL/WindowsAppRuntime_BootstrapDLL.vcxproj
+++ b/dev/WindowsAppRuntime_BootstrapDLL/WindowsAppRuntime_BootstrapDLL.vcxproj
@@ -107,9 +107,7 @@
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
   <ImportGroup Label="ExtensionSettings">
   </ImportGroup>
-  <ImportGroup Label="Shared">
-    <Import Project="..\Common\Common.vcxitems" Label="Shared" />
-  </ImportGroup>
+  <ImportGroup Label="Shared" />
   <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
   </ImportGroup>
@@ -172,7 +170,7 @@
       <PrecompiledHeader>Use</PrecompiledHeader>
       <WarningLevel>Level4</WarningLevel>
       <SDLCheck>true</SDLCheck>
-      <AdditionalIncludeDirectories>%(AdditionalIncludeDirectories);$(OutDir)\..\WindowsAppRuntime_DLL;$(OutDir)\..\IDynamicDependencyLifetimeManager;$(MSBuildThisFileDirectory)$(PlatformTarget)\$(Configuration);$(SolutionDir)common</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>%(AdditionalIncludeDirectories);$(OutDir)\..\WindowsAppRuntime_DLL;$(OutDir)\..\IDynamicDependencyLifetimeManager;$(MSBuildThisFileDirectory)$(PlatformTarget)\$(Configuration);$(RepoRoot)\dev\common</AdditionalIncludeDirectories>
       <PreprocessorDefinitions>WIN32;_DEBUG;WINDOWSAPPRUNTIMEBOOTSTRAPDLL_EXPORTS;_WINDOWS;_USRDLL;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
       <PrecompiledHeaderFile>pch.h</PrecompiledHeaderFile>
@@ -200,7 +198,7 @@
       <PrecompiledHeader>Use</PrecompiledHeader>
       <WarningLevel>Level4</WarningLevel>
       <SDLCheck>true</SDLCheck>
-      <AdditionalIncludeDirectories>%(AdditionalIncludeDirectories);$(OutDir)\..\WindowsAppRuntime_DLL;$(OutDir)\..\IDynamicDependencyLifetimeManager;$(MSBuildThisFileDirectory)$(PlatformTarget)\$(Configuration);$(SolutionDir)common</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>%(AdditionalIncludeDirectories);$(OutDir)\..\WindowsAppRuntime_DLL;$(OutDir)\..\IDynamicDependencyLifetimeManager;$(MSBuildThisFileDirectory)$(PlatformTarget)\$(Configuration);$(RepoRoot)\dev\common</AdditionalIncludeDirectories>
       <PreprocessorDefinitions>WIN32;_DEBUG;WINDOWSAPPRUNTIMEBOOTSTRAPDLL_EXPORTS;_WINDOWS;_USRDLL;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
       <PrecompiledHeaderFile>pch.h</PrecompiledHeaderFile>
@@ -228,7 +226,7 @@
       <PrecompiledHeader>Use</PrecompiledHeader>
       <WarningLevel>Level4</WarningLevel>
       <SDLCheck>true</SDLCheck>
-      <AdditionalIncludeDirectories>%(AdditionalIncludeDirectories);$(OutDir)\..\WindowsAppRuntime_DLL;$(OutDir)\..\IDynamicDependencyLifetimeManager;$(MSBuildThisFileDirectory)$(PlatformTarget)\$(Configuration);$(SolutionDir)common</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>%(AdditionalIncludeDirectories);$(OutDir)\..\WindowsAppRuntime_DLL;$(OutDir)\..\IDynamicDependencyLifetimeManager;$(MSBuildThisFileDirectory)$(PlatformTarget)\$(Configuration);$(RepoRoot)\dev\common</AdditionalIncludeDirectories>
       <PreprocessorDefinitions>_DEBUG;WINDOWSAPPRUNTIMEBOOTSTRAPDLL_EXPORTS;_WINDOWS;_USRDLL;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
       <PrecompiledHeaderFile>pch.h</PrecompiledHeaderFile>
@@ -256,7 +254,7 @@
       <PrecompiledHeader>Use</PrecompiledHeader>
       <WarningLevel>Level4</WarningLevel>
       <SDLCheck>true</SDLCheck>
-      <AdditionalIncludeDirectories>%(AdditionalIncludeDirectories);$(OutDir)\..\WindowsAppRuntime_DLL;$(OutDir)\..\IDynamicDependencyLifetimeManager;$(MSBuildThisFileDirectory)$(PlatformTarget)\$(Configuration);$(SolutionDir)common</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>%(AdditionalIncludeDirectories);$(OutDir)\..\WindowsAppRuntime_DLL;$(OutDir)\..\IDynamicDependencyLifetimeManager;$(MSBuildThisFileDirectory)$(PlatformTarget)\$(Configuration);$(RepoRoot)\dev\common</AdditionalIncludeDirectories>
       <PreprocessorDefinitions>_DEBUG;WINDOWSAPPRUNTIMEBOOTSTRAPDLL_EXPORTS;_WINDOWS;_USRDLL;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
       <PrecompiledHeaderFile>pch.h</PrecompiledHeaderFile>
@@ -286,7 +284,7 @@
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <SDLCheck>true</SDLCheck>
-      <AdditionalIncludeDirectories>%(AdditionalIncludeDirectories);$(OutDir)\..\WindowsAppRuntime_DLL;$(OutDir)\..\IDynamicDependencyLifetimeManager;$(MSBuildThisFileDirectory)$(PlatformTarget)\$(Configuration);$(SolutionDir)common</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>%(AdditionalIncludeDirectories);$(OutDir)\..\WindowsAppRuntime_DLL;$(OutDir)\..\IDynamicDependencyLifetimeManager;$(MSBuildThisFileDirectory)$(PlatformTarget)\$(Configuration);$(RepoRoot)\dev\common</AdditionalIncludeDirectories>
       <PreprocessorDefinitions>WIN32;NDEBUG;WINDOWSAPPRUNTIMEBOOTSTRAPDLL_EXPORTS;_WINDOWS;_USRDLL;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
       <PrecompiledHeaderFile>pch.h</PrecompiledHeaderFile>
@@ -318,7 +316,7 @@
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <SDLCheck>true</SDLCheck>
-      <AdditionalIncludeDirectories>%(AdditionalIncludeDirectories);$(OutDir)\..\WindowsAppRuntime_DLL;$(OutDir)\..\IDynamicDependencyLifetimeManager;$(MSBuildThisFileDirectory)$(PlatformTarget)\$(Configuration);$(SolutionDir)common</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>%(AdditionalIncludeDirectories);$(OutDir)\..\WindowsAppRuntime_DLL;$(OutDir)\..\IDynamicDependencyLifetimeManager;$(MSBuildThisFileDirectory)$(PlatformTarget)\$(Configuration);$(RepoRoot)\dev\common</AdditionalIncludeDirectories>
       <PreprocessorDefinitions>WIN32;NDEBUG;WINDOWSAPPRUNTIMEBOOTSTRAPDLL_EXPORTS;_WINDOWS;_USRDLL;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
       <PrecompiledHeaderFile>pch.h</PrecompiledHeaderFile>
@@ -350,7 +348,7 @@
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <SDLCheck>true</SDLCheck>
-      <AdditionalIncludeDirectories>%(AdditionalIncludeDirectories);$(OutDir)\..\WindowsAppRuntime_DLL;$(OutDir)\..\IDynamicDependencyLifetimeManager;$(MSBuildThisFileDirectory)$(PlatformTarget)\$(Configuration);$(SolutionDir)common</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>%(AdditionalIncludeDirectories);$(OutDir)\..\WindowsAppRuntime_DLL;$(OutDir)\..\IDynamicDependencyLifetimeManager;$(MSBuildThisFileDirectory)$(PlatformTarget)\$(Configuration);$(RepoRoot)\dev\common</AdditionalIncludeDirectories>
       <PreprocessorDefinitions>NDEBUG;WINDOWSAPPRUNTIMEBOOTSTRAPDLL_EXPORTS;_WINDOWS;_USRDLL;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
       <PrecompiledHeaderFile>pch.h</PrecompiledHeaderFile>
@@ -382,7 +380,7 @@
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <SDLCheck>true</SDLCheck>
-      <AdditionalIncludeDirectories>%(AdditionalIncludeDirectories);$(OutDir)\..\WindowsAppRuntime_DLL;$(OutDir)\..\IDynamicDependencyLifetimeManager;$(MSBuildThisFileDirectory)$(PlatformTarget)\$(Configuration);$(SolutionDir)common</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>%(AdditionalIncludeDirectories);$(OutDir)\..\WindowsAppRuntime_DLL;$(OutDir)\..\IDynamicDependencyLifetimeManager;$(MSBuildThisFileDirectory)$(PlatformTarget)\$(Configuration);$(RepoRoot)\dev\common</AdditionalIncludeDirectories>
       <PreprocessorDefinitions>NDEBUG;WINDOWSAPPRUNTIMEBOOTSTRAPDLL_EXPORTS;_WINDOWS;_USRDLL;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
       <PrecompiledHeaderFile>pch.h</PrecompiledHeaderFile>

--- a/dev/WindowsAppRuntime_BootstrapDLL/framework.h
+++ b/dev/WindowsAppRuntime_BootstrapDLL/framework.h
@@ -25,7 +25,8 @@
 #include <winrt/Windows.Management.Deployment.h>
 
 #include <appmodel.identity.h>
-#include <security.integritylevel.h>
 #include <iswindowsversion.h>
+#include <security.integritylevel.h>
+#include <WindowsAppRuntime.VersionInfo.h>
 
 #include "wil_msixdynamicdependency.h"

--- a/dev/WindowsAppRuntime_DLL/WindowsAppRuntime.def
+++ b/dev/WindowsAppRuntime_DLL/WindowsAppRuntime.def
@@ -22,6 +22,7 @@ EXPORTS
     WindowsAppRuntime_IsSelfContained
 
     WindowsAppRuntime_VersionInfo_MSIX_Framework_PackageFamilyName_Get
+    WindowsAppRuntime_VersionInfo_MSIX_Main_PackageFamilyName_Get
     WindowsAppRuntime_VersionInfo_TestInitialize
 
     WindowsAppRuntime_EnsureIsLoaded

--- a/dev/WindowsAppRuntime_DLL/pch.h
+++ b/dev/WindowsAppRuntime_DLL/pch.h
@@ -53,5 +53,6 @@
 #include <microsoft.utf8.h>
 #include <security.integritylevel.h>
 #include <windowsappruntime.selfcontained.h>
+#include <windowsappruntime.versioninfo.h>
 
 #define MIDL_NS_PREFIX

--- a/test/Common/Test_SelfContained.cpp
+++ b/test/Common/Test_SelfContained.cpp
@@ -37,7 +37,7 @@ namespace Test::Common
                 ::TB::CleanupBootstrap();
             });
             const auto c_doesNotExistPackageFamilyName{ L"Test.PackageFamilyName.DoesNotExist_1234567890abc" };
-            ::WindowsAppRuntime::VersionInfo::TestInitialize(c_doesNotExistPackageFamilyName);
+            ::WindowsAppRuntime::VersionInfo::TestInitialize(c_doesNotExistPackageFamilyName, c_doesNotExistPackageFamilyName);
 
             VERIFY_IS_TRUE(::WindowsAppRuntime::SelfContained::IsSelfContained());
         }
@@ -50,7 +50,8 @@ namespace Test::Common
                     ::WindowsAppRuntime::VersionInfo::TestShutdown();
                     ::TB::CleanupBootstrap();
                 });
-                WindowsAppRuntime::VersionInfo::TestInitialize(::TP::WindowsAppRuntimeFramework::c_PackageFamilyName);
+                WindowsAppRuntime::VersionInfo::TestInitialize(::TP::WindowsAppRuntimeFramework::c_PackageFamilyName,
+                                                               ::TP::WindowsAppRuntimeMain::c_PackageFamilyName);
 
                 VERIFY_IS_FALSE(::WindowsAppRuntime::SelfContained::IsSelfContained());
             }
@@ -64,12 +65,13 @@ namespace Test::Common
                 ::TB::CleanupBootstrap();
             });
             const auto c_doesNotExistPackageFamilyName{ L"Test.PackageFamilyName.DoesNotExist_1234567890abc" };
-            WindowsAppRuntime::VersionInfo::TestInitialize(c_doesNotExistPackageFamilyName);
+            WindowsAppRuntime::VersionInfo::TestInitialize(c_doesNotExistPackageFamilyName, c_doesNotExistPackageFamilyName);
             VERIFY_IS_TRUE(::WindowsAppRuntime::SelfContained::IsSelfContained());
 
-            WindowsAppRuntime::VersionInfo::TestInitialize(::TP::WindowsAppRuntimeFramework::c_PackageFamilyName);
+            WindowsAppRuntime::VersionInfo::TestInitialize(::TP::WindowsAppRuntimeFramework::c_PackageFamilyName,
+                                                           ::TP::WindowsAppRuntimeMain::c_PackageFamilyName);
             VERIFY_IS_FALSE(::WindowsAppRuntime::SelfContained::IsSelfContained());
-            WindowsAppRuntime::VersionInfo::TestInitialize(c_doesNotExistPackageFamilyName);
+            WindowsAppRuntime::VersionInfo::TestInitialize(c_doesNotExistPackageFamilyName, c_doesNotExistPackageFamilyName);
 
             VERIFY_IS_TRUE(::WindowsAppRuntime::SelfContained::IsSelfContained());
         }

--- a/test/Deployment/Deployment-RealNameFramework-AppxManifest.xml
+++ b/test/Deployment/Deployment-RealNameFramework-AppxManifest.xml
@@ -21,7 +21,7 @@
 
   <Dependencies>
     <TargetDeviceFamily Name="Windows.Universal" MinVersion="10.0.17763.0" MaxVersionTested="10.0.19041.0" />
-    <PackageDependency Name="Microsoft.WindowsAppRuntime.Framework" Publisher="CN=Microsoft Corporation, O=Microsoft Corporation, L=Redmond, S=Washington, C=US" MinVersion="0.0.0.0"/>
+    <PackageDependency Name="Microsoft.WindowsAppRuntime.Framework-4.1" Publisher="CN=Microsoft Corporation, O=Microsoft Corporation, L=Redmond, S=Washington, C=US" MinVersion="0.0.0.0"/>
   </Dependencies>
 
   <Resources>

--- a/test/DynamicDependency/Test_Win32/TestPackages.cpp
+++ b/test/DynamicDependency/Test_Win32/TestPackages.cpp
@@ -97,6 +97,11 @@ namespace Test::Packages
         return GetPackagePath(packageFullName.c_str());
     }
 
+    winrt::hstring GetPackagePath(const winrt::hstring& packageFullName)
+    {
+        return winrt::hstring{ GetPackagePath(packageFullName.c_str()) };
+    }
+
     void AddPackage_DynamicDependencyLifetimeManager()
     {
         AddPackage(Test::Packages::DynamicDependencyLifetimeManager::c_PackageDirName, Test::Packages::DynamicDependencyLifetimeManager::c_PackageFullName);

--- a/test/DynamicDependency/Test_Win32/TestPackages.h
+++ b/test/DynamicDependency/Test_Win32/TestPackages.h
@@ -1,21 +1,23 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
-namespace Test::Packages::FrameworkMathAdd
+namespace Test::Packages
+{
+namespace FrameworkMathAdd
 {
     constexpr PCWSTR c_PackageDirName = L"Framework.Math.Add";
     constexpr PCWSTR c_PackageFamilyName = L"WindowsAppRuntime.Test.DynDep.Fwk.Math.Add_8wekyb3d8bbwe";
     constexpr PCWSTR c_PackageFullName = L"WindowsAppRuntime.Test.DynDep.Fwk.Math.Add_1.2.3.4_neutral__8wekyb3d8bbwe";
 }
 
-namespace Test::Packages::FrameworkMathMultiply
+namespace FrameworkMathMultiply
 {
     constexpr PCWSTR c_PackageDirName = L"Framework.Math.Multiply";
     constexpr PCWSTR c_PackageFamilyName = L"WindowsAppRuntime.Test.DynDep.Fwk.Math.Multiply_8wekyb3d8bbwe";
     constexpr PCWSTR c_PackageFullName = L"WindowsAppRuntime.Test.DynDep.Fwk.Math.Multiply_1.2.3.4_neutral__8wekyb3d8bbwe";
 }
 
-namespace Test::Packages::FrameworkWidgets
+namespace FrameworkWidgets
 {
     constexpr PCWSTR c_PackageDirName = L"Framework.Widgets";
     constexpr PCWSTR c_PackageFamilyName = L"WindowsAppRuntime.Test.DynDep.Fwk.Widgets_8wekyb3d8bbwe";
@@ -39,7 +41,7 @@ namespace Test::Packages::FrameworkWidgets
 #define TEST_PACKAGE_DDLM_PUBLISHERID   L"8wekyb3d8bbwe"
 #define TEST_PACKAGE_DDLM_FAMILYNAME    TEST_PACKAGE_DDLM_NAME L"_" TEST_PACKAGE_DDLM_PUBLISHERID
 #define TEST_PACKAGE_DDLM_FULLNAME      TEST_PACKAGE_DDLM_NAME L"_" TEST_PACKAGE_DDLM_VERSION L"_" TEST_PACKAGE_DDLM_ARCHITECTURE L"__" TEST_PACKAGE_DDLM_PUBLISHERID
-namespace Test::Packages::DynamicDependencyLifetimeManager
+namespace DynamicDependencyLifetimeManager
 {
     constexpr PCWSTR c_PackageDirName = L"DynamicDependencyLifetimeManager";
     constexpr PCWSTR c_PackageNamePrefix = TEST_PACKAGE_DDLM_NAMEPREFIX;
@@ -65,14 +67,14 @@ namespace Test::Packages::DynamicDependencyLifetimeManager
 }
 
 #define TEST_PACKAGE_DDLMGC_NAMEPREFIX  TEST_PACKAGE_DDLM_NAMEPREFIX L".GC"
-namespace Test::Packages::DynamicDependencyLifetimeManagerGC
+namespace DynamicDependencyLifetimeManagerGC
 {
     constexpr PCWSTR c_PackageNamePrefix = TEST_PACKAGE_DDLMGC_NAMEPREFIX;
     constexpr PCWSTR c_PackagePublisherId = TEST_PACKAGE_DDLM_PUBLISHERID;
 }
 
 #define TEST_PACKAGE_DDLMGC1000_NAME    TEST_PACKAGE_DDLMGC_NAMEPREFIX L"-1.0.0.0-" TEST_PACKAGE_DDLM_ARCHITECTURE
-namespace Test::Packages::DynamicDependencyLifetimeManagerGC1000
+namespace DynamicDependencyLifetimeManagerGC1000
 {
     constexpr PCWSTR c_PackageDirName = L"DynamicDependencyLifetimeManagerGC1000";
     constexpr PCWSTR c_PackageNamePrefix = TEST_PACKAGE_DDLMGC_NAMEPREFIX;
@@ -98,7 +100,7 @@ namespace Test::Packages::DynamicDependencyLifetimeManagerGC1000
 }
 
 #define TEST_PACKAGE_DDLMGC1010_NAME    TEST_PACKAGE_DDLMGC_NAMEPREFIX L"-1.0.1.0-" TEST_PACKAGE_DDLM_ARCHITECTURE
-namespace Test::Packages::DynamicDependencyLifetimeManagerGC1010
+namespace DynamicDependencyLifetimeManagerGC1010
 {
     constexpr PCWSTR c_PackageDirName = L"DynamicDependencyLifetimeManagerGC1010";
     constexpr PCWSTR c_PackageNamePrefix = TEST_PACKAGE_DDLMGC_NAMEPREFIX;
@@ -123,11 +125,12 @@ namespace Test::Packages::DynamicDependencyLifetimeManagerGC1010
     constexpr const UINT32 c_Version_MajorMinor = GetPackageVersionMajorMinor();
 }
 
-namespace Test::Packages::WindowsAppRuntimeFramework
+namespace WindowsAppRuntimeFramework
 {
     constexpr PCWSTR c_PackageDirName = L"Microsoft.WindowsAppRuntime.Framework";
-    constexpr PCWSTR c_PackageFamilyName = L"Microsoft.WindowsAppRuntime.Framework_8wekyb3d8bbwe";
-    constexpr PCWSTR c_PackageFullName = L"Microsoft.WindowsAppRuntime.Framework_4.1.1967.333_neutral__8wekyb3d8bbwe";
+    constexpr PCWSTR c_PackageNamePrefix = L"Microsoft.WindowsAppRuntime.Framework";
+    constexpr PCWSTR c_PackageFamilyName = L"Microsoft.WindowsAppRuntime.Framework-4.1_8wekyb3d8bbwe";
+    constexpr PCWSTR c_PackageFullName = L"Microsoft.WindowsAppRuntime.Framework-4.1_4.1.1967.333_neutral__8wekyb3d8bbwe";
     constexpr const PACKAGE_VERSION GetPackageVersion()
     {
         PACKAGE_VERSION version{};
@@ -146,64 +149,66 @@ namespace Test::Packages::WindowsAppRuntimeFramework
     constexpr const UINT32 c_Version_MajorMinor = GetPackageVersionMajorMinor();
 }
 
-namespace Test::Packages::DynamicDependencyDataStore
+namespace DynamicDependencyDataStore
 {
     constexpr PCWSTR c_PackageDirName = L"DynamicDependency.DataStore";
-    constexpr PCWSTR c_PackageFamilyName = L"WindowsAppRuntime.Test.DynDep.DataStore_8wekyb3d8bbwe";
-    constexpr PCWSTR c_PackageFullName = L"WindowsAppRuntime.Test.DynDep.DataStore_4.1.1967.333_neutral__8wekyb3d8bbwe";
+    constexpr PCWSTR c_PackageNamePrefix = L"WindowsAppRuntime.Test.DynDep.DataStore";
+    constexpr PCWSTR c_PackageFamilyName = L"WindowsAppRuntime.Test.DynDep.DataStore-4.1_8wekyb3d8bbwe";
+    constexpr PCWSTR c_PackageFullName = L"WindowsAppRuntime.Test.DynDep.DataStore-4.1_4.1.1967.333_neutral__8wekyb3d8bbwe";
 }
+namespace WindowsAppRuntimeMain = DynamicDependencyDataStore;
 
-namespace Test::Packages
-{
-    void AddPackageIfNecessary(PCWSTR packageDirName, PCWSTR packageFullName);
+void AddPackageIfNecessary(PCWSTR packageDirName, PCWSTR packageFullName);
 
-    void AddPackage(PCWSTR packageDirName, PCWSTR packageFullName);
+void AddPackage(PCWSTR packageDirName, PCWSTR packageFullName);
 
-    void RemovePackageIfNecessary(PCWSTR packageFullName);
+void RemovePackageIfNecessary(PCWSTR packageFullName);
 
-    void RemovePackage(PCWSTR packageFullName);
+void RemovePackage(PCWSTR packageFullName);
 
-    bool IsPackageRegistered(PCWSTR packageFullName);
+bool IsPackageRegistered(PCWSTR packageFullName);
 
-    std::wstring GetPackagePath(PCWSTR packageFullName);
+std::wstring GetPackagePath(PCWSTR packageFullName);
 
-    std::wstring GetPackagePath(const std::wstring& packageFullName);
+std::wstring GetPackagePath(const std::wstring& packageFullName);
 
-    void AddPackage_DynamicDependencyLifetimeManager();
+winrt::hstring GetPackagePath(const winrt::hstring& packageFullName);
 
-    void RemovePackage_DynamicDependencyLifetimeManager();
+void AddPackage_DynamicDependencyLifetimeManager();
 
-    void AddPackageIfNecessary_DynamicDependencyLifetimeManagerGC1000();
+void RemovePackage_DynamicDependencyLifetimeManager();
 
-    void AddPackage_DynamicDependencyLifetimeManagerGC1000();
+void AddPackageIfNecessary_DynamicDependencyLifetimeManagerGC1000();
 
-    void RemovePackage_DynamicDependencyLifetimeManagerGC1000();
+void AddPackage_DynamicDependencyLifetimeManagerGC1000();
 
-    void AddPackageIfNecessary_DynamicDependencyLifetimeManagerGC1010();
+void RemovePackage_DynamicDependencyLifetimeManagerGC1000();
 
-    void AddPackage_DynamicDependencyLifetimeManagerGC1010();
+void AddPackageIfNecessary_DynamicDependencyLifetimeManagerGC1010();
 
-    void RemovePackage_DynamicDependencyLifetimeManagerGC1010();
+void AddPackage_DynamicDependencyLifetimeManagerGC1010();
 
-    void AddPackage_WindowsAppRuntimeFramework();
+void RemovePackage_DynamicDependencyLifetimeManagerGC1010();
 
-    void RemovePackage_WindowsAppRuntimeFramework();
+void AddPackage_WindowsAppRuntimeFramework();
 
-    void AddPackage_FrameworkMathAdd();
+void RemovePackage_WindowsAppRuntimeFramework();
 
-    void RemovePackage_FrameworkMathAdd();
+void AddPackage_FrameworkMathAdd();
 
-    void AddPackage_FrameworkMathMultiply();
+void RemovePackage_FrameworkMathAdd();
 
-    void RemovePackage_FrameworkMathMultiply();
+void AddPackage_FrameworkMathMultiply();
 
-    void AddPackage_FrameworkWidgets();
+void RemovePackage_FrameworkMathMultiply();
 
-    void RemovePackage_FrameworkWidgets();
+void AddPackage_FrameworkWidgets();
 
-    void AddPackage_DynamicDependencyDataStore();
+void RemovePackage_FrameworkWidgets();
 
-    void RemovePackage_DynamicDependencyDataStore();
+void AddPackage_DynamicDependencyDataStore();
 
-    std::filesystem::path GetWindowsAppRuntimeFrameworkMsixPath();
+void RemovePackage_DynamicDependencyDataStore();
+
+std::filesystem::path GetWindowsAppRuntimeFrameworkMsixPath();
 }

--- a/test/DynamicDependency/Test_Win32/Test_GetCurrentPackageInfo.cpp
+++ b/test/DynamicDependency/Test_Win32/Test_GetCurrentPackageInfo.cpp
@@ -34,6 +34,7 @@ namespace Test::DynamicDependency
             TP::RemovePackage_FrameworkMathAdd();
             TP::AddPackage_FrameworkMathAdd();
             TP::AddPackage_WindowsAppRuntimeFramework();
+            TP::AddPackage_DynamicDependencyDataStore();
             TP::AddPackage_DynamicDependencyLifetimeManager();
 
             // Load the DLL hooking GetCurrentPackageInfo*()
@@ -56,6 +57,7 @@ namespace Test::DynamicDependency
             m_dll.reset();
 
             TP::RemovePackage_DynamicDependencyLifetimeManager();
+            TP::RemovePackage_DynamicDependencyDataStore();
             TP::RemovePackage_WindowsAppRuntimeFramework();
             TP::RemovePackage_FrameworkMathAdd();
 

--- a/test/DynamicDependency/Test_Win32/Test_LifetimeManagement.cpp
+++ b/test/DynamicDependency/Test_Win32/Test_LifetimeManagement.cpp
@@ -43,11 +43,15 @@ namespace Test::DynamicDependency
             TP::RemovePackage_FrameworkMathMultiply();
             TP::RemovePackage_FrameworkMathAdd();
             TP::AddPackage_WindowsAppRuntimeFramework();
+            TP::AddPackage_DynamicDependencyDataStore();
             TP::AddPackage_DynamicDependencyLifetimeManager();
 
             m_bootstrapDll = std::move(bootstrapDll);
 
-            VERIFY_ARE_EQUAL(S_OK, MddBootstrapTestInitialize(Test::Packages::DynamicDependencyLifetimeManager::c_PackageNamePrefix, Test::Packages::DynamicDependencyLifetimeManager::c_PackagePublisherId));
+            VERIFY_ARE_EQUAL(S_OK, MddBootstrapTestInitialize(Test::Packages::DynamicDependencyLifetimeManager::c_PackageNamePrefix,
+                                                              Test::Packages::DynamicDependencyLifetimeManager::c_PackagePublisherId,
+                                                              Test::Packages::WindowsAppRuntimeFramework::c_PackageNamePrefix,
+                                                              Test::Packages::WindowsAppRuntimeMain::c_PackageNamePrefix));
 
             // Major.Minor version, MinVersion=0 to find any framework package for this major.minor version
             const UINT32 c_Version_MajorMinor{ Test::Packages::DynamicDependencyLifetimeManager::c_Version_MajorMinor };
@@ -68,6 +72,7 @@ namespace Test::DynamicDependency
             TP::RemovePackage_DynamicDependencyLifetimeManagerGC1010();
             TP::RemovePackage_DynamicDependencyLifetimeManagerGC1000();
             TP::RemovePackage_DynamicDependencyLifetimeManager();
+            TP::RemovePackage_DynamicDependencyDataStore();
             TP::RemovePackage_WindowsAppRuntimeFramework();
 
             return true;

--- a/test/DynamicDependency/Test_Win32/Test_Win32.cpp
+++ b/test/DynamicDependency/Test_Win32/Test_Win32.cpp
@@ -46,7 +46,10 @@ bool Test::DynamicDependency::Test_Win32::Setup()
         VERIFY_IS_NOT_NULL(bootstrapDll.get(), message.get());
     }
 
-    VERIFY_ARE_EQUAL(S_OK, MddBootstrapTestInitialize(Test::Packages::DynamicDependencyLifetimeManager::c_PackageNamePrefix, Test::Packages::DynamicDependencyLifetimeManager::c_PackagePublisherId));
+    VERIFY_ARE_EQUAL(S_OK, MddBootstrapTestInitialize(Test::Packages::DynamicDependencyLifetimeManager::c_PackageNamePrefix,
+                                                      Test::Packages::DynamicDependencyLifetimeManager::c_PackagePublisherId,
+                                                      Test::Packages::WindowsAppRuntimeFramework::c_PackageNamePrefix,
+                                                      Test::Packages::WindowsAppRuntimeMain::c_PackageNamePrefix));
 
     // Major.Minor version, MinVersion=0 to find any framework package for this major.minor version
     const UINT32 c_Version_MajorMinor{ Test::Packages::DynamicDependencyLifetimeManager::c_Version_MajorMinor };

--- a/test/DynamicDependency/Test_WinRT/TestPackages.cpp
+++ b/test/DynamicDependency/Test_WinRT/TestPackages.cpp
@@ -44,7 +44,7 @@ namespace Test::Packages
         auto deploymentResult{ packageManager.AddPackageAsync(msixUri, nullptr, options).get() };
         if (FAILED(deploymentResult.ExtendedErrorCode()))
         {
-            auto message = wil::str_printf<wil::unique_process_heap_string>(L"AddPackageAsync('%s') = 0x%0X %s", packageFullName, deploymentResult.ExtendedErrorCode(), deploymentResult.ErrorText().c_str());
+            auto message = wil::str_printf<wil::unique_process_heap_string>(L"AddPackageAsync('%s') = 0x%0X %s", packageFullName, deploymentResult.ExtendedErrorCode().value, deploymentResult.ErrorText().c_str());
             VERIFY_FAIL(message.get());
         }
     }
@@ -63,7 +63,7 @@ namespace Test::Packages
         auto deploymentResult{ packageManager.RemovePackageAsync(packageFullName).get() };
         if (!deploymentResult)
         {
-            auto message = wil::str_printf<wil::unique_process_heap_string>(L"RemovePackageAsync('%s') = 0x%0X %s", packageFullName, deploymentResult.ExtendedErrorCode(), deploymentResult.ErrorText().c_str());
+            auto message = wil::str_printf<wil::unique_process_heap_string>(L"RemovePackageAsync('%s') = 0x%0X %s", packageFullName, deploymentResult.ExtendedErrorCode().value, deploymentResult.ErrorText().c_str());
             VERIFY_FAIL(message.get());
         }
     }
@@ -206,6 +206,22 @@ namespace Test::Packages
         //
         // Thus, do a *IfNecessary removal
         RemovePackageIfNecessary(Test::Packages::FrameworkMathMultiply::c_PackageFullName);
+    }
+
+    void AddPackage_FrameworkWidgets()
+    {
+        AddPackage(Test::Packages::FrameworkWidgets::c_PackageDirName, Test::Packages::FrameworkWidgets::c_PackageFullName);
+    }
+
+    void RemovePackage_FrameworkWidgets()
+    {
+        // Best-effort removal. PackageManager.RemovePackage errors if the package
+        // is not registered, but if it's not registered we're good. "'Tis the destination
+        // that matters, not the journey" so regardless how much or little work
+        // we need do, we're happy as long as the package isn't registered when we're done
+        //
+        // Thus, do a *IfNecessary removal
+        RemovePackageIfNecessary(Test::Packages::FrameworkWidgets::c_PackageFullName);
     }
 
     void AddPackage_DynamicDependencyDataStore()

--- a/test/DynamicDependency/Test_WinRT/TestPackages.h
+++ b/test/DynamicDependency/Test_WinRT/TestPackages.h
@@ -1,18 +1,27 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
-namespace Test::Packages::FrameworkMathAdd
+namespace Test::Packages
+{
+namespace FrameworkMathAdd
 {
     constexpr PCWSTR c_PackageDirName = L"Framework.Math.Add";
     constexpr PCWSTR c_PackageFamilyName = L"WindowsAppRuntime.Test.DynDep.Fwk.Math.Add_8wekyb3d8bbwe";
     constexpr PCWSTR c_PackageFullName = L"WindowsAppRuntime.Test.DynDep.Fwk.Math.Add_1.2.3.4_neutral__8wekyb3d8bbwe";
 }
 
-namespace Test::Packages::FrameworkMathMultiply
+namespace FrameworkMathMultiply
 {
     constexpr PCWSTR c_PackageDirName = L"Framework.Math.Multiply";
     constexpr PCWSTR c_PackageFamilyName = L"WindowsAppRuntime.Test.DynDep.Fwk.Math.Multiply_8wekyb3d8bbwe";
     constexpr PCWSTR c_PackageFullName = L"WindowsAppRuntime.Test.DynDep.Fwk.Math.Multiply_1.2.3.4_neutral__8wekyb3d8bbwe";
+}
+
+namespace FrameworkWidgets
+{
+    constexpr PCWSTR c_PackageDirName = L"Framework.Widgets";
+    constexpr PCWSTR c_PackageFamilyName = L"WindowsAppRuntime.Test.DynDep.Fwk.Widgets_8wekyb3d8bbwe";
+    constexpr PCWSTR c_PackageFullName = L"WindowsAppRuntime.Test.DynDep.Fwk.Widgets_1.2.3.4_neutral__8wekyb3d8bbwe";
 }
 
 #define TEST_PACKAGE_DDLM_NAMEPREFIX    L"WindowsAppRuntime.Test.DDLM"
@@ -32,7 +41,7 @@ namespace Test::Packages::FrameworkMathMultiply
 #define TEST_PACKAGE_DDLM_PUBLISHERID   L"8wekyb3d8bbwe"
 #define TEST_PACKAGE_DDLM_FAMILYNAME    TEST_PACKAGE_DDLM_NAME L"_" TEST_PACKAGE_DDLM_PUBLISHERID
 #define TEST_PACKAGE_DDLM_FULLNAME      TEST_PACKAGE_DDLM_NAME L"_" TEST_PACKAGE_DDLM_VERSION L"_" TEST_PACKAGE_DDLM_ARCHITECTURE L"__" TEST_PACKAGE_DDLM_PUBLISHERID
-namespace Test::Packages::DynamicDependencyLifetimeManager
+namespace DynamicDependencyLifetimeManager
 {
     constexpr PCWSTR c_PackageDirName = L"DynamicDependencyLifetimeManager";
     constexpr PCWSTR c_PackageNamePrefix = TEST_PACKAGE_DDLM_NAMEPREFIX;
@@ -58,14 +67,14 @@ namespace Test::Packages::DynamicDependencyLifetimeManager
 }
 
 #define TEST_PACKAGE_DDLMGC_NAMEPREFIX  TEST_PACKAGE_DDLM_NAMEPREFIX L".GC"
-namespace Test::Packages::DynamicDependencyLifetimeManagerGC
+namespace DynamicDependencyLifetimeManagerGC
 {
     constexpr PCWSTR c_PackageNamePrefix = TEST_PACKAGE_DDLMGC_NAMEPREFIX;
     constexpr PCWSTR c_PackagePublisherId = TEST_PACKAGE_DDLM_PUBLISHERID;
 }
 
 #define TEST_PACKAGE_DDLMGC1000_NAME    TEST_PACKAGE_DDLMGC_NAMEPREFIX L"-1.0.0.0-" TEST_PACKAGE_DDLM_ARCHITECTURE
-namespace Test::Packages::DynamicDependencyLifetimeManagerGC1000
+namespace DynamicDependencyLifetimeManagerGC1000
 {
     constexpr PCWSTR c_PackageDirName = L"DynamicDependencyLifetimeManagerGC1000";
     constexpr PCWSTR c_PackageNamePrefix = TEST_PACKAGE_DDLMGC_NAMEPREFIX;
@@ -91,7 +100,7 @@ namespace Test::Packages::DynamicDependencyLifetimeManagerGC1000
 }
 
 #define TEST_PACKAGE_DDLMGC1010_NAME    TEST_PACKAGE_DDLMGC_NAMEPREFIX L"-1.0.1.0-" TEST_PACKAGE_DDLM_ARCHITECTURE
-namespace Test::Packages::DynamicDependencyLifetimeManagerGC1010
+namespace DynamicDependencyLifetimeManagerGC1010
 {
     constexpr PCWSTR c_PackageDirName = L"DynamicDependencyLifetimeManagerGC1010";
     constexpr PCWSTR c_PackageNamePrefix = TEST_PACKAGE_DDLMGC_NAMEPREFIX;
@@ -116,69 +125,90 @@ namespace Test::Packages::DynamicDependencyLifetimeManagerGC1010
     constexpr const UINT32 c_Version_MajorMinor = GetPackageVersionMajorMinor();
 }
 
-namespace Test::Packages::WindowsAppRuntimeFramework
+namespace WindowsAppRuntimeFramework
 {
     constexpr PCWSTR c_PackageDirName = L"Microsoft.WindowsAppRuntime.Framework";
-    constexpr PCWSTR c_PackageFamilyName = L"Microsoft.WindowsAppRuntime.Framework_8wekyb3d8bbwe";
-    constexpr PCWSTR c_PackageFullName = L"Microsoft.WindowsAppRuntime.Framework_4.1.1967.333_neutral__8wekyb3d8bbwe";
+    constexpr PCWSTR c_PackageNamePrefix = L"Microsoft.WindowsAppRuntime.Framework";
+    constexpr PCWSTR c_PackageFamilyName = L"Microsoft.WindowsAppRuntime.Framework-4.1_8wekyb3d8bbwe";
+    constexpr PCWSTR c_PackageFullName = L"Microsoft.WindowsAppRuntime.Framework-4.1_4.1.1967.333_neutral__8wekyb3d8bbwe";
+    constexpr const PACKAGE_VERSION GetPackageVersion()
+    {
+        PACKAGE_VERSION version{};
+        version.Major = 4;
+        version.Minor = 1;
+        version.Build = 1967;
+        version.Revision = 333;
+        return version;
+    }
+    constexpr const PACKAGE_VERSION c_Version = GetPackageVersion();
+
+    constexpr const UINT32 GetPackageVersionMajorMinor()
+    {
+        return static_cast<UINT32>((GetPackageVersion().Major << 16) | GetPackageVersion().Minor);
+    }
+    constexpr const UINT32 c_Version_MajorMinor = GetPackageVersionMajorMinor();
 }
 
-namespace Test::Packages::DynamicDependencyDataStore
+namespace DynamicDependencyDataStore
 {
     constexpr PCWSTR c_PackageDirName = L"DynamicDependency.DataStore";
-    constexpr PCWSTR c_PackageFamilyName = L"WindowsAppRuntime.Test.DynDep.DataStore_8wekyb3d8bbwe";
-    constexpr PCWSTR c_PackageFullName = L"WindowsAppRuntime.Test.DynDep.DataStore_4.1.1967.333_neutral__8wekyb3d8bbwe";
+    constexpr PCWSTR c_PackageNamePrefix = L"WindowsAppRuntime.Test.DynDep.DataStore";
+    constexpr PCWSTR c_PackageFamilyName = L"WindowsAppRuntime.Test.DynDep.DataStore-4.1_8wekyb3d8bbwe";
+    constexpr PCWSTR c_PackageFullName = L"WindowsAppRuntime.Test.DynDep.DataStore-4.1_4.1.1967.333_neutral__8wekyb3d8bbwe";
 }
+namespace WindowsAppRuntimeMain = DynamicDependencyDataStore;
 
-namespace Test::Packages
-{
-    void AddPackageIfNecessary(PCWSTR packageDirName, PCWSTR packageFullName);
+void AddPackageIfNecessary(PCWSTR packageDirName, PCWSTR packageFullName);
 
-    void AddPackage(PCWSTR packageDirName, PCWSTR packageFullName);
+void AddPackage(PCWSTR packageDirName, PCWSTR packageFullName);
 
-    void RemovePackageIfNecessary(PCWSTR packageFullName);
+void RemovePackageIfNecessary(PCWSTR packageFullName);
 
-    void RemovePackage(PCWSTR packageFullName);
+void RemovePackage(PCWSTR packageFullName);
 
-    bool IsPackageRegistered(PCWSTR packageFullName);
+bool IsPackageRegistered(PCWSTR packageFullName);
 
-    std::wstring GetPackagePath(PCWSTR packageFullName);
+std::wstring GetPackagePath(PCWSTR packageFullName);
 
-    std::wstring GetPackagePath(const std::wstring& packageFullName);
+std::wstring GetPackagePath(const std::wstring& packageFullName);
 
-    winrt::hstring GetPackagePath(const winrt::hstring& packageFullName);
+winrt::hstring GetPackagePath(const winrt::hstring& packageFullName);
 
-    void AddPackage_DynamicDependencyLifetimeManager();
+void AddPackage_DynamicDependencyLifetimeManager();
 
-    void RemovePackage_DynamicDependencyLifetimeManager();
+void RemovePackage_DynamicDependencyLifetimeManager();
 
-    void AddPackageIfNecessary_DynamicDependencyLifetimeManagerGC1000();
+void AddPackageIfNecessary_DynamicDependencyLifetimeManagerGC1000();
 
-    void AddPackage_DynamicDependencyLifetimeManagerGC1000();
+void AddPackage_DynamicDependencyLifetimeManagerGC1000();
 
-    void RemovePackage_DynamicDependencyLifetimeManagerGC1000();
+void RemovePackage_DynamicDependencyLifetimeManagerGC1000();
 
-    void AddPackageIfNecessary_DynamicDependencyLifetimeManagerGC1010();
+void AddPackageIfNecessary_DynamicDependencyLifetimeManagerGC1010();
 
-    void AddPackage_DynamicDependencyLifetimeManagerGC1010();
+void AddPackage_DynamicDependencyLifetimeManagerGC1010();
 
-    void RemovePackage_DynamicDependencyLifetimeManagerGC1010();
+void RemovePackage_DynamicDependencyLifetimeManagerGC1010();
 
-    void AddPackage_WindowsAppRuntimeFramework();
+void AddPackage_WindowsAppRuntimeFramework();
 
-    void RemovePackage_WindowsAppRuntimeFramework();
+void RemovePackage_WindowsAppRuntimeFramework();
 
-    void AddPackage_FrameworkMathAdd();
+void AddPackage_FrameworkMathAdd();
 
-    void RemovePackage_FrameworkMathAdd();
+void RemovePackage_FrameworkMathAdd();
 
-    void AddPackage_FrameworkMathMultiply();
+void AddPackage_FrameworkMathMultiply();
 
-    void RemovePackage_FrameworkMathMultiply();
+void RemovePackage_FrameworkMathMultiply();
 
-    void AddPackage_DynamicDependencyDataStore();
+void AddPackage_FrameworkWidgets();
 
-    void RemovePackage_DynamicDependencyDataStore();
+void RemovePackage_FrameworkWidgets();
 
-    std::filesystem::path GetWindowsAppRuntimeFrameworkMsixPath();
+void AddPackage_DynamicDependencyDataStore();
+
+void RemovePackage_DynamicDependencyDataStore();
+
+std::filesystem::path GetWindowsAppRuntimeFrameworkMsixPath();
 }

--- a/test/DynamicDependency/Test_WinRT/Test_WinRT.cpp
+++ b/test/DynamicDependency/Test_WinRT/Test_WinRT.cpp
@@ -46,7 +46,10 @@ bool Test::DynamicDependency::Test_WinRT::Setup()
         VERIFY_IS_NOT_NULL(bootstrapDll.get(), message.get());
     }
 
-    VERIFY_ARE_EQUAL(S_OK, MddBootstrapTestInitialize(Test::Packages::DynamicDependencyLifetimeManager::c_PackageNamePrefix, Test::Packages::DynamicDependencyLifetimeManager::c_PackagePublisherId));
+    VERIFY_ARE_EQUAL(S_OK, MddBootstrapTestInitialize(Test::Packages::DynamicDependencyLifetimeManager::c_PackageNamePrefix,
+                                                      Test::Packages::DynamicDependencyLifetimeManager::c_PackagePublisherId,
+                                                      Test::Packages::WindowsAppRuntimeFramework::c_PackageNamePrefix,
+                                                      Test::Packages::WindowsAppRuntimeMain::c_PackageNamePrefix));
 
     // Major.Minor version, MinVersion=0 to find any framework package for this major.minor version
     const UINT32 c_Version_MajorMinor{ Test::Packages::DynamicDependencyLifetimeManager::c_Version_MajorMinor };

--- a/test/DynamicDependency/data/DynamicDependency.DataStore.Msix/appxmanifest.xml
+++ b/test/DynamicDependency/data/DynamicDependency.DataStore.Msix/appxmanifest.xml
@@ -10,19 +10,19 @@
   IgnorableNamespaces="uap uap3 uap5 com rescap">
 
   <Identity
-    Name="WindowsAppRuntime.Test.DynDep.DataStore"
+    Name="WindowsAppRuntime.Test.DynDep.DataStore-4.1"
     Publisher="CN=Microsoft Corporation, O=Microsoft Corporation, L=Redmond, S=Washington, C=US"
     Version="4.1.1967.333" />
 
   <Properties>
-    <DisplayName>WindowsAppRuntime.Test.DynDep.DataStore (aka Microsoft.WindowsAppRuntime.Main) fake for tests</DisplayName>
+    <DisplayName>WindowsAppRuntime.Test.DynDep.DataStore v4.1 (aka MicrosoftCorporationII.WinAppRuntime.Main) fake for tests</DisplayName>
     <PublisherDisplayName>Microsoft Corporation</PublisherDisplayName>
     <Logo>Assets\logo.png</Logo>
   </Properties>
 
   <Dependencies>
     <TargetDeviceFamily Name="Windows.Universal" MinVersion="10.0.17763.0" MaxVersionTested="10.0.19041.0" />
-    <PackageDependency Name="Microsoft.WindowsAppRuntime.Framework" Publisher="CN=Microsoft Corporation, O=Microsoft Corporation, L=Redmond, S=Washington, C=US" MinVersion="0.0.0.0"/>
+    <PackageDependency Name="Microsoft.WindowsAppRuntime.Framework-4.1" Publisher="CN=Microsoft Corporation, O=Microsoft Corporation, L=Redmond, S=Washington, C=US" MinVersion="0.0.0.0"/>
   </Dependencies>
 
   <Resources>
@@ -34,7 +34,7 @@
       Executable="DynamicDependency.DataStore.exe"
       EntryPoint="Windows.FullTrustApplication">
       <uap:VisualElements
-        DisplayName="WindowsAppRuntime.Test.DynDep.DataStore"
+        DisplayName="WindowsAppRuntime.Test.DynDep.DataStore-4.1"
         Square150x150Logo="Assets\Square150x150Logo.png"
         Square44x44Logo="Assets\Square44x44Logo.png"
         Description="Windows App SDK Test DynamicDependency DataStore"

--- a/test/DynamicDependency/data/DynamicDependencyLifetimeManager.Msix/appxmanifest-arm64.xml
+++ b/test/DynamicDependency/data/DynamicDependencyLifetimeManager.Msix/appxmanifest-arm64.xml
@@ -23,7 +23,7 @@
 
   <Dependencies>
     <TargetDeviceFamily Name="Windows.Universal" MinVersion="10.0.17763.0" MaxVersionTested="10.0.19041.0" />
-    <PackageDependency Name="Microsoft.WindowsAppRuntime.Framework" Publisher="CN=Microsoft Corporation, O=Microsoft Corporation, L=Redmond, S=Washington, C=US" MinVersion="0.0.0.0"/>
+    <PackageDependency Name="Microsoft.WindowsAppRuntime.Framework-4.1" Publisher="CN=Microsoft Corporation, O=Microsoft Corporation, L=Redmond, S=Washington, C=US" MinVersion="0.0.0.0"/>
   </Dependencies>
 
   <Resources>

--- a/test/DynamicDependency/data/DynamicDependencyLifetimeManager.Msix/appxmanifest-x64.xml
+++ b/test/DynamicDependency/data/DynamicDependencyLifetimeManager.Msix/appxmanifest-x64.xml
@@ -23,7 +23,7 @@
 
   <Dependencies>
     <TargetDeviceFamily Name="Windows.Universal" MinVersion="10.0.17763.0" MaxVersionTested="10.0.19041.0" />
-    <PackageDependency Name="Microsoft.WindowsAppRuntime.Framework" Publisher="CN=Microsoft Corporation, O=Microsoft Corporation, L=Redmond, S=Washington, C=US" MinVersion="0.0.0.0"/>
+    <PackageDependency Name="Microsoft.WindowsAppRuntime.Framework-4.1" Publisher="CN=Microsoft Corporation, O=Microsoft Corporation, L=Redmond, S=Washington, C=US" MinVersion="0.0.0.0"/>
   </Dependencies>
 
   <Resources>

--- a/test/DynamicDependency/data/DynamicDependencyLifetimeManager.Msix/appxmanifest-x86.xml
+++ b/test/DynamicDependency/data/DynamicDependencyLifetimeManager.Msix/appxmanifest-x86.xml
@@ -23,7 +23,7 @@
 
   <Dependencies>
     <TargetDeviceFamily Name="Windows.Universal" MinVersion="10.0.17763.0" MaxVersionTested="10.0.19041.0" />
-    <PackageDependency Name="Microsoft.WindowsAppRuntime.Framework" Publisher="CN=Microsoft Corporation, O=Microsoft Corporation, L=Redmond, S=Washington, C=US" MinVersion="0.0.0.0"/>
+    <PackageDependency Name="Microsoft.WindowsAppRuntime.Framework-4.1" Publisher="CN=Microsoft Corporation, O=Microsoft Corporation, L=Redmond, S=Washington, C=US" MinVersion="0.0.0.0"/>
   </Dependencies>
 
   <Resources>

--- a/test/DynamicDependency/data/DynamicDependencyLifetimeManagerGC1000.Msix/appxmanifest-arm64.xml
+++ b/test/DynamicDependency/data/DynamicDependencyLifetimeManagerGC1000.Msix/appxmanifest-arm64.xml
@@ -23,7 +23,7 @@
 
   <Dependencies>
     <TargetDeviceFamily Name="Windows.Universal" MinVersion="10.0.17763.0" MaxVersionTested="10.0.19041.0" />
-    <PackageDependency Name="Microsoft.WindowsAppRuntime.Framework" Publisher="CN=Microsoft Corporation, O=Microsoft Corporation, L=Redmond, S=Washington, C=US" MinVersion="0.0.0.0"/>
+    <PackageDependency Name="Microsoft.WindowsAppRuntime.Framework-4.1" Publisher="CN=Microsoft Corporation, O=Microsoft Corporation, L=Redmond, S=Washington, C=US" MinVersion="0.0.0.0"/>
   </Dependencies>
 
   <Resources>

--- a/test/DynamicDependency/data/DynamicDependencyLifetimeManagerGC1000.Msix/appxmanifest-x64.xml
+++ b/test/DynamicDependency/data/DynamicDependencyLifetimeManagerGC1000.Msix/appxmanifest-x64.xml
@@ -23,7 +23,7 @@
 
   <Dependencies>
     <TargetDeviceFamily Name="Windows.Universal" MinVersion="10.0.17763.0" MaxVersionTested="10.0.19041.0" />
-    <PackageDependency Name="Microsoft.WindowsAppRuntime.Framework" Publisher="CN=Microsoft Corporation, O=Microsoft Corporation, L=Redmond, S=Washington, C=US" MinVersion="0.0.0.0"/>
+    <PackageDependency Name="Microsoft.WindowsAppRuntime.Framework-4.1" Publisher="CN=Microsoft Corporation, O=Microsoft Corporation, L=Redmond, S=Washington, C=US" MinVersion="0.0.0.0"/>
   </Dependencies>
 
   <Resources>

--- a/test/DynamicDependency/data/DynamicDependencyLifetimeManagerGC1000.Msix/appxmanifest-x86.xml
+++ b/test/DynamicDependency/data/DynamicDependencyLifetimeManagerGC1000.Msix/appxmanifest-x86.xml
@@ -23,7 +23,7 @@
 
   <Dependencies>
     <TargetDeviceFamily Name="Windows.Universal" MinVersion="10.0.17763.0" MaxVersionTested="10.0.19041.0" />
-    <PackageDependency Name="Microsoft.WindowsAppRuntime.Framework" Publisher="CN=Microsoft Corporation, O=Microsoft Corporation, L=Redmond, S=Washington, C=US" MinVersion="0.0.0.0"/>
+    <PackageDependency Name="Microsoft.WindowsAppRuntime.Framework-4.1" Publisher="CN=Microsoft Corporation, O=Microsoft Corporation, L=Redmond, S=Washington, C=US" MinVersion="0.0.0.0"/>
   </Dependencies>
 
   <Resources>

--- a/test/DynamicDependency/data/DynamicDependencyLifetimeManagerGC1010.Msix/appxmanifest-arm64.xml
+++ b/test/DynamicDependency/data/DynamicDependencyLifetimeManagerGC1010.Msix/appxmanifest-arm64.xml
@@ -23,7 +23,7 @@
 
   <Dependencies>
     <TargetDeviceFamily Name="Windows.Universal" MinVersion="10.0.17763.0" MaxVersionTested="10.0.19041.0" />
-    <PackageDependency Name="Microsoft.WindowsAppRuntime.Framework" Publisher="CN=Microsoft Corporation, O=Microsoft Corporation, L=Redmond, S=Washington, C=US" MinVersion="0.0.0.0"/>
+    <PackageDependency Name="Microsoft.WindowsAppRuntime.Framework-4.1" Publisher="CN=Microsoft Corporation, O=Microsoft Corporation, L=Redmond, S=Washington, C=US" MinVersion="0.0.0.0"/>
   </Dependencies>
 
   <Resources>

--- a/test/DynamicDependency/data/DynamicDependencyLifetimeManagerGC1010.Msix/appxmanifest-x64.xml
+++ b/test/DynamicDependency/data/DynamicDependencyLifetimeManagerGC1010.Msix/appxmanifest-x64.xml
@@ -23,7 +23,7 @@
 
   <Dependencies>
     <TargetDeviceFamily Name="Windows.Universal" MinVersion="10.0.17763.0" MaxVersionTested="10.0.19041.0" />
-    <PackageDependency Name="Microsoft.WindowsAppRuntime.Framework" Publisher="CN=Microsoft Corporation, O=Microsoft Corporation, L=Redmond, S=Washington, C=US" MinVersion="0.0.0.0"/>
+    <PackageDependency Name="Microsoft.WindowsAppRuntime.Framework-4.1" Publisher="CN=Microsoft Corporation, O=Microsoft Corporation, L=Redmond, S=Washington, C=US" MinVersion="0.0.0.0"/>
   </Dependencies>
 
   <Resources>

--- a/test/DynamicDependency/data/DynamicDependencyLifetimeManagerGC1010.Msix/appxmanifest-x86.xml
+++ b/test/DynamicDependency/data/DynamicDependencyLifetimeManagerGC1010.Msix/appxmanifest-x86.xml
@@ -23,7 +23,7 @@
 
   <Dependencies>
     <TargetDeviceFamily Name="Windows.Universal" MinVersion="10.0.17763.0" MaxVersionTested="10.0.19041.0" />
-    <PackageDependency Name="Microsoft.WindowsAppRuntime.Framework" Publisher="CN=Microsoft Corporation, O=Microsoft Corporation, L=Redmond, S=Washington, C=US" MinVersion="0.0.0.0"/>
+    <PackageDependency Name="Microsoft.WindowsAppRuntime.Framework-4.1" Publisher="CN=Microsoft Corporation, O=Microsoft Corporation, L=Redmond, S=Washington, C=US" MinVersion="0.0.0.0"/>
   </Dependencies>
 
   <Resources>

--- a/test/DynamicDependency/data/Microsoft.WindowsAppRuntime.Framework/appxmanifest.xml
+++ b/test/DynamicDependency/data/Microsoft.WindowsAppRuntime.Framework/appxmanifest.xml
@@ -6,12 +6,12 @@
   IgnorableNamespaces="uap">
 
   <Identity
-    Name="Microsoft.WindowsAppRuntime.Framework"
+    Name="Microsoft.WindowsAppRuntime.Framework-4.1"
     Publisher="CN=Microsoft Corporation, O=Microsoft Corporation, L=Redmond, S=Washington, C=US"
     Version="4.1.1967.333" />
 
   <Properties>
-    <DisplayName>Microsoft.WindowsAppRuntime.Framework fake for tests</DisplayName>
+    <DisplayName>Microsoft.WindowsAppRuntime.Framework 4.1 fake for tests</DisplayName>
     <PublisherDisplayName>Windows App Runtime</PublisherDisplayName>
     <Logo>logo.png</Logo>
     <Framework>true</Framework>

--- a/test/DynamicDependency/data/WindowsAppRuntime.Test.Singleton.Msix/appxmanifest.xml
+++ b/test/DynamicDependency/data/WindowsAppRuntime.Test.Singleton.Msix/appxmanifest.xml
@@ -22,7 +22,7 @@
 
   <Dependencies>
     <TargetDeviceFamily Name="Windows.Universal" MinVersion="10.0.17763.0" MaxVersionTested="10.0.19041.0" />
-    <PackageDependency Name="Microsoft.WindowsAppRuntime.Framework" Publisher="CN=Microsoft Corporation, O=Microsoft Corporation, L=Redmond, S=Washington, C=US" MinVersion="0.0.0.0"/>
+    <PackageDependency Name="Microsoft.WindowsAppRuntime.Framework-4.1" Publisher="CN=Microsoft Corporation, O=Microsoft Corporation, L=Redmond, S=Washington, C=US" MinVersion="0.0.0.0"/>
   </Dependencies>
 
   <Resources>
@@ -73,7 +73,7 @@
             </uap5:Extension>
         </Extensions>
       </Application>
-    </Applications> 
+    </Applications>
 
   <Capabilities>
     <rescap:Capability Name="runFullTrust" />

--- a/test/EnvironmentManagerTests/AppxManifest.pkg.xml
+++ b/test/EnvironmentManagerTests/AppxManifest.pkg.xml
@@ -15,7 +15,7 @@
     </Properties>
     <Dependencies>
         <TargetDeviceFamily Name="Windows.Universal" MinVersion="10.0.0.0" MaxVersionTested="10.0.0.0" />
-        <PackageDependency Name="Microsoft.WindowsAppRuntime.Framework" Publisher="CN=Microsoft Corporation, O=Microsoft Corporation, L=Redmond, S=Washington, C=US" MinVersion="0.0.0.0"/>
+        <PackageDependency Name="Microsoft.WindowsAppRuntime.Framework-4.1" Publisher="CN=Microsoft Corporation, O=Microsoft Corporation, L=Redmond, S=Washington, C=US" MinVersion="0.0.0.0"/>
     </Dependencies>
     <Resources>
         <Resource Language="en-us" />

--- a/test/EnvironmentManagerTests/CentennialAppxManifest.pkg.xml
+++ b/test/EnvironmentManagerTests/CentennialAppxManifest.pkg.xml
@@ -17,7 +17,7 @@
     </Properties>
     <Dependencies>
         <TargetDeviceFamily Name="Windows.Desktop" MinVersion="10.0.0.0" MaxVersionTested="12.0.0.0" />
-        <PackageDependency Name="Microsoft.WindowsAppRuntime.Framework" Publisher="CN=Microsoft Corporation, O=Microsoft Corporation, L=Redmond, S=Washington, C=US" MinVersion="0.0.0.0"/>
+        <PackageDependency Name="Microsoft.WindowsAppRuntime.Framework-4.1" Publisher="CN=Microsoft Corporation, O=Microsoft Corporation, L=Redmond, S=Washington, C=US" MinVersion="0.0.0.0"/>
     </Dependencies>
     <Resources>
         <Resource Language="en-us" />

--- a/test/PowerNotifications/PowerNotifications-AppxManifest.xml
+++ b/test/PowerNotifications/PowerNotifications-AppxManifest.xml
@@ -21,7 +21,7 @@
 
   <Dependencies>
     <TargetDeviceFamily Name="Windows.Universal" MinVersion="10.0.17763.0" MaxVersionTested="10.0.19041.0" />
-    <PackageDependency Name="Microsoft.WindowsAppRuntime.Framework" Publisher="CN=Microsoft Corporation, O=Microsoft Corporation, L=Redmond, S=Washington, C=US" MinVersion="0.0.0.0"/>
+    <PackageDependency Name="Microsoft.WindowsAppRuntime.Framework-4.1" Publisher="CN=Microsoft Corporation, O=Microsoft Corporation, L=Redmond, S=Washington, C=US" MinVersion="0.0.0.0"/>
   </Dependencies>
 
   <Resources>

--- a/test/PushNotificationTests/BaseTestSuite.cpp
+++ b/test/PushNotificationTests/BaseTestSuite.cpp
@@ -27,7 +27,8 @@ void BaseTestSuite::ClassSetup()
 
     if (!isSelfContained)
     {
-        ::WindowsAppRuntime::VersionInfo::TestInitialize(::Test::Bootstrap::TP::WindowsAppRuntimeFramework::c_PackageFamilyName);
+        ::WindowsAppRuntime::VersionInfo::TestInitialize(::Test::Bootstrap::TP::WindowsAppRuntimeFramework::c_PackageFamilyName,
+                                                         ::Test::Bootstrap::TP::WindowsAppRuntimeMain::c_PackageFamilyName);
     }
 }
 

--- a/test/PushNotificationTests/PushNotifications-AppxManifest.xml
+++ b/test/PushNotificationTests/PushNotifications-AppxManifest.xml
@@ -14,18 +14,18 @@
       Name="WindowsAppRuntime.Test.PushNotifications"
       Publisher="CN=Microsoft Corporation, O=Microsoft Corporation, L=Redmond, S=Washington, C=US"
       Version="4.1.1967.333" />
-    
+
     <Properties>
         <DisplayName>WindowsAppRuntime.Test.PushNotifications for tests</DisplayName>
         <PublisherDisplayName>Windows APP SDK</PublisherDisplayName>
         <Logo>taef.png</Logo>
     </Properties>
-    
+
     <Dependencies>
         <TargetDeviceFamily Name="Windows.Desktop" MinVersion="10.0.0.0" MaxVersionTested="12.0.0.0" />
-        <PackageDependency Name="Microsoft.WindowsAppRuntime.Framework" Publisher="CN=Microsoft Corporation, O=Microsoft Corporation, L=Redmond, S=Washington, C=US" MinVersion="0.0.0.0"/>
+        <PackageDependency Name="Microsoft.WindowsAppRuntime.Framework-4.1" Publisher="CN=Microsoft Corporation, O=Microsoft Corporation, L=Redmond, S=Washington, C=US" MinVersion="0.0.0.0"/>
     </Dependencies>
-    
+
   <Resources>
     <Resource Language="en-us" />
   </Resources>
@@ -50,5 +50,5 @@
       <rescap:Capability Name="runFullTrust" />
       <rescap:Capability Name="packageManagement" />
       <rescap:Capability Name="packageQuery" />
-  </Capabilities> 
+  </Capabilities>
 </Package>

--- a/test/PushNotifications/PushNotificationsLongRunningTask.Msix/appxmanifest.xml
+++ b/test/PushNotifications/PushNotificationsLongRunningTask.Msix/appxmanifest.xml
@@ -22,7 +22,7 @@
 
     <Dependencies>
         <TargetDeviceFamily Name="Windows.Universal" MinVersion="10.0.17763.0" MaxVersionTested="10.0.19041.0" />
-        <PackageDependency Name="Microsoft.WindowsAppRuntime.Framework" Publisher="CN=Microsoft Corporation, O=Microsoft Corporation, L=Redmond, S=Washington, C=US" MinVersion="0.0.0.0"/>
+        <PackageDependency Name="Microsoft.WindowsAppRuntime.Framework-4.1" Publisher="CN=Microsoft Corporation, O=Microsoft Corporation, L=Redmond, S=Washington, C=US" MinVersion="0.0.0.0"/>
     </Dependencies>
 
     <Resources>

--- a/test/TestApps/AccessControlTestAppPackage/AccessControlTestAppPackage.wapproj
+++ b/test/TestApps/AccessControlTestAppPackage/AccessControlTestAppPackage.wapproj
@@ -64,7 +64,6 @@
     <Content Include="Images\Square44x44Logo.targetsize-24_altform-unplated.png" />
     <Content Include="Images\StoreLogo.png" />
     <Content Include="Images\Wide310x150Logo.scale-200.png" />
-    <None Include="MSTest.pfx" />
   </ItemGroup>
   <Import Project="$(WapProjPath)\Microsoft.DesktopBridge.targets" />
   <ItemGroup>

--- a/test/TestApps/AccessControlTestAppPackage/Package.appxmanifest
+++ b/test/TestApps/AccessControlTestAppPackage/Package.appxmanifest
@@ -21,7 +21,7 @@
 
   <Dependencies>
     <TargetDeviceFamily Name="Windows.Universal" MinVersion="10.0.17763.0" MaxVersionTested="10.0.19041.0" />
-    <PackageDependency Name="Microsoft.WindowsAppRuntime.Framework" Publisher="CN=Microsoft Corporation, O=Microsoft Corporation, L=Redmond, S=Washington, C=US" MinVersion="0.0.0.0"/>
+    <PackageDependency Name="Microsoft.WindowsAppRuntime.Framework-4.1" Publisher="CN=Microsoft Corporation, O=Microsoft Corporation, L=Redmond, S=Washington, C=US" MinVersion="0.0.0.0"/>
   </Dependencies>
 
   <Resources>

--- a/test/TestApps/AppLifecycleTestApp/Helpers.cpp
+++ b/test/TestApps/AppLifecycleTestApp/Helpers.cpp
@@ -6,7 +6,7 @@
 
 const wchar_t* g_bootStrapDllName = L"Microsoft.WindowsAppRuntime.Bootstrap.dll";
 
-typedef HRESULT (*BootStrapTestInit)(PCWSTR prefix, PCWSTR publisherId);
+typedef HRESULT (*BootStrapTestInit)(PCWSTR ddlmPrefix, PCWSTR publisherId, PCWSTR frameworkPrefix, PCWSTR mainPrefix);
 typedef HRESULT (*BootStrapInit)(const UINT32 majorMinorVersion, PCWSTR versionTag, const PACKAGE_VERSION minVersion);
 typedef void (*BootStrapShutdown)();
 
@@ -42,7 +42,9 @@ HRESULT BootstrapInitialize()
 
     constexpr PCWSTR c_PackageNamePrefix{ L"WindowsAppRuntime.Test.DDLM" };
     constexpr PCWSTR c_PackagePublisherId{ L"8wekyb3d8bbwe" };
-    RETURN_IF_FAILED(mddTestInitialize(c_PackageNamePrefix, c_PackagePublisherId));
+    constexpr PCWSTR c_FrameworkPackageFamilyName = L"Microsoft.WindowsAppRuntime.Framework-4.1_8wekyb3d8bbwe";
+    constexpr PCWSTR c_MainPackageFamilyName = L"WindowsAppRuntime.Test.DynDep.DataStore-4.1_8wekyb3d8bbwe";
+    RETURN_IF_FAILED(mddTestInitialize(c_PackageNamePrefix, c_PackagePublisherId, c_FrameworkPackageFamilyName, c_MainPackageFamilyName));
 
     // Major.Minor version, MinVersion=0 to find any framework package for this major.minor version
     const UINT32 c_Version_MajorMinor{ 0x00040001 };

--- a/test/TestApps/AppLifecycleTestPackage/Package.appxmanifest
+++ b/test/TestApps/AppLifecycleTestPackage/Package.appxmanifest
@@ -20,7 +20,7 @@
   <Dependencies>
     <TargetDeviceFamily Name="Windows.Universal" MinVersion="10.0.0.0" MaxVersionTested="10.0.0.0" />
     <TargetDeviceFamily Name="Windows.Desktop" MinVersion="10.0.17763.0" MaxVersionTested="10.0.18362.0" />
-    <PackageDependency Name="Microsoft.WindowsAppRuntime.Framework" Publisher="CN=Microsoft Corporation, O=Microsoft Corporation, L=Redmond, S=Washington, C=US" MinVersion="0.0.0.0"/>
+    <PackageDependency Name="Microsoft.WindowsAppRuntime.Framework-4.1" Publisher="CN=Microsoft Corporation, O=Microsoft Corporation, L=Redmond, S=Washington, C=US" MinVersion="0.0.0.0"/>
   </Dependencies>
 
   <Resources>

--- a/test/TestApps/ManualTestApp/main.cpp
+++ b/test/TestApps/ManualTestApp/main.cpp
@@ -35,7 +35,9 @@ HRESULT BootstrapInitialize()
 
     constexpr PCWSTR c_PackageNamePrefix{ L"WindowsAppRuntime.Test.DDLM" };
     constexpr PCWSTR c_PackagePublisherId{ L"8wekyb3d8bbwe" };
-    RETURN_IF_FAILED(MddBootstrapTestInitialize(c_PackageNamePrefix, c_PackagePublisherId));
+    constexpr PCWSTR c_FrameworkPackageFamilyName = L"Microsoft.WindowsAppRuntime.Framework-4.1_8wekyb3d8bbwe";
+    constexpr PCWSTR c_MainPackageFamilyName = L"WindowsAppRuntime.Test.DynDep.DataStore-4.1_8wekyb3d8bbwe";
+    RETURN_IF_FAILED(MddBootstrapTestInitialize(c_PackageNamePrefix, c_PackagePublisherId, c_FrameworkPackageFamilyName, c_MainPackageFamilyName));
 
     // Major.Minor version, MinVersion=0 to find any framework package for this major.minor version
     const UINT32 c_Version_MajorMinor{ 0x00040001 };

--- a/test/TestApps/PushNotificationsDemoApp/main.cpp
+++ b/test/TestApps/PushNotificationsDemoApp/main.cpp
@@ -93,7 +93,9 @@ int main()
     {
         constexpr PCWSTR c_PackageNamePrefix{ L"WindowsAppRuntime.Test.DDLM" };
         constexpr PCWSTR c_PackagePublisherId{ L"8wekyb3d8bbwe" };
-        RETURN_IF_FAILED(MddBootstrapTestInitialize(c_PackageNamePrefix, c_PackagePublisherId));
+        constexpr PCWSTR c_FrameworkPackageFamilyName = L"Microsoft.WindowsAppRuntime.Framework-4.1_8wekyb3d8bbwe";
+        constexpr PCWSTR c_MainPackageFamilyName = L"WindowsAppRuntime.Test.DynDep.DataStore-4.1_8wekyb3d8bbwe";
+        RETURN_IF_FAILED(MddBootstrapTestInitialize(c_PackageNamePrefix, c_PackagePublisherId, c_FrameworkPackageFamilyName, c_MainPackageFamilyName));
 
         // Major.Minor version, MinVersion=0 to find any framework package for this major.minor version
         const UINT32 c_Version_MajorMinor{ 0x00040001 };

--- a/test/TestApps/PushNotificationsDemoPackage/Package.appxmanifest
+++ b/test/TestApps/PushNotificationsDemoPackage/Package.appxmanifest
@@ -22,7 +22,7 @@
 
 	<Dependencies>
     <TargetDeviceFamily Name="Windows.Universal" MinVersion="10.0.17763.0" MaxVersionTested="10.0.19041.0" />
-    <PackageDependency Name="Microsoft.WindowsAppRuntime.Framework" Publisher="CN=Microsoft Corporation, O=Microsoft Corporation, L=Redmond, S=Washington, C=US" MinVersion="0.0.0.0"/>
+    <PackageDependency Name="Microsoft.WindowsAppRuntime.Framework-4.1" Publisher="CN=Microsoft Corporation, O=Microsoft Corporation, L=Redmond, S=Washington, C=US" MinVersion="0.0.0.0"/>
 	</Dependencies>
 
 	<Resources>

--- a/test/TestApps/PushNotificationsTestApp/main.cpp
+++ b/test/TestApps/PushNotificationsTestApp/main.cpp
@@ -319,7 +319,8 @@ int main() try
 
 
     // Test hook to ensure that the app is not self-contained
-    WindowsAppRuntime::VersionInfo::TestInitialize(::Test::Bootstrap::TP::WindowsAppRuntimeFramework::c_PackageFamilyName);
+    WindowsAppRuntime::VersionInfo::TestInitialize(::Test::Bootstrap::TP::WindowsAppRuntimeFramework::c_PackageFamilyName,
+                                                   ::Test::Bootstrap::TP::WindowsAppRuntimeMain::c_PackageFamilyName);
 
     auto scope_exit = wil::scope_exit([&] {
         ::WindowsAppRuntime::VersionInfo::TestShutdown();

--- a/test/TestApps/PushNotificationsTestAppPackage/Package.appxmanifest
+++ b/test/TestApps/PushNotificationsTestAppPackage/Package.appxmanifest
@@ -21,7 +21,7 @@
 
   <Dependencies>
     <TargetDeviceFamily Name="Windows.Universal" MinVersion="10.0.17763.0" MaxVersionTested="10.0.19041.0" />
-    <PackageDependency Name="Microsoft.WindowsAppRuntime.Framework" Publisher="CN=Microsoft Corporation, O=Microsoft Corporation, L=Redmond, S=Washington, C=US" MinVersion="0.0.0.0"/>
+    <PackageDependency Name="Microsoft.WindowsAppRuntime.Framework-4.1" Publisher="CN=Microsoft Corporation, O=Microsoft Corporation, L=Redmond, S=Washington, C=US" MinVersion="0.0.0.0"/>
   </Dependencies>
 
   <Resources>

--- a/test/TestApps/ToastNotificationsDemoApp/main.cpp
+++ b/test/TestApps/ToastNotificationsDemoApp/main.cpp
@@ -141,7 +141,9 @@ int main()
     {
         constexpr PCWSTR c_PackageNamePrefix{ L"WindowsAppRuntime.Test.DDLM" };
         constexpr PCWSTR c_PackagePublisherId{ L"8wekyb3d8bbwe" };
-        RETURN_IF_FAILED(MddBootstrapTestInitialize(c_PackageNamePrefix, c_PackagePublisherId));
+        constexpr PCWSTR c_FrameworkPackageFamilyName = L"Microsoft.WindowsAppRuntime.Framework-4.1_8wekyb3d8bbwe";
+        constexpr PCWSTR c_MainPackageFamilyName = L"WindowsAppRuntime.Test.DynDep.DataStore-4.1_8wekyb3d8bbwe";
+        RETURN_IF_FAILED(MddBootstrapTestInitialize(c_PackageNamePrefix, c_PackagePublisherId, c_FrameworkPackageFamilyName, c_MainPackageFamilyName));
 
         // Major.Minor version, MinVersion=0 to find any framework package for this major.minor version
         const UINT32 c_Version_MajorMinor{ 0x00040001 };

--- a/test/TestApps/ToastNotificationsDemoAppPackage/Package.appxmanifest
+++ b/test/TestApps/ToastNotificationsDemoAppPackage/Package.appxmanifest
@@ -22,7 +22,7 @@
 
 	<Dependencies>
     <TargetDeviceFamily Name="Windows.Universal" MinVersion="10.0.17763.0" MaxVersionTested="10.0.19041.0" />
-    <PackageDependency Name="Microsoft.WindowsAppRuntime.Framework" Publisher="CN=Microsoft Corporation, O=Microsoft Corporation, L=Redmond, S=Washington, C=US" MinVersion="0.0.0.0"/>
+    <PackageDependency Name="Microsoft.WindowsAppRuntime.Framework-4.1" Publisher="CN=Microsoft Corporation, O=Microsoft Corporation, L=Redmond, S=Washington, C=US" MinVersion="0.0.0.0"/>
 	</Dependencies>
 
   <Resources>

--- a/test/TestApps/ToastNotificationsDemoPackage/Package.appxmanifest
+++ b/test/TestApps/ToastNotificationsDemoPackage/Package.appxmanifest
@@ -22,7 +22,7 @@
 
 	<Dependencies>
     <TargetDeviceFamily Name="Windows.Universal" MinVersion="10.0.17763.0" MaxVersionTested="10.0.19041.0" />
-    <PackageDependency Name="Microsoft.WindowsAppRuntime.Framework" Publisher="CN=Microsoft Corporation, O=Microsoft Corporation, L=Redmond, S=Washington, C=US" MinVersion="0.0.0.0"/>
+    <PackageDependency Name="Microsoft.WindowsAppRuntime.Framework-4.1" Publisher="CN=Microsoft Corporation, O=Microsoft Corporation, L=Redmond, S=Washington, C=US" MinVersion="0.0.0.0"/>
 	</Dependencies>
 
   <Resources>

--- a/test/TestApps/ToastNotificationsDemoPackage/ToastNotificationsDemoPackage.wapproj
+++ b/test/TestApps/ToastNotificationsDemoPackage/ToastNotificationsDemoPackage.wapproj
@@ -42,7 +42,8 @@
     <EntryPointProjectUniqueName>..\ToastNotificationsDemoApp\ToastNotificationsDemoApp.vcxproj</EntryPointProjectUniqueName>
     <GenerateAppxPackageOnBuild>true</GenerateAppxPackageOnBuild>
     <GenerateAppInstallerFile>False</GenerateAppInstallerFile>
-    <PackageCertificateKeyFile>$(SolutionDir)temp\MSTest.pfx</PackageCertificateKeyFile>
+    <PackageCertificateKeyFile>$(RepoTestCertificatePFX)</PackageCertificateKeyFile>
+    <PackageCertificatePassword>$(RepoTestCertificatePassword)</PackageCertificatePassword>
     <AppxPackageSigningTimestampDigestAlgorithm>SHA256</AppxPackageSigningTimestampDigestAlgorithm>
     <AppxAutoIncrementPackageRevision>True</AppxAutoIncrementPackageRevision>
     <GenerateTestArtifacts>True</GenerateTestArtifacts>

--- a/test/TestApps/ToastNotificationsTestAppPackage/Package.appxmanifest
+++ b/test/TestApps/ToastNotificationsTestAppPackage/Package.appxmanifest
@@ -21,7 +21,7 @@
 
   <Dependencies>
     <TargetDeviceFamily Name="Windows.Universal" MinVersion="10.0.17763.0" MaxVersionTested="10.0.19041.0" />
-    <PackageDependency Name="Microsoft.WindowsAppRuntime.Framework" Publisher="CN=Microsoft Corporation, O=Microsoft Corporation, L=Redmond, S=Washington, C=US" MinVersion="0.0.0.0"/>
+    <PackageDependency Name="Microsoft.WindowsAppRuntime.Framework-4.1" Publisher="CN=Microsoft Corporation, O=Microsoft Corporation, L=Redmond, S=Washington, C=US" MinVersion="0.0.0.0"/>
   </Dependencies>
 
   <Resources>

--- a/test/inc/WindowsAppRuntime.Test.Bootstrap.h
+++ b/test/inc/WindowsAppRuntime.Test.Bootstrap.h
@@ -122,7 +122,10 @@ namespace Test::Bootstrap
         }
 
         // Initialize the bootstrapper (for testing purposes)
-        VERIFY_SUCCEEDED(MddBootstrapTestInitialize(TP::DynamicDependencyLifetimeManager::c_PackageNamePrefix, TP::DynamicDependencyLifetimeManager::c_PackagePublisherId));
+        VERIFY_SUCCEEDED(MddBootstrapTestInitialize(TP::DynamicDependencyLifetimeManager::c_PackageNamePrefix,
+                                                    TP::DynamicDependencyLifetimeManager::c_PackagePublisherId,
+                                                    TP::WindowsAppRuntimeFramework::c_PackageNamePrefix,
+                                                    TP::WindowsAppRuntimeMain::c_PackageNamePrefix));
 
         // Major.Minor version, MinVersion=0 to find any framework package for this major.minor version
         const UINT32 c_Version_MajorMinor{ Test::Packages::DynamicDependencyLifetimeManager::c_Version_MajorMinor };

--- a/test/inc/WindowsAppRuntime.Test.Metadata.h
+++ b/test/inc/WindowsAppRuntime.Test.Metadata.h
@@ -13,9 +13,9 @@
 
 #define WINDOWSAPPRUNTIME_TEST_MSIX_PUBLISHERID            L"8wekyb3d8bbwe"
 
-#define WINDOWSAPPRUNTIME_TEST_MSIX_FRAMEWORK_PACKAGE_NAME L"Microsoft.WindowsAppRuntime.Framework"
+#define WINDOWSAPPRUNTIME_TEST_MSIX_FRAMEWORK_PACKAGE_NAME L"Microsoft.WindowsAppRuntime.Framework-4.1"
 #define WINDOWSAPPRUNTIME_TEST_MSIX_DDLM_PACKAGE_NAME      L"Microsoft.WindowsAppRuntime.DDLM"
-#define WINDOWSAPPRUNTIME_TEST_MSIX_MAIN_PACKAGE_NAME      L"Microsoft.WindowsAppRuntime.Main"
+#define WINDOWSAPPRUNTIME_TEST_MSIX_MAIN_PACKAGE_NAME      L"Microsoft.WindowsAppRuntime.Main-4.1"
 #define WINDOWSAPPRUNTIME_TEST_MSIX_SINGLETON_PACKAGE_NAME L"Microsoft.WindowsAppRuntime.Singleton"
 
 #define WINDOWSAPPRUNTIME_TEST_PACKAGE_DDLM_NAMEPREFIX     L"WindowsAppRuntime.Test.DDLM"

--- a/test/inc/WindowsAppRuntime.Test.Package.h
+++ b/test/inc/WindowsAppRuntime.Test.Package.h
@@ -16,12 +16,13 @@
 #define WINDOWSAPPRUNTIME_TEST_METADATA_VERSION_BUILD      1967
 #define WINDOWSAPPRUNTIME_TEST_METADATA_VERSION_REVISION   333
 #define WINDOWSAPPRUNTIME_TEST_METADATA_VERSION_STRING     L"4.1.1967.333"
+#define WINDOWSAPPRUNTIME_TEST_METADATA_RELEASE_STRING     L"4.1"
 
 #define WINDOWSAPPRUNTIME_TEST_MSIX_PUBLISHERID            L"8wekyb3d8bbwe"
 
-#define WINDOWSAPPRUNTIME_TEST_MSIX_FRAMEWORK_PACKAGE_NAME L"Microsoft.WindowsAppRuntime.Framework"
+#define WINDOWSAPPRUNTIME_TEST_MSIX_FRAMEWORK_PACKAGE_NAME L"Microsoft.WindowsAppRuntime.Framework-4.1"
 #define WINDOWSAPPRUNTIME_TEST_MSIX_DDLM_PACKAGE_NAME      L"Microsoft.WindowsAppRuntime.DDLM"
-#define WINDOWSAPPRUNTIME_TEST_MSIX_MAIN_PACKAGE_NAME      L"Microsoft.WindowsAppRuntime.Main"
+#define WINDOWSAPPRUNTIME_TEST_MSIX_MAIN_PACKAGE_NAME      L"Microsoft.WindowsAppRuntime.Main-4.1"
 #define WINDOWSAPPRUNTIME_TEST_MSIX_SINGLETON_PACKAGE_NAME L"Microsoft.WindowsAppRuntime.Singleton"
 
 #define WINDOWSAPPRUNTIME_TEST_MSIX_DEPLOYMENT_FRAMEWORK_PACKAGE_NAME L"Microsoft.WindowsAppRuntime.1.0-Test"
@@ -46,7 +47,9 @@
 #define WINDOWSAPPRUNTIME_TEST_PACKAGE_DDLM_FAMILYNAME     WINDOWSAPPRUNTIME_TEST_PACKAGE_DDLM_NAME L"_" WINDOWSAPPRUNTIME_TEST_PACKAGE_DDLM_PUBLISHERID
 #define WINDOWSAPPRUNTIME_TEST_PACKAGE_DDLM_FULLNAME       WINDOWSAPPRUNTIME_TEST_PACKAGE_DDLM_NAME L"_" WINDOWSAPPRUNTIME_TEST_PACKAGE_DDLM_VERSION L"_" WINDOWSAPPRUNTIME_TEST_PACKAGE_DDLM_ARCHITECTURE L"__" WINDOWSAPPRUNTIME_TEST_PACKAGE_DDLM_PUBLISHERID
 
-namespace Test::Packages::DynamicDependencyLifetimeManager
+namespace Test::Packages
+{
+namespace DynamicDependencyLifetimeManager
 {
     constexpr PCWSTR c_PackageDirName = L"DynamicDependencyLifetimeManager";
     constexpr PCWSTR c_PackageNamePrefix = WINDOWSAPPRUNTIME_TEST_PACKAGE_DDLM_NAMEPREFIX;
@@ -71,331 +74,331 @@ namespace Test::Packages::DynamicDependencyLifetimeManager
     constexpr const UINT32 c_Version_MajorMinor = GetPackageVersionMajorMinor();
 }
 
-namespace Test::Packages::WindowsAppRuntimeFramework
+namespace WindowsAppRuntimeFramework
 {
     constexpr PCWSTR c_PackageDirName = L"Microsoft.WindowsAppRuntime.Framework";
     constexpr PCWSTR c_PackageMsixFilename = L"Microsoft.WindowsAppRuntime.Framework.msix";
+    constexpr PCWSTR c_PackageNamePrefix = L"Microsoft.WindowsAppRuntime.Framework";
     constexpr PCWSTR c_PackageFamilyName = WINDOWSAPPRUNTIME_TEST_MSIX_FRAMEWORK_PACKAGE_NAME L"_" WINDOWSAPPRUNTIME_TEST_MSIX_PUBLISHERID;
     constexpr PCWSTR c_PackageFullName = WINDOWSAPPRUNTIME_TEST_MSIX_FRAMEWORK_PACKAGE_NAME L"_" WINDOWSAPPRUNTIME_TEST_METADATA_VERSION_STRING L"_neutral__" WINDOWSAPPRUNTIME_TEST_MSIX_PUBLISHERID;
 }
 
-namespace Test::Packages::DynamicDependencyDataStore
+namespace DynamicDependencyDataStore
 {
     constexpr PCWSTR c_PackageDirName = L"DynamicDependency.DataStore";
-    constexpr PCWSTR c_PackageFamilyName = L"WindowsAppRuntime.Test.DynDep.DataStore_" WINDOWSAPPRUNTIME_TEST_MSIX_PUBLISHERID;
-    constexpr PCWSTR c_PackageFullName = L"WindowsAppRuntime.Test.DynDep.DataStore_" WINDOWSAPPRUNTIME_TEST_PACKAGE_DDLM_VERSION L"_neutral__" WINDOWSAPPRUNTIME_TEST_MSIX_PUBLISHERID;
+    constexpr PCWSTR c_PackageNamePrefix = L"WindowsAppRuntime.Test.DynDep.DataStore";
+    constexpr PCWSTR c_PackageFamilyName = L"WindowsAppRuntime.Test.DynDep.DataStore-" WINDOWSAPPRUNTIME_TEST_METADATA_RELEASE_STRING "_" WINDOWSAPPRUNTIME_TEST_MSIX_PUBLISHERID;
+    constexpr PCWSTR c_PackageFullName = L"WindowsAppRuntime.Test.DynDep.DataStore-" WINDOWSAPPRUNTIME_TEST_METADATA_RELEASE_STRING "_" WINDOWSAPPRUNTIME_TEST_PACKAGE_DDLM_VERSION L"_neutral__" WINDOWSAPPRUNTIME_TEST_MSIX_PUBLISHERID;
 }
+namespace WindowsAppRuntimeMain = DynamicDependencyDataStore;
 
-namespace Test::Packages::WindowsAppRuntimeSingleton
+namespace WindowsAppRuntimeSingleton
 {
     constexpr PCWSTR c_PackageDirName = L"WindowsAppRuntime.Test.Singleton";
     constexpr PCWSTR c_PackageFamilyName = L"WindowsAppRuntime.Test.Singleton_" WINDOWSAPPRUNTIME_TEST_MSIX_PUBLISHERID;
     constexpr PCWSTR c_PackageFullName = L"WindowsAppRuntime.Test.Singleton_" WINDOWSAPPRUNTIME_TEST_PACKAGE_DDLM_VERSION L"_neutral__" WINDOWSAPPRUNTIME_TEST_MSIX_PUBLISHERID;
 }
 
-namespace Test::Packages::PushNotificationsLongRunningTask
+namespace PushNotificationsLongRunningTask
 {
     constexpr PCWSTR c_PackageDirName = L"PushNotificationsLongRunningTask";
     constexpr PCWSTR c_PackageFamilyName = L"WindowsAppRuntime.Test.PushNotificationsTask_" WINDOWSAPPRUNTIME_TEST_MSIX_PUBLISHERID;
     constexpr PCWSTR c_PackageFullName = L"WindowsAppRuntime.Test.PushNotificationsTask_" WINDOWSAPPRUNTIME_TEST_PACKAGE_DDLM_VERSION L"_neutral__" WINDOWSAPPRUNTIME_TEST_MSIX_PUBLISHERID;
 }
 
-namespace Test::Packages::DeploymentWindowsAppRuntimeFramework
+namespace DeploymentWindowsAppRuntimeFramework
 {
     constexpr PCWSTR c_PackageDirName = L"Deployment.WindowsAppRuntime.Test.Framework";
     constexpr PCWSTR c_PackageFamilyName = WINDOWSAPPRUNTIME_TEST_MSIX_DEPLOYMENT_FRAMEWORK_PACKAGE_NAME L"_" WINDOWSAPPRUNTIME_TEST_MSIX_PUBLISHERID;
     constexpr PCWSTR c_PackageFullName = WINDOWSAPPRUNTIME_TEST_MSIX_DEPLOYMENT_FRAMEWORK_PACKAGE_NAME L"_" WINDOWSAPPRUNTIME_TEST_METADATA_VERSION_STRING L"_neutral__" WINDOWSAPPRUNTIME_TEST_MSIX_PUBLISHERID;
 }
 
-namespace Test::Packages::DeploymentWindowsAppRuntimeMain
+namespace DeploymentWindowsAppRuntimeMain
 {
     constexpr PCWSTR c_PackageDirName = L"Deployment.WindowsAppRuntime.Test.Main";
     constexpr PCWSTR c_PackageFamilyName = WINDOWSAPPRUNTIME_TEST_MSIX_DEPLOYMENT_MAIN_PACKAGE_NAME L"_" WINDOWSAPPRUNTIME_TEST_MSIX_PUBLISHERID;
     constexpr PCWSTR c_PackageFullName = WINDOWSAPPRUNTIME_TEST_MSIX_DEPLOYMENT_MAIN_PACKAGE_NAME L"_" WINDOWSAPPRUNTIME_TEST_METADATA_VERSION_STRING L"_neutral__" WINDOWSAPPRUNTIME_TEST_MSIX_PUBLISHERID;
 }
 
-namespace Test::Packages::DeploymentWindowsAppRuntimeSingleton
+namespace DeploymentWindowsAppRuntimeSingleton
 {
     constexpr PCWSTR c_PackageDirName = L"Deployment.WindowsAppRuntime.Test.Singleton";
     constexpr PCWSTR c_PackageFamilyName = WINDOWSAPPRUNTIME_TEST_MSIX_DEPLOYMENT_SINGLETON_PACKAGE_NAME L"_" WINDOWSAPPRUNTIME_TEST_MSIX_PUBLISHERID;
     constexpr PCWSTR c_PackageFullName = WINDOWSAPPRUNTIME_TEST_MSIX_DEPLOYMENT_SINGLETON_PACKAGE_NAME L"_" WINDOWSAPPRUNTIME_TEST_METADATA_VERSION_STRING L"_neutral__" WINDOWSAPPRUNTIME_TEST_MSIX_PUBLISHERID;
 }
 
-namespace Test::Packages
+inline std::wstring GetPackagePath(PCWSTR packageFullName)
 {
-    inline std::wstring GetPackagePath(PCWSTR packageFullName)
+    UINT32 pathLength{};
+    const auto rc{ GetPackagePathByFullName(packageFullName, &pathLength, nullptr) };
+    if (rc == ERROR_NOT_FOUND)
     {
-        UINT32 pathLength{};
-        const auto rc{ GetPackagePathByFullName(packageFullName, &pathLength, nullptr) };
-        if (rc == ERROR_NOT_FOUND)
-        {
-            return std::wstring();
-        }
-
-        VERIFY_ARE_EQUAL(ERROR_INSUFFICIENT_BUFFER, rc);
-        auto path = wil::make_process_heap_string(nullptr, pathLength);
-        VERIFY_ARE_EQUAL(ERROR_SUCCESS, GetPackagePathByFullName(packageFullName, &pathLength, path.get()));
-        return std::wstring(path.get());
+        return std::wstring();
     }
 
-    inline std::wstring GetPackagePath(const std::wstring& packageFullName)
-    {
-        return GetPackagePath(packageFullName.c_str());
-    }
+    VERIFY_ARE_EQUAL(ERROR_INSUFFICIENT_BUFFER, rc);
+    auto path = wil::make_process_heap_string(nullptr, pathLength);
+    VERIFY_ARE_EQUAL(ERROR_SUCCESS, GetPackagePathByFullName(packageFullName, &pathLength, path.get()));
+    return std::wstring(path.get());
+}
 
-    inline bool IsPackageRegistered(PCWSTR packageFullName)
-    {
-        // Check if the package is registered to the current user via GetPackagePath().
-        // GetPackagePath() fails if the package isn't registerd to the current user.
-        // Simplest and most portable test across the platforms we might run on
-        const auto path = GetPackagePath(packageFullName);
-        return !path.empty();
-    }
+inline std::wstring GetPackagePath(const std::wstring& packageFullName)
+{
+    return GetPackagePath(packageFullName.c_str());
+}
 
-    inline void AddPackage(PCWSTR packageDirName, PCWSTR packageFullName)
+inline bool IsPackageRegistered(PCWSTR packageFullName)
+{
+    // Check if the package is registered to the current user via GetPackagePath().
+    // GetPackagePath() fails if the package isn't registerd to the current user.
+    // Simplest and most portable test across the platforms we might run on
+    const auto path = GetPackagePath(packageFullName);
+    return !path.empty();
+}
+
+inline void AddPackage(PCWSTR packageDirName, PCWSTR packageFullName)
+{
+    // Build the target package's .msix filename. It's under the Solution's $(OutDir)
+    // NOTE: It could live in ...\Something.msix\... or ...\Something\...
+    auto solutionOutDirPath = ::Test::FileSystem::GetSolutionOutDirPath();
+    //
+    // Look in ...\Something.msix\...
+    auto msix(solutionOutDirPath);
+    msix /= packageDirName;
+    msix += L".msix";
+    msix /= packageDirName;
+    msix += L".msix";
+    if (!std::filesystem::is_regular_file(msix))
     {
-        // Build the target package's .msix filename. It's under the Solution's $(OutDir)
-        // NOTE: It could live in ...\Something.msix\... or ...\Something\...
-        auto solutionOutDirPath = ::Test::FileSystem::GetSolutionOutDirPath();
-        //
-        // Look in ...\Something.msix\...
-        auto msix(solutionOutDirPath);
+        // Look in ...\Something\...
+        msix = solutionOutDirPath;
+        msix /= packageDirName;
         msix /= packageDirName;
         msix += L".msix";
-        msix /= packageDirName;
-        msix += L".msix";
-        if (!std::filesystem::is_regular_file(msix))
-        {
-            // Look in ...\Something\...
-            msix = solutionOutDirPath;
-            msix /= packageDirName;
-            msix /= packageDirName;
-            msix += L".msix";
-            WIN32_FILE_ATTRIBUTE_DATA data{};
-            const auto ok{ GetFileAttributesExW(msix.c_str(), GetFileExInfoStandard, &data) };
-            const auto lastError{ ::GetLastError() };
-            WEX::Logging::Log::Comment(WEX::Common::String().Format(L"GetFileAttributesExW(%ls):%d LastError:%u", msix.c_str(), static_cast<int>(ok), lastError));
+        WIN32_FILE_ATTRIBUTE_DATA data{};
+        const auto ok{ GetFileAttributesExW(msix.c_str(), GetFileExInfoStandard, &data) };
+        const auto lastError{ ::GetLastError() };
+        WEX::Logging::Log::Comment(WEX::Common::String().Format(L"GetFileAttributesExW(%ls):%d LastError:%u", msix.c_str(), static_cast<int>(ok), lastError));
 
-            std::error_code errorcode{};
-            auto isregularfile{ std::filesystem::is_regular_file(msix, errorcode) };
-            WEX::Logging::Log::Comment(WEX::Common::String().Format(L"std::filesystem::is_regular_file(%ls):%ls error_code:%d %hs", msix.c_str(), isregularfile ? L"True" : L"False", errorcode.value(), errorcode.message().c_str()));
+        std::error_code errorcode{};
+        auto isregularfile{ std::filesystem::is_regular_file(msix, errorcode) };
+        WEX::Logging::Log::Comment(WEX::Common::String().Format(L"std::filesystem::is_regular_file(%ls):%ls error_code:%d %hs", msix.c_str(), isregularfile ? L"True" : L"False", errorcode.value(), errorcode.message().c_str()));
 
-            //VERIFY_IS_TRUE(std::filesystem::is_regular_file(msix));
-        }
-        auto msixUri = winrt::Windows::Foundation::Uri(msix.c_str());
-
-        // Install the package
-        winrt::Windows::Management::Deployment::PackageManager packageManager;
-        auto options{ winrt::Windows::Management::Deployment::DeploymentOptions::None };
-        auto deploymentResult{ packageManager.AddPackageAsync(msixUri, nullptr, options).get() };
-        VERIFY_SUCCEEDED(deploymentResult.ExtendedErrorCode(), WEX::Common::String().Format(L"AddPackageAsync('%s') = 0x%0X %s", packageFullName, deploymentResult.ExtendedErrorCode(), deploymentResult.ErrorText().c_str()));
+        //VERIFY_IS_TRUE(std::filesystem::is_regular_file(msix));
     }
+    auto msixUri = winrt::Windows::Foundation::Uri(msix.c_str());
 
-    inline void AddPackageIfNecessary(PCWSTR packageDirName, PCWSTR packageFullName)
-    {
-        if (!IsPackageRegistered(packageFullName))
-        {
-            AddPackage(packageDirName, packageFullName);
-        }
-    }
+    // Install the package
+    winrt::Windows::Management::Deployment::PackageManager packageManager;
+    auto options{ winrt::Windows::Management::Deployment::DeploymentOptions::None };
+    auto deploymentResult{ packageManager.AddPackageAsync(msixUri, nullptr, options).get() };
+    VERIFY_SUCCEEDED(deploymentResult.ExtendedErrorCode(), WEX::Common::String().Format(L"AddPackageAsync('%s') = 0x%0X %s", packageFullName, deploymentResult.ExtendedErrorCode(), deploymentResult.ErrorText().c_str()));
+}
 
-    inline void RemovePackage(PCWSTR packageFullName)
+inline void AddPackageIfNecessary(PCWSTR packageDirName, PCWSTR packageFullName)
+{
+    if (!IsPackageRegistered(packageFullName))
     {
-        winrt::Windows::Management::Deployment::PackageManager packageManager;
-        auto deploymentResult{ packageManager.RemovePackageAsync(packageFullName).get() };
-        if (!deploymentResult)
-        {
-            VERIFY_FAIL(WEX::Common::String().Format(L"RemovePackageAsync('%s') = 0x%0X %s", packageFullName, deploymentResult.ExtendedErrorCode(), deploymentResult.ErrorText().c_str()));
-        }
-    }
-
-    inline void RemovePackageIfNecessary(PCWSTR packageFullName)
-    {
-        if (IsPackageRegistered(packageFullName))
-        {
-            RemovePackage(packageFullName);
-        }
-    }
-
-    inline void AddPackage_DynamicDependencyLifetimeManager()
-    {
-        AddPackage(Test::Packages::DynamicDependencyLifetimeManager::c_PackageDirName, Test::Packages::DynamicDependencyLifetimeManager::c_PackageFullName);
-    }
-
-    inline void RemovePackage_DynamicDependencyLifetimeManager()
-    {
-        // Best-effort removal. PackageManager.RemovePackage errors if the package
-        // is not registered, but if it's not registered we're good. "'Tis the destination
-        // that matters, not the journey" so regardless how much or little work
-        // we need do, we're happy as long as the package isn't registered when we're done
-        //
-        // Thus, do a *IfNecessary removal
-        RemovePackageIfNecessary(Test::Packages::DynamicDependencyLifetimeManager::c_PackageFullName);
-    }
-
-    inline bool IsPackageRegistered_DynamicDependencyLifetimeManager()
-    {
-        return IsPackageRegistered(Test::Packages::DynamicDependencyLifetimeManager::c_PackageFullName);
-    }
-
-    inline void AddPackage_WindowsAppRuntimeFramework()
-    {
-        AddPackage(Test::Packages::WindowsAppRuntimeFramework::c_PackageDirName, Test::Packages::WindowsAppRuntimeFramework::c_PackageFullName);
-    }
-
-    inline void RemovePackage_WindowsAppRuntimeFramework()
-    {
-        // Best-effort removal. PackageManager.RemovePackage errors if the package
-        // is not registered, but if it's not registered we're good. "'Tis the destination
-        // that matters, not the journey" so regardless how much or little work
-        // we need do, we're happy as long as the package isn't registered when we're done
-        //
-        // Thus, do a *IfNecessary removal
-        RemovePackageIfNecessary(Test::Packages::WindowsAppRuntimeFramework::c_PackageFullName);
-    }
-
-    inline bool IsPackageRegistered_WindowsAppRuntimeFramework()
-    {
-        return IsPackageRegistered(Test::Packages::WindowsAppRuntimeFramework::c_PackageFullName);
-    }
-
-    inline void AddPackage_DynamicDependencyDataStore()
-    {
-        AddPackage(Test::Packages::DynamicDependencyDataStore::c_PackageDirName, Test::Packages::DynamicDependencyDataStore::c_PackageFullName);
-    }
-
-    inline void RemovePackage_DynamicDependencyDataStore()
-    {
-        // Best-effort removal. PackageManager.RemovePackage errors if the package
-        // is not registered, but if it's not registered we're good. "'Tis the destination
-        // that matters, not the journey" so regardless how much or little work
-        // we need do, we're happy as long as the package isn't registered when we're done
-        //
-        // Thus, do a *IfNecessary removal
-        RemovePackageIfNecessary(Test::Packages::DynamicDependencyDataStore::c_PackageFullName);
-    }
-
-    inline bool IsPackageRegistered_DynamicDependencyDataStore()
-    {
-        return IsPackageRegistered(Test::Packages::DynamicDependencyDataStore::c_PackageFullName);
-    }
-
-    inline void AddPackage_WindowsAppRuntimeSingleton()
-    {
-        AddPackage(Test::Packages::WindowsAppRuntimeSingleton::c_PackageDirName, Test::Packages::WindowsAppRuntimeSingleton::c_PackageFullName);
-    }
-
-    inline void RemovePackage_WindowsAppRuntimeSingleton()
-    {
-        // Best-effort removal. PackageManager.RemovePackage errors if the package
-        // is not registered, but if it's not registered we're good. "'Tis the destination
-        // that matters, not the journey" so regardless how much or little work
-        // we need do, we're happy as long as the package isn't registered when we're done
-        //
-        // Thus, do a *IfNecessary removal
-        RemovePackageIfNecessary(Test::Packages::WindowsAppRuntimeSingleton::c_PackageFullName);
-    }
-
-    inline bool IsPackageRegistered_WindowsAppRuntimeSingleton()
-    {
-        return IsPackageRegistered(Test::Packages::WindowsAppRuntimeSingleton::c_PackageFullName);
-    }
-
-    inline void AddPackage_PushNotificationsLongRunningTask()
-    {
-        AddPackage(Test::Packages::PushNotificationsLongRunningTask::c_PackageDirName, Test::Packages::PushNotificationsLongRunningTask::c_PackageFullName);
-    }
-
-    inline void RemovePackage_PushNotificationsLongRunningTask()
-    {
-        // Best-effort removal. PackageManager.RemovePackage errors if the package
-        // is not registered, but if it's not registered we're good. "'Tis the destination
-        // that matters, not the journey" so regardless how much or little work
-        // we need do, we're happy as long as the package isn't registered when we're done
-        //
-        // Thus, do a *IfNecessary removal
-        RemovePackageIfNecessary(Test::Packages::PushNotificationsLongRunningTask::c_PackageFullName);
-    }
-
-    inline bool IsPackageRegistered_PushNotificationsLongRunningTask()
-    {
-        return IsPackageRegistered(Test::Packages::PushNotificationsLongRunningTask::c_PackageFullName);
-    }
-
-    inline void AddPackage_DeploymentWindowsAppRuntimeFramework()
-    {
-        AddPackage(Test::Packages::DeploymentWindowsAppRuntimeFramework::c_PackageDirName, Test::Packages::DeploymentWindowsAppRuntimeFramework::c_PackageFullName);
-    }
-
-    inline void RemovePackage_DeploymentWindowsAppRuntimeFramework()
-    {
-        // Best-effort removal. PackageManager.RemovePackage errors if the package
-        // is not registered, but if it's not registered we're good. "'Tis the destination
-        // that matters, not the journey" so regardless how much or little work
-        // we need do, we're happy as long as the package isn't registered when we're done
-        //
-        // Thus, do a *IfNecessary removal
-        RemovePackageIfNecessary(Test::Packages::DeploymentWindowsAppRuntimeFramework::c_PackageFullName);
-    }
-
-    inline bool IsPackageRegistered_DeploymentWindowsAppRuntimeFramework()
-    {
-        return IsPackageRegistered(Test::Packages::DeploymentWindowsAppRuntimeFramework::c_PackageFullName);
-    }
-
-    inline void AddPackage_DeploymentWindowsAppRuntimeMain()
-    {
-        AddPackage(Test::Packages::DeploymentWindowsAppRuntimeMain::c_PackageDirName, Test::Packages::DeploymentWindowsAppRuntimeMain::c_PackageFullName);
-    }
-
-    inline void RemovePackage_DeploymentWindowsAppRuntimeMain()
-    {
-        // Best-effort removal. PackageManager.RemovePackage errors if the package
-        // is not registered, but if it's not registered we're good. "'Tis the destination
-        // that matters, not the journey" so regardless how much or little work
-        // we need do, we're happy as long as the package isn't registered when we're done
-        //
-        // Thus, do a *IfNecessary removal
-        RemovePackageIfNecessary(Test::Packages::DeploymentWindowsAppRuntimeMain::c_PackageFullName);
-    }
-
-    inline bool IsPackageRegistered_DeploymentWindowsAppRuntimeMain()
-    {
-        return IsPackageRegistered(Test::Packages::DeploymentWindowsAppRuntimeMain::c_PackageFullName);
-    }
-
-    inline void AddPackage_DeploymentWindowsAppRuntimeSingleton()
-    {
-        AddPackage(Test::Packages::DeploymentWindowsAppRuntimeSingleton::c_PackageDirName, Test::Packages::DeploymentWindowsAppRuntimeSingleton::c_PackageFullName);
-    }
-
-    inline void RemovePackage_DeploymentWindowsAppRuntimeSingleton()
-    {
-        // Best-effort removal. PackageManager.RemovePackage errors if the package
-        // is not registered, but if it's not registered we're good. "'Tis the destination
-        // that matters, not the journey" so regardless how much or little work
-        // we need do, we're happy as long as the package isn't registered when we're done
-        //
-        // Thus, do a *IfNecessary removal
-        RemovePackageIfNecessary(Test::Packages::DeploymentWindowsAppRuntimeSingleton::c_PackageFullName);
-    }
-
-    inline bool IsPackageRegistered_DeploymentWindowsAppRuntimeSingleton()
-    {
-        return IsPackageRegistered(Test::Packages::DeploymentWindowsAppRuntimeSingleton::c_PackageFullName);
-    }
-
-    inline std::filesystem::path GetWindowsAppRuntimeFrameworkMsixPath()
-    {
-        // Determine the location of the WindowsAppRuntime Framework's msix. See GetSolutionOutDirPath() for more details.
-        auto path = ::Test::FileSystem::GetSolutionOutDirPath();
-        path /= Test::Packages::WindowsAppRuntimeFramework::c_PackageDirName;
-        path /= Test::Packages::WindowsAppRuntimeFramework::c_PackageMsixFilename;
-        return path;
+        AddPackage(packageDirName, packageFullName);
     }
 }
 
-namespace Test::Packages::WapProj
+inline void RemovePackage(PCWSTR packageFullName)
+{
+    winrt::Windows::Management::Deployment::PackageManager packageManager;
+    auto deploymentResult{ packageManager.RemovePackageAsync(packageFullName).get() };
+    if (!deploymentResult)
+    {
+        VERIFY_FAIL(WEX::Common::String().Format(L"RemovePackageAsync('%s') = 0x%0X %s", packageFullName, deploymentResult.ExtendedErrorCode(), deploymentResult.ErrorText().c_str()));
+    }
+}
+
+inline void RemovePackageIfNecessary(PCWSTR packageFullName)
+{
+    if (IsPackageRegistered(packageFullName))
+    {
+        RemovePackage(packageFullName);
+    }
+}
+
+inline void AddPackage_DynamicDependencyLifetimeManager()
+{
+    AddPackage(Test::Packages::DynamicDependencyLifetimeManager::c_PackageDirName, Test::Packages::DynamicDependencyLifetimeManager::c_PackageFullName);
+}
+
+inline void RemovePackage_DynamicDependencyLifetimeManager()
+{
+    // Best-effort removal. PackageManager.RemovePackage errors if the package
+    // is not registered, but if it's not registered we're good. "'Tis the destination
+    // that matters, not the journey" so regardless how much or little work
+    // we need do, we're happy as long as the package isn't registered when we're done
+    //
+    // Thus, do a *IfNecessary removal
+    RemovePackageIfNecessary(Test::Packages::DynamicDependencyLifetimeManager::c_PackageFullName);
+}
+
+inline bool IsPackageRegistered_DynamicDependencyLifetimeManager()
+{
+    return IsPackageRegistered(Test::Packages::DynamicDependencyLifetimeManager::c_PackageFullName);
+}
+
+inline void AddPackage_WindowsAppRuntimeFramework()
+{
+    AddPackage(Test::Packages::WindowsAppRuntimeFramework::c_PackageDirName, Test::Packages::WindowsAppRuntimeFramework::c_PackageFullName);
+}
+
+inline void RemovePackage_WindowsAppRuntimeFramework()
+{
+    // Best-effort removal. PackageManager.RemovePackage errors if the package
+    // is not registered, but if it's not registered we're good. "'Tis the destination
+    // that matters, not the journey" so regardless how much or little work
+    // we need do, we're happy as long as the package isn't registered when we're done
+    //
+    // Thus, do a *IfNecessary removal
+    RemovePackageIfNecessary(Test::Packages::WindowsAppRuntimeFramework::c_PackageFullName);
+}
+
+inline bool IsPackageRegistered_WindowsAppRuntimeFramework()
+{
+    return IsPackageRegistered(Test::Packages::WindowsAppRuntimeFramework::c_PackageFullName);
+}
+
+inline void AddPackage_DynamicDependencyDataStore()
+{
+    AddPackage(Test::Packages::DynamicDependencyDataStore::c_PackageDirName, Test::Packages::DynamicDependencyDataStore::c_PackageFullName);
+}
+
+inline void RemovePackage_DynamicDependencyDataStore()
+{
+    // Best-effort removal. PackageManager.RemovePackage errors if the package
+    // is not registered, but if it's not registered we're good. "'Tis the destination
+    // that matters, not the journey" so regardless how much or little work
+    // we need do, we're happy as long as the package isn't registered when we're done
+    //
+    // Thus, do a *IfNecessary removal
+    RemovePackageIfNecessary(Test::Packages::DynamicDependencyDataStore::c_PackageFullName);
+}
+
+inline bool IsPackageRegistered_DynamicDependencyDataStore()
+{
+    return IsPackageRegistered(Test::Packages::DynamicDependencyDataStore::c_PackageFullName);
+}
+
+inline void AddPackage_WindowsAppRuntimeSingleton()
+{
+    AddPackage(Test::Packages::WindowsAppRuntimeSingleton::c_PackageDirName, Test::Packages::WindowsAppRuntimeSingleton::c_PackageFullName);
+}
+
+inline void RemovePackage_WindowsAppRuntimeSingleton()
+{
+    // Best-effort removal. PackageManager.RemovePackage errors if the package
+    // is not registered, but if it's not registered we're good. "'Tis the destination
+    // that matters, not the journey" so regardless how much or little work
+    // we need do, we're happy as long as the package isn't registered when we're done
+    //
+    // Thus, do a *IfNecessary removal
+    RemovePackageIfNecessary(Test::Packages::WindowsAppRuntimeSingleton::c_PackageFullName);
+}
+
+inline bool IsPackageRegistered_WindowsAppRuntimeSingleton()
+{
+    return IsPackageRegistered(Test::Packages::WindowsAppRuntimeSingleton::c_PackageFullName);
+}
+
+inline void AddPackage_PushNotificationsLongRunningTask()
+{
+    AddPackage(Test::Packages::PushNotificationsLongRunningTask::c_PackageDirName, Test::Packages::PushNotificationsLongRunningTask::c_PackageFullName);
+}
+
+inline void RemovePackage_PushNotificationsLongRunningTask()
+{
+    // Best-effort removal. PackageManager.RemovePackage errors if the package
+    // is not registered, but if it's not registered we're good. "'Tis the destination
+    // that matters, not the journey" so regardless how much or little work
+    // we need do, we're happy as long as the package isn't registered when we're done
+    //
+    // Thus, do a *IfNecessary removal
+    RemovePackageIfNecessary(Test::Packages::PushNotificationsLongRunningTask::c_PackageFullName);
+}
+
+inline bool IsPackageRegistered_PushNotificationsLongRunningTask()
+{
+    return IsPackageRegistered(Test::Packages::PushNotificationsLongRunningTask::c_PackageFullName);
+}
+
+inline void AddPackage_DeploymentWindowsAppRuntimeFramework()
+{
+    AddPackage(Test::Packages::DeploymentWindowsAppRuntimeFramework::c_PackageDirName, Test::Packages::DeploymentWindowsAppRuntimeFramework::c_PackageFullName);
+}
+
+inline void RemovePackage_DeploymentWindowsAppRuntimeFramework()
+{
+    // Best-effort removal. PackageManager.RemovePackage errors if the package
+    // is not registered, but if it's not registered we're good. "'Tis the destination
+    // that matters, not the journey" so regardless how much or little work
+    // we need do, we're happy as long as the package isn't registered when we're done
+    //
+    // Thus, do a *IfNecessary removal
+    RemovePackageIfNecessary(Test::Packages::DeploymentWindowsAppRuntimeFramework::c_PackageFullName);
+}
+
+inline bool IsPackageRegistered_DeploymentWindowsAppRuntimeFramework()
+{
+    return IsPackageRegistered(Test::Packages::DeploymentWindowsAppRuntimeFramework::c_PackageFullName);
+}
+
+inline void AddPackage_DeploymentWindowsAppRuntimeMain()
+{
+    AddPackage(Test::Packages::DeploymentWindowsAppRuntimeMain::c_PackageDirName, Test::Packages::DeploymentWindowsAppRuntimeMain::c_PackageFullName);
+}
+
+inline void RemovePackage_DeploymentWindowsAppRuntimeMain()
+{
+    // Best-effort removal. PackageManager.RemovePackage errors if the package
+    // is not registered, but if it's not registered we're good. "'Tis the destination
+    // that matters, not the journey" so regardless how much or little work
+    // we need do, we're happy as long as the package isn't registered when we're done
+    //
+    // Thus, do a *IfNecessary removal
+    RemovePackageIfNecessary(Test::Packages::DeploymentWindowsAppRuntimeMain::c_PackageFullName);
+}
+
+inline bool IsPackageRegistered_DeploymentWindowsAppRuntimeMain()
+{
+    return IsPackageRegistered(Test::Packages::DeploymentWindowsAppRuntimeMain::c_PackageFullName);
+}
+
+inline void AddPackage_DeploymentWindowsAppRuntimeSingleton()
+{
+    AddPackage(Test::Packages::DeploymentWindowsAppRuntimeSingleton::c_PackageDirName, Test::Packages::DeploymentWindowsAppRuntimeSingleton::c_PackageFullName);
+}
+
+inline void RemovePackage_DeploymentWindowsAppRuntimeSingleton()
+{
+    // Best-effort removal. PackageManager.RemovePackage errors if the package
+    // is not registered, but if it's not registered we're good. "'Tis the destination
+    // that matters, not the journey" so regardless how much or little work
+    // we need do, we're happy as long as the package isn't registered when we're done
+    //
+    // Thus, do a *IfNecessary removal
+    RemovePackageIfNecessary(Test::Packages::DeploymentWindowsAppRuntimeSingleton::c_PackageFullName);
+}
+
+inline bool IsPackageRegistered_DeploymentWindowsAppRuntimeSingleton()
+{
+    return IsPackageRegistered(Test::Packages::DeploymentWindowsAppRuntimeSingleton::c_PackageFullName);
+}
+
+inline std::filesystem::path GetWindowsAppRuntimeFrameworkMsixPath()
+{
+    // Determine the location of the WindowsAppRuntime Framework's msix. See GetSolutionOutDirPath() for more details.
+    auto path = ::Test::FileSystem::GetSolutionOutDirPath();
+    path /= Test::Packages::WindowsAppRuntimeFramework::c_PackageDirName;
+    path /= Test::Packages::WindowsAppRuntimeFramework::c_PackageMsixFilename;
+    return path;
+}
+
+namespace WapProj
 {
     inline void AddPackage(std::filesystem::path packagePath, const PCWSTR& packageName, const PCWSTR& packageExtension)
     {
@@ -409,5 +412,6 @@ namespace Test::Packages::WapProj
         auto deploymentResult{ packageManager.AddPackageAsync(packagePathUri, nullptr, options).get() };
         VERIFY_SUCCEEDED(deploymentResult.ExtendedErrorCode(), WEX::Common::String().Format(L"AddPackageAsync('%s') = 0x%0X %s", packagePath.c_str(), deploymentResult.ExtendedErrorCode(), deploymentResult.ErrorText().c_str()));
     }
+}
 }
 #endif // __WINDOWSAPPRUNTIME_TEST_PACKAGE_H


### PR DESCRIPTION
!cherry-pick 42ba331
!cherry-pick 6198c22

1.1-servicing of v1.1 SDK throws an access violation from MddBootstrapInitialize's logging code if no matching packages are installed #2592 (#2608)

Summary

* Telemetry char=crash. Needs be string-literal
* Retrieve the *Main* package's family name for AppData for the release matching the framework (not always 1.0)
* Add/Remove the test Main package (DataStore) just like we do the test Framework
* Fixup test packages with naming more aligned with the actual runtime (test package Names were "blah" but product is "blah-1.2", and we now have code that parses release out of package name for further processing)

For more details see #2608 

https://task.ms/39995920 for 1.1-servicing consideration