### PR TITLE
AppNotificationBuilder - Code Improvements

### DIFF
--- a/dev/AppNotifications/AppNotificationBuilder/AppNotificationBuilder.cpp
+++ b/dev/AppNotifications/AppNotificationBuilder/AppNotificationBuilder.cpp
@@ -32,7 +32,7 @@ namespace winrt::Microsoft::Windows::AppNotifications::Builder::implementation
     winrt::Microsoft::Windows::AppNotifications::Builder::AppNotificationBuilder AppNotificationBuilder::SetTimeStamp(winrt::Windows::Foundation::DateTime const& value)
     {
         auto seconds{ winrt::clock::to_time_t(value) };
-        struct tm buf;
+        struct tm buf {};
         gmtime_s(&buf, &seconds);
 
         std::wstringstream buffer;
@@ -178,13 +178,13 @@ namespace winrt::Microsoft::Windows::AppNotifications::Builder::implementation
 
     winrt::Microsoft::Windows::AppNotifications::Builder::AppNotificationBuilder AppNotificationBuilder::SetAudioEvent(AppNotificationSoundEvent const& soundEvent)
     {
-        m_audio = wil::str_printf<std::wstring>(L"<audio src='%ls'/>", GetWinSoundEventString(soundEvent).c_str());
+        m_audio = wil::str_printf<std::wstring>(L"<audio src='%ls'/>", GetWinSoundEventString(soundEvent));
         return *this;
     }
 
     winrt::Microsoft::Windows::AppNotifications::Builder::AppNotificationBuilder AppNotificationBuilder::SetAudioEvent(AppNotificationSoundEvent const& soundEvent, AppNotificationAudioLooping const& loop)
     {
-        m_audio = wil::str_printf<std::wstring>(L"<audio src='%ls' loop='%ls'/>", GetWinSoundEventString(soundEvent).c_str(), loop == AppNotificationAudioLooping::Loop ? L"true" : L"false");
+        m_audio = wil::str_printf<std::wstring>(L"<audio src='%ls' loop='%ls'/>", GetWinSoundEventString(soundEvent), loop == AppNotificationAudioLooping::Loop ? L"true" : L"false");
         return *this;
     }
 

--- a/dev/AppNotifications/AppNotificationBuilder/AppNotificationBuilder.cpp
+++ b/dev/AppNotifications/AppNotificationBuilder/AppNotificationBuilder.cpp
@@ -33,7 +33,7 @@ namespace winrt::Microsoft::Windows::AppNotifications::Builder::implementation
     winrt::Microsoft::Windows::AppNotifications::Builder::AppNotificationBuilder AppNotificationBuilder::SetTimeStamp(winrt::Windows::Foundation::DateTime const& value)
     {
         auto seconds{ winrt::clock::to_time_t(value) };
-        struct tm buf {};
+        struct tm buf{};
         gmtime_s(&buf, &seconds);
 
         std::wstringstream buffer;

--- a/dev/AppNotifications/AppNotificationBuilder/AppNotificationBuilder.cpp
+++ b/dev/AppNotifications/AppNotificationBuilder/AppNotificationBuilder.cpp
@@ -10,6 +10,7 @@
 #include <iomanip>
 #include <ctime>
 #include <sstream>
+#include <IsWindowsVersion.h>
 
 using namespace winrt::Windows::Globalization;
 using namespace winrt::Windows::Globalization::DateTimeFormatting;
@@ -18,7 +19,7 @@ namespace winrt::Microsoft::Windows::AppNotifications::Builder::implementation
 {
     bool AppNotificationBuilder::IsUrgentScenarioSupported()
     {
-        return GetBuildNumber() >= 19041;
+        return WindowsVersion::IsWindows10_20H1OrGreater();
     }
 
     winrt::Microsoft::Windows::AppNotifications::Builder::AppNotificationBuilder AppNotificationBuilder::AddArgument(hstring const& key, hstring const& value)

--- a/dev/AppNotifications/AppNotificationBuilder/AppNotificationBuilder.cpp
+++ b/dev/AppNotifications/AppNotificationBuilder/AppNotificationBuilder.cpp
@@ -23,7 +23,7 @@ namespace winrt::Microsoft::Windows::AppNotifications::Builder::implementation
 
     winrt::Microsoft::Windows::AppNotifications::Builder::AppNotificationBuilder AppNotificationBuilder::AddArgument(hstring const& key, hstring const& value)
     {
-        THROW_HR_IF_MSG(E_INVALIDARG, key.empty(), "You must provide a key when adding an argument.");
+        THROW_HR_IF_MSG(E_INVALIDARG, key.empty(), "You must provide a key when adding an argument");
 
         m_arguments.Insert(key, value);
         return *this;
@@ -38,7 +38,7 @@ namespace winrt::Microsoft::Windows::AppNotifications::Builder::implementation
         std::wstringstream buffer;
         buffer << std::put_time(&buf, L"%FT%T");
 
-        m_timeStamp = wil::str_printf<std::wstring>(L" displayTimestamp='%wsZ'", buffer.str().c_str());
+        m_timeStamp = wil::str_printf<std::wstring>(L" displayTimestamp='%lsZ'", buffer.str().c_str());
         return *this;
     }
 
@@ -56,18 +56,18 @@ namespace winrt::Microsoft::Windows::AppNotifications::Builder::implementation
 
     winrt::Microsoft::Windows::AppNotifications::Builder::AppNotificationBuilder AppNotificationBuilder::AddText(hstring const& text)
     {
-        THROW_HR_IF_MSG(E_INVALIDARG, m_textLines.size() >= c_maxTextElements, "Maximum number of text elements added.");
+        THROW_HR_IF_MSG(E_INVALIDARG, m_textLines.size() >= c_maxTextElements, "Maximum number of text elements added");
 
-        m_textLines.push_back(wil::str_printf<std::wstring>(L"<text>%ws</text>", text.c_str()).c_str());
+        m_textLines.push_back(wil::str_printf<std::wstring>(L"<text>%ls</text>", text.c_str()).c_str());
         return *this;
     }
 
     winrt::Microsoft::Windows::AppNotifications::Builder::AppNotificationBuilder AppNotificationBuilder::AddText(hstring const& text, AppNotificationTextProperties const& properties)
     {
-        THROW_HR_IF_MSG(E_INVALIDARG, m_textLines.size() >= c_maxTextElements, "Maximum number of text elements added.");
+        THROW_HR_IF_MSG(E_INVALIDARG, m_textLines.size() >= c_maxTextElements, "Maximum number of text elements added");
 
         std::wstring props{ properties.as<winrt::Windows::Foundation::IStringable>().ToString() };
-        m_textLines.push_back(wil::str_printf<std::wstring>(L"%ws%ws</text>", props.c_str(), text.c_str()).c_str());
+        m_textLines.push_back(wil::str_printf<std::wstring>(L"%ls%ls</text>", props.c_str(), text.c_str()).c_str());
 
         if (properties.IncomingCallAlignment())
         {
@@ -78,21 +78,21 @@ namespace winrt::Microsoft::Windows::AppNotifications::Builder::implementation
 
     winrt::Microsoft::Windows::AppNotifications::Builder::AppNotificationBuilder AppNotificationBuilder::SetAttributionText(hstring const& text)
     {
-        m_attributionText = wil::str_printf<std::wstring>(L"<text placement='attribution'>%ws</text>", text.c_str());
+        m_attributionText = wil::str_printf<std::wstring>(L"<text placement='attribution'>%ls</text>", text.c_str());
         return *this;
     }
 
     winrt::Microsoft::Windows::AppNotifications::Builder::AppNotificationBuilder AppNotificationBuilder::SetAttributionText(hstring const& text, hstring const& language)
     {
-        THROW_HR_IF_MSG(E_INVALIDARG, language.empty(), "You must provide a language calling SetAttributionText.");
+        THROW_HR_IF_MSG(E_INVALIDARG, language.empty(), "You must provide a language calling SetAttributionText");
 
-        m_attributionText = wil::str_printf<std::wstring>(L"<text placement='attribution' lang='%ws'>%ws</text>", language.c_str(), text.c_str());
+        m_attributionText = wil::str_printf<std::wstring>(L"<text placement='attribution' lang='%ls'>%ls</text>", language.c_str(), text.c_str());
         return *this;
     }
 
     winrt::Microsoft::Windows::AppNotifications::Builder::AppNotificationBuilder AppNotificationBuilder::SetInlineImage(winrt::Windows::Foundation::Uri const& imageUri)
     {
-        m_inlineImage = wil::str_printf<std::wstring>(L"<image src='%ws'/>", imageUri.ToString().c_str());
+        m_inlineImage = wil::str_printf<std::wstring>(L"<image src='%ls'/>", imageUri.ToString().c_str());
         return *this;
     }
 
@@ -100,7 +100,7 @@ namespace winrt::Microsoft::Windows::AppNotifications::Builder::implementation
     {
         if (imageCrop == AppNotificationImageCrop::Circle)
         {
-            m_inlineImage = wil::str_printf<std::wstring>(L"<image src='%ws' hint-crop='circle'/>", imageUri.ToString().c_str());
+            m_inlineImage = wil::str_printf<std::wstring>(L"<image src='%ls' hint-crop='circle'/>", imageUri.ToString().c_str());
         }
         else
         {
@@ -112,17 +112,17 @@ namespace winrt::Microsoft::Windows::AppNotifications::Builder::implementation
 
     winrt::Microsoft::Windows::AppNotifications::Builder::AppNotificationBuilder AppNotificationBuilder::SetInlineImage(winrt::Windows::Foundation::Uri const& imageUri, AppNotificationImageCrop const& imageCrop, hstring const& alternateText)
     {
-        THROW_HR_IF_MSG(E_INVALIDARG, alternateText.empty(), "You must provide an alternate text string calling SetInlineImage.");
+        THROW_HR_IF_MSG(E_INVALIDARG, alternateText.empty(), "You must provide an alternate text string calling SetInlineImage");
 
         std::wstring hintCrop { imageCrop == AppNotificationImageCrop::Circle ? L" hint-crop='circle'" : L"" };
-        m_inlineImage = wil::str_printf<std::wstring>(L"<image src='%ws' alt='%ws'%ws/>", imageUri.ToString().c_str(), alternateText.c_str(), hintCrop.c_str());
+        m_inlineImage = wil::str_printf<std::wstring>(L"<image src='%ls' alt='%ls'%ls/>", imageUri.ToString().c_str(), alternateText.c_str(), hintCrop.c_str());
 
         return *this;
     }
 
     winrt::Microsoft::Windows::AppNotifications::Builder::AppNotificationBuilder AppNotificationBuilder::SetAppLogoOverride(winrt::Windows::Foundation::Uri const& imageUri)
     {
-        m_appLogoOverride = wil::str_printf<std::wstring>(L"<image placement='appLogoOverride' src='%ws'/>", imageUri.ToString().c_str());
+        m_appLogoOverride = wil::str_printf<std::wstring>(L"<image placement='appLogoOverride' src='%ls'/>", imageUri.ToString().c_str());
         return *this;
     }
 
@@ -130,7 +130,7 @@ namespace winrt::Microsoft::Windows::AppNotifications::Builder::implementation
     {
         if (imageCrop == AppNotificationImageCrop::Circle)
         {
-            m_appLogoOverride = wil::str_printf<std::wstring>(L"<image placement='appLogoOverride' src='%ws' hint-crop='circle'/>", imageUri.ToString().c_str());
+            m_appLogoOverride = wil::str_printf<std::wstring>(L"<image placement='appLogoOverride' src='%ls' hint-crop='circle'/>", imageUri.ToString().c_str());
         }
         else
         {
@@ -142,49 +142,49 @@ namespace winrt::Microsoft::Windows::AppNotifications::Builder::implementation
 
     winrt::Microsoft::Windows::AppNotifications::Builder::AppNotificationBuilder AppNotificationBuilder::SetAppLogoOverride(winrt::Windows::Foundation::Uri const& imageUri, AppNotificationImageCrop const& imageCrop, hstring const& alternateText)
     {
-        THROW_HR_IF_MSG(E_INVALIDARG, alternateText.empty(), "You must provide an alternate text string calling SetAppLogoOverride.");
+        THROW_HR_IF_MSG(E_INVALIDARG, alternateText.empty(), "You must provide an alternate text string calling SetAppLogoOverride");
 
         std::wstring hintCrop{ imageCrop == AppNotificationImageCrop::Circle ? L" hint-crop='circle'" : L"" };
-        m_appLogoOverride = wil::str_printf<std::wstring>(L"<image placement='appLogoOverride' src='%ws' alt='%ws'%ws/>", imageUri.ToString().c_str(), alternateText.c_str(), hintCrop.c_str());
+        m_appLogoOverride = wil::str_printf<std::wstring>(L"<image placement='appLogoOverride' src='%ls' alt='%ls'%ls/>", imageUri.ToString().c_str(), alternateText.c_str(), hintCrop.c_str());
 
         return *this;
     }
 
     winrt::Microsoft::Windows::AppNotifications::Builder::AppNotificationBuilder AppNotificationBuilder::SetHeroImage(winrt::Windows::Foundation::Uri const& imageUri)
     {
-        m_heroImage = wil::str_printf<std::wstring>(L"<image placement='hero' src='%ws'/>", imageUri.ToString().c_str());
+        m_heroImage = wil::str_printf<std::wstring>(L"<image placement='hero' src='%ls'/>", imageUri.ToString().c_str());
         return *this;
     }
 
     winrt::Microsoft::Windows::AppNotifications::Builder::AppNotificationBuilder AppNotificationBuilder::SetHeroImage(winrt::Windows::Foundation::Uri const& imageUri, hstring const& alternateText)
     {
-        THROW_HR_IF_MSG(E_INVALIDARG, alternateText.empty(), "You must provide an alternate text string calling SetHeroImage.");
+        THROW_HR_IF_MSG(E_INVALIDARG, alternateText.empty(), "You must provide an alternate text string calling SetHeroImage");
 
-        m_heroImage = wil::str_printf<std::wstring>(L"<image placement='hero' src='%ws' alt='%ws'/>", imageUri.ToString().c_str(), alternateText.c_str());
+        m_heroImage = wil::str_printf<std::wstring>(L"<image placement='hero' src='%ls' alt='%ls'/>", imageUri.ToString().c_str(), alternateText.c_str());
         return *this;
     }
 
     winrt::Microsoft::Windows::AppNotifications::Builder::AppNotificationBuilder AppNotificationBuilder::SetAudioUri(winrt::Windows::Foundation::Uri const& audioUri)
     {
-        m_audio = wil::str_printf<std::wstring>(L"<audio src='%ws'/>", audioUri.ToString().c_str());
+        m_audio = wil::str_printf<std::wstring>(L"<audio src='%ls'/>", audioUri.ToString().c_str());
         return *this;
     }
 
     winrt::Microsoft::Windows::AppNotifications::Builder::AppNotificationBuilder AppNotificationBuilder::SetAudioUri(winrt::Windows::Foundation::Uri const& audioUri, AppNotificationAudioLooping const& loop)
     {
-        m_audio = wil::str_printf<std::wstring>(L"<audio src='%ws' loop='%ws'/>", audioUri.ToString().c_str(), loop == AppNotificationAudioLooping::Loop ? L"true" : L"false");
+        m_audio = wil::str_printf<std::wstring>(L"<audio src='%ls' loop='%ls'/>", audioUri.ToString().c_str(), loop == AppNotificationAudioLooping::Loop ? L"true" : L"false");
         return *this;
     }
 
     winrt::Microsoft::Windows::AppNotifications::Builder::AppNotificationBuilder AppNotificationBuilder::SetAudioEvent(AppNotificationSoundEvent const& soundEvent)
     {
-        m_audio = wil::str_printf<std::wstring>(L"<audio src='%ws'/>", GetWinSoundEventString(soundEvent).c_str());
+        m_audio = wil::str_printf<std::wstring>(L"<audio src='%ls'/>", GetWinSoundEventString(soundEvent).c_str());
         return *this;
     }
 
     winrt::Microsoft::Windows::AppNotifications::Builder::AppNotificationBuilder AppNotificationBuilder::SetAudioEvent(AppNotificationSoundEvent const& soundEvent, AppNotificationAudioLooping const& loop)
     {
-        m_audio = wil::str_printf<std::wstring>(L"<audio src='%ws' loop='%ws'/>", GetWinSoundEventString(soundEvent).c_str(), loop == AppNotificationAudioLooping::Loop ? L"true" : L"false");
+        m_audio = wil::str_printf<std::wstring>(L"<audio src='%ls' loop='%ls'/>", GetWinSoundEventString(soundEvent).c_str(), loop == AppNotificationAudioLooping::Loop ? L"true" : L"false");
         return *this;
     }
 
@@ -196,7 +196,7 @@ namespace winrt::Microsoft::Windows::AppNotifications::Builder::implementation
 
     winrt::Microsoft::Windows::AppNotifications::Builder::AppNotificationBuilder AppNotificationBuilder::AddButton(AppNotificationButton const& value)
     {
-        THROW_HR_IF_MSG(E_INVALIDARG, m_buttonList.size() >= c_maxButtonElements, "Maximum number of buttons added.");
+        THROW_HR_IF_MSG(E_INVALIDARG, m_buttonList.size() >= c_maxButtonElements, "Maximum number of buttons added");
 
         m_buttonList.push_back(value);
         return *this;
@@ -242,21 +242,21 @@ namespace winrt::Microsoft::Windows::AppNotifications::Builder::implementation
         // Add launch arguments if given arguments
         if (m_arguments.Size())
         {
-            std::wstring arguments{ };
+            std::wstring arguments;
             for (auto pair : m_arguments)
             {
                 if (!pair.Value().empty())
                 {
-                    arguments.append(wil::str_printf<std::wstring>(L"%ws=%ws;", pair.Key().c_str(), pair.Value().c_str()));
+                    arguments.append(wil::str_printf<std::wstring>(L"%ls=%ls;", pair.Key().c_str(), pair.Value().c_str()));
                 }
                 else
                 {
-                    arguments.append(wil::str_printf<std::wstring>(L"%ws;", pair.Key().c_str()));
+                    arguments.append(wil::str_printf<std::wstring>(L"%ls;", pair.Key().c_str()));
                 }
             }
             arguments.pop_back();
 
-            return wil::str_printf<std::wstring>(L" launch='%ws'", arguments.c_str());
+            return wil::str_printf<std::wstring>(L" launch='%ls'", arguments.c_str());
         }
         else
         {
@@ -277,7 +277,7 @@ namespace winrt::Microsoft::Windows::AppNotifications::Builder::implementation
 
     std::wstring AppNotificationBuilder::GetImages()
     {
-        return wil::str_printf<std::wstring>(L"%ws%ws%ws", m_inlineImage.c_str(), m_heroImage.c_str(), m_appLogoOverride.c_str());
+        return wil::str_printf<std::wstring>(L"%ls%ls%ls", m_inlineImage.c_str(), m_heroImage.c_str(), m_appLogoOverride.c_str());
     }
 
     std::wstring AppNotificationBuilder::GetButtons()
@@ -295,7 +295,7 @@ namespace winrt::Microsoft::Windows::AppNotifications::Builder::implementation
                 result.append(input.as<winrt::Windows::Foundation::IStringable>().ToString().c_str());
             }
 
-            return wil::str_printf<std::wstring>(L"<actions>%ws</actions>", result.c_str());
+            return wil::str_printf<std::wstring>(L"<actions>%ls</actions>", result.c_str());
         }
         else
         {

--- a/dev/AppNotifications/AppNotificationBuilder/AppNotificationBuilderUtility.h
+++ b/dev/AppNotifications/AppNotificationBuilder/AppNotificationBuilderUtility.h
@@ -5,9 +5,9 @@
 #include "pch.h"
 #include "winrt/Microsoft.Windows.AppNotifications.Builder.h"
 
-inline const size_t c_maxAppNotificationPayload{ 5120 };
-inline const uint8_t c_maxTextElements{ 3 };
-inline const uint8_t c_maxButtonElements{ 5 };
+constexpr size_t c_maxAppNotificationPayload{ 5120 };
+constexpr uint8_t c_maxTextElements{ 3 };
+constexpr uint8_t c_maxButtonElements{ 5 };
 
 namespace AppNotificationBuilder
 {

--- a/dev/AppNotifications/AppNotificationBuilder/AppNotificationBuilderUtility.h
+++ b/dev/AppNotifications/AppNotificationBuilder/AppNotificationBuilderUtility.h
@@ -70,20 +70,3 @@ inline PCWSTR GetWinSoundEventString(AppNotificationBuilder::AppNotificationSoun
         return L"ms-winsoundevent:Notification.Default";
     }
 }
-
-inline int GetBuildNumber()
-{
-    wchar_t regString[MAX_PATH]{ L"\0" };
-    DWORD length{ MAX_PATH };
-    const LSTATUS regResult{ ::RegGetValue(
-        HKEY_LOCAL_MACHINE,
-        L"SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion",
-        L"CurrentBuild",
-        RRF_RT_REG_SZ,
-        nullptr,
-        regString,
-        &length) };
-
-    THROW_IF_FAILED_MSG(regResult, "Failed to retrieve Windows build number.");
-    return _wtoi(regString);
-}

--- a/dev/AppNotifications/AppNotificationBuilder/AppNotificationBuilderUtility.h
+++ b/dev/AppNotifications/AppNotificationBuilder/AppNotificationBuilderUtility.h
@@ -14,7 +14,7 @@ namespace AppNotificationBuilder
     using namespace winrt::Microsoft::Windows::AppNotifications::Builder;
 }
 
-inline std::wstring GetWinSoundEventString(AppNotificationBuilder::AppNotificationSoundEvent soundEvent)
+inline PCWSTR GetWinSoundEventString(AppNotificationBuilder::AppNotificationSoundEvent soundEvent)
 {
     switch (soundEvent)
     {

--- a/dev/AppNotifications/AppNotificationBuilder/AppNotificationButton.cpp
+++ b/dev/AppNotifications/AppNotificationBuilder/AppNotificationButton.cpp
@@ -4,7 +4,7 @@
 #include "pch.h"
 #include "AppNotificationButton.h"
 #include "Microsoft.Windows.AppNotifications.Builder.AppNotificationButton.g.cpp"
-#include "AppNotificationBuilderUtility.h"
+#include <IsWindowsVersion.h>
 
 namespace winrt::Microsoft::Windows::AppNotifications::Builder::implementation
 {
@@ -12,12 +12,12 @@ namespace winrt::Microsoft::Windows::AppNotifications::Builder::implementation
 
     bool AppNotificationButton::IsToolTipSupported()
     {
-        return GetBuildNumber() >= 19041;
+        return WindowsVersion::IsWindows10_20H1OrGreater();
     }
 
     bool AppNotificationButton::IsButtonStyleSupported()
     {
-        return GetBuildNumber() >= 19041;
+        return WindowsVersion::IsWindows10_20H1OrGreater();
     }
 
     winrt::Microsoft::Windows::AppNotifications::Builder::AppNotificationButton AppNotificationButton::AddArgument(winrt::hstring const& key, winrt::hstring const& value)

--- a/dev/AppNotifications/AppNotificationBuilder/AppNotificationButton.cpp
+++ b/dev/AppNotifications/AppNotificationBuilder/AppNotificationButton.cpp
@@ -22,8 +22,8 @@ namespace winrt::Microsoft::Windows::AppNotifications::Builder::implementation
 
     winrt::Microsoft::Windows::AppNotifications::Builder::AppNotificationButton AppNotificationButton::AddArgument(winrt::hstring const& key, winrt::hstring const& value)
     {
-        THROW_HR_IF_MSG(E_INVALIDARG, key.empty(), "You must provide a key when adding an argument.");
-        THROW_HR_IF_MSG(E_INVALIDARG, m_protocolUri, "You cannot add an argument after calling SetInvokeUri.");
+        THROW_HR_IF_MSG(E_INVALIDARG, key.empty(), "You must provide a key when adding an argument");
+        THROW_HR_IF_MSG(E_INVALIDARG, m_protocolUri, "You cannot add an argument after calling SetInvokeUri");
 
         m_arguments.Insert(key, value);
         return *this;
@@ -61,7 +61,7 @@ namespace winrt::Microsoft::Windows::AppNotifications::Builder::implementation
 
     winrt::Microsoft::Windows::AppNotifications::Builder::AppNotificationButton AppNotificationButton::SetInvokeUri(winrt::Windows::Foundation::Uri const& protocolUri)
     {
-        THROW_HR_IF_MSG(E_INVALIDARG, m_arguments.Size() > 0u, "You cannot add a protocol activation uri after calling AddArgument.");
+        THROW_HR_IF_MSG(E_INVALIDARG, m_arguments.Size() > 0u, "You cannot add a protocol activation uri after calling AddArgument");
 
         m_protocolUri = protocolUri;
         return *this;
@@ -69,7 +69,7 @@ namespace winrt::Microsoft::Windows::AppNotifications::Builder::implementation
 
     winrt::Microsoft::Windows::AppNotifications::Builder::AppNotificationButton AppNotificationButton::SetInvokeUri(winrt::Windows::Foundation::Uri const& protocolUri, winrt::hstring const& targetAppId)
     {
-        THROW_HR_IF_MSG(E_INVALIDARG, m_arguments.Size() > 0u, "You cannot add a protocol activation uri after calling AddArgument.");
+        THROW_HR_IF_MSG(E_INVALIDARG, m_arguments.Size() > 0u, "You cannot add a protocol activation uri after calling AddArgument");
 
         m_protocolUri = protocolUri;
         m_targetApplicationPfn = targetAppId;
@@ -80,26 +80,26 @@ namespace winrt::Microsoft::Windows::AppNotifications::Builder::implementation
     {
         if (m_protocolUri)
         {
-            std::wstring protocolTargetPfn{ !m_targetApplicationPfn.empty() ? wil::str_printf<std::wstring>(L" protocolActivationTargetApplicationPfn='%ws'", m_targetApplicationPfn.c_str()) : L"" };
-            return wil::str_printf<std::wstring>(L" arguments='%ws' activationType='protocol'%ws", m_protocolUri.ToString().c_str(), protocolTargetPfn.c_str());
+            std::wstring protocolTargetPfn{ !m_targetApplicationPfn.empty() ? wil::str_printf<std::wstring>(L" protocolActivationTargetApplicationPfn='%ls'", m_targetApplicationPfn.c_str()) : L"" };
+            return wil::str_printf<std::wstring>(L" arguments='%ws' activationType='protocol'%ls", m_protocolUri.ToString().c_str(), protocolTargetPfn.c_str());
         }
         else
         {
-            std::wstring arguments{};
+            std::wstring arguments;
             for (auto pair : m_arguments)
             {
                 if (!pair.Value().empty())
                 {
-                    arguments.append(wil::str_printf<std::wstring>(L"%ws=%ws;", pair.Key().c_str(), pair.Value().c_str()));
+                    arguments.append(wil::str_printf<std::wstring>(L"%ls=%ls;", pair.Key().c_str(), pair.Value().c_str()));
                 }
                 else
                 {
-                    arguments.append(wil::str_printf<std::wstring>(L"%ws;", pair.Key().c_str()));
+                    arguments.append(wil::str_printf<std::wstring>(L"%ls;", pair.Key().c_str()));
                 }
             }
             arguments.pop_back();
 
-            return wil::str_printf<std::wstring>(L" arguments='%ws'", arguments.c_str());
+            return wil::str_printf<std::wstring>(L" arguments='%ls'", arguments.c_str());
         }
     }
 
@@ -111,19 +111,19 @@ namespace winrt::Microsoft::Windows::AppNotifications::Builder::implementation
         }
 
         std::wstring style{ m_buttonStyle == AppNotificationButtonStyle::Success ? L"Success" : L"Critical" };
-        return wil::str_printf<std::wstring>(L" hint-buttonStyle='%ws'", style.c_str());
+        return wil::str_printf<std::wstring>(L" hint-buttonStyle='%ls'", style.c_str());
     }
 
     winrt::hstring AppNotificationButton::ToString()
     {
-        std::wstring xmlResult{ wil::str_printf<std::wstring>(L"<action content='%ws'%ws%ws%ws%ws%ws%ws/>",
+        std::wstring xmlResult{ wil::str_printf<std::wstring>(L"<action content='%ls'%ls%ls%ls%ls%ls%ls/>",
             m_content.c_str(),
             GetActivationArguments().c_str(),
             m_useContextMenuPlacement ? L" placement='contextMenu'" : L"",
-            m_iconUri ? wil::str_printf<std::wstring>(L" imageUri='%ws'", m_iconUri.ToString().c_str()).c_str() : L"",
-            !m_inputId.empty() ? wil::str_printf<std::wstring>(L" hint-inputId='%ws'", m_inputId.c_str()).c_str() : L"",
+            m_iconUri ? wil::str_printf<std::wstring>(L" imageUri='%ls'", m_iconUri.ToString().c_str()).c_str() : L"",
+            !m_inputId.empty() ? wil::str_printf<std::wstring>(L" hint-inputId='%ls'", m_inputId.c_str()).c_str() : L"",
             GetButtonStyle().c_str(),
-            !m_toolTip.empty() ? wil::str_printf<std::wstring>(L" hint-toolTip='%ws'", m_toolTip.c_str()).c_str() : L"") };
+            !m_toolTip.empty() ? wil::str_printf<std::wstring>(L" hint-toolTip='%ls'", m_toolTip.c_str()).c_str() : L"") };
 
         return xmlResult.c_str();
     }

--- a/dev/AppNotifications/AppNotificationBuilder/AppNotificationButton.h
+++ b/dev/AppNotifications/AppNotificationBuilder/AppNotificationButton.h
@@ -64,13 +64,13 @@ namespace winrt::Microsoft::Windows::AppNotifications::Builder::implementation
         std::wstring GetActivationArguments();
         std::wstring GetButtonStyle();
 
-        winrt::hstring m_content;
+        winrt::hstring m_content{};
         winrt::Windows::Foundation::Collections::IMap<winrt::hstring, winrt::hstring> m_arguments { winrt::single_threaded_map<winrt::hstring, winrt::hstring>() };
         winrt::Windows::Foundation::Uri m_iconUri{ nullptr };
         winrt::Windows::Foundation::Uri m_protocolUri{ nullptr };
-        winrt::hstring m_targetApplicationPfn;
-        winrt::hstring m_toolTip;
-        winrt::hstring m_inputId;
+        winrt::hstring m_targetApplicationPfn{};
+        winrt::hstring m_toolTip{};
+        winrt::hstring m_inputId{};
         bool m_useContextMenuPlacement{};
         AppNotificationButtonStyle m_buttonStyle { AppNotificationButtonStyle::Default };
     };

--- a/dev/AppNotifications/AppNotificationBuilder/AppNotificationTextProperties.cpp
+++ b/dev/AppNotifications/AppNotificationBuilder/AppNotificationTextProperties.cpp
@@ -27,10 +27,10 @@ namespace winrt::Microsoft::Windows::AppNotifications::Builder::implementation
 
     winrt::hstring AppNotificationTextProperties::ToString()
     {
-        std::wstring language{ !m_language.empty() ? wil::str_printf<std::wstring>(L" lang='%ws'", m_language.c_str()) : L""};
+        std::wstring language{ !m_language.empty() ? wil::str_printf<std::wstring>(L" lang='%ls'", m_language.c_str()) : L""};
         std::wstring callScenarioAlign{ m_useCallScenarioAlign ? L" hint-callScenarioCenterAlign='true'" : L""};
         std::wstring hintMaxLines{ m_maxLines ? wil::str_printf<std::wstring>(L" hint-maxLines='%d'", m_maxLines) : L"" };
 
-        return wil::str_printf<std::wstring>(L"<text%ws%ws%ws>", language.c_str(), hintMaxLines.c_str(), callScenarioAlign.c_str()).c_str();
+        return wil::str_printf<std::wstring>(L"<text%ls%ls%ls>", language.c_str(), hintMaxLines.c_str(), callScenarioAlign.c_str()).c_str();
     }
 }

--- a/dev/AppNotifications/AppNotificationBuilder/AppNotificationTextProperties.h
+++ b/dev/AppNotifications/AppNotificationBuilder/AppNotificationTextProperties.h
@@ -32,7 +32,7 @@ namespace winrt::Microsoft::Windows::AppNotifications::Builder::implementation
 
     private:
         int m_maxLines{ 0 };
-        winrt::hstring m_language;
+        winrt::hstring m_language{};
         bool m_useCallScenarioAlign{};
     };
 }

--- a/test/AppNotificationBuilderTests/APITests.cpp
+++ b/test/AppNotificationBuilderTests/APITests.cpp
@@ -290,7 +290,7 @@ namespace Test::AppNotification::Builder
                 .AddButton(AppNotificationButton(L"content").AddArgument(L"key6", L"value6")), E_INVALIDARG);
         }
 
-        TEST_METHOD(AddButtonWithProtocolActivation)
+        TEST_METHOD(AppNotificationBuilderAddButtonWithProtocolActivation)
         {
             auto builder{ AppNotificationBuilder()
                 .AddButton(AppNotificationButton(L"content")
@@ -323,7 +323,7 @@ namespace Test::AppNotification::Builder
                     .AddArgument(L"", L"value")), E_INVALIDARG);
         }
 
-        TEST_METHOD(AddButtonWithArgumentAndProtocol)
+        TEST_METHOD(AppNotificationBuilderAddButtonWithArgumentAndProtocol)
         {
             VERIFY_THROWS_HR(AppNotificationBuilder()
                 .AddButton(AppNotificationButton(L"content")
@@ -336,7 +336,7 @@ namespace Test::AppNotification::Builder
                     .AddArgument(L"key", L"value")), E_INVALIDARG);
         }
 
-        TEST_METHOD(SetAudioWithUri)
+        TEST_METHOD(AppNotificationBuilderSetAudioWithUri)
         {
             auto builder{ AppNotificationBuilder()
                     .SetAudioUri(c_sampleUri) };
@@ -345,7 +345,7 @@ namespace Test::AppNotification::Builder
             VERIFY_ARE_EQUAL(builder.BuildNotification().Payload(), expected);
         }
 
-        TEST_METHOD(SetAudioWithUriAndDuration)
+        TEST_METHOD(AppNotificationBuilderSetAudioWithUriAndDuration)
         {
             auto builder{ AppNotificationBuilder()
                     .SetDuration(AppNotificationDuration::Long)
@@ -355,7 +355,7 @@ namespace Test::AppNotification::Builder
             VERIFY_ARE_EQUAL(builder.BuildNotification().Payload(), expected);
         }
 
-        TEST_METHOD(SetAudioWithSoundEvent)
+        TEST_METHOD(AppNotificationBuilderSetAudioWithSoundEvent)
         {
             auto builder{ AppNotificationBuilder()
                     .SetAudioEvent(AppNotificationSoundEvent::Reminder) };
@@ -364,7 +364,7 @@ namespace Test::AppNotification::Builder
             VERIFY_ARE_EQUAL(builder.BuildNotification().Payload(), expected);
         }
 
-        TEST_METHOD(SetAudioWithSoundEventAndDuration)
+        TEST_METHOD(AppNotificationBuilderSetAudioWithSoundEventAndDuration)
         {
             auto builder{ AppNotificationBuilder()
                     .SetDuration(AppNotificationDuration::Long)
@@ -374,7 +374,7 @@ namespace Test::AppNotification::Builder
             VERIFY_ARE_EQUAL(builder.BuildNotification().Payload(), expected);
         }
 
-        TEST_METHOD(MuteAudio)
+        TEST_METHOD(AppNotificationBuilderMuteAudio)
         {
             auto builder{ AppNotificationBuilder().MuteAudio() };
             auto expected{ L"<toast><visual><binding template='ToastGeneric'></binding></visual><audio silent='true'/></toast>" };


### PR DESCRIPTION
Addressing last round of feedback from: https://github.com/microsoft/WindowsAppSDK/pull/2786

Beside nits, one important issue that must addressed in this PR is retrieving the version number. Dev/Common should have a utility function to retrieve the version number. Let's make sure that whatever solution we used, it's the same for all WindowsAppSDK.

From @DrusTheAxe 
> Ugh. Version checks. That's a minefield (as in, a reliable answer is a minefield...)
> 
> Please use functions in dev\common\IsWindowsVersion.h e.g. WindowsVersion::IsWindows10_19H10OrGreater(). That has checks for >=19H1 and >=20H1, and if additional version checks are needed extend as appropos.
> 
> That avoids the minefield of GetVersion mechanisms which don't necessarily yield the expected answer