### PR TITLE
Allowing developers to override the Data field in AppActivationArguments via a new method.

### DIFF
--- a/specs/AppLifecycle/Instancing/CustomEventArgs.md
+++ b/specs/AppLifecycle/Instancing/CustomEventArgs.md
@@ -3,45 +3,40 @@ Custom Activated Event Args for App Redirection.
 
 # Background
 
-Each AppInstance can redirect its activation to another AppInstance and pass in an AppActivatedEventArgs
-object via GetActivatedEventArgs.  This works if all you want to do is pass the arguments to
-another instance.  This solution does not support the scenario of passing in different arguments because
+Each AppInstance can redirect its activation to another AppInstance and pass in an [AppActivationArguments](https://docs.microsoft.com/windows/windows-app-sdk/api/winrt/microsoft.windows.applifecycle.appactivationarguments)
+object via [GetActivatedEventArgs](https://docs.microsoft.com/windows/windows-app-sdk/api/winrt/microsoft.windows.applifecycle.appinstance.getactivatedeventargs).  This works if all you want to do is pass the arguments to
+another instance.  However, the arguments can't be changed.  This is because
 
-  1. AppActivatedEventArgs does not have a projected constructor, and
-  2. AppActivatedEventArgs can't be modified.
+  1. [AppActivationArguments](https://docs.microsoft.com/windows/windows-app-sdk/api/winrt/microsoft.windows.applifecycle.appactivationarguments) does not have a projected constructor, and
+  2. [AppActivationArguments](https://docs.microsoft.com/windows/windows-app-sdk/api/winrt/microsoft.windows.applifecycle.appactivationarguments) can't be modified.
 
 Custom arguments would allow apps to communicate "why" the instance was redirected.  For example
 an app could redirect to another instance with the argument "/SafeMode" to tell the new instance
 something is wrong and should start in safe mode.
 
 The proposal is
-  1. Add a new method `AddCustomArgs(IInspectable args)` That would change the activation kind to
-  `UserDefined` and `Data` would be replaced with the passed in args.
+  1. Add a new method `AddCustomArgs(IInspectable newArgs)` That would change the activation kind to
+  `UserDefined` and `Data` would be replaced with the passed in `newArgs`.
   2. Add a new ExtendedActivationKind `UserDefined`
   
 
 # Conceptual pages (How To)
+A page for [App Instancing](https://docs.microsoft.com/windows/apps/windows-app-sdk/applifecycle/applifecycle-instancing) exists.
 
-_(This is conceptual documentation that will go to docs.microsoft.com "how to" page)_
-
-A page for App Instancing [exists](https://docs.microsoft.com/windows/apps/windows-app-sdk/applifecycle/applifecycle-instancing).
-
-This can be added to the section [How the Windows App SDK instancing differs from UWP instancing](https://docs.microsoft.com/windows/apps/windows-app-sdk/applifecycle/applifecycle-instancing#how-the-windows-app-sdk-instancing-differs-from-uwp-instancing)
+The below section can be added to the section [How the Windows App SDK instancing differs from UWP instancing](https://docs.microsoft.com/windows/apps/windows-app-sdk/applifecycle/applifecycle-instancing#how-the-windows-app-sdk-instancing-differs-from-uwp-instancing)
 
 ## Passing arguments into the instance redirection target
 
  * _UWP_: Does not allow arguments to be passed into the activated instance.  To get the activated
-    events the activated instance can call [GetActivatedEventArgs](https://docs.microsoft.com/uwp/api/windows.applicationmodel.appinstance.getactivatedeventargs)
- * _Windows App SDK_: Arguments can be passed in my calling [GetActivatedEventArgs](https://docs.microsoft.com/windows/windows-app-sdk/api/winrt/microsoft.windows.applifecycle.appinstance.getactivatedeventargs#microsoft-windows-applifecycle-appinstance-getactivatedeventargs).
-   `AddCustomArgs` can be called to pass in custom arguments.
+    events call [GetActivatedEventArgs](https://docs.microsoft.com/uwp/api/windows.applicationmodel.appinstance.getactivatedeventargs) 
+	* _Windows App SDK_: Custom arguments can be passed into a new instance by first calling [GetActivatedEventArgs](https://docs.microsoft.com/windows/windows-app-sdk/api/winrt/microsoft.windows.applifecycle.appinstance.getactivatedeventargs#microsoft-windows-applifecycle-appinstance-getactivatedeventargs)
+   then `AddCustomArgs` and the returned object from [GetActivatedEventArgs](https://docs.microsoft.com/windows/windows-app-sdk/api/winrt/microsoft.windows.applifecycle.appinstance.getactivatedeventargs#microsoft-windows-applifecycle-appinstance-getactivatedeventargs).
 
 # API Pages
 
-_(Each of the following L2 sections correspond to a page that will be on docs.microsoft.com)_
-
 ## AppActivationArguments
 
-A page for [AppActivationArguments exists] (https://docs.microsoft.com/windows/windows-app-sdk/api/winrt/microsoft.windows.applifecycle.appactivationarguments).
+A page for [AppActivationArguments](https://docs.microsoft.com/windows/windows-app-sdk/api/winrt/microsoft.windows.applifecycle.appactivationarguments) exists.
 
 The following is added to the [Remarks](https://docs.microsoft.com/windows/windows-app-sdk/api/winrt/microsoft.windows.applifecycle.appactivationarguments) section.
 
@@ -49,31 +44,33 @@ If an app wants to pass in custom arguments, the app can call the set methods on
 
 ## AppActivationArguments.Data
 
-A page for [AppActivationArguments.Data exists](https://docs.microsoft.com/windows/windows-app-sdk/api/winrt/microsoft.windows.applifecycle.appactivationarguments.data#microsoft-windows-applifecycle-appactivationarguments-data).
+A page for [AppActivationArguments.Data](https://docs.microsoft.com/windows/windows-app-sdk/api/winrt/microsoft.windows.applifecycle.appactivationarguments.data#microsoft-windows-applifecycle-appactivationarguments-data) exists.
 
 The following would be added to the table in the [Remarks](https://docs.microsoft.com/windows/windows-app-sdk/api/winrt/microsoft.windows.applifecycle.appactivationarguments.data#remarks) section.
 
 |_ActivationKind_|_DataType_                             |
-| `UserDefined`  |A custom object that is know to the app|
+|----------------|---------------------------------------|
+| `UserDefined`  |A custom object that is known to the app|
 
 ## Microsoft.Windows.AppLifecycle.ExtendedActivationKind
 
-A page for [Microsoft.Windows.AppLifecycle.ExtendedActivationKind exists](https://docs.microsoft.com/windows/windows-app-sdk/api/winrt/microsoft.windows.applifecycle.extendedactivationkind).
+A page for [Microsoft.Windows.AppLifecycle.ExtendedActivationKind](https://docs.microsoft.com/windows/windows-app-sdk/api/winrt/microsoft.windows.applifecycle.extendedactivationkind) exists.
 
 The following would be added to [Fields](https://docs.microsoft.com/windows/windows-app-sdk/api/winrt/microsoft.windows.applifecycle.extendedactivationkind).
 
-|_Name_|_Contract_|_Description_|
+|_Name_|_Contract_|_Description_                       |
+|------|----------|------------------------------------|
 |UserDefined| 1   | `Data` consists of a custom object.|
 
 
 ## AppActivationArguments.AddCustomArgs method
 
-This is the class for AppActivationArguments.  The only change is adding AddCustomArgs
+This is the class for [AppActivationArguments](https://docs.microsoft.com/windows/windows-app-sdk/api/winrt/microsoft.windows.applifecycle.appactivationarguments).  The only change is adding AddCustomArgs
 
 Example:
 
 ```c#
-// rest of the class.
+// The rest of AppActivationArguments here.
 
 public void AddCustomArgs(IInspectable newArguments) 
 {
@@ -145,7 +142,7 @@ namespace Microsoft.Windows.AppLifecycle
         [contract(AppLifecycleContract, 2)]
         AppNotification,
 		
-		[contract(AppLifecycleContract, 3)]
+        [contract(AppLifecycleContract, 3)]
         UserDefined,
     };
 
@@ -155,8 +152,8 @@ namespace Microsoft.Windows.AppLifecycle
         ExtendedActivationKind Kind { get; };
         IInspectable Data{ get; };
 		
-		[contract(AppLifecycleContract, 3)]
-		void AddCustomArgs(IInspectable newArguments);
+        [contract(AppLifecycleContract, 3)]
+        void AddCustomArgs(IInspectable newArguments);
     };
 }
 ```
@@ -165,7 +162,7 @@ namespace Microsoft.Windows.AppLifecycle
 
 The open issue for this is [here](https://github.com/microsoft/WindowsAppSDK/discussions/2568).
 
-Other propsed solutions.
+Other proposed solutions.
 1. Making `Kind` and `Data` settable. Rejected because, if `Data` was only changed and redirect apps might try to cast `Data` to the object defined by `Kind`.
-2. Add a new settable property. Rejected because a crash could happen if the object can't be value marshled.
-3. Adding a public constructor to `AppActivationArguments`.  This is another good solution and can be swaped with the above solution.
+2. Add a new settable property. Rejected because a crash could happen if the object can't be value marshaled.
+3. Adding a public constructor to `AppActivationArguments`.  This is another good solution and can be swapped with the above solution.

--- a/specs/AppLifecycle/Instancing/CustomEventArgs.md
+++ b/specs/AppLifecycle/Instancing/CustomEventArgs.md
@@ -4,7 +4,7 @@ Custom Activated Event Args for App Redirection.
 # Background
 
 Each AppInstance can redirect its activation to another AppInstance and pass in an [AppActivationArguments](https://docs.microsoft.com/windows/windows-app-sdk/api/winrt/microsoft.windows.applifecycle.appactivationarguments)
-object via [GetActivatedEventArgs](https://docs.microsoft.com/windows/windows-app-sdk/api/winrt/microsoft.windows.applifecycle.appinstance.getactivatedeventargs).  This works if all you want to do is pass the arguments to
+object obtained [GetActivatedEventArgs](https://docs.microsoft.com/windows/windows-app-sdk/api/winrt/microsoft.windows.applifecycle.appinstance.getactivatedeventargs).  This works if all you want to do is pass the arguments to
 another instance.  However, the arguments can't be changed.  This is because
 
   1. [AppActivationArguments](https://docs.microsoft.com/windows/windows-app-sdk/api/winrt/microsoft.windows.applifecycle.appactivationarguments) does not have a projected constructor, and
@@ -15,8 +15,8 @@ an app could redirect to another instance with the argument "/SafeMode" to tell 
 something is wrong and should start in safe mode.
 
 The proposal is
-  1. Add a new method `AddCustomArgs(IInspectable newArgs)` That would change the activation kind to
-  `UserDefined` and `Data` would be replaced with the passed in `newArgs`.
+  1. Add a new method `AddCustomArgs(IInspectable newArgs)` That would change the [activation kind](https://docs.microsoft.com/windows/windows-app-sdk/api/winrt/microsoft.windows.applifecycle.extendedactivationkind) to
+  `UserDefined` and [Data](https://docs.microsoft.com/windows/windows-app-sdk/api/winrt/microsoft.windows.applifecycle.appactivationarguments.data#microsoft-windows-applifecycle-appactivationarguments-data) would be replaced with the passed in `newArgs`.
   2. Add a new ExtendedActivationKind `UserDefined`
   
 
@@ -40,7 +40,8 @@ A page for [AppActivationArguments](https://docs.microsoft.com/windows/windows-a
 
 The following is added to the [Remarks](https://docs.microsoft.com/windows/windows-app-sdk/api/winrt/microsoft.windows.applifecycle.appactivationarguments) section.
 
-If an app wants to pass in custom arguments, the app can call the set methods on both `Data` and `Kind`.
+If an app wants to pass in custom arguments, the app can call `AddCustomArgs(IInspectable newArgs)` on the [AppActivationArguments](https://docs.microsoft.com/windows/windows-app-sdk/api/winrt/microsoft.windows.applifecycle.appactivationarguments)
+object returned from [GetActivatedEventArgs](https://docs.microsoft.com/windows/windows-app-sdk/api/winrt/microsoft.windows.applifecycle.appinstance.getactivatedeventargs).
 
 ## AppActivationArguments.Data
 

--- a/specs/AppLifecycle/Instancing/CustomEventArgs.md
+++ b/specs/AppLifecycle/Instancing/CustomEventArgs.md
@@ -29,8 +29,9 @@ The below section can be added to the section [How the Windows App SDK instancin
 
  * _UWP_: Does not allow arguments to be passed into the activated instance.  To get the activated
     events call [GetActivatedEventArgs](https://docs.microsoft.com/uwp/api/windows.applicationmodel.appinstance.getactivatedeventargs) 
-	* _Windows App SDK_: Custom arguments can be passed into a new instance by first calling [GetActivatedEventArgs](https://docs.microsoft.com/windows/windows-app-sdk/api/winrt/microsoft.windows.applifecycle.appinstance.getactivatedeventargs#microsoft-windows-applifecycle-appinstance-getactivatedeventargs)
-   then `AddCustomArgs` and the returned object from [GetActivatedEventArgs](https://docs.microsoft.com/windows/windows-app-sdk/api/winrt/microsoft.windows.applifecycle.appinstance.getactivatedeventargs#microsoft-windows-applifecycle-appinstance-getactivatedeventargs).
+ * _Windows App SDK_: Custom arguments can be passed into the new instance by first calling [GetActivatedEventArgs](https://docs.microsoft.com/windows/windows-app-sdk/api/winrt/microsoft.windows.applifecycle.appinstance.getactivatedeventargs#microsoft-windows-applifecycle-appinstance-getactivatedeventargs)
+   then `AddCustomArgs` on the returned object from [GetActivatedEventArgs](https://docs.microsoft.com/windows/windows-app-sdk/api/winrt/microsoft.windows.applifecycle.appinstance.getactivatedeventargs#microsoft-windows-applifecycle-appinstance-getactivatedeventargs).
+   The modified [AppActivationArguments](https://docs.microsoft.com/windows/windows-app-sdk/api/winrt/microsoft.windows.applifecycle.appactivationarguments) object can be passed into [RedirectToTargetAsync]()
 
 # API Pages
 

--- a/specs/AppLifecycle/Instancing/CustomEventArgs.md
+++ b/specs/AppLifecycle/Instancing/CustomEventArgs.md
@@ -1,0 +1,171 @@
+Custom Activated Event Args for App Redirection.
+===
+
+# Background
+
+Each AppInstance can redirect its activation to another AppInstance and pass in an AppActivatedEventArgs
+object via GetActivatedEventArgs.  This works if all you want to do is pass the arguments to
+another instance.  This solution does not support the scenario of passing in different arguments because
+
+  1. AppActivatedEventArgs does not have a projected constructor, and
+  2. AppActivatedEventArgs can't be modified.
+
+Custom arguments would allow apps to communicate "why" the instance was redirected.  For example
+an app could redirect to another instance with the argument "/SafeMode" to tell the new instance
+something is wrong and should start in safe mode.
+
+The proposal is
+  1. Add a new method `AddCustomArgs(IInspectable args)` That would change the activation kind to
+  `UserDefined` and `Data` would be replaced with the passed in args.
+  2. Add a new ExtendedActivationKind `UserDefined`
+  
+
+# Conceptual pages (How To)
+
+_(This is conceptual documentation that will go to docs.microsoft.com "how to" page)_
+
+A page for App Instancing [exists](https://docs.microsoft.com/windows/apps/windows-app-sdk/applifecycle/applifecycle-instancing).
+
+This can be added to the section [How the Windows App SDK instancing differs from UWP instancing](https://docs.microsoft.com/windows/apps/windows-app-sdk/applifecycle/applifecycle-instancing#how-the-windows-app-sdk-instancing-differs-from-uwp-instancing)
+
+## Passing arguments into the instance redirection target
+
+ * _UWP_: Does not allow arguments to be passed into the activated instance.  To get the activated
+    events the activated instance can call [GetActivatedEventArgs](https://docs.microsoft.com/uwp/api/windows.applicationmodel.appinstance.getactivatedeventargs)
+ * _Windows App SDK_: Arguments can be passed in my calling [GetActivatedEventArgs](https://docs.microsoft.com/windows/windows-app-sdk/api/winrt/microsoft.windows.applifecycle.appinstance.getactivatedeventargs#microsoft-windows-applifecycle-appinstance-getactivatedeventargs).
+   `AddCustomArgs` can be called to pass in custom arguments.
+
+# API Pages
+
+_(Each of the following L2 sections correspond to a page that will be on docs.microsoft.com)_
+
+## AppActivationArguments
+
+A page for [AppActivationArguments exists] (https://docs.microsoft.com/windows/windows-app-sdk/api/winrt/microsoft.windows.applifecycle.appactivationarguments).
+
+The following is added to the [Remarks](https://docs.microsoft.com/windows/windows-app-sdk/api/winrt/microsoft.windows.applifecycle.appactivationarguments) section.
+
+If an app wants to pass in custom arguments, the app can call the set methods on both `Data` and `Kind`.
+
+## AppActivationArguments.Data
+
+A page for [AppActivationArguments.Data exists](https://docs.microsoft.com/windows/windows-app-sdk/api/winrt/microsoft.windows.applifecycle.appactivationarguments.data#microsoft-windows-applifecycle-appactivationarguments-data).
+
+The following would be added to the table in the [Remarks](https://docs.microsoft.com/windows/windows-app-sdk/api/winrt/microsoft.windows.applifecycle.appactivationarguments.data#remarks) section.
+
+|_ActivationKind_|_DataType_                             |
+| `UserDefined`  |A custom object that is know to the app|
+
+## Microsoft.Windows.AppLifecycle.ExtendedActivationKind
+
+A page for [Microsoft.Windows.AppLifecycle.ExtendedActivationKind exists](https://docs.microsoft.com/windows/windows-app-sdk/api/winrt/microsoft.windows.applifecycle.extendedactivationkind).
+
+The following would be added to [Fields](https://docs.microsoft.com/windows/windows-app-sdk/api/winrt/microsoft.windows.applifecycle.extendedactivationkind).
+
+|_Name_|_Contract_|_Description_|
+|UserDefined| 1   | `Data` consists of a custom object.|
+
+
+## AppActivationArguments.AddCustomArgs method
+
+This is the class for AppActivationArguments.  The only change is adding AddCustomArgs
+
+Example:
+
+```c#
+// rest of the class.
+
+public void AddCustomArgs(IInspectable newArguments) 
+{
+	m_Kind = Microsoft.Windows.AppLifecycle.ExtendedActivationKind.UserDefined;
+	m_Data = newArguments;
+}
+```
+
+# API Details
+
+```c# (but really MIDL3)
+namespace Microsoft.Windows.AppLifecycle
+{
+    [contractversion(3)]
+    apicontract AppLifecycleContract {};
+
+    [contract(AppLifecycleContract, 1)]
+    enum ExtendedActivationKind
+    {
+        Launch = 0,
+        Search,
+        ShareTarget,
+        File,
+        Protocol,
+        FileOpenPicker,
+        FileSavePicker,
+        CachedFileUpdater,
+        ContactPicker,
+        Device,
+        PrintTaskSettings,
+        CameraSettings,
+        RestrictedLaunch,
+        AppointmentsProvider,
+        Contact,
+        LockScreenCall,
+        VoiceCommand,
+        LockScreen,
+        PickerReturned = 1000,
+        WalletAction,
+        PickFileContinuation,
+        PickSaveFileContinuation,
+        PickFolderContinuation,
+        WebAuthenticationBrokerContinuation,
+        WebAccountProvider,
+        ComponentUI,
+        ProtocolForResults = 1009,
+        ToastNotification,
+        Print3DWorkflow,
+        DialReceiver,
+        DevicePairing,
+        UserDataAccountsProvider,
+        FilePickerExperience,
+        LockScreenComponent,
+        ContactPanel,
+        PrintWorkflowForegroundTask,
+        GameUIProvider,
+        StartupTask,
+        CommandLineLaunch,
+        BarcodeScannerProvider,
+        PrintSupportJobUI,
+        PrintSupportSettingsUI,
+        PhoneCallActivation,
+        VpnForeground,
+        // NOTE: Values below 5000 are designated for the platform.  The above list is kept in sync with
+        // Windows.ApplicationModel.Activation.ActivationKind.
+
+        Push = 5000,
+
+        [contract(AppLifecycleContract, 2)]
+        AppNotification,
+		
+		[contract(AppLifecycleContract, 3)]
+        UserDefined,
+    };
+
+    [contract(AppLifecycleContract, 1)]
+    runtimeclass AppActivationArguments
+    {
+        ExtendedActivationKind Kind { get; };
+        IInspectable Data{ get; };
+		
+		[contract(AppLifecycleContract, 3)]
+		void AddCustomArgs(IInspectable newArguments);
+    };
+}
+```
+
+# Appendix
+
+The open issue for this is [here](https://github.com/microsoft/WindowsAppSDK/discussions/2568).
+
+Other propsed solutions.
+1. Making `Kind` and `Data` settable. Rejected because, if `Data` was only changed and redirect apps might try to cast `Data` to the object defined by `Kind`.
+2. Add a new settable property. Rejected because a crash could happen if the object can't be value marshled.
+3. Adding a public constructor to `AppActivationArguments`.  This is another good solution and can be swaped with the above solution.

--- a/specs/AppLifecycle/Instancing/CustomEventArgs.md
+++ b/specs/AppLifecycle/Instancing/CustomEventArgs.md
@@ -15,7 +15,7 @@ an app could redirect to another instance with the argument "/SafeMode" to tell 
 something is wrong and should start in safe mode.
 
 The proposal is
-  1. Add a new method `AddCustomArgs(IInspectable newArgs)` That would change the [activation kind](https://docs.microsoft.com/windows/windows-app-sdk/api/winrt/microsoft.windows.applifecycle.extendedactivationkind) to
+  1. Add a new method `AddCustomArgs(IInspectable newArgs)` That would change the [activation kind](https://docs.microsoft.com/windows/windows-app-sdk/api/winrt/microsoft.windows.applifecycle.appactivationarguments.kind#microsoft-windows-applifecycle-appactivationarguments-kind) to
   `UserDefined` and [Data](https://docs.microsoft.com/windows/windows-app-sdk/api/winrt/microsoft.windows.applifecycle.appactivationarguments.data#microsoft-windows-applifecycle-appactivationarguments-data) would be replaced with the passed in `newArgs`.
   2. Add a new ExtendedActivationKind `UserDefined`
   

--- a/specs/AppLifecycle/Instancing/CustomEventArgs.md
+++ b/specs/AppLifecycle/Instancing/CustomEventArgs.md
@@ -31,7 +31,7 @@ The below section can be added to the section [How the Windows App SDK instancin
     events call [GetActivatedEventArgs](https://docs.microsoft.com/uwp/api/windows.applicationmodel.appinstance.getactivatedeventargs) 
  * _Windows App SDK_: Custom arguments can be passed into the new instance by first calling [GetActivatedEventArgs](https://docs.microsoft.com/windows/windows-app-sdk/api/winrt/microsoft.windows.applifecycle.appinstance.getactivatedeventargs#microsoft-windows-applifecycle-appinstance-getactivatedeventargs)
    then `AddCustomArgs` on the returned object from [GetActivatedEventArgs](https://docs.microsoft.com/windows/windows-app-sdk/api/winrt/microsoft.windows.applifecycle.appinstance.getactivatedeventargs#microsoft-windows-applifecycle-appinstance-getactivatedeventargs).
-   The modified [AppActivationArguments](https://docs.microsoft.com/windows/windows-app-sdk/api/winrt/microsoft.windows.applifecycle.appactivationarguments) object can be passed into [RedirectToTargetAsync]()
+   The modified [AppActivationArguments](https://docs.microsoft.com/windows/windows-app-sdk/api/winrt/microsoft.windows.applifecycle.appactivationarguments) object can be passed into [RedirectActivationToAsync](https://docs.microsoft.com/windows/windows-app-sdk/api/winrt/microsoft.windows.applifecycle.appinstance.redirectactivationtoasync#microsoft-windows-applifecycle-appinstance-redirectactivationtoasync(microsoft-windows-applifecycle-appactivationarguments)).
 
 # API Pages
 
@@ -39,7 +39,7 @@ The below section can be added to the section [How the Windows App SDK instancin
 
 A page for [AppActivationArguments](https://docs.microsoft.com/windows/windows-app-sdk/api/winrt/microsoft.windows.applifecycle.appactivationarguments) exists.
 
-The following is added to the [Remarks](https://docs.microsoft.com/windows/windows-app-sdk/api/winrt/microsoft.windows.applifecycle.appactivationarguments) section.
+The following is added to the [Remarks](https://docs.microsoft.com/windows/windows-app-sdk/api/winrt/microsoft.windows.applifecycle.appactivationarguments#remarks) section.
 
 If an app wants to pass in custom arguments, the app can call `AddCustomArgs(IInspectable newArgs)` on the [AppActivationArguments](https://docs.microsoft.com/windows/windows-app-sdk/api/winrt/microsoft.windows.applifecycle.appactivationarguments)
 object returned from [GetActivatedEventArgs](https://docs.microsoft.com/windows/windows-app-sdk/api/winrt/microsoft.windows.applifecycle.appinstance.getactivatedeventargs).


### PR DESCRIPTION
[AppActivationArguments](https://docs.microsoft.com/windows/windows-app-sdk/api/winrt/microsoft.windows.applifecycle.appactivationarguments) does not allow developers to pass in custom arguments to a redirected instance because [AppActivationArguments](https://docs.microsoft.com/windows/windows-app-sdk/api/winrt/microsoft.windows.applifecycle.appactivationarguments) can't be constructed, and  [Data](https://docs.microsoft.com/windows/windows-app-sdk/api/winrt/microsoft.windows.applifecycle.appactivationarguments.data#microsoft-windows-applifecycle-appactivationarguments-data) isn't settable.

This spec is to allow developers to override the [Data](https://docs.microsoft.com/windows/windows-app-sdk/api/winrt/microsoft.windows.applifecycle.appactivationarguments.data#microsoft-windows-applifecycle-appactivationarguments-data) field in [AppActivationArguments](https://docs.microsoft.com/windows/windows-app-sdk/api/winrt/microsoft.windows.applifecycle.appactivationarguments) so custom arguments can be passed into a new instance.