### PR TITLE
WindowsAppRuntimeInstaller.exe fails if newer version present

### DIFF
--- a/installer/dev/install.cpp
+++ b/installer/dev/install.cpp
@@ -62,6 +62,11 @@ namespace WindowsAppRuntimeInstaller
                 RETURN_IF_FAILED(RegisterPackage(packageProperties->fullName.get()));
                 return S_OK;
             }
+            else if (hrAddPackage == ERROR_INSTALL_PACKAGE_DOWNGRADE)
+            {
+                // Higher version of the package already exists so we're good! Nothing to do!
+                return S_OK;
+            }
             else
             {
                 const auto deploymentResult{ deploymentOperation.GetResults() };


### PR DESCRIPTION
!cherry-pick 7095161

1.1-servicing variant of [WindowsAppRuntimeInstaller.exe fails if newer version present #2723](https://github.com/microsoft/WindowsAppSDK/pull/2723)

 https://task.ms/40411679