### PR TITLE
Only default WindowsAppSdkBootstrapInitializer if OutputType=Exe|Winexe

### DIFF
--- a/build/NuSpecs/Microsoft.WindowsAppSDK.BootstrapCommon.targets
+++ b/build/NuSpecs/Microsoft.WindowsAppSDK.BootstrapCommon.targets
@@ -2,13 +2,13 @@
 
     <!-- Targets file common to both managed and native projects that helps enable access to Framework packages-->
 
-    <PropertyGroup Condition="'$(WindowsAppSdkBootstrapInitialize)'=='' and '$(WindowsAppSDKSelfContained)'!='true' and '$(WindowsPackageType)'=='None'">
+    <PropertyGroup Condition="'$(WindowsAppSdkBootstrapInitialize)'=='' and '$(WindowsAppSDKSelfContained)'!='true' and '$(WindowsPackageType)'=='None' and ('$(OutputType)'=='Exe' or '$(OutputType)'=='Winexe')">
         <!--Allows GenerateBootstrapCS/GenerateBootstrapCpp to run-->
         <WindowsAppSdkBootstrapInitialize>true</WindowsAppSdkBootstrapInitialize>
     </PropertyGroup>
 
     <PropertyGroup Condition="'$(WindowsAppSdkBootstrapInitialize)'== 'true'">
         <PublishAppxPackage>false</PublishAppxPackage>
-    </PropertyGroup>      
-    
+    </PropertyGroup>
+
 </Project>


### PR DESCRIPTION
Only default WindowsAppSdkBootstrapInitializer if OutputType=Exe|Winexe

Don't set WindowsAppSdkBootstrapInitializer=true when making libraries, only executables

See https://github.com/microsoft/WindowsAppSDK/issues/2456#issuecomment-1115834582 for more details.

#closes 2456