### PR TITLE
User/sachinta/fix deployment manager telemetry

### DIFF
--- a/dev/Deployment/DeploymentManager.cpp
+++ b/dev/Deployment/DeploymentManager.cpp
@@ -46,10 +46,10 @@ namespace winrt::Microsoft::Windows::ApplicationModel::WindowsAppRuntime::implem
 
     winrt::Microsoft::Windows::ApplicationModel::WindowsAppRuntime::DeploymentResult DeploymentManager::Initialize()
     {
-        ::WindowsAppRuntime::Deployment::Activity::Context::Get().GetActivity().Start(false,
-                                                                                      Security::IntegrityLevel::IsElevated(),
-                                                                                      AppModel::Identity::IsPackagedProcess(),
-                                                                                      Security::IntegrityLevel::GetIntegrityLevel());
+        ::WindowsAppRuntime::Deployment::Activity::Context::Get().SetActivity(WindowsAppRuntimeDeployment_TraceLogger::Initialize::Start(false,
+                                                                                        Security::IntegrityLevel::IsElevated(),
+                                                                                        AppModel::Identity::IsPackagedProcess(),
+                                                                                        Security::IntegrityLevel::GetIntegrityLevel()));
 
         FAIL_FAST_HR_IF(HRESULT_FROM_WIN32(APPMODEL_ERROR_NO_PACKAGE), !AppModel::Identity::IsPackagedProcess());
         return Initialize(GetCurrentFrameworkPackageFullName());
@@ -57,10 +57,11 @@ namespace winrt::Microsoft::Windows::ApplicationModel::WindowsAppRuntime::implem
 
     winrt::Microsoft::Windows::ApplicationModel::WindowsAppRuntime::DeploymentResult DeploymentManager::Initialize(winrt::Microsoft::Windows::ApplicationModel::WindowsAppRuntime::DeploymentInitializeOptions const& deploymentInitializeOptions)
     {
-        ::WindowsAppRuntime::Deployment::Activity::Context::Get().GetActivity().Start(deploymentInitializeOptions.ForceDeployment(),
-                                                                                      Security::IntegrityLevel::IsElevated(),
-                                                                                      AppModel::Identity::IsPackagedProcess(),
-                                                                                      Security::IntegrityLevel::GetIntegrityLevel());
+        ::WindowsAppRuntime::Deployment::Activity::Context::Get().SetActivity(WindowsAppRuntimeDeployment_TraceLogger::Initialize::Start(
+                                                                                        deploymentInitializeOptions.ForceDeployment(),
+                                                                                        Security::IntegrityLevel::IsElevated(),
+                                                                                        AppModel::Identity::IsPackagedProcess(),
+                                                                                        Security::IntegrityLevel::GetIntegrityLevel()));
 
         FAIL_FAST_HR_IF(HRESULT_FROM_WIN32(APPMODEL_ERROR_NO_PACKAGE), !AppModel::Identity::IsPackagedProcess());
         return Initialize(GetCurrentFrameworkPackageFullName(), deploymentInitializeOptions);

--- a/dev/Deployment/DeploymentTraceLogging.h
+++ b/dev/Deployment/DeploymentTraceLogging.h
@@ -73,10 +73,9 @@ public:
         }
         else
         {
-            TraceLoggingClassWriteStop(Install,
+            TraceLoggingClassWriteStop(Initialize,
                 _GENERIC_PARTB_FIELDS_ENABLED,
-                TraceLoggingValue(preInitializeStatus, "preInitializeStatus"),
-                TraceLoggingValue(isFullTrustPackage, "isFullTrustPackage"));
+                TraceLoggingValue(preInitializeStatus, "preInitializeStatus"));
         }
     }
     END_ACTIVITY_CLASS();


### PR DESCRIPTION
1. Rectified setting up of Deployment Manager Initialize Activity Object within the context object which fixes the crash in packaged app when initialize API is called multiple times within single packaged app session.
- This also helps us in fixing telemetry tracking of Deployment Manager Initialize API because start and stop events of the API are not connected with same activity Id due to the issue being fixed. That impacts telemetry data processing causing us unable to see the filter values that we log in Start event (ex: isElevated, isPackagedProcess, IntegrityLevel etc).
- This also helps us in connecting DeploymentAgent.exe telemetry with DeploymentManager's for a single Initialize API call. Without the fix, DeploymentAgent.exe is always recording the corelated Intialize API call activityID as GUID_NULL.

2. Remove IsFullTrustPackage field when preInitializationStatus is already in OK status (i.e. Main and Singleton packages are already installed).