### PR TITLE
<Copy> vs XCOPY.EXE -- Unbreak WindowsAppSDK-Nuget-Native.C.props

### DIFF
--- a/build/NuSpecs/WindowsAppSDK-Nuget-Native.C.props
+++ b/build/NuSpecs/WindowsAppSDK-Nuget-Native.C.props
@@ -29,7 +29,7 @@
       </AdditionalDependencies>
     </Link>
     <PostBuildEvent>
-      <Copy SourceFiles="$(MSBuildThisFileDirectory)..\..\runtimes\win10-$(_WindowsAppSDKFoundationPlatform)\native\Microsoft.WindowsAppRuntime.Bootstrap.dll" DestinationFolder="$(OutDir)" />
+      <Command>xcopy.exe /y "$(MSBuildThisFileDirectory)..\..\runtimes\win10-$(_WindowsAppSDKFoundationPlatform)\native\Microsoft.WindowsAppRuntime.Bootstrap.dll" "$(OutDir)"</Command>
     </PostBuildEvent>
   </ItemDefinitionGroup>
 


### PR DESCRIPTION
Not-Build break 'build\native\WindowsAppSDK-Nuget-Native.C.props(32,13): error MSB4066: The attribute 'SourceFiles' in element <Copy> is unrecognized.' -- Foundation builds but the aggregator doesn't. I suspect it's because of the <Copy> command can't go in a <PostBuildEvent>, maybe something more complicated with the PostBuildEvent DependsOn a <Target> to do the copy...but I can't find any clear docs or net links clearly spelling it out so rather than fiddling while Rome burns I'm switching back to the original xcopy.exe solution to un-break the pipeline.

Will follow up with folks to understand why the PR's build didn't pick this up