### PR TITLE
WindowsAppRuntimeInstaller.exe fails if newer version present

### DIFF
--- a/installer/dev/install.cpp
+++ b/installer/dev/install.cpp
@@ -42,6 +42,11 @@ namespace WindowsAppRuntimeInstaller
                 RETURN_IF_FAILED(RegisterPackage(packageProperties->fullName.get()));
                 return S_OK;
             }
+            else if (hrAddPackage == ERROR_INSTALL_PACKAGE_DOWNGRADE)
+            {
+                // Higher version of the package already exists so we're good! Nothing to do!
+                return S_OK;
+            }
             else
             {
                 RETURN_HR(hrAddPackage);


### PR DESCRIPTION
Discussion #2708: [WindowsAppRuntime installation error: The package could not be installed because a higher version of this package is already installed](https://github.com/microsoft/WindowsAppSDK/discussions/2708)

>Microsoft.WindowsAppRuntime.1.1_1000.516.2156.0_x64__8wekyb3d8bbwe Package deployment result : 0x80073d06 The package could not be installed because a higher version of this package is already installed. One or more install operations failed. Result: 0x80073d06

That's a bug - it should be OK, not an error.

If v1.1.3 is installed and you run the installer for v1.1.2 we call packageManager.AddPackageAsync(...v1.1.2...) which returns 0x80073d06 == `ERROR_INSTALL_PACKAGE_DOWNGRADE` which is technically an error but functionally it's OK. If you build with 1.1.2 we don't require the runtime packages exactly match 1.1.2, but rather that there needs to be a package equal-or-higher than 1.1.2 (i.e. `>=1.1.2` not `==1.1.2`). If 1.1.3 is installed then all is well.

Problem is we should be trapping `ERROR_INSTALL_PACKAGE_DOWNGRADE` and treating it as success. That's a bug on our part. 

!cherry-pick 7095161

1.0-servicing variant of [WindowsAppRuntimeInstaller.exe fails if newer version present #2723](https://github.com/microsoft/WindowsAppSDK/pull/2723)

 https://task.ms/40460275