### PR TITLE
Update Newtonsoft.Json explicit reference

### DIFF
--- a/dev/VSIX/Extension/ProjectReunion.Extension.csproj
+++ b/dev/VSIX/Extension/ProjectReunion.Extension.csproj
@@ -53,6 +53,7 @@
     <Reference Include="System" />
   </ItemGroup>
   <ItemGroup>
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
     <PackageReference Include="Microsoft.VisualStudio.SDK" Version="17.0.0-previews-1-31325-273" ExcludeAssets="runtime">
       <IncludeAssets>compile; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>


### PR DESCRIPTION
There's a vulnerability in Newtonsoft.Json older versions. We don't use it directly, but the VSIX projects bring it in via dependencies. Adding an explicit reference to the new version.

(copied from main #2662 )