### PR TITLE
Fix the .NET SDK installer script used by MRT Core, and don't run the script anymore

### DIFF
--- a/build/build-mrt.yml
+++ b/build/build-mrt.yml
@@ -78,19 +78,19 @@ steps:
 #      PathtoPublish: '${{ parameters.MRTSourcesDirectory }}\msbuild-install-logs'
 #      artifactName: 'installlogs'
 
-- task: powershell@2
-  displayName: 'Installing .NET SDK'
-  inputs:
-    targetType: filePath
-    workingDirectory: ${{ parameters.MRTSourcesDirectory }}\build
-    filePath: ${{ parameters.MRTSourcesDirectory }}\build\DownloadDotNetCoreSdk.ps1
+# - task: powershell@2
+#   displayName: 'Installing .NET SDK'
+#   inputs:
+#     targetType: filePath
+#     workingDirectory: ${{ parameters.MRTSourcesDirectory }}\build
+#     filePath: ${{ parameters.MRTSourcesDirectory }}\build\DownloadDotNetCoreSdk.ps1
 
-- task: BatchScript@1
-  displayName: 'Use .NET SDK'
-  inputs:
-    filename: '${{ parameters.MRTSourcesDirectory }}\build\SetDotnetVars.cmd'
-    arguments: '${{ parameters.MRTSourcesDirectory }}'
-    modifyEnvironment: true
+# - task: BatchScript@1
+#   displayName: 'Use .NET SDK'
+#   inputs:
+#     filename: '${{ parameters.MRTSourcesDirectory }}\build\SetDotnetVars.cmd'
+#     arguments: '${{ parameters.MRTSourcesDirectory }}'
+#     modifyEnvironment: true
 
 - task: powershell@2
   displayName: 'Create test pfx to sign MSIX test packages (DevCheck)'

--- a/dev/MRTCore/build/DownloadDotNetCoreSdk.ps1
+++ b/dev/MRTCore/build/DownloadDotNetCoreSdk.ps1
@@ -7,7 +7,7 @@ param(
 $dotnetInstallScript = "$env:TEMP\dotnet-install.ps1"
 
 $repoInstallDir  = [System.IO.Path]::GetFullPath("$PSScriptRoot\..\.dotnet")
-$versionPropsFilePropertyGroup = ([xml](Get-Content -Raw "$PSScriptRoot\..\..\..\eng\versions.props")).Project.PropertyGroup[0]
+$versionPropsFilePropertyGroup = ([xml](Get-Content -Raw "$PSScriptRoot\..\..\..\eng\versions.props")).Project.PropertyGroup
 $dotNetSdkVersion = $versionPropsFilePropertyGroup.CsWinRTDependencyDotNetCoreSdkPackageVersion
 $dotNetSdkVersionLkg =  if (-not $skipLKG) { $versionPropsFilePropertyGroup.CsWinRTDependencyDotNetCoreSdkLkgPackageVersion }
 
@@ -108,7 +108,7 @@ $latestAlreadyInstalled = Is-Installed $dotNetSdkVersion
 $lkgAlreadyInstalled = $true
 
 # Only try to install the lkg sdk if specified
-if (-not [string]::IsNullOrEmpty($dotNetSdkVersionLkg))
+if ((-not [string]::IsNullOrEmpty($dotNetSdkVersionLkg)) -and ($dotNetSdkVersionLkg -ine '$(CsWinRTDependencyDotNetCoreSdkPackageVersion)'))
 {
     $lkgAlreadyInstalled = Is-Installed $dotNetSdkVersionLkg
 }
@@ -161,4 +161,3 @@ if (-not $lkgAlreadyInstalled)
 {
     Install-SDK -version $dotNetSdkVersionLkg -channel "master"
 }
-

--- a/dev/MRTCore/global.json
+++ b/dev/MRTCore/global.json
@@ -1,8 +1,4 @@
 {
-    "sdk": {
-        "version": "5.0.404",
-        "rollForward": "latestMajor"
-    },
     "msbuild-sdks": {
         "Microsoft.Build.NoTargets" : "1.0.88"
     }


### PR DESCRIPTION
This is a follow-up to PR #1916.

The old `versions.props` file used by the script used to have two PropertyGroup XML nodes, and the new file only has one. This means that script ends up *not* getting the version from the new `Versions.props` file, which ultimately means that nothing actually gets installed. (Overall the script is a no-op).

We also need to add a check on `$dotNetSdkVersionLkg` as in the script, as within the `Versions.props` file it's defined to be `$(CsWinRTDependencyDotNetCoreSdkPackageVersion)`. But this doesn't get interpreted by PowerShell, so the string exists verbatim. This later causes the `dotnet-install.ps1` to fail, as it wants a real version number. But if its set to `$(CsWinRTDependencyDotNetCoreSdkPackageVersion)` we should just skip the second install step, since it's the same version.

We also don't actually need to run the `DownloadDotNetCoreSdk.ps1` script in the pipeline anymore, as the .NET SDK is already installed.