### PR TITLE
Remove noexcept from Bootstrapper API so it can be used from C

### DIFF
--- a/dev/WindowsAppRuntime_BootstrapDLL/MddBootstrap.cpp
+++ b/dev/WindowsAppRuntime_BootstrapDLL/MddBootstrap.cpp
@@ -89,7 +89,7 @@ static std::wstring g_test_mainPackageNamePrefix;
 STDAPI MddBootstrapInitialize(
     UINT32 majorMinorVersion,
     PCWSTR versionTag,
-    PACKAGE_VERSION minVersion)
+    PACKAGE_VERSION minVersion) noexcept
 {
     return MddBootstrapInitialize2(majorMinorVersion, versionTag, minVersion, MddBootstrapInitializeOptions_None);
 }
@@ -98,7 +98,7 @@ STDAPI MddBootstrapInitialize2(
     UINT32 majorMinorVersion,
     PCWSTR versionTag,
     PACKAGE_VERSION minVersion,
-    MddBootstrapInitializeOptions options) try
+    MddBootstrapInitializeOptions options) noexcept try
 {
     auto lock{ std::lock_guard(g_initializationLock) };
 
@@ -212,7 +212,7 @@ HRESULT _MddBootstrapInitialize(
 }
 CATCH_RETURN();
 
-STDAPI_(void) MddBootstrapShutdown()
+STDAPI_(void) MddBootstrapShutdown() noexcept
 {
     auto lock{ std::lock_guard(g_initializationLock) };
 

--- a/dev/WindowsAppRuntime_BootstrapDLL/MddBootstrap.cpp
+++ b/dev/WindowsAppRuntime_BootstrapDLL/MddBootstrap.cpp
@@ -89,7 +89,7 @@ static std::wstring g_test_mainPackageNamePrefix;
 STDAPI MddBootstrapInitialize(
     UINT32 majorMinorVersion,
     PCWSTR versionTag,
-    PACKAGE_VERSION minVersion) noexcept
+    PACKAGE_VERSION minVersion)
 {
     return MddBootstrapInitialize2(majorMinorVersion, versionTag, minVersion, MddBootstrapInitializeOptions_None);
 }
@@ -98,7 +98,7 @@ STDAPI MddBootstrapInitialize2(
     UINT32 majorMinorVersion,
     PCWSTR versionTag,
     PACKAGE_VERSION minVersion,
-    MddBootstrapInitializeOptions options) noexcept try
+    MddBootstrapInitializeOptions options) try
 {
     auto lock{ std::lock_guard(g_initializationLock) };
 
@@ -212,7 +212,7 @@ HRESULT _MddBootstrapInitialize(
 }
 CATCH_RETURN();
 
-STDAPI_(void) MddBootstrapShutdown() noexcept
+STDAPI_(void) MddBootstrapShutdown()
 {
     auto lock{ std::lock_guard(g_initializationLock) };
 

--- a/dev/WindowsAppRuntime_BootstrapDLL/MddBootstrap.h
+++ b/dev/WindowsAppRuntime_BootstrapDLL/MddBootstrap.h
@@ -48,7 +48,7 @@ DEFINE_ENUM_FLAG_OPERATORS(MddBootstrapInitializeOptions)
 STDAPI MddBootstrapInitialize(
     UINT32 majorMinorVersion,
     PCWSTR versionTag,
-    PACKAGE_VERSION minVersion) noexcept;
+    PACKAGE_VERSION minVersion);
 
 /// Initialize the calling process to use Windows App Runtime framework package.
 ///
@@ -68,13 +68,13 @@ STDAPI MddBootstrapInitialize2(
     UINT32 majorMinorVersion,
     PCWSTR versionTag,
     PACKAGE_VERSION minVersion,
-    MddBootstrapInitializeOptions options) noexcept;
+    MddBootstrapInitializeOptions options);
 
 /// Undo the changes made by MddBoostrapInitialize().
 ///
 /// @warning Packages made available via MddBootstrapInitialize2() and
 ///          the Dynamic Dependencies API should not be used after this call.
-STDAPI_(void) MddBootstrapShutdown() noexcept;
+STDAPI_(void) MddBootstrapShutdown();
 
 // C++ friendly APIs
 #if defined(__cplusplus)

--- a/dev/WindowsAppRuntime_BootstrapDLL/MddBootstrap.h
+++ b/dev/WindowsAppRuntime_BootstrapDLL/MddBootstrap.h
@@ -6,6 +6,12 @@
 
 #include <appmodel.h>
 
+#if defined(__cplusplus)
+#define MDDBOOTSTRAP_NOEXCEPT   noexcept
+#else
+#define MDDBOOTSTRAP_NOEXCEPT
+#endif // defined(__cplusplus)
+
 /// Options for Bootstrap initialization
 typedef enum MddBootstrapInitializeOptions
 {
@@ -48,7 +54,7 @@ DEFINE_ENUM_FLAG_OPERATORS(MddBootstrapInitializeOptions)
 STDAPI MddBootstrapInitialize(
     UINT32 majorMinorVersion,
     PCWSTR versionTag,
-    PACKAGE_VERSION minVersion);
+    PACKAGE_VERSION minVersion) MDDBOOTSTRAP_NOEXCEPT;
 
 /// Initialize the calling process to use Windows App Runtime framework package.
 ///
@@ -68,13 +74,13 @@ STDAPI MddBootstrapInitialize2(
     UINT32 majorMinorVersion,
     PCWSTR versionTag,
     PACKAGE_VERSION minVersion,
-    MddBootstrapInitializeOptions options);
+    MddBootstrapInitializeOptions options) MDDBOOTSTRAP_NOEXCEPT;
 
 /// Undo the changes made by MddBoostrapInitialize().
 ///
 /// @warning Packages made available via MddBootstrapInitialize2() and
 ///          the Dynamic Dependencies API should not be used after this call.
-STDAPI_(void) MddBootstrapShutdown();
+STDAPI_(void) MddBootstrapShutdown() MDDBOOTSTRAP_NOEXCEPT;
 
 // C++ friendly APIs
 #if defined(__cplusplus)


### PR DESCRIPTION
As requested by [Fix 'noexcept' C compile errors #2686](https://github.com/microsoft/WindowsAppSDK/pull/2686)