### PR TITLE
Adding copyright headers to required files and enforcing requirement in build pipelines

### DIFF
--- a/build/ProjectReunion-BuildFoundation.yml
+++ b/build/ProjectReunion-BuildFoundation.yml
@@ -59,7 +59,7 @@ jobs:
     and
     (
       eq(variables['useBuildOutputFromBuildId'],''),
-      in(dependencies.VerifyCopyrightHeaders.result, 'Succeeded', 'SucceededWithIssues', 'Skipped')
+      in(dependencies.VerifyCopyrightHeaders.result, 'Succeeded')
     )
   pool: $(ProjectReunionBuildPool)
   timeoutInMinutes: 120
@@ -141,7 +141,7 @@ jobs:
     and
     (
       eq(variables['useBuildOutputFromBuildId'],''),
-      in(dependencies.VerifyCopyrightHeaders.result, 'Succeeded', 'SucceededWithIssues', 'Skipped')
+      in(dependencies.VerifyCopyrightHeaders.result, 'Succeeded')
     )
   pool: $(ProjectReunionBuildPool)
   timeoutInMinutes: 120

--- a/build/ProjectReunion-BuildFoundation.yml
+++ b/build/ProjectReunion-BuildFoundation.yml
@@ -40,8 +40,18 @@ jobs:
 # This relatively low-cost job is always run, in parallel w/ the Build job.
 - template: AzurePipelinesTemplates\WindowsAppSDK-SourceAnalysis-job.yml
 
-- job: Build
+- job: VerifyCopyrightHeaders
   dependsOn: []
+  pool: $(ProjectReunionBuildPool)
+  - task: powershell@2
+    displayName: 'Verify copyright headers'
+    inputs:
+      targetType: filePath
+      filePath: tools\VerifyCopyrightHeaders.ps1
+
+- job: Build
+  dependsOn:
+    - VerifyCopyrightHeaders
   # Skip the build job if we are reusing the output of a previous build.
   # useBuildOutputFromBuildId variable is set on the Pipeline at Queue time.
   condition:
@@ -74,12 +84,6 @@ jobs:
   # Required by the Packaged ES SDL Templates.
   - checkout: self
     persistCredentials: true
-
-  - task: powershell@2
-    displayName: 'Verify copyright headers'
-    inputs:
-      targetType: filePath
-      filePath: tools\VerifyCopyrightHeaders.ps1
 
   - task: NuGetAuthenticate@0
     inputs:

--- a/build/ProjectReunion-BuildFoundation.yml
+++ b/build/ProjectReunion-BuildFoundation.yml
@@ -43,6 +43,7 @@ jobs:
 - job: VerifyCopyrightHeaders
   dependsOn: []
   pool: $(ProjectReunionBuildPool)
+  steps:
   - task: powershell@2
     displayName: 'Verify copyright headers'
     inputs:

--- a/build/ProjectReunion-BuildFoundation.yml
+++ b/build/ProjectReunion-BuildFoundation.yml
@@ -135,6 +135,8 @@ jobs:
 - job: BuildAnyCPU
   # For now, this job just builds Microsoft.WindowsAppRuntime.Bootstrap.Net.dll in AnyCPU
   # Can be expanded to add any other binary as needed
