### PR TITLE
[1.1][AppLifecycle] Properly ignore cleanup event if it can't be opened.

### DIFF
--- a/dev/AppLifecycle/AppInstance.cpp
+++ b/dev/AppLifecycle/AppInstance.cpp
@@ -202,8 +202,7 @@ namespace winrt::Microsoft::Windows::AppLifecycle::implementation
 
             std::wstring eventName = name + c_activatedEventNameSuffix;
             wil::unique_event cleanupEvent;
-            cleanupEvent.open(eventName.c_str());
-            if (cleanupEvent)
+            if (cleanupEvent.try_open(eventName.c_str()))
             {
                 // If the event is missing, it means the waiter gave up.  Ignore the error.
                 cleanupEvent.SetEvent();


### PR DESCRIPTION
If we can't open the cleanup event, ignore it.

Fixes ADO#38606299

Cherry-picked from #2658