### PR TITLE
add explicit Newtonsoft.Json reference

### DIFF
--- a/dev/MRTCore/mrt/Microsoft.Windows.ApplicationModel.Resources/unittests/MrtCoreManagedTest.csproj
+++ b/dev/MRTCore/mrt/Microsoft.Windows.ApplicationModel.Resources/unittests/MrtCoreManagedTest.csproj
@@ -155,6 +155,9 @@
     <PackageReference Include="MSTest.TestFramework">
       <Version>1.4.0</Version>
     </PackageReference>
+    <PackageReference Include="Newtonsoft.Json">
+      <Version>13.0.1</Version>
+    </PackageReference>
   </ItemGroup>
   <ItemGroup>
     <None Include="MrtCoreManagedTests.runsettings">


### PR DESCRIPTION
The existing reference to Newtonsoft.Json version 9.0.1 comes from Microsoft.NET.Test.Sdk, and has vulnerabilities. Even the latest Microsoft.NET.Test.Sdk package still uses that version. So add a reference to version 13.0.1 explicitly.