+  dependsOn:
+    - VerifyCopyrightHeaders
   condition: |
     and
     (
@@ -221,6 +223,8 @@ jobs:
 
 - job: BuildMRT
   pool: $(ProjectReunionBuildPool)
+  dependsOn:
+    - VerifyCopyrightHeaders
   condition: in(dependencies.VerifyCopyrightHeaders.result, 'Succeeded')
   strategy:
     maxParallel: 10

--- a/build/ProjectReunion-BuildFoundation.yml
+++ b/build/ProjectReunion-BuildFoundation.yml
@@ -55,8 +55,12 @@ jobs:
     - VerifyCopyrightHeaders
   # Skip the build job if we are reusing the output of a previous build.
   # useBuildOutputFromBuildId variable is set on the Pipeline at Queue time.
-  condition:
-    eq(variables['useBuildOutputFromBuildId'],'')
+  condition: |
+    and
+    (
+      eq(variables['useBuildOutputFromBuildId'],''),
+      in(dependencies.VerifyCopyrightHeaders.result, 'Succeeded', 'SucceededWithIssues', 'Skipped')
+    )
   pool: $(ProjectReunionBuildPool)
   timeoutInMinutes: 120
   strategy:

--- a/build/ProjectReunion-BuildFoundation.yml
+++ b/build/ProjectReunion-BuildFoundation.yml
@@ -75,6 +75,12 @@ jobs:
   - checkout: self
     persistCredentials: true
 
+  - task: powershell@2
+    displayName: 'Verify copyright headers'
+    inputs:
+      targetType: filePath
+      filePath: tools\VerifyCopyrightHeaders.ps1
+
   - task: NuGetAuthenticate@0
     inputs:
       nuGetServiceConnections: 'TelemetryInternal'

--- a/build/ProjectReunion-BuildFoundation.yml
+++ b/build/ProjectReunion-BuildFoundation.yml
@@ -135,8 +135,12 @@ jobs:
 - job: BuildAnyCPU
   # For now, this job just builds Microsoft.WindowsAppRuntime.Bootstrap.Net.dll in AnyCPU
   # Can be expanded to add any other binary as needed
-  condition:
-    eq(variables['useBuildOutputFromBuildId'],'')
+  condition: |
+    and
+    (
+      eq(variables['useBuildOutputFromBuildId'],''),
+      in(dependencies.VerifyCopyrightHeaders.result, 'Succeeded', 'SucceededWithIssues', 'Skipped')
+    )
   pool: $(ProjectReunionBuildPool)
   timeoutInMinutes: 120
   variables:
@@ -217,6 +221,7 @@ jobs:
 
 - job: BuildMRT
   pool: $(ProjectReunionBuildPool)
+  condition: in(dependencies.VerifyCopyrightHeaders.result, 'Succeeded')
   strategy:
     maxParallel: 10
     matrix:

--- a/build/ProjectReunion-CI.yml
+++ b/build/ProjectReunion-CI.yml
@@ -46,7 +46,8 @@ jobs:
       ToolLogsNotFoundAction: 'Standard'
 
 - job: VerifyCopyrightHeaders
-  pool: $(ProjectReunionBuildPool)
+  pool:
+    vmImage: 'windows-2019'
   steps:
   - task: powershell@2
     displayName: 'Verify copyright headers'

--- a/build/ProjectReunion-CI.yml
+++ b/build/ProjectReunion-CI.yml
@@ -45,7 +45,19 @@ jobs:
       TSLint: false
       ToolLogsNotFoundAction: 'Standard'
 
+- job: VerifyCopyrightHeaders
+  pool: $(ProjectReunionBuildPool)
+  steps:
+  - task: powershell@2
+    displayName: 'Verify copyright headers'
+    inputs:
+      targetType: filePath
+      filePath: tools\VerifyCopyrightHeaders.ps1
+
 - job: Build
+  dependsOn:
+    - VerifyCopyrightHeaders
+  condition: in(dependencies.VerifyCopyrightHeaders.result, 'Succeeded')
   pool:
     vmImage: 'windows-2019'
   timeoutInMinutes: 120
@@ -113,6 +125,9 @@ jobs:
       ToolLogsNotFoundAction: 'Standard'
 
 - job: BuildMRT
+  dependsOn:
+    - VerifyCopyrightHeaders
+  condition: in(dependencies.VerifyCopyrightHeaders.result, 'Succeeded')
   pool:
     vmImage: 'windows-latest'
   strategy:
@@ -189,6 +204,7 @@ jobs:
     publishToMaestro: false
     jobName: CreateNugetPackage
     dependsOn:
+      - VerifyCopyrightHeaders
       - Build
       - PublishMRT
     prereleaseVersionTag: ci
@@ -196,5 +212,6 @@ jobs:
       and
       (
         in(dependencies.PublishMRT.result, 'Succeeded', 'SucceededWithIssues', 'Skipped'),
-        in(dependencies.Build.result, 'Succeeded', 'SucceededWithIssues', 'Skipped')
+        in(dependencies.Build.result, 'Succeeded', 'SucceededWithIssues', 'Skipped'),
+        in(dependencies.VerifyCopyrightHeaders.result, 'Succeeded')
       )

--- a/dev/AccessControl/GetSecurityDescriptorForAppContainerNames.cpp
+++ b/dev/AccessControl/GetSecurityDescriptorForAppContainerNames.cpp
@@ -1,4 +1,7 @@
-﻿#include <pch.h>
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+#include <pch.h>
 #include <accctrl.h>
 #include <aclapi.h>
 #include <userenv.h>

--- a/dev/AccessControl/Microsoft.Windows.Security.AccessControl.cpp
+++ b/dev/AccessControl/Microsoft.Windows.Security.AccessControl.cpp
@@ -1,4 +1,7 @@
-﻿#include <pch.h>
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+#include <pch.h>
 #include "Microsoft.Windows.Security.AccessControl.h"
 #include "Microsoft.Windows.Security.AccessControl.SecurityDescriptorHelpers.g.cpp"
 #include "Security.AccessControl.h"

--- a/dev/AccessControl/Microsoft.Windows.Security.AccessControl.h
+++ b/dev/AccessControl/Microsoft.Windows.Security.AccessControl.h
@@ -1,4 +1,7 @@
-﻿#pragma once
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+#pragma once
 #include "Microsoft.Windows.Security.AccessControl.SecurityDescriptorHelpers.g.h"
 
 namespace winrt::Microsoft::Windows::Security::AccessControl::implementation

--- a/dev/AccessControl/Security.AccessControl.h
+++ b/dev/AccessControl/Security.AccessControl.h
@@ -1,4 +1,7 @@
-﻿#pragma once
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+#pragma once
 
 #include <Windows.h>
 

--- a/dev/AccessControl/SecurityDescriptorHelpers.h
+++ b/dev/AccessControl/SecurityDescriptorHelpers.h
@@ -1,4 +1,7 @@
-﻿#pragma once
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+#pragma once
 
 #include <Windows.h>
 #include <wil/resource.h>

--- a/dev/AppNotifications/AppNotification.cpp
+++ b/dev/AppNotifications/AppNotification.cpp
@@ -1,4 +1,7 @@
-﻿#include "pch.h"
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+#include "pch.h"
 #include "AppNotification.h"
 #include "Microsoft.Windows.AppNotifications.AppNotification.g.cpp"
 

--- a/dev/AppNotifications/AppNotification.h
+++ b/dev/AppNotifications/AppNotification.h
@@ -1,4 +1,7 @@
-﻿#pragma once
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+#pragma once
 #include "Microsoft.Windows.AppNotifications.AppNotification.g.h"
 
 namespace winrt::Microsoft::Windows::AppNotifications::implementation

--- a/dev/AppNotifications/AppNotificationActivatedEventArgs.h
+++ b/dev/AppNotifications/AppNotificationActivatedEventArgs.h
@@ -1,4 +1,7 @@
-﻿#pragma once
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+#pragma once
 #include "Microsoft.Windows.AppNotifications.AppNotificationActivatedEventArgs.g.h"
 
 namespace winrt::Microsoft::Windows::AppNotifications::implementation

--- a/dev/AppNotifications/AppNotificationManager.cpp
+++ b/dev/AppNotifications/AppNotificationManager.cpp
@@ -1,4 +1,7 @@
-﻿#include "pch.h"
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+#include "pch.h"
 #include "AppNotificationManager.h"
 #include "Microsoft.Windows.AppNotifications.AppNotificationManager.g.cpp"
 #include <winrt/Windows.ApplicationModel.Core.h>

--- a/dev/AppNotifications/AppNotificationManager.h
+++ b/dev/AppNotifications/AppNotificationManager.h
@@ -1,4 +1,7 @@
-﻿#pragma once
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+#pragma once
 #include "Microsoft.Windows.AppNotifications.AppNotificationManager.g.h"
 #include "NotificationActivationCallback.h"
 #include "AppNotificationUtility.h"

--- a/dev/AppNotifications/AppNotificationProgressData.cpp
+++ b/dev/AppNotifications/AppNotificationProgressData.cpp
@@ -1,4 +1,7 @@
-﻿#include "pch.h"
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+#include "pch.h"
 #include "AppNotificationProgressData.h"
 #include "Microsoft.Windows.AppNotifications.AppNotificationProgressData.g.cpp"
 

--- a/dev/AppNotifications/AppNotificationProgressData.h
+++ b/dev/AppNotifications/AppNotificationProgressData.h
@@ -1,4 +1,7 @@
-﻿#pragma once
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+#pragma once
 #include "Microsoft.Windows.AppNotifications.AppNotificationProgressData.g.h"
 
 namespace winrt::Microsoft::Windows::AppNotifications::implementation

--- a/dev/Deployment/DeploymentInitializeOptions.h
+++ b/dev/Deployment/DeploymentInitializeOptions.h
@@ -1,4 +1,7 @@
-﻿// Copyright(c) Microsoft Corporation.All rights reserved.
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+// Copyright(c) Microsoft Corporation.All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
 #pragma once

--- a/dev/Detours/disolarm.cpp
+++ b/dev/Detours/disolarm.cpp
@@ -1,5 +1,2 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License. See LICENSE in the project root for license information.
-
 #define DETOURS_ARM_OFFLINE_LIBRARY
 #include "disasm.cpp"

--- a/dev/Detours/disolarm.cpp
+++ b/dev/Detours/disolarm.cpp
@@ -1,2 +1,5 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
 #define DETOURS_ARM_OFFLINE_LIBRARY
 #include "disasm.cpp"

--- a/dev/Detours/disolarm64.cpp
+++ b/dev/Detours/disolarm64.cpp
@@ -1,2 +1,5 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
 #define DETOURS_ARM64_OFFLINE_LIBRARY
 #include "disasm.cpp"

--- a/dev/Detours/disolarm64.cpp
+++ b/dev/Detours/disolarm64.cpp
@@ -1,5 +1,2 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License. See LICENSE in the project root for license information.
-
 #define DETOURS_ARM64_OFFLINE_LIBRARY
 #include "disasm.cpp"

--- a/dev/Detours/disolia64.cpp
+++ b/dev/Detours/disolia64.cpp
@@ -1,5 +1,2 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License. See LICENSE in the project root for license information.
-
 #define DETOURS_IA64_OFFLINE_LIBRARY
 #include "disasm.cpp"

--- a/dev/Detours/disolia64.cpp
+++ b/dev/Detours/disolia64.cpp
@@ -1,2 +1,5 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
 #define DETOURS_IA64_OFFLINE_LIBRARY
 #include "disasm.cpp"

--- a/dev/Detours/disolx64.cpp
+++ b/dev/Detours/disolx64.cpp
@@ -1,2 +1,5 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
 #define DETOURS_X64_OFFLINE_LIBRARY
 #include "disasm.cpp"

--- a/dev/Detours/disolx64.cpp
+++ b/dev/Detours/disolx64.cpp
@@ -1,5 +1,2 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License. See LICENSE in the project root for license information.
-
 #define DETOURS_X64_OFFLINE_LIBRARY
 #include "disasm.cpp"

--- a/dev/Detours/disolx86.cpp
+++ b/dev/Detours/disolx86.cpp
@@ -1,5 +1,2 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License. See LICENSE in the project root for license information.
-
 #define DETOURS_X86_OFFLINE_LIBRARY
 #include "disasm.cpp"

--- a/dev/Detours/disolx86.cpp
+++ b/dev/Detours/disolx86.cpp
@@ -1,2 +1,5 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
 #define DETOURS_X86_OFFLINE_LIBRARY
 #include "disasm.cpp"

--- a/dev/EnvironmentManager/API/Microsoft.Windows.System.EnvironmentManager.Insights.h
+++ b/dev/EnvironmentManager/API/Microsoft.Windows.System.EnvironmentManager.Insights.h
@@ -1,4 +1,7 @@
-﻿#pragma once
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+#pragma once
 #include "Microsoft.Windows.System.EnvironmentManager.h"
 #include <WindowsAppRuntimeInsights.h>
 

--- a/dev/EnvironmentManager/API/Microsoft.Windows.System.EnvironmentManager.cpp
+++ b/dev/EnvironmentManager/API/Microsoft.Windows.System.EnvironmentManager.cpp
@@ -1,4 +1,7 @@
-﻿#include "pch.h"
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+#include "pch.h"
 #include "Microsoft.Windows.System.EnvironmentManager.h"
 #include "Microsoft.Windows.System.EnvironmentManager.g.cpp"
 #include "Microsoft.Windows.System.EnvironmentManager.Insights.h"

--- a/dev/EnvironmentManager/API/Microsoft.Windows.System.EnvironmentManager.h
+++ b/dev/EnvironmentManager/API/Microsoft.Windows.System.EnvironmentManager.h
@@ -1,4 +1,7 @@
-﻿#pragma once
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+#pragma once
 #include "Microsoft.Windows.System.EnvironmentManager.g.h"
 
 using namespace winrt::Windows::Foundation::Collections;

--- a/dev/MRTCore/mrt/Microsoft.Windows.ApplicationModel.Resources/unittests/UnitTestApp.xaml
+++ b/dev/MRTCore/mrt/Microsoft.Windows.ApplicationModel.Resources/unittests/UnitTestApp.xaml
@@ -1,4 +1,7 @@
-﻿<Application
+<!-- Copyright (c) Microsoft Corporation. All rights reserved. -->
+<!-- Licensed under the MIT License. See LICENSE in the project root for license information. -->
+
+<Application
     x:Class="CoreMrtManagedTest.App"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"

--- a/dev/MRTCore/packaging/ProjectItemsSchema.xaml
+++ b/dev/MRTCore/packaging/ProjectItemsSchema.xaml
@@ -1,10 +1,13 @@
-ï»¿<?xml version="1.0" encoding="utf-8"?>
+<!-- Copyright (c) Microsoft Corporation. All rights reserved. -->
+<!-- Licensed under the MIT License. See LICENSE in the project root for license information. -->
+
+<?xml version="1.0" encoding="utf-8"?>
 <ProjectSchemaDefinitions xmlns="http://schemas.microsoft.com/build/2009/properties">
     <!--
-    The â€œUpToDateCheckInputâ€ attribute on the ItemType definition informs the Fast Up To Date (FUTD) system that it
-    should be tracked as part of the *default* set of inputs/outputs. This isnâ€™t the behavior we want, though, because
-    .resw files are not an input that influence the â€œdefaultâ€ set of outputs (e.g. .dll/.exe/.pdb); the timestamp of
-    .resw files should not be compared with that of the .dll/.exe/.pdb because thereâ€™s no correlation between the two.
+    The “UpToDateCheckInput” attribute on the ItemType definition informs the Fast Up To Date (FUTD) system that it
+    should be tracked as part of the *default* set of inputs/outputs. This isn’t the behavior we want, though, because
+    .resw files are not an input that influence the “default” set of outputs (e.g. .dll/.exe/.pdb); the timestamp of
+    .resw files should not be compared with that of the .dll/.exe/.pdb because there’s no correlation between the two.
     So we override the built-in ItemType definition with our own, which turns off the automatic tracking, and then
     in MrtCore.PriGen.targets explicitly add *.resw to @(UpToDateCheckInputs) as part of a custom FUTD set for the
     output of the project PRI file.

--- a/dev/PushNotifications/PushBackgroundTaskInstance.h
+++ b/dev/PushNotifications/PushBackgroundTaskInstance.h
@@ -1,4 +1,7 @@
-﻿#include <winrt/Windows.ApplicationModel.background.h>
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+#include <winrt/Windows.ApplicationModel.background.h>
 
 // Mocks IBackgroundTaskInstance to send raw payloads to packaged apps in
 // PushNotificationBackgroundTask::Run by com activation from PushNotificationsLongRunningProcess

--- a/dev/PushNotifications/PushNotificationReceivedEventArgs.h
+++ b/dev/PushNotifications/PushNotificationReceivedEventArgs.h
@@ -1,4 +1,7 @@
-﻿#pragma once
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+#pragma once
 #include "Microsoft.Windows.PushNotifications.PushNotificationReceivedEventArgs.g.h"
 #include <NotificationsLongRunningProcess_h.h>
 #include <winrt\Windows.Networking.PushNotifications.h>

--- a/dev/PushNotifications/PushNotificationsLongRunningTask.ProxyStub/pch.cpp
+++ b/dev/PushNotifications/PushNotificationsLongRunningTask.ProxyStub/pch.cpp
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
 // pch.cpp: source file corresponding to the pre-compiled header
 
 #include "pch.h"

--- a/dev/PushNotifications/PushNotificationsLongRunningTask.StartupTask/pch.cpp
+++ b/dev/PushNotifications/PushNotificationsLongRunningTask.StartupTask/pch.cpp
@@ -1,1 +1,4 @@
-﻿#include "pch.h"
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+#include "pch.h"

--- a/dev/PushNotifications/PushNotificationsLongRunningTask.StartupTask/pch.h
+++ b/dev/PushNotifications/PushNotificationsLongRunningTask.StartupTask/pch.h
@@ -1,4 +1,7 @@
-﻿#pragma once
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+#pragma once
 
 #include <unknwn.h>
 #include <appmodel.h>

--- a/dev/PushNotifications/PushNotificationsLongRunningTask.StartupTask/winmain.cpp
+++ b/dev/PushNotifications/PushNotificationsLongRunningTask.StartupTask/winmain.cpp
@@ -1,4 +1,7 @@
-﻿#include <windows.h>
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+#include <windows.h>
 #include "pch.h"
 
 #include "PushNotificationsLongRunningPlatform-Startup.h"

--- a/dev/PushNotifications/PushNotificationsLongRunningTask/ForegroundSinkManager.cpp
+++ b/dev/PushNotifications/PushNotificationsLongRunningTask/ForegroundSinkManager.cpp
@@ -1,4 +1,7 @@
-﻿#pragma once
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+#pragma once
 
 #include "pch.h"
 

--- a/dev/PushNotifications/PushNotificationsLongRunningTask/NotificationListener.cpp
+++ b/dev/PushNotifications/PushNotificationsLongRunningTask/NotificationListener.cpp
@@ -1,4 +1,7 @@
-﻿#pragma once
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+#pragma once
 
 #include "pch.h"
 #include "../PushNotificationUtility.h"

--- a/dev/PushNotifications/PushNotificationsLongRunningTask/NotificationListener.h
+++ b/dev/PushNotifications/PushNotificationsLongRunningTask/NotificationListener.h
@@ -1,4 +1,7 @@
-﻿#pragma once
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+#pragma once
 
 #include <FrameworkUdk/PushNotificationsRT.h>
 #include <FrameworkUdk/ToastNotificationsRT.h>

--- a/dev/PushNotifications/PushNotificationsLongRunningTask/NotificationListenerManager.cpp
+++ b/dev/PushNotifications/PushNotificationsLongRunningTask/NotificationListenerManager.cpp
@@ -1,4 +1,7 @@
-﻿#include "pch.h"
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+#include "pch.h"
 
 using namespace Microsoft::WRL;
 using namespace ::ABI::Microsoft::Internal::PushNotifications;

--- a/dev/PushNotifications/PushNotificationsLongRunningTask/NotificationListenerManager.h
+++ b/dev/PushNotifications/PushNotificationsLongRunningTask/NotificationListenerManager.h
@@ -1,4 +1,7 @@
-﻿#pragma once
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+#pragma once
 
 #include <map>
 #include <string>

--- a/dev/PushNotifications/PushNotificationsLongRunningTask/PlatformLifetimeManager.cpp
+++ b/dev/PushNotifications/PushNotificationsLongRunningTask/PlatformLifetimeManager.cpp
@@ -1,4 +1,7 @@
-﻿#include "pch.h"
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+#include "pch.h"
 
 #include "PlatformLifetimeManager.h"
 

--- a/dev/PushNotifications/PushNotificationsLongRunningTask/PlatformLifetimeManager.h
+++ b/dev/PushNotifications/PushNotificationsLongRunningTask/PlatformLifetimeManager.h
@@ -1,4 +1,7 @@
-﻿#pragma once
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+#pragma once
 
 class PlatformLifetimeManager
 {

--- a/dev/PushNotifications/PushNotificationsLongRunningTask/ToastRegistrationManager.cpp
+++ b/dev/PushNotifications/PushNotificationsLongRunningTask/ToastRegistrationManager.cpp
@@ -1,4 +1,7 @@
-﻿#pragma once
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+#pragma once
 #include "pch.h"
 
 ToastRegistrationManager::ToastRegistrationManager()

--- a/dev/PushNotifications/PushNotificationsLongRunningTask/platform.cpp
+++ b/dev/PushNotifications/PushNotificationsLongRunningTask/platform.cpp
@@ -1,4 +1,7 @@
-﻿#include "pch.h"
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+#include "pch.h"
 
 #include "platform.h"
 #include "platformfactory.h"

--- a/dev/PushNotifications/PushNotificationsLongRunningTask/platform.h
+++ b/dev/PushNotifications/PushNotificationsLongRunningTask/platform.h
@@ -1,4 +1,7 @@
-﻿#pragma once
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+#pragma once
 
 #include "../PushNotifications-Constants.h"
 

--- a/dev/PushNotifications/PushNotificationsLongRunningTask/platformfactory.cpp
+++ b/dev/PushNotifications/PushNotificationsLongRunningTask/platformfactory.cpp
@@ -1,4 +1,7 @@
-﻿#include "pch.h"
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+#include "pch.h"
 
 #include "platform.h"
 #include <wrl/implements.h>

--- a/dev/PushNotifications/PushNotificationsLongRunningTask/platformfactory.h
+++ b/dev/PushNotifications/PushNotificationsLongRunningTask/platformfactory.h
@@ -1,4 +1,7 @@
-﻿#pragma once
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+#pragma once
 
 struct NotificationsLongRunningProcessFactory WrlFinal : public Microsoft::WRL::ClassFactory<>
 {

--- a/dev/RestartAgent/main.cpp
+++ b/dev/RestartAgent/main.cpp
@@ -1,4 +1,7 @@
-﻿#include "pch.h"
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+#include "pch.h"
 
 using namespace winrt;
 using namespace winrt::Windows::Foundation;

--- a/dev/RestartAgent/pch.cpp
+++ b/dev/RestartAgent/pch.cpp
@@ -1,1 +1,4 @@
-﻿#include "pch.h"
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+#include "pch.h"

--- a/dev/RestartAgent/pch.h
+++ b/dev/RestartAgent/pch.h
@@ -1,4 +1,7 @@
-﻿#pragma once
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+#pragma once
 #include <Windows.h>
 #include <shellapi.h>
 #include <MddBootstrap.h>

--- a/dev/VSIX/Extension/Cpp/Dev16/VSPackage.cs
+++ b/dev/VSIX/Extension/Cpp/Dev16/VSPackage.cs
@@ -1,4 +1,7 @@
-﻿using Microsoft.VisualStudio.Shell;
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using Microsoft.VisualStudio.Shell;
 using System;
 using System.Runtime.InteropServices;
 using System.Threading;

--- a/dev/VSIX/Extension/Cpp/Dev17/VSPackage.cs
+++ b/dev/VSIX/Extension/Cpp/Dev17/VSPackage.cs
@@ -1,4 +1,7 @@
-﻿using Microsoft.VisualStudio.Shell;
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using Microsoft.VisualStudio.Shell;
 using System;
 using System.Runtime.InteropServices;
 using System.Threading;

--- a/dev/VSIX/Extension/Cs/Dev16/VSPackage.cs
+++ b/dev/VSIX/Extension/Cs/Dev16/VSPackage.cs
@@ -1,4 +1,7 @@
-﻿using Microsoft.VisualStudio.Shell;
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using Microsoft.VisualStudio.Shell;
 using System;
 using System.Runtime.InteropServices;
 using System.Threading;

--- a/dev/VSIX/Extension/Cs/Dev17/VSPackage.cs
+++ b/dev/VSIX/Extension/Cs/Dev17/VSPackage.cs
@@ -1,4 +1,7 @@
-﻿using Microsoft.VisualStudio.Shell;
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using Microsoft.VisualStudio.Shell;
 using System;
 using System.Runtime.InteropServices;
 using System.Threading;

--- a/dev/VSIX/ItemTemplates/Desktop/CSharp/BlankWindow/BlankWindow.xaml
+++ b/dev/VSIX/ItemTemplates/Desktop/CSharp/BlankWindow/BlankWindow.xaml
@@ -1,4 +1,7 @@
-﻿<Window
+<!-- Copyright (c) Microsoft Corporation. All rights reserved. -->
+<!-- Licensed under the MIT License. See LICENSE in the project root for license information. -->
+
+<Window
     x:Class="$rootnamespace$.$safeitemname$"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"

--- a/dev/VSIX/ItemTemplates/Desktop/CSharp/BlankWindow/BlankWindow.xaml.cs
+++ b/dev/VSIX/ItemTemplates/Desktop/CSharp/BlankWindow/BlankWindow.xaml.cs
@@ -1,4 +1,7 @@
-﻿using System;
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;

--- a/dev/VSIX/ItemTemplates/Desktop/CppWinRT/BlankWindow/BlankWindow.cpp
+++ b/dev/VSIX/ItemTemplates/Desktop/CppWinRT/BlankWindow/BlankWindow.cpp
@@ -1,4 +1,7 @@
-﻿#include "pch.h"
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+#include "pch.h"
 #include "$safeitemname$.xaml.h"
 #if __has_include("$safeitemname$.g.cpp")
 #include "$safeitemname$.g.cpp"

--- a/dev/VSIX/ItemTemplates/Desktop/CppWinRT/BlankWindow/BlankWindow.h
+++ b/dev/VSIX/ItemTemplates/Desktop/CppWinRT/BlankWindow/BlankWindow.h
@@ -1,4 +1,7 @@
-﻿#pragma once
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+#pragma once
 
 #include "$safeitemname$.g.h"
 

--- a/dev/VSIX/ItemTemplates/Desktop/CppWinRT/BlankWindow/BlankWindow.idl
+++ b/dev/VSIX/ItemTemplates/Desktop/CppWinRT/BlankWindow/BlankWindow.idl
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
 namespace $rootnamespace$
 {
     [default_interface]

--- a/dev/VSIX/ItemTemplates/Desktop/CppWinRT/BlankWindow/BlankWindow.xaml
+++ b/dev/VSIX/ItemTemplates/Desktop/CppWinRT/BlankWindow/BlankWindow.xaml
@@ -1,4 +1,7 @@
-﻿<Window
+<!-- Copyright (c) Microsoft Corporation. All rights reserved. -->
+<!-- Licensed under the MIT License. See LICENSE in the project root for license information. -->
+
+<Window
     x:Class="$rootnamespace$.$safeitemname$"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"

--- a/dev/VSIX/ItemTemplates/Neutral/CSharp/BlankPage/BlankPage.xaml
+++ b/dev/VSIX/ItemTemplates/Neutral/CSharp/BlankPage/BlankPage.xaml
@@ -1,4 +1,7 @@
-﻿<Page
+<!-- Copyright (c) Microsoft Corporation. All rights reserved. -->
+<!-- Licensed under the MIT License. See LICENSE in the project root for license information. -->
+
+<Page
     x:Class="$rootnamespace$.$safeitemname$"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"

--- a/dev/VSIX/ItemTemplates/Neutral/CSharp/BlankPage/BlankPage.xaml.cs
+++ b/dev/VSIX/ItemTemplates/Neutral/CSharp/BlankPage/BlankPage.xaml.cs
@@ -1,4 +1,7 @@
-﻿using System;
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;

--- a/dev/VSIX/ItemTemplates/Neutral/CSharp/ResourceDictionary/ResourceDictionary.xaml
+++ b/dev/VSIX/ItemTemplates/Neutral/CSharp/ResourceDictionary/ResourceDictionary.xaml
@@ -1,4 +1,7 @@
-﻿<ResourceDictionary
+<!-- Copyright (c) Microsoft Corporation. All rights reserved. -->
+<!-- Licensed under the MIT License. See LICENSE in the project root for license information. -->
+
+<ResourceDictionary
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
     xmlns:local="using:$rootnamespace$">

--- a/dev/VSIX/ItemTemplates/Neutral/CSharp/TemplatedControl/CustomControl.cs
+++ b/dev/VSIX/ItemTemplates/Neutral/CSharp/TemplatedControl/CustomControl.cs
@@ -1,4 +1,7 @@
-﻿using System;
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Runtime.InteropServices.WindowsRuntime;

--- a/dev/VSIX/ItemTemplates/Neutral/CSharp/UserControl/UserControl.xaml
+++ b/dev/VSIX/ItemTemplates/Neutral/CSharp/UserControl/UserControl.xaml
@@ -1,4 +1,7 @@
-﻿<UserControl
+<!-- Copyright (c) Microsoft Corporation. All rights reserved. -->
+<!-- Licensed under the MIT License. See LICENSE in the project root for license information. -->
+
+<UserControl
     x:Class="$rootnamespace$.$safeitemname$"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"

--- a/dev/VSIX/ItemTemplates/Neutral/CSharp/UserControl/UserControl.xaml.cs
+++ b/dev/VSIX/ItemTemplates/Neutral/CSharp/UserControl/UserControl.xaml.cs
@@ -1,4 +1,7 @@
-﻿using System;
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;

--- a/dev/VSIX/ItemTemplates/Neutral/CppWinRT/BlankPage/BlankPage.cpp
+++ b/dev/VSIX/ItemTemplates/Neutral/CppWinRT/BlankPage/BlankPage.cpp
@@ -1,4 +1,7 @@
-﻿#include "pch.h"
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+#include "pch.h"
 #include "$safeitemname$.xaml.h"
 #if __has_include("$safeitemname$.g.cpp")
 #include "$safeitemname$.g.cpp"

--- a/dev/VSIX/ItemTemplates/Neutral/CppWinRT/BlankPage/BlankPage.h
+++ b/dev/VSIX/ItemTemplates/Neutral/CppWinRT/BlankPage/BlankPage.h
@@ -1,4 +1,7 @@
-﻿#pragma once
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+#pragma once
 
 #include "$safeitemname$.g.h"
 

--- a/dev/VSIX/ItemTemplates/Neutral/CppWinRT/BlankPage/BlankPage.idl
+++ b/dev/VSIX/ItemTemplates/Neutral/CppWinRT/BlankPage/BlankPage.idl
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
 namespace $rootnamespace$
 {
     [default_interface]

--- a/dev/VSIX/ItemTemplates/Neutral/CppWinRT/BlankPage/BlankPage.xaml
+++ b/dev/VSIX/ItemTemplates/Neutral/CppWinRT/BlankPage/BlankPage.xaml
@@ -1,4 +1,7 @@
-﻿<Page
+<!-- Copyright (c) Microsoft Corporation. All rights reserved. -->
+<!-- Licensed under the MIT License. See LICENSE in the project root for license information. -->
+
+<Page
     x:Class="$rootnamespace$.$safeitemname$"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"

--- a/dev/VSIX/ItemTemplates/Neutral/CppWinRT/ResourceDictionary/ResourceDictionary.xaml
+++ b/dev/VSIX/ItemTemplates/Neutral/CppWinRT/ResourceDictionary/ResourceDictionary.xaml
@@ -1,4 +1,7 @@
-﻿<ResourceDictionary
+<!-- Copyright (c) Microsoft Corporation. All rights reserved. -->
+<!-- Licensed under the MIT License. See LICENSE in the project root for license information. -->
+
+<ResourceDictionary
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
     xmlns:local="using:$rootnamespace$">

--- a/dev/VSIX/ItemTemplates/Neutral/CppWinRT/TemplatedControl/TemplatedControl.cpp
+++ b/dev/VSIX/ItemTemplates/Neutral/CppWinRT/TemplatedControl/TemplatedControl.cpp
@@ -1,4 +1,7 @@
-﻿#include "pch.h"
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+#include "pch.h"
 #include "$safeitemname$.h"
 #if __has_include("$safeitemname$.g.cpp")
 #include "$safeitemname$.g.cpp"

--- a/dev/VSIX/ItemTemplates/Neutral/CppWinRT/TemplatedControl/TemplatedControl.h
+++ b/dev/VSIX/ItemTemplates/Neutral/CppWinRT/TemplatedControl/TemplatedControl.h
@@ -1,4 +1,7 @@
-﻿#pragma once
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+#pragma once
 
 #include "winrt/Microsoft.UI.Xaml.h"
 #include "winrt/Microsoft.UI.Xaml.Markup.h"

--- a/dev/VSIX/ItemTemplates/Neutral/CppWinRT/TemplatedControl/TemplatedControl.idl
+++ b/dev/VSIX/ItemTemplates/Neutral/CppWinRT/TemplatedControl/TemplatedControl.idl
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
 namespace $rootnamespace$
 {
     [default_interface]

--- a/dev/VSIX/ItemTemplates/Neutral/CppWinRT/UserControl/UserControl.cpp
+++ b/dev/VSIX/ItemTemplates/Neutral/CppWinRT/UserControl/UserControl.cpp
@@ -1,4 +1,7 @@
-﻿#include "pch.h"
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+#include "pch.h"
 #include "$safeitemname$.xaml.h"
 #if __has_include("$safeitemname$.g.cpp")
 #include "$safeitemname$.g.cpp"

--- a/dev/VSIX/ItemTemplates/Neutral/CppWinRT/UserControl/UserControl.h
+++ b/dev/VSIX/ItemTemplates/Neutral/CppWinRT/UserControl/UserControl.h
@@ -1,4 +1,7 @@
-﻿#pragma once
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+#pragma once
 
 #include "winrt/Microsoft.UI.Xaml.h"
 #include "winrt/Microsoft.UI.Xaml.Markup.h"

--- a/dev/VSIX/ItemTemplates/Neutral/CppWinRT/UserControl/UserControl.idl
+++ b/dev/VSIX/ItemTemplates/Neutral/CppWinRT/UserControl/UserControl.idl
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
 namespace $rootnamespace$
 {
     [default_interface]

--- a/dev/VSIX/ItemTemplates/Neutral/CppWinRT/UserControl/UserControl.xaml
+++ b/dev/VSIX/ItemTemplates/Neutral/CppWinRT/UserControl/UserControl.xaml
@@ -1,4 +1,7 @@
-﻿<UserControl
+<!-- Copyright (c) Microsoft Corporation. All rights reserved. -->
+<!-- Licensed under the MIT License. See LICENSE in the project root for license information. -->
+
+<UserControl
     x:Class="$rootnamespace$.$safeitemname$"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"

--- a/dev/VSIX/ProjectTemplates/Desktop/CSharp/ClassLibrary/Class1.cs
+++ b/dev/VSIX/ProjectTemplates/Desktop/CSharp/ClassLibrary/Class1.cs
@@ -1,4 +1,7 @@
-﻿using System;
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;

--- a/dev/VSIX/ProjectTemplates/Desktop/CSharp/PackagedApp/BlankApp/App.xaml
+++ b/dev/VSIX/ProjectTemplates/Desktop/CSharp/PackagedApp/BlankApp/App.xaml
@@ -1,4 +1,7 @@
-﻿<Application
+<!-- Copyright (c) Microsoft Corporation. All rights reserved. -->
+<!-- Licensed under the MIT License. See LICENSE in the project root for license information. -->
+
+<Application
     x:Class="$safeprojectname$.App"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"

--- a/dev/VSIX/ProjectTemplates/Desktop/CSharp/PackagedApp/BlankApp/App.xaml.cs
+++ b/dev/VSIX/ProjectTemplates/Desktop/CSharp/PackagedApp/BlankApp/App.xaml.cs
@@ -1,4 +1,7 @@
-﻿using System;
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;

--- a/dev/VSIX/ProjectTemplates/Desktop/CSharp/PackagedApp/BlankApp/MainWindow.xaml
+++ b/dev/VSIX/ProjectTemplates/Desktop/CSharp/PackagedApp/BlankApp/MainWindow.xaml
@@ -1,4 +1,7 @@
-﻿<Window
+<!-- Copyright (c) Microsoft Corporation. All rights reserved. -->
+<!-- Licensed under the MIT License. See LICENSE in the project root for license information. -->
+
+<Window
     x:Class="$safeprojectname$.MainWindow"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"

--- a/dev/VSIX/ProjectTemplates/Desktop/CSharp/PackagedApp/BlankApp/MainWindow.xaml.cs
+++ b/dev/VSIX/ProjectTemplates/Desktop/CSharp/PackagedApp/BlankApp/MainWindow.xaml.cs
@@ -1,4 +1,7 @@
-﻿using System;
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;

--- a/dev/VSIX/ProjectTemplates/Desktop/CSharp/SingleProjectPackagedApp/App.xaml
+++ b/dev/VSIX/ProjectTemplates/Desktop/CSharp/SingleProjectPackagedApp/App.xaml
@@ -1,4 +1,7 @@
-﻿<Application
+<!-- Copyright (c) Microsoft Corporation. All rights reserved. -->
+<!-- Licensed under the MIT License. See LICENSE in the project root for license information. -->
+
+<Application
     x:Class="$safeprojectname$.App"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"

--- a/dev/VSIX/ProjectTemplates/Desktop/CSharp/SingleProjectPackagedApp/App.xaml.cs
+++ b/dev/VSIX/ProjectTemplates/Desktop/CSharp/SingleProjectPackagedApp/App.xaml.cs
@@ -1,4 +1,7 @@
-﻿using System;
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;

--- a/dev/VSIX/ProjectTemplates/Desktop/CSharp/SingleProjectPackagedApp/MainWindow.xaml
+++ b/dev/VSIX/ProjectTemplates/Desktop/CSharp/SingleProjectPackagedApp/MainWindow.xaml
@@ -1,4 +1,7 @@
-﻿<Window
+<!-- Copyright (c) Microsoft Corporation. All rights reserved. -->
+<!-- Licensed under the MIT License. See LICENSE in the project root for license information. -->
+
+<Window
     x:Class="$safeprojectname$.MainWindow"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"

--- a/dev/VSIX/ProjectTemplates/Desktop/CSharp/SingleProjectPackagedApp/MainWindow.xaml.cs
+++ b/dev/VSIX/ProjectTemplates/Desktop/CSharp/SingleProjectPackagedApp/MainWindow.xaml.cs
@@ -1,4 +1,7 @@
-﻿using System;
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;

--- a/dev/VSIX/ProjectTemplates/Desktop/CppWinRT/PackagedApp/BlankApp/App.cpp
+++ b/dev/VSIX/ProjectTemplates/Desktop/CppWinRT/PackagedApp/BlankApp/App.cpp
@@ -1,4 +1,7 @@
-﻿#include "pch.h"
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+#include "pch.h"
 
 #include "App.xaml.h"
 #include "MainWindow.xaml.h"

--- a/dev/VSIX/ProjectTemplates/Desktop/CppWinRT/PackagedApp/BlankApp/App.h
+++ b/dev/VSIX/ProjectTemplates/Desktop/CppWinRT/PackagedApp/BlankApp/App.h
@@ -1,4 +1,7 @@
-﻿#pragma once
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+#pragma once
 
 #include "App.xaml.g.h"
 

--- a/dev/VSIX/ProjectTemplates/Desktop/CppWinRT/PackagedApp/BlankApp/App.idl
+++ b/dev/VSIX/ProjectTemplates/Desktop/CppWinRT/PackagedApp/BlankApp/App.idl
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
 namespace $safeprojectname$
 {
 }

--- a/dev/VSIX/ProjectTemplates/Desktop/CppWinRT/PackagedApp/BlankApp/App.xaml
+++ b/dev/VSIX/ProjectTemplates/Desktop/CppWinRT/PackagedApp/BlankApp/App.xaml
@@ -1,4 +1,7 @@
-﻿<Application
+<!-- Copyright (c) Microsoft Corporation. All rights reserved. -->
+<!-- Licensed under the MIT License. See LICENSE in the project root for license information. -->
+
+<Application
     x:Class="$safeprojectname$.App"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"

--- a/dev/VSIX/ProjectTemplates/Desktop/CppWinRT/PackagedApp/BlankApp/MainWindow.cpp
+++ b/dev/VSIX/ProjectTemplates/Desktop/CppWinRT/PackagedApp/BlankApp/MainWindow.cpp
@@ -1,4 +1,7 @@
-﻿#include "pch.h"
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+#include "pch.h"
 #include "MainWindow.xaml.h"
 #if __has_include("MainWindow.g.cpp")
 #include "MainWindow.g.cpp"

--- a/dev/VSIX/ProjectTemplates/Desktop/CppWinRT/PackagedApp/BlankApp/MainWindow.h
+++ b/dev/VSIX/ProjectTemplates/Desktop/CppWinRT/PackagedApp/BlankApp/MainWindow.h
@@ -1,4 +1,7 @@
-﻿#pragma once
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+#pragma once
 #include "MainWindow.g.h"
 
 namespace winrt::$safeprojectname$::implementation

--- a/dev/VSIX/ProjectTemplates/Desktop/CppWinRT/PackagedApp/BlankApp/MainWindow.idl
+++ b/dev/VSIX/ProjectTemplates/Desktop/CppWinRT/PackagedApp/BlankApp/MainWindow.idl
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
 namespace $safeprojectname$
 {
     [default_interface]

--- a/dev/VSIX/ProjectTemplates/Desktop/CppWinRT/PackagedApp/BlankApp/MainWindow.xaml
+++ b/dev/VSIX/ProjectTemplates/Desktop/CppWinRT/PackagedApp/BlankApp/MainWindow.xaml
@@ -1,4 +1,7 @@
-﻿<Window
+<!-- Copyright (c) Microsoft Corporation. All rights reserved. -->
+<!-- Licensed under the MIT License. See LICENSE in the project root for license information. -->
+
+<Window
     x:Class="$safeprojectname$.MainWindow"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"

--- a/dev/VSIX/ProjectTemplates/Desktop/CppWinRT/PackagedApp/BlankApp/pch.cpp
+++ b/dev/VSIX/ProjectTemplates/Desktop/CppWinRT/PackagedApp/BlankApp/pch.cpp
@@ -1,1 +1,4 @@
-﻿#include "pch.h"
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+#include "pch.h"

--- a/dev/VSIX/ProjectTemplates/Desktop/CppWinRT/PackagedApp/BlankApp/pch.h
+++ b/dev/VSIX/ProjectTemplates/Desktop/CppWinRT/PackagedApp/BlankApp/pch.h
@@ -1,4 +1,7 @@
-﻿#pragma once
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+#pragma once
 #include <windows.h>
 #include <unknwn.h>
 #include <restrictederrorinfo.h>

--- a/dev/VSIX/ProjectTemplates/Desktop/CppWinRT/SingleProjectPackagedApp/App.cpp
+++ b/dev/VSIX/ProjectTemplates/Desktop/CppWinRT/SingleProjectPackagedApp/App.cpp
@@ -1,4 +1,7 @@
-﻿#include "pch.h"
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+#include "pch.h"
 
 #include "App.xaml.h"
 #include "MainWindow.xaml.h"

--- a/dev/VSIX/ProjectTemplates/Desktop/CppWinRT/SingleProjectPackagedApp/App.h
+++ b/dev/VSIX/ProjectTemplates/Desktop/CppWinRT/SingleProjectPackagedApp/App.h
@@ -1,4 +1,7 @@
-﻿#pragma once
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+#pragma once
 
 #include "App.xaml.g.h"
 

--- a/dev/VSIX/ProjectTemplates/Desktop/CppWinRT/SingleProjectPackagedApp/App.idl
+++ b/dev/VSIX/ProjectTemplates/Desktop/CppWinRT/SingleProjectPackagedApp/App.idl
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
 namespace $safeprojectname$
 {
 }

--- a/dev/VSIX/ProjectTemplates/Desktop/CppWinRT/SingleProjectPackagedApp/App.xaml
+++ b/dev/VSIX/ProjectTemplates/Desktop/CppWinRT/SingleProjectPackagedApp/App.xaml
@@ -1,4 +1,7 @@
-﻿<Application
+<!-- Copyright (c) Microsoft Corporation. All rights reserved. -->
+<!-- Licensed under the MIT License. See LICENSE in the project root for license information. -->
+
+<Application
     x:Class="$safeprojectname$.App"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"

--- a/dev/VSIX/ProjectTemplates/Desktop/CppWinRT/SingleProjectPackagedApp/MainWindow.cpp
+++ b/dev/VSIX/ProjectTemplates/Desktop/CppWinRT/SingleProjectPackagedApp/MainWindow.cpp
@@ -1,4 +1,7 @@
-﻿#include "pch.h"
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+#include "pch.h"
 #include "MainWindow.xaml.h"
 #if __has_include("MainWindow.g.cpp")
 #include "MainWindow.g.cpp"

--- a/dev/VSIX/ProjectTemplates/Desktop/CppWinRT/SingleProjectPackagedApp/MainWindow.h
+++ b/dev/VSIX/ProjectTemplates/Desktop/CppWinRT/SingleProjectPackagedApp/MainWindow.h
@@ -1,4 +1,7 @@
-﻿#pragma once
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+#pragma once
 
 #include "MainWindow.g.h"
 

--- a/dev/VSIX/ProjectTemplates/Desktop/CppWinRT/SingleProjectPackagedApp/MainWindow.idl
+++ b/dev/VSIX/ProjectTemplates/Desktop/CppWinRT/SingleProjectPackagedApp/MainWindow.idl
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
 namespace $safeprojectname$
 {
     [default_interface]

--- a/dev/VSIX/ProjectTemplates/Desktop/CppWinRT/SingleProjectPackagedApp/MainWindow.xaml
+++ b/dev/VSIX/ProjectTemplates/Desktop/CppWinRT/SingleProjectPackagedApp/MainWindow.xaml
@@ -1,4 +1,7 @@
-﻿<Window
+<!-- Copyright (c) Microsoft Corporation. All rights reserved. -->
+<!-- Licensed under the MIT License. See LICENSE in the project root for license information. -->
+
+<Window
     x:Class="$safeprojectname$.MainWindow"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"

--- a/dev/VSIX/ProjectTemplates/Desktop/CppWinRT/SingleProjectPackagedApp/pch.cpp
+++ b/dev/VSIX/ProjectTemplates/Desktop/CppWinRT/SingleProjectPackagedApp/pch.cpp
@@ -1,1 +1,4 @@
-﻿#include "pch.h"
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+#include "pch.h"

--- a/dev/VSIX/ProjectTemplates/Desktop/CppWinRT/SingleProjectPackagedApp/pch.h
+++ b/dev/VSIX/ProjectTemplates/Desktop/CppWinRT/SingleProjectPackagedApp/pch.h
@@ -1,4 +1,7 @@
-﻿#pragma once
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+#pragma once
 #include <windows.h>
 #include <unknwn.h>
 #include <restrictederrorinfo.h>

--- a/dev/VSIX/ProjectTemplates/Neutral/CppWinRT/RuntimeComponent/Class.cpp
+++ b/dev/VSIX/ProjectTemplates/Neutral/CppWinRT/RuntimeComponent/Class.cpp
@@ -1,4 +1,7 @@
-﻿#include "pch.h"
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+#include "pch.h"
 #include "Class.h"
 #if __has_include("Class.g.cpp")
 #include "Class.g.cpp"

--- a/dev/VSIX/ProjectTemplates/Neutral/CppWinRT/RuntimeComponent/Class.h
+++ b/dev/VSIX/ProjectTemplates/Neutral/CppWinRT/RuntimeComponent/Class.h
@@ -1,4 +1,7 @@
-﻿#pragma once
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+#pragma once
 
 #include "Class.g.h"
 

--- a/dev/VSIX/ProjectTemplates/Neutral/CppWinRT/RuntimeComponent/Class.idl
+++ b/dev/VSIX/ProjectTemplates/Neutral/CppWinRT/RuntimeComponent/Class.idl
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
 namespace $safeprojectname$
 {
     [default_interface]

--- a/dev/VSIX/ProjectTemplates/Neutral/CppWinRT/RuntimeComponent/pch.cpp
+++ b/dev/VSIX/ProjectTemplates/Neutral/CppWinRT/RuntimeComponent/pch.cpp
@@ -1,1 +1,4 @@
-﻿#include "pch.h"
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+#include "pch.h"

--- a/dev/VSIX/ProjectTemplates/Neutral/CppWinRT/RuntimeComponent/pch.h
+++ b/dev/VSIX/ProjectTemplates/Neutral/CppWinRT/RuntimeComponent/pch.h
@@ -1,4 +1,7 @@
-﻿#pragma once
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+#pragma once
 #include <unknwn.h>
 #include <winrt/Windows.Foundation.h>
 #include <winrt/Windows.Foundation.Collections.h>

--- a/dev/VSIX/ProjectTemplates/UWP/CSharp/BlankApp/App.xaml
+++ b/dev/VSIX/ProjectTemplates/UWP/CSharp/BlankApp/App.xaml
@@ -1,4 +1,7 @@
-﻿<Application
+<!-- Copyright (c) Microsoft Corporation. All rights reserved. -->
+<!-- Licensed under the MIT License. See LICENSE in the project root for license information. -->
+
+<Application
     x:Class="$safeprojectname$.App"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"

--- a/dev/VSIX/ProjectTemplates/UWP/CSharp/BlankApp/App.xaml.cs
+++ b/dev/VSIX/ProjectTemplates/UWP/CSharp/BlankApp/App.xaml.cs
@@ -1,4 +1,7 @@
-﻿using System;
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;

--- a/dev/VSIX/ProjectTemplates/UWP/CSharp/BlankApp/MainPage.xaml
+++ b/dev/VSIX/ProjectTemplates/UWP/CSharp/BlankApp/MainPage.xaml
@@ -1,4 +1,7 @@
-﻿<Page
+<!-- Copyright (c) Microsoft Corporation. All rights reserved. -->
+<!-- Licensed under the MIT License. See LICENSE in the project root for license information. -->
+
+<Page
     x:Class="$safeprojectname$.MainPage"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"

--- a/dev/VSIX/ProjectTemplates/UWP/CSharp/BlankApp/MainPage.xaml.cs
+++ b/dev/VSIX/ProjectTemplates/UWP/CSharp/BlankApp/MainPage.xaml.cs
@@ -1,4 +1,7 @@
-﻿using System;
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;

--- a/dev/VSIX/ProjectTemplates/UWP/CSharp/BlankApp/Properties/AssemblyInfo.cs
+++ b/dev/VSIX/ProjectTemplates/UWP/CSharp/BlankApp/Properties/AssemblyInfo.cs
@@ -1,4 +1,7 @@
-﻿using System.Reflection;
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using System.Reflection;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 
@@ -10,7 +13,7 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCompany("$registeredorganization$")]
 [assembly: AssemblyProduct("$projectname$")]
-[assembly: AssemblyCopyright("Copyright © $registeredorganization$ $year$")]
+[assembly: AssemblyCopyright("Copyright � $registeredorganization$ $year$")]
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
 

--- a/dev/VSIX/ProjectTemplates/UWP/CSharp/ClassLibrary/Class1.cs
+++ b/dev/VSIX/ProjectTemplates/UWP/CSharp/ClassLibrary/Class1.cs
@@ -1,4 +1,7 @@
-﻿using System;
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;

--- a/dev/VSIX/ProjectTemplates/UWP/CSharp/ClassLibrary/Properties/AssemblyInfo.cs
+++ b/dev/VSIX/ProjectTemplates/UWP/CSharp/ClassLibrary/Properties/AssemblyInfo.cs
@@ -1,4 +1,7 @@
-﻿using System.Reflection;
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using System.Reflection;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 
@@ -10,7 +13,7 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCompany("$registeredorganization$")]
 [assembly: AssemblyProduct("$projectname$")]
-[assembly: AssemblyCopyright("Copyright © $registeredorganization$ $year$")]
+[assembly: AssemblyCopyright("Copyright � $registeredorganization$ $year$")]
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
 

--- a/dev/VSIX/ProjectTemplates/UWP/CSharp/RuntimeComponent/Class1.cs
+++ b/dev/VSIX/ProjectTemplates/UWP/CSharp/RuntimeComponent/Class1.cs
@@ -1,4 +1,7 @@
-﻿using System;
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;

--- a/dev/VSIX/ProjectTemplates/UWP/CSharp/RuntimeComponent/Properties/AssemblyInfo.cs
+++ b/dev/VSIX/ProjectTemplates/UWP/CSharp/RuntimeComponent/Properties/AssemblyInfo.cs
@@ -1,4 +1,7 @@
-﻿using System.Reflection;
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using System.Reflection;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 
@@ -10,7 +13,7 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCompany("$registeredorganization$")]
 [assembly: AssemblyProduct("$projectname$")]
-[assembly: AssemblyCopyright("Copyright © $registeredorganization$ $year$")]
+[assembly: AssemblyCopyright("Copyright � $registeredorganization$ $year$")]
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
 

--- a/dev/VSIX/ProjectTemplates/UWP/CppWinRT/BlankApp/App.cpp
+++ b/dev/VSIX/ProjectTemplates/UWP/CppWinRT/BlankApp/App.cpp
@@ -1,4 +1,7 @@
-﻿#include "pch.h"
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+#include "pch.h"
 
 #include "App.xaml.h"
 #include "MainPage.xaml.h"

--- a/dev/VSIX/ProjectTemplates/UWP/CppWinRT/BlankApp/App.h
+++ b/dev/VSIX/ProjectTemplates/UWP/CppWinRT/BlankApp/App.h
@@ -1,4 +1,7 @@
-﻿#pragma once
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+#pragma once
 #include "App.xaml.g.h"
 
 namespace winrt::$safeprojectname$::implementation

--- a/dev/VSIX/ProjectTemplates/UWP/CppWinRT/BlankApp/App.idl
+++ b/dev/VSIX/ProjectTemplates/UWP/CppWinRT/BlankApp/App.idl
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
 namespace $safeprojectname$
 {
 }

--- a/dev/VSIX/ProjectTemplates/UWP/CppWinRT/BlankApp/App.xaml
+++ b/dev/VSIX/ProjectTemplates/UWP/CppWinRT/BlankApp/App.xaml
@@ -1,4 +1,7 @@
-﻿<Application
+<!-- Copyright (c) Microsoft Corporation. All rights reserved. -->
+<!-- Licensed under the MIT License. See LICENSE in the project root for license information. -->
+
+<Application
     x:Class="$safeprojectname$.App"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"

--- a/dev/VSIX/ProjectTemplates/UWP/CppWinRT/BlankApp/MainPage.cpp
+++ b/dev/VSIX/ProjectTemplates/UWP/CppWinRT/BlankApp/MainPage.cpp
@@ -1,4 +1,7 @@
-﻿#include "pch.h"
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+#include "pch.h"
 #include "MainPage.xaml.h"
 #if __has_include("MainPage.g.cpp")
 #include "MainPage.g.cpp"

--- a/dev/VSIX/ProjectTemplates/UWP/CppWinRT/BlankApp/MainPage.h
+++ b/dev/VSIX/ProjectTemplates/UWP/CppWinRT/BlankApp/MainPage.h
@@ -1,4 +1,7 @@
-﻿#pragma once
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+#pragma once
 
 #include "MainPage.g.h"
 

--- a/dev/VSIX/ProjectTemplates/UWP/CppWinRT/BlankApp/MainPage.idl
+++ b/dev/VSIX/ProjectTemplates/UWP/CppWinRT/BlankApp/MainPage.idl
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
 namespace $safeprojectname$
 {
     [default_interface]

--- a/dev/VSIX/ProjectTemplates/UWP/CppWinRT/BlankApp/MainPage.xaml
+++ b/dev/VSIX/ProjectTemplates/UWP/CppWinRT/BlankApp/MainPage.xaml
@@ -1,4 +1,7 @@
-﻿<Page
+<!-- Copyright (c) Microsoft Corporation. All rights reserved. -->
+<!-- Licensed under the MIT License. See LICENSE in the project root for license information. -->
+
+<Page
     x:Class="$safeprojectname$.MainPage"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"

--- a/dev/VSIX/ProjectTemplates/UWP/CppWinRT/BlankApp/pch.cpp
+++ b/dev/VSIX/ProjectTemplates/UWP/CppWinRT/BlankApp/pch.cpp
@@ -1,1 +1,4 @@
-﻿#include "pch.h"
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+#include "pch.h"

--- a/dev/VSIX/ProjectTemplates/UWP/CppWinRT/BlankApp/pch.h
+++ b/dev/VSIX/ProjectTemplates/UWP/CppWinRT/BlankApp/pch.h
@@ -1,4 +1,7 @@
-﻿#pragma once
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+#pragma once
 #include <windows.h>
 #include <unknwn.h>
 #include <restrictederrorinfo.h>

--- a/dev/WindowsAppRuntime_DLL/pch.cpp
+++ b/dev/WindowsAppRuntime_DLL/pch.cpp
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
 // pch.cpp: source file corresponding to the pre-compiled header
 
 #include "pch.h"

--- a/installer/test/InstallerFunctionalTests/FunctionalTests.cpp
+++ b/installer/test/InstallerFunctionalTests/FunctionalTests.cpp
@@ -1,4 +1,7 @@
-﻿#include "pch.h"
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+#include "pch.h"
 #include "helpers.h"
 #include "constants.h"
 

--- a/installer/test/InstallerFunctionalTests/constants.h
+++ b/installer/test/InstallerFunctionalTests/constants.h
@@ -1,4 +1,7 @@
-﻿#pragma once
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+#pragma once
 
 #if defined(_M_IX86)
     #define ARCH L"x86"

--- a/installer/test/InstallerFunctionalTests/helpers.cpp
+++ b/installer/test/InstallerFunctionalTests/helpers.cpp
@@ -1,4 +1,7 @@
-﻿#include "pch.h"
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+#include "pch.h"
 #include "constants.h"
 #include "helpers.h"
 

--- a/installer/test/InstallerFunctionalTests/helpers.h
+++ b/installer/test/InstallerFunctionalTests/helpers.h
@@ -1,4 +1,7 @@
-﻿#pragma once
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+#pragma once
 #include "pch.h"
 
 namespace WindowsAppRuntimeInstallerTests

--- a/installer/test/InstallerFunctionalTests/pch.cpp
+++ b/installer/test/InstallerFunctionalTests/pch.cpp
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
 // pch.cpp: source file corresponding to the pre-compiled header
 
 #include "pch.h"

--- a/installer/test/InstallerFunctionalTests/pch.h
+++ b/installer/test/InstallerFunctionalTests/pch.h
@@ -1,4 +1,7 @@
-﻿// pch.h: This is a precompiled header file.
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+// pch.h: This is a precompiled header file.
 // Files listed below are compiled only once, improving build performance for future builds.
 // This also affects IntelliSense performance, including code completion and many code browsing features.
 // However, files listed here are ALL re-compiled if any one of them is updated between builds.

--- a/test/AccessControlTests/pch.cpp
+++ b/test/AccessControlTests/pch.cpp
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
 // pch.cpp: source file corresponding to the pre-compiled header
 
 #include "pch.h"

--- a/test/AccessControlTests/pch.h
+++ b/test/AccessControlTests/pch.h
@@ -1,4 +1,7 @@
-﻿// pch.h: This is a precompiled header file.
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+// pch.h: This is a precompiled header file.
 // Files listed below are compiled only once, improving build performance for future builds.
 // This also affects IntelliSense performance, including code completion and many code browsing features.
 // However, files listed here are ALL re-compiled if any one of them is updated between builds.

--- a/test/AppLifecycle/pch.cpp
+++ b/test/AppLifecycle/pch.cpp
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
 // pch.cpp: source file corresponding to the pre-compiled header
 
 #include "pch.h"

--- a/test/Common/pch.cpp
+++ b/test/Common/pch.cpp
@@ -1,4 +1,7 @@
-﻿// pch.cpp: source file corresponding to the pre-compiled header
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+// pch.cpp: source file corresponding to the pre-compiled header
 
 #include "pch.h"
 

--- a/test/Common/pch.h
+++ b/test/Common/pch.h
@@ -1,4 +1,7 @@
-﻿// pch.h: This is a precompiled header file.
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+// pch.h: This is a precompiled header file.
 // Files listed below are compiled only once, improving build performance for future builds.
 // This also affects IntelliSense performance, including code completion and many code browsing features.
 // However, files listed here are ALL re-compiled if any one of them is updated between builds.

--- a/test/Deployment/pch.cpp
+++ b/test/Deployment/pch.cpp
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
 // pch.cpp: source file corresponding to the pre-compiled header
 
 #include "pch.h"

--- a/test/DynamicDependency/Test_Win32/pch.cpp
+++ b/test/DynamicDependency/Test_Win32/pch.cpp
@@ -1,4 +1,7 @@
-﻿// pch.cpp: source file corresponding to the pre-compiled header
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+// pch.cpp: source file corresponding to the pre-compiled header
 
 #include "pch.h"
 

--- a/test/DynamicDependency/Test_Win32/pch.h
+++ b/test/DynamicDependency/Test_Win32/pch.h
@@ -1,4 +1,7 @@
-﻿// pch.h: This is a precompiled header file.
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+// pch.h: This is a precompiled header file.
 // Files listed below are compiled only once, improving build performance for future builds.
 // This also affects IntelliSense performance, including code completion and many code browsing features.
 // However, files listed here are ALL re-compiled if any one of them is updated between builds.

--- a/test/DynamicDependency/Test_WinRT/pch.cpp
+++ b/test/DynamicDependency/Test_WinRT/pch.cpp
@@ -1,4 +1,7 @@
-﻿// pch.cpp: source file corresponding to the pre-compiled header
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+// pch.cpp: source file corresponding to the pre-compiled header
 
 #include "pch.h"
 

--- a/test/DynamicDependency/Test_WinRT/pch.h
+++ b/test/DynamicDependency/Test_WinRT/pch.h
@@ -1,4 +1,7 @@
-﻿// pch.h: This is a precompiled header file.
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+// pch.h: This is a precompiled header file.
 // Files listed below are compiled only once, improving build performance for future builds.
 // This also affects IntelliSense performance, including code completion and many code browsing features.
 // However, files listed here are ALL re-compiled if any one of them is updated between builds.

--- a/test/DynamicDependency/data/Framework.Math.Add/dllmain.cpp
+++ b/test/DynamicDependency/data/Framework.Math.Add/dllmain.cpp
@@ -1,4 +1,7 @@
-﻿#include "pch.h"
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+#include "pch.h"
 
 BOOL APIENTRY DllMain(HMODULE /* hModule */, DWORD ul_reason_for_call, LPVOID /* lpReserved */)
 {

--- a/test/DynamicDependency/data/Framework.Math.Add/pch.cpp
+++ b/test/DynamicDependency/data/Framework.Math.Add/pch.cpp
@@ -1,1 +1,4 @@
-﻿#include "pch.h"
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+#include "pch.h"

--- a/test/DynamicDependency/data/Framework.Math.Add/pch.h
+++ b/test/DynamicDependency/data/Framework.Math.Add/pch.h
@@ -1,4 +1,7 @@
-﻿#pragma once
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+#pragma once
 
 #include "targetver.h"
 

--- a/test/DynamicDependency/data/Framework.Math.Add/targetver.h
+++ b/test/DynamicDependency/data/Framework.Math.Add/targetver.h
@@ -1,4 +1,7 @@
-﻿#pragma once
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+#pragma once
 
 // Including SDKDDKVer.h defines the highest available Windows platform.
 

--- a/test/DynamicDependency/data/Framework.Math.Multiply/dllmain.cpp
+++ b/test/DynamicDependency/data/Framework.Math.Multiply/dllmain.cpp
@@ -1,4 +1,7 @@
-﻿#include "pch.h"
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+#include "pch.h"
 
 BOOL APIENTRY DllMain(HMODULE /* hModule */, DWORD ul_reason_for_call, LPVOID /* lpReserved */)
 {

--- a/test/DynamicDependency/data/Framework.Math.Multiply/pch.cpp
+++ b/test/DynamicDependency/data/Framework.Math.Multiply/pch.cpp
@@ -1,1 +1,4 @@
-﻿#include "pch.h"
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+#include "pch.h"

--- a/test/DynamicDependency/data/Framework.Math.Multiply/pch.h
+++ b/test/DynamicDependency/data/Framework.Math.Multiply/pch.h
@@ -1,4 +1,7 @@
-﻿#pragma once
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+#pragma once
 
 #include "targetver.h"
 

--- a/test/DynamicDependency/data/Framework.Math.Multiply/targetver.h
+++ b/test/DynamicDependency/data/Framework.Math.Multiply/targetver.h
@@ -1,4 +1,7 @@
-﻿#pragma once
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+#pragma once
 
 // Including SDKDDKVer.h defines the highest available Windows platform.
 

--- a/test/DynamicDependency/data/Framework.Widgets/Microsoft.Test.DynamicDependency.Widgets.Widget1.cpp
+++ b/test/DynamicDependency/data/Framework.Widgets/Microsoft.Test.DynamicDependency.Widgets.Widget1.cpp
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
 #include "pch.h"
 #include "Microsoft.Test.DynamicDependency.Widgets.Widget1.h"
 #include "Microsoft.Test.DynamicDependency.Widgets.Widget1.g.cpp"

--- a/test/DynamicDependency/data/Framework.Widgets/Microsoft.Test.DynamicDependency.Widgets.Widget1.h
+++ b/test/DynamicDependency/data/Framework.Widgets/Microsoft.Test.DynamicDependency.Widgets.Widget1.h
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
 #pragma once
 #include "Microsoft.Test.DynamicDependency.Widgets.Widget1.g.h"
 

--- a/test/DynamicDependency/data/Framework.Widgets/Microsoft.Test.DynamicDependency.Widgets.Widget2.cpp
+++ b/test/DynamicDependency/data/Framework.Widgets/Microsoft.Test.DynamicDependency.Widgets.Widget2.cpp
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
 #include "pch.h"
 #include "Microsoft.Test.DynamicDependency.Widgets.Widget2.h"
 #include "Microsoft.Test.DynamicDependency.Widgets.Widget2.g.cpp"

--- a/test/DynamicDependency/data/Framework.Widgets/Microsoft.Test.DynamicDependency.Widgets.Widget2.h
+++ b/test/DynamicDependency/data/Framework.Widgets/Microsoft.Test.DynamicDependency.Widgets.Widget2.h
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
 #pragma once
 #include "Microsoft.Test.DynamicDependency.Widgets.Widget2.g.h"
 

--- a/test/DynamicDependency/data/Framework.Widgets/dllmain.cpp
+++ b/test/DynamicDependency/data/Framework.Widgets/dllmain.cpp
@@ -1,4 +1,7 @@
-﻿#include "pch.h"
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+#include "pch.h"
 
 BOOL APIENTRY DllMain(HMODULE /* hModule */, DWORD ul_reason_for_call, LPVOID /* lpReserved */)
 {

--- a/test/DynamicDependency/data/Framework.Widgets/pch.cpp
+++ b/test/DynamicDependency/data/Framework.Widgets/pch.cpp
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
 // pch.cpp: source file corresponding to the pre-compiled header
 
 #include "pch.h"

--- a/test/DynamicDependency/data/Framework.Widgets/targetver.h
+++ b/test/DynamicDependency/data/Framework.Widgets/targetver.h
@@ -1,4 +1,7 @@
-﻿#pragma once
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+#pragma once
 
 // Including SDKDDKVer.h defines the highest available Windows platform.
 

--- a/test/EnvironmentManagerTests/ChangeTrackerHelper.h
+++ b/test/EnvironmentManagerTests/ChangeTrackerHelper.h
@@ -1,4 +1,7 @@
-﻿#pragma once
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+#pragma once
 
 inline wil::unique_hkey GetKeyForTrackingChange()
 {

--- a/test/EnvironmentManagerTests/TestCommon.h
+++ b/test/EnvironmentManagerTests/TestCommon.h
@@ -1,4 +1,7 @@
-﻿#pragma once
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+#pragma once
 #include "pch.h"
 
 inline constexpr PCWSTR c_UserEvRegLocation = L"Environment";

--- a/test/EnvironmentManagerTests/TestSetupAndTeardownHelper.h
+++ b/test/EnvironmentManagerTests/TestSetupAndTeardownHelper.h
@@ -1,4 +1,7 @@
-﻿#pragma once
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+#pragma once
 #include "TestCommon.h"
 #include "EnvironmentVariableHelper.h"
 #include "ChangeTrackerHelper.h"

--- a/test/EnvironmentManagerTests/framework.h
+++ b/test/EnvironmentManagerTests/framework.h
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
 #pragma once
 
 #define WIN32_LEAN_AND_MEAN             // Exclude rarely-used stuff from Windows headers

--- a/test/PowerNotifications/pch.cpp
+++ b/test/PowerNotifications/pch.cpp
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
 // pch.cpp: source file corresponding to the pre-compiled header
 
 #include "pch.h"

--- a/test/PushNotificationTests/MockBackgroundTaskInstance.cpp
+++ b/test/PushNotificationTests/MockBackgroundTaskInstance.cpp
@@ -1,4 +1,7 @@
-﻿#pragma once
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+#pragma once
 
 #include "pch.h"
 #include "MockBackgroundTaskInstance.h"

--- a/test/PushNotificationTests/MockBackgroundTaskInstance.h
+++ b/test/PushNotificationTests/MockBackgroundTaskInstance.h
@@ -1,4 +1,7 @@
-﻿#include <winrt/Windows.ApplicationModel.background.h>
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+#include <winrt/Windows.ApplicationModel.background.h>
 
 struct MockBackgroundTaskInstance : winrt::implements<MockBackgroundTaskInstance, winrt::Windows::ApplicationModel::Background::IBackgroundTaskInstance>
 {

--- a/test/PushNotificationTests/MockRawNotification.cpp
+++ b/test/PushNotificationTests/MockRawNotification.cpp
@@ -1,4 +1,7 @@
-﻿#include "pch.h"
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+#include "pch.h"
 #include "MockRawNotification.h"
 
 winrt::Windows::Foundation::Collections::IMapView<winrt::hstring, winrt::hstring> MockRawNotification::Headers()

--- a/test/PushNotificationTests/MockRawNotification.h
+++ b/test/PushNotificationTests/MockRawNotification.h
@@ -1,4 +1,7 @@
-﻿#include <winrt/Windows.ApplicationModel.background.h>
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+#include <winrt/Windows.ApplicationModel.background.h>
 #include <winrt/Windows.Storage.Streams.h>
 #include <TestDef.h>
 

--- a/test/PushNotificationTests/pch.cpp
+++ b/test/PushNotificationTests/pch.cpp
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
 // pch.cpp: source file corresponding to the pre-compiled header
 
 #include "pch.h"

--- a/test/TestApps/AccessControlTestApp/main.cpp
+++ b/test/TestApps/AccessControlTestApp/main.cpp
@@ -1,4 +1,7 @@
-﻿#include "pch.h"
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+#include "pch.h"
 #include <testdef.h>
 #include <iostream>
 #include <sstream>

--- a/test/TestApps/ManualTestApp/resource.h
+++ b/test/TestApps/ManualTestApp/resource.h
@@ -1,4 +1,7 @@
-﻿//{{NO_DEPENDENCIES}}
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+//{{NO_DEPENDENCIES}}
 // Microsoft Visual C++ generated include file.
 // Used by ManualTestApp.rc
 //

--- a/test/TestApps/PushNotificationsTestApp/main.cpp
+++ b/test/TestApps/PushNotificationsTestApp/main.cpp
@@ -1,4 +1,7 @@
-﻿#include "pch.h"
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+#include "pch.h"
 #include <iostream>
 #include <sstream>
 #include <wil/win32_helpers.h>

--- a/test/TestApps/ToastNotificationsDemoApp/resource.h
+++ b/test/TestApps/ToastNotificationsDemoApp/resource.h
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
 //{{NO_DEPENDENCIES}}
 // Microsoft Visual C++ generated include file.
 // Used by ToastNotificationsDemoApp.rc

--- a/test/TestApps/ToastNotificationsTestApp/main.cpp
+++ b/test/TestApps/ToastNotificationsTestApp/main.cpp
@@ -1,4 +1,7 @@
-﻿#include "pch.h"
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+#include "pch.h"
 #include <iostream>
 #include <wil/win32_helpers.h>
 #include "WindowsAppRuntime.Test.AppModel.h"

--- a/test/TestApps/ToastNotificationsTestApp/resource.h
+++ b/test/TestApps/ToastNotificationsTestApp/resource.h
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
 //{{NO_DEPENDENCIES}}
 // Microsoft Visual C++ generated include file.
 // Used by ToastNotificationsTestApp.rc

--- a/test/ToastNotificationTests/APITests.cpp
+++ b/test/ToastNotificationTests/APITests.cpp
@@ -1,4 +1,7 @@
-﻿#include "pch.h"
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+#include "pch.h"
 #include "NotificationActivationCallback.h"
 #include "AppNotification-Test-Constants.h"
 

--- a/test/ToastNotificationTests/pch.cpp
+++ b/test/ToastNotificationTests/pch.cpp
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
 // pch.cpp: source file corresponding to the pre-compiled header
 
 #include "pch.h"

--- a/test/WindowsAppSDK.Helix.Test.NetCore/Program.cs
+++ b/test/WindowsAppSDK.Helix.Test.NetCore/Program.cs
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
 using System;
 
 namespace WindowsAppSDK.Helix.Test.App

--- a/test/WindowsAppSDK.Helix.TestCommon/TestAssembly.cs
+++ b/test/WindowsAppSDK.Helix.TestCommon/TestAssembly.cs
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
 using System;
 using System.Collections.Generic;
 using System.Linq;

--- a/tools/VerifyCopyrightHeaders.ps1
+++ b/tools/VerifyCopyrightHeaders.ps1
@@ -2,9 +2,13 @@ Param(
     [switch]$Fix = $false
 )
 
+$copyrightHeaderText = (
+    "Copyright (c) Microsoft Corporation. All rights reserved.",
+    "Licensed under the MIT License. See LICENSE in the project root for license information."
+)
+
 $include = ('*.cs', '*.cpp', '*.h', '*.idl', '*.xaml')
-$exclude = [RegEx]'\\packages\\|\\bin\\|\\BuildOutput\\.*\\MSIX\\|\\BuildOutput\\AppXContents\\|\\MsixContent\\'
-$files = dir $PSScriptRoot\..\* -recurse -include $include | Where FullName -notmatch $exclude
+$files = dir $PSScriptRoot\..\* -recurse -include $include
 
 $errorCount = 0
 foreach ($file in $files) {
@@ -12,7 +16,15 @@ foreach ($file in $files) {
     if ([string]::IsNullOrEmpty($found)) {
         $errorCount++
         if ($Fix) {
-            (Get-Content $PSScriptRoot\VerifyCopyrightHeaders.txt) + "`r" + (Get-Content $file.FullName) | Set-Content $file.FullName
+            $copyrightText = "";
+            if ($file.Extension -eq ".xaml") {
+                $copyrightText = "<!-- " + $copyrightHeaderText[0] + " -->" + [Environment]::NewLine `
+                               + "<!-- " + $copyrightHeaderText[1] + " -->" + [Environment]::NewLine + [Environment]::NewLine
+            } else {
+                $copyrightText = "// " + $copyrightHeaderText[0] + [Environment]::NewLine `
+                               + "// " + $copyrightHeaderText[1] + [Environment]::NewLine + [Environment]::NewLine
+            }
+            $copyrightText + ((Get-Content $file.FullName) -join [Environment]::NewLine) | Set-Content $file.FullName
             Write-Host $file.FullName -ForegroundColor green
         } else {
             Write-Host $file.FullName -ForegroundColor red

--- a/tools/VerifyCopyrightHeaders.ps1
+++ b/tools/VerifyCopyrightHeaders.ps1
@@ -1,0 +1,31 @@
+Param(
+    [switch]$Fix = $false
+)
+
+$include = ('*.cs', '*.cpp', '*.h', '*.idl', '*.xaml')
+$exclude = [RegEx]'\\packages\\|\\bin\\|\\BuildOutput\\.*\\MSIX\\|\\BuildOutput\\AppXContents\\|\\MsixContent\\'
+$files = dir $PSScriptRoot\..\* -recurse -include $include | Where FullName -notmatch $exclude
+
+$errorCount = 0
+foreach ($file in $files) {
+    $found = Select-String -Path $file.FullName -Pattern 'Copyright (c) Microsoft Corporation' -CaseSensitive -SimpleMatch
+    if ([string]::IsNullOrEmpty($found)) {
+        $errorCount++
+        if ($Fix) {
+            (Get-Content $PSScriptRoot\VerifyCopyrightHeaders.txt) + "`r" + (Get-Content $file.FullName) | Set-Content $file.FullName
+            Write-Host $file.FullName -ForegroundColor green
+        } else {
+            Write-Host $file.FullName -ForegroundColor red
+        }
+    }
+}
+
+if ($errorCount -gt 0) {
+    if ($Fix) {
+        Write-Host "Added copyright text to $errorCount files." -ForegroundColor green
+        Exit 0
+    } else {
+        Write-Host "Copyright missing from $errorCount files." -ForegroundColor red
+        Exit 1
+    }
+}

--- a/tools/VerifyCopyrightHeaders.ps1
+++ b/tools/VerifyCopyrightHeaders.ps1
@@ -26,6 +26,7 @@ if ($errorCount -gt 0) {
         Exit 0
     } else {
         Write-Host "Copyright missing from $errorCount files." -ForegroundColor red
+        Write-Host "Run 'VerifyCopyrightHeaders.ps1 -Fix' locally to update files."
         Exit 1
     }
 }

--- a/tools/VerifyCopyrightHeaders.ps1
+++ b/tools/VerifyCopyrightHeaders.ps1
@@ -8,7 +8,8 @@ $copyrightHeaderText = (
 )
 
 $include = ('*.cs', '*.cpp', '*.h', '*.idl', '*.xaml')
-$files = dir $PSScriptRoot\..\* -recurse -include $include
+$exclude = [RegEx]'\\dev\\Detours\\'
+$files = dir $PSScriptRoot\..\* -recurse -include $include | Where FullName -notmatch $exclude
 
 $errorCount = 0
 foreach ($file in $files) {

--- a/tools/VerifyCopyrightHeaders.txt
+++ b/tools/VerifyCopyrightHeaders.txt
@@ -1,2 +1,0 @@
-// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.

--- a/tools/VerifyCopyrightHeaders.txt
+++ b/tools/VerifyCopyrightHeaders.txt
@@ -1,0 +1,2 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.


### PR DESCRIPTION
cs/cpp/h/idl/xaml files all need copyright headers.  This change adds the required copyright information and adds a script VerifyCopyrightHeaders.ps1.  This script is run at the beginning of builds to verify all checked in files are marked correctly.  The script can also be ran locally to update any needed files to make it easier for users adding new files via "VerifyCopyrightHeaders.ps1 -Fix"