### PR TITLE
Encoding/Decoding AppNotificationBuilder arguments

### DIFF
--- a/dev/AppNotifications/AppNotificationActivatedEventArgs.cpp
+++ b/dev/AppNotifications/AppNotificationActivatedEventArgs.cpp
@@ -16,7 +16,8 @@ namespace winrt::Microsoft::Windows::AppNotifications::implementation
         size_t pos{ 0 };
 
         // Separate the key/value pairs by ';' as the delimiter
-        while ((pos = arguments.find(L';')) != std::wstring::npos) {
+        while ((pos = arguments.find(L';')) != std::wstring::npos)
+        {
             pairs.push_back(arguments.substr(0, pos));
             arguments.erase(0, pos + 1);
         }

--- a/dev/AppNotifications/AppNotificationActivatedEventArgs.cpp
+++ b/dev/AppNotifications/AppNotificationActivatedEventArgs.cpp
@@ -1,0 +1,42 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+#include "pch.h"
+#include "AppNotificationActivatedEventArgs.h"
+#include "Microsoft.Windows.AppNotifications.AppNotificationActivatedEventArgs.g.cpp"
+#include "AppNotificationBuilder/AppNotificationBuilderUtility.h"
+
+namespace winrt::Microsoft::Windows::AppNotifications::implementation
+{
+    winrt::Windows::Foundation::Collections::IMap<hstring, hstring> AppNotificationActivatedEventArgs::DecodeArguments(std::wstring arguments)
+    {
+        auto result{ winrt::single_threaded_map<winrt::hstring, winrt::hstring>() };
+
+        std::vector<std::wstring> pairs{};
+        size_t pos{ 0 };
+
+        // Separate the key/value pairs by ';' as the delimiter
+        while ((pos = arguments.find(L';')) != std::wstring::npos) {
+            pairs.push_back(arguments.substr(0, pos));
+            arguments.erase(0, pos + 1);
+        }
+
+        // Need to push back final string
+        pairs.push_back(arguments);
+
+        for (auto pair : pairs)
+        {
+            // Get the key/value individual values separated by '='
+            pos = pair.find(L'=');
+            if (pos == std::wstring::npos)
+            {
+                result.Insert(Decode(pair).c_str(), L"");
+            }
+            else
+            {
+                result.Insert(Decode(pair.substr(0, pos)).c_str(), Decode(pair.substr(pos + 1)).c_str());
+            }
+        }
+        return result;
+    }
+}

--- a/dev/AppNotifications/AppNotificationActivatedEventArgs.h
+++ b/dev/AppNotifications/AppNotificationActivatedEventArgs.h
@@ -10,12 +10,14 @@ namespace winrt::Microsoft::Windows::AppNotifications::implementation
     {
         AppNotificationActivatedEventArgs() = default;
 
-        AppNotificationActivatedEventArgs(winrt::hstring const& arguments, winrt::Windows::Foundation::Collections::IMap<winrt::hstring, winrt::hstring> const& userInput) : m_arguments(arguments), m_userInput(userInput) {};
-        winrt::hstring Argument() { return m_arguments; };
+        AppNotificationActivatedEventArgs(winrt::hstring const& argument, winrt::Windows::Foundation::Collections::IMap<winrt::hstring, winrt::hstring> const& userInput) : m_argument(argument), m_userInput(userInput) {};
+        winrt::hstring Argument() { return m_argument; };
         winrt::Windows::Foundation::Collections::IMap<hstring, hstring> UserInput() { return m_userInput; };
+        winrt::Windows::Foundation::Collections::IMap<hstring, hstring> Arguments() { return m_arguments; };
 
     private:
-        winrt::hstring m_arguments;
+        winrt::hstring m_argument;
         winrt::Windows::Foundation::Collections::IMap<winrt::hstring, winrt::hstring> m_userInput;
+        winrt::Windows::Foundation::Collections::IMap<winrt::hstring, winrt::hstring> m_arguments{ nullptr };
     };
 }

--- a/dev/AppNotifications/AppNotificationActivatedEventArgs.h
+++ b/dev/AppNotifications/AppNotificationActivatedEventArgs.h
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
 #pragma once
@@ -10,12 +10,15 @@ namespace winrt::Microsoft::Windows::AppNotifications::implementation
     {
         AppNotificationActivatedEventArgs() = default;
 
-        AppNotificationActivatedEventArgs(winrt::hstring const& argument, winrt::Windows::Foundation::Collections::IMap<winrt::hstring, winrt::hstring> const& userInput) : m_argument(argument), m_userInput(userInput) {};
+        AppNotificationActivatedEventArgs(winrt::hstring const& argument, winrt::Windows::Foundation::Collections::IMap<winrt::hstring, winrt::hstring> const& userInput)
+            : m_argument(argument), m_userInput(userInput), m_arguments(DecodeArguments(argument.c_str())) {};
         winrt::hstring Argument() { return m_argument; };
         winrt::Windows::Foundation::Collections::IMap<hstring, hstring> UserInput() { return m_userInput; };
         winrt::Windows::Foundation::Collections::IMap<hstring, hstring> Arguments() { return m_arguments; };
 
     private:
+        winrt::Windows::Foundation::Collections::IMap<hstring, hstring> DecodeArguments(std::wstring arguments);
+
         winrt::hstring m_argument;
         winrt::Windows::Foundation::Collections::IMap<winrt::hstring, winrt::hstring> m_userInput;
         winrt::Windows::Foundation::Collections::IMap<winrt::hstring, winrt::hstring> m_arguments{ nullptr };

--- a/dev/AppNotifications/AppNotificationBuilder/AppNotificationBuilder.cpp
+++ b/dev/AppNotifications/AppNotificationBuilder/AppNotificationBuilder.cpp
@@ -64,7 +64,7 @@ namespace winrt::Microsoft::Windows::AppNotifications::Builder::implementation
     {
         THROW_HR_IF_MSG(E_INVALIDARG, m_textLines.size() >= c_maxTextElements, "Maximum number of text elements added");
 
-        m_textLines.push_back(wil::str_printf<std::wstring>(L"<text>%ls</text>", EncodeXml(text.c_str()).c_str()).c_str());
+        m_textLines.push_back(wil::str_printf<std::wstring>(L"<text>%ls</text>", EncodeXml(text).c_str()).c_str());
         return *this;
     }
 
@@ -73,7 +73,7 @@ namespace winrt::Microsoft::Windows::AppNotifications::Builder::implementation
         THROW_HR_IF_MSG(E_INVALIDARG, m_textLines.size() >= c_maxTextElements, "Maximum number of text elements added");
 
         std::wstring props{ properties.as<winrt::Windows::Foundation::IStringable>().ToString() };
-        m_textLines.push_back(wil::str_printf<std::wstring>(L"%ls%ls</text>", props.c_str(), EncodeXml(text.c_str()).c_str()).c_str());
+        m_textLines.push_back(wil::str_printf<std::wstring>(L"%ls%ls</text>", props.c_str(), EncodeXml(text).c_str()).c_str());
 
         if (properties.IncomingCallAlignment())
         {
@@ -84,7 +84,7 @@ namespace winrt::Microsoft::Windows::AppNotifications::Builder::implementation
 
     winrt::Microsoft::Windows::AppNotifications::Builder::AppNotificationBuilder AppNotificationBuilder::SetAttributionText(hstring const& text)
     {
-        m_attributionText = wil::str_printf<std::wstring>(L"<text placement='attribution'>%ls</text>", EncodeXml(text.c_str()).c_str());
+        m_attributionText = wil::str_printf<std::wstring>(L"<text placement='attribution'>%ls</text>", EncodeXml(text).c_str());
         return *this;
     }
 
@@ -92,7 +92,7 @@ namespace winrt::Microsoft::Windows::AppNotifications::Builder::implementation
     {
         THROW_HR_IF_MSG(E_INVALIDARG, language.empty(), "You must provide a language calling SetAttributionText");
 
-        m_attributionText = wil::str_printf<std::wstring>(L"<text placement='attribution' lang='%ls'>%ls</text>", language.c_str(), EncodeXml(text.c_str()).c_str());
+        m_attributionText = wil::str_printf<std::wstring>(L"<text placement='attribution' lang='%ls'>%ls</text>", language.c_str(), EncodeXml(text).c_str());
         return *this;
     }
 
@@ -121,7 +121,7 @@ namespace winrt::Microsoft::Windows::AppNotifications::Builder::implementation
         THROW_HR_IF_MSG(E_INVALIDARG, alternateText.empty(), "You must provide an alternate text string calling SetInlineImage");
 
         std::wstring hintCrop { imageCrop == AppNotificationImageCrop::Circle ? L" hint-crop='circle'" : L"" };
-        m_inlineImage = wil::str_printf<std::wstring>(L"<image src='%ls' alt='%ls'%ls/>", imageUri.ToString().c_str(), alternateText.c_str(), hintCrop.c_str());
+        m_inlineImage = wil::str_printf<std::wstring>(L"<image src='%ls' alt='%ls'%ls/>", imageUri.ToString().c_str(), EncodeXml(alternateText).c_str(), hintCrop.c_str());
 
         return *this;
     }
@@ -151,7 +151,7 @@ namespace winrt::Microsoft::Windows::AppNotifications::Builder::implementation
         THROW_HR_IF_MSG(E_INVALIDARG, alternateText.empty(), "You must provide an alternate text string calling SetAppLogoOverride");
 
         std::wstring hintCrop{ imageCrop == AppNotificationImageCrop::Circle ? L" hint-crop='circle'" : L"" };
-        m_appLogoOverride = wil::str_printf<std::wstring>(L"<image placement='appLogoOverride' src='%ls' alt='%ls'%ls/>", imageUri.ToString().c_str(), alternateText.c_str(), hintCrop.c_str());
+        m_appLogoOverride = wil::str_printf<std::wstring>(L"<image placement='appLogoOverride' src='%ls' alt='%ls'%ls/>", imageUri.ToString().c_str(), EncodeXml(alternateText).c_str(), hintCrop.c_str());
 
         return *this;
     }
@@ -166,7 +166,7 @@ namespace winrt::Microsoft::Windows::AppNotifications::Builder::implementation
     {
         THROW_HR_IF_MSG(E_INVALIDARG, alternateText.empty(), "You must provide an alternate text string calling SetHeroImage");
 
-        m_heroImage = wil::str_printf<std::wstring>(L"<image placement='hero' src='%ls' alt='%ls'/>", imageUri.ToString().c_str(), alternateText.c_str());
+        m_heroImage = wil::str_printf<std::wstring>(L"<image placement='hero' src='%ls' alt='%ls'/>", imageUri.ToString().c_str(), EncodeXml(alternateText).c_str());
         return *this;
     }
 
@@ -213,7 +213,7 @@ namespace winrt::Microsoft::Windows::AppNotifications::Builder::implementation
         THROW_HR_IF_MSG(E_INVALIDARG, id.empty(), "You must provide an id for the TextBox");
 
 
-        m_textBoxList.push_back(wil::str_printf<std::wstring>(L"<input id='%ls' type='text'/>", id.c_str()));
+        m_textBoxList.push_back(wil::str_printf<std::wstring>(L"<input id='%ls' type='text'/>", EncodeXml(id).c_str()));
         return *this;
     }
 
@@ -222,7 +222,7 @@ namespace winrt::Microsoft::Windows::AppNotifications::Builder::implementation
         ThrowIfMaxInputItemsExceeded();
         THROW_HR_IF_MSG(E_INVALIDARG, id.empty(), "You must provide an id for the TextBox");
 
-        m_textBoxList.push_back(wil::str_printf<std::wstring>(L"<input id='%ls' type='text' placeHolderContent='%ls' title='%ls'/>", id.c_str(), placeHolderText.c_str(), title.c_str()));
+        m_textBoxList.push_back(wil::str_printf<std::wstring>(L"<input id='%ls' type='text' placeHolderContent='%ls' title='%ls'/>", EncodeXml(id).c_str(), EncodeXml(placeHolderText).c_str(), EncodeXml(title).c_str()));
         return *this;
     }
 

--- a/dev/AppNotifications/AppNotificationBuilder/AppNotificationBuilder.cpp
+++ b/dev/AppNotifications/AppNotificationBuilder/AppNotificationBuilder.cpp
@@ -26,7 +26,7 @@ namespace winrt::Microsoft::Windows::AppNotifications::Builder::implementation
     {
         THROW_HR_IF_MSG(E_INVALIDARG, key.empty(), "You must provide a key when adding an argument");
 
-        m_arguments.Insert(Encode(key.c_str()), Encode(value.c_str()));
+        m_arguments.Insert(EncodeArgument(key.c_str()), EncodeArgument(value.c_str()));
         return *this;
     }
 
@@ -59,7 +59,7 @@ namespace winrt::Microsoft::Windows::AppNotifications::Builder::implementation
     {
         THROW_HR_IF_MSG(E_INVALIDARG, m_textLines.size() >= c_maxTextElements, "Maximum number of text elements added");
 
-        m_textLines.push_back(wil::str_printf<std::wstring>(L"<text>%ls</text>", text.c_str()).c_str());
+        m_textLines.push_back(wil::str_printf<std::wstring>(L"<text>%ls</text>", EncodeXml(text.c_str()).c_str()).c_str());
         return *this;
     }
 
@@ -68,7 +68,7 @@ namespace winrt::Microsoft::Windows::AppNotifications::Builder::implementation
         THROW_HR_IF_MSG(E_INVALIDARG, m_textLines.size() >= c_maxTextElements, "Maximum number of text elements added");
 
         std::wstring props{ properties.as<winrt::Windows::Foundation::IStringable>().ToString() };
-        m_textLines.push_back(wil::str_printf<std::wstring>(L"%ls%ls</text>", props.c_str(), text.c_str()).c_str());
+        m_textLines.push_back(wil::str_printf<std::wstring>(L"%ls%ls</text>", props.c_str(), EncodeXml(text.c_str()).c_str()).c_str());
 
         if (properties.IncomingCallAlignment())
         {
@@ -79,7 +79,7 @@ namespace winrt::Microsoft::Windows::AppNotifications::Builder::implementation
 
     winrt::Microsoft::Windows::AppNotifications::Builder::AppNotificationBuilder AppNotificationBuilder::SetAttributionText(hstring const& text)
     {
-        m_attributionText = wil::str_printf<std::wstring>(L"<text placement='attribution'>%ls</text>", text.c_str());
+        m_attributionText = wil::str_printf<std::wstring>(L"<text placement='attribution'>%ls</text>", EncodeXml(text.c_str()).c_str());
         return *this;
     }
 
@@ -87,7 +87,7 @@ namespace winrt::Microsoft::Windows::AppNotifications::Builder::implementation
     {
         THROW_HR_IF_MSG(E_INVALIDARG, language.empty(), "You must provide a language calling SetAttributionText");
 
-        m_attributionText = wil::str_printf<std::wstring>(L"<text placement='attribution' lang='%ls'>%ls</text>", language.c_str(), text.c_str());
+        m_attributionText = wil::str_printf<std::wstring>(L"<text placement='attribution' lang='%ls'>%ls</text>", language.c_str(), EncodeXml(text.c_str()).c_str());
         return *this;
     }
 

--- a/dev/AppNotifications/AppNotificationBuilder/AppNotificationBuilder.cpp
+++ b/dev/AppNotifications/AppNotificationBuilder/AppNotificationBuilder.cpp
@@ -26,7 +26,7 @@ namespace winrt::Microsoft::Windows::AppNotifications::Builder::implementation
     {
         THROW_HR_IF_MSG(E_INVALIDARG, key.empty(), "You must provide a key when adding an argument");
 
-        m_arguments.Insert(Encode(key), Encode(value));
+        m_arguments.Insert(Encode(key.c_str()), Encode(value.c_str()));
         return *this;
     }
 

--- a/dev/AppNotifications/AppNotificationBuilder/AppNotificationBuilder.cpp
+++ b/dev/AppNotifications/AppNotificationBuilder/AppNotificationBuilder.cpp
@@ -25,7 +25,7 @@ namespace winrt::Microsoft::Windows::AppNotifications::Builder::implementation
     {
         THROW_HR_IF_MSG(E_INVALIDARG, key.empty(), "You must provide a key when adding an argument.");
 
-        m_arguments.Insert(key, value);
+        m_arguments.Insert(Encode(key), Encode(value));
         return *this;
     }
 

--- a/dev/AppNotifications/AppNotificationBuilder/AppNotificationBuilderUtility.h
+++ b/dev/AppNotifications/AppNotificationBuilder/AppNotificationBuilderUtility.h
@@ -4,6 +4,7 @@
 #pragma once
 #include "pch.h"
 #include "winrt/Microsoft.Windows.AppNotifications.Builder.h"
+#include <algorithm>
 
 inline const size_t c_maxAppNotificationPayload{ 5120 };
 inline const uint8_t c_maxTextElements{ 3 };
@@ -69,6 +70,28 @@ inline std::wstring GetWinSoundEventString(AppNotificationBuilder::AppNotificati
     default:
         return L"ms-winsoundevent:Notification.Default";
     }
+}
+
+inline std::wstring Encode(winrt::hstring const& value)
+{
+    std::wstring encodedValue{};
+    for (auto ch : value)
+    {
+        switch (ch) {
+        case '%':
+            encodedValue.append(L"%25");
+            break;
+        case ';':
+            encodedValue.append(L"%3B");
+            break;
+        case '=':
+            encodedValue.append(L"%3D");
+            break;
+        default:
+            encodedValue.push_back(ch);
+        }
+    }
+    return encodedValue;
 }
 
 inline int GetBuildNumber()

--- a/dev/AppNotifications/AppNotificationBuilder/AppNotificationBuilderUtility.h
+++ b/dev/AppNotifications/AppNotificationBuilder/AppNotificationBuilderUtility.h
@@ -120,7 +120,7 @@ inline std::wstring EncodeArgument(std::wstring const& value)
     return encodedValue;
 }
 
-inline std::wstring EncodeXml(std::wstring const& value)
+inline std::wstring EncodeXml(winrt::hstring const& value)
 {
     std::wstring encodedValue{};
 

--- a/dev/AppNotifications/AppNotificationBuilder/AppNotificationBuilderUtility.h
+++ b/dev/AppNotifications/AppNotificationBuilder/AppNotificationBuilderUtility.h
@@ -16,9 +16,9 @@ namespace AppNotificationBuilder
     using namespace winrt::Microsoft::Windows::AppNotifications::Builder;
 }
 
-inline std::map<wchar_t, PCWSTR> GetCharacterEncodings()
+inline std::map<PCWSTR, PCWSTR> GetCharacterEncodings()
 {
-    static std::map<wchar_t, PCWSTR> encodings = { { L'%', L"%25"}, { L';', L"%3B"}, { L'=', L"%3D"}};
+    static std::map<PCWSTR, PCWSTR> encodings = { { L"%", L"%25"}, {L";", L"%3B"}, {L"=", L"%3D"}};
     return encodings;
 }
 
@@ -81,20 +81,15 @@ inline PCWSTR GetWinSoundEventString(AppNotificationBuilder::AppNotificationSoun
 
 inline std::wstring Encode(std::wstring const& value)
 {
-    std::wstring encodedValue{};
+    std::wstring encodedValue{ value };
 
     auto encodings{ GetCharacterEncodings() };
-    for (auto ch : value)
+    for (auto encoding : encodings)
     {
-        if(encodings.find(ch) != encodings.end())
-        {
-            encodedValue.append(encodings[ch]);
-        }
-        else
-        {
-            encodedValue.push_back(ch);
-        }
+        // Replace literal special chars with encoding
+        encodedValue = std::regex_replace(encodedValue, std::wregex(encoding.first), encoding.second);
     }
+
     return encodedValue;
 }
 
@@ -107,8 +102,8 @@ inline std::wstring Decode(std::wstring const& value)
     // Need to unescape special characters
     for (auto encoding : GetCharacterEncodings())
     {
-        std::wstring specialCharacter{ encoding.first };
-        result = std::regex_replace(result, std::wregex(encoding.second), specialCharacter);
+        // Replace encoding with literal special chars
+        result = std::regex_replace(result, std::wregex(encoding.second), encoding.first);
     }
 
     return result;

--- a/dev/AppNotifications/AppNotificationBuilder/AppNotificationBuilderUtility.h
+++ b/dev/AppNotifications/AppNotificationBuilder/AppNotificationBuilderUtility.h
@@ -16,9 +16,9 @@ namespace AppNotificationBuilder
     using namespace winrt::Microsoft::Windows::AppNotifications::Builder;
 }
 
-inline std::map<PCWSTR, PCWSTR> GetCharacterEncodings()
+inline std::map<wchar_t, PCWSTR> GetCharacterEncodings()
 {
-    static std::map<PCWSTR, PCWSTR> encodings = { { L"%", L"%25"}, { L";", L"%3B"}, {L"=", L"%3D"} };
+    static std::map<wchar_t, PCWSTR> encodings = { { L'%', L"%25"}, { L';', L"%3B"}, { L'=', L"%3D"}};
     return encodings;
 }
 
@@ -79,24 +79,19 @@ inline PCWSTR GetWinSoundEventString(AppNotificationBuilder::AppNotificationSoun
     }
 }
 
-inline std::wstring Encode(winrt::hstring const& value)
+inline std::wstring Encode(std::wstring const& value)
 {
     std::wstring encodedValue{};
 
     auto encodings{ GetCharacterEncodings() };
     for (auto ch : value)
     {
-        switch (ch) {
-        case '%':
-            encodedValue.append(encodings[L"%"]);
-            break;
-        case ';':
-            encodedValue.append(encodings[L";"]);
-            break;
-        case '=':
-            encodedValue.append(encodings[L"="]);
-            break;
-        default:
+        if(encodings.find(ch) != encodings.end())
+        {
+            encodedValue.append(encodings[ch]);
+        }
+        else
+        {
             encodedValue.push_back(ch);
         }
     }
@@ -112,7 +107,8 @@ inline std::wstring Decode(std::wstring const& value)
     // Need to unescape special characters
     for (auto encoding : GetCharacterEncodings())
     {
-        result = std::regex_replace(result, std::wregex(encoding.second), encoding.first);
+        std::wstring specialCharacter{ encoding.first };
+        result = std::regex_replace(result, std::wregex(encoding.second), specialCharacter);
     }
 
     return result;

--- a/dev/AppNotifications/AppNotificationBuilder/AppNotificationBuilderUtility.h
+++ b/dev/AppNotifications/AppNotificationBuilder/AppNotificationBuilderUtility.h
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
-#pragma once
 #include "pch.h"
 #include "winrt/Microsoft.Windows.AppNotifications.Builder.h"
 #include <algorithm>
@@ -115,7 +114,7 @@ inline std::wstring DecodeString(std::wstring value, std::wstring const& encoded
 
 // Decoding process based off the Windows Community Toolkit:
 // https://github.com/CommunityToolkit/WindowsCommunityToolkit/blob/rel/7.1.0/Microsoft.Toolkit.Uwp.Notifications/Toasts/ToastArguments.cs#L389inline
-std::wstring Decode(std::wstring const& value)
+inline std::wstring Decode(std::wstring const& value)
 {
     std::wstring result{ value };
 

--- a/dev/AppNotifications/AppNotificationBuilder/AppNotificationButton.cpp
+++ b/dev/AppNotifications/AppNotificationBuilder/AppNotificationButton.cpp
@@ -26,7 +26,7 @@ namespace winrt::Microsoft::Windows::AppNotifications::Builder::implementation
         THROW_HR_IF_MSG(E_INVALIDARG, key.empty(), "You must provide a key when adding an argument");
         THROW_HR_IF_MSG(E_INVALIDARG, m_protocolUri, "You cannot add an argument after calling SetInvokeUri");
 
-        m_arguments.Insert(Encode(key.c_str()), Encode(value.c_str()));
+        m_arguments.Insert(EncodeArgument(key.c_str()), EncodeArgument(value.c_str()));
         return *this;
     }
 
@@ -38,7 +38,7 @@ namespace winrt::Microsoft::Windows::AppNotifications::Builder::implementation
 
     winrt::Microsoft::Windows::AppNotifications::Builder::AppNotificationButton AppNotificationButton::SetToolTip(winrt::hstring const& value)
     {
-        m_toolTip = value;
+        m_toolTip = EncodeXml(value.c_str()).c_str();
         return *this;
     }
 
@@ -56,7 +56,7 @@ namespace winrt::Microsoft::Windows::AppNotifications::Builder::implementation
 
     winrt::Microsoft::Windows::AppNotifications::Builder::AppNotificationButton AppNotificationButton::SetInputId(winrt::hstring const& value)
     {
-        m_inputId = value;
+        m_inputId = EncodeXml(value.c_str()).c_str();
         return *this;
     }
 

--- a/dev/AppNotifications/AppNotificationBuilder/AppNotificationButton.cpp
+++ b/dev/AppNotifications/AppNotificationBuilder/AppNotificationButton.cpp
@@ -5,6 +5,7 @@
 #include "AppNotificationButton.h"
 #include "Microsoft.Windows.AppNotifications.Builder.AppNotificationButton.g.cpp"
 #include <IsWindowsVersion.h>
+#include "AppNotificationBuilderUtility.h"
 
 namespace winrt::Microsoft::Windows::AppNotifications::Builder::implementation
 {

--- a/dev/AppNotifications/AppNotificationBuilder/AppNotificationButton.cpp
+++ b/dev/AppNotifications/AppNotificationBuilder/AppNotificationButton.cpp
@@ -26,7 +26,7 @@ namespace winrt::Microsoft::Windows::AppNotifications::Builder::implementation
         THROW_HR_IF_MSG(E_INVALIDARG, key.empty(), "You must provide a key when adding an argument");
         THROW_HR_IF_MSG(E_INVALIDARG, m_protocolUri, "You cannot add an argument after calling SetInvokeUri");
 
-        m_arguments.Insert(Encode(key), Encode(value));
+        m_arguments.Insert(Encode(key.c_str()), Encode(value.c_str()));
         return *this;
     }
 

--- a/dev/AppNotifications/AppNotificationBuilder/AppNotificationButton.cpp
+++ b/dev/AppNotifications/AppNotificationBuilder/AppNotificationButton.cpp
@@ -25,7 +25,7 @@ namespace winrt::Microsoft::Windows::AppNotifications::Builder::implementation
         THROW_HR_IF_MSG(E_INVALIDARG, key.empty(), "You must provide a key when adding an argument.");
         THROW_HR_IF_MSG(E_INVALIDARG, m_protocolUri, "You cannot add an argument after calling SetInvokeUri.");
 
-        m_arguments.Insert(key, value);
+        m_arguments.Insert(Encode(key), Encode(value));
         return *this;
     }
 

--- a/dev/AppNotifications/AppNotificationBuilder/AppNotificationComboBox.cpp
+++ b/dev/AppNotifications/AppNotificationBuilder/AppNotificationComboBox.cpp
@@ -8,9 +8,10 @@
 
 namespace winrt::Microsoft::Windows::AppNotifications::Builder::implementation
 {
-    AppNotificationComboBox::AppNotificationComboBox(hstring const& id) : m_id(id)
+    AppNotificationComboBox::AppNotificationComboBox(hstring const& id)
     {
         THROW_HR_IF_MSG(E_INVALIDARG, id.empty(), "You must provide an id for the ComboBox");
+        m_id = EncodeXml(id).c_str();
     };
 
     winrt::Microsoft::Windows::AppNotifications::Builder::AppNotificationComboBox AppNotificationComboBox::AddItem(winrt::hstring const& id, winrt::hstring const& content)
@@ -18,14 +19,14 @@ namespace winrt::Microsoft::Windows::AppNotifications::Builder::implementation
         THROW_HR_IF_MSG(E_INVALIDARG, m_items.Size() >= c_maxSelectionElements, "Maximum number of items added");
         THROW_HR_IF_MSG(E_INVALIDARG, id.empty(), "You must provide an id for the item");
 
-        m_items.Insert(id, content);
+        m_items.Insert(EncodeXml(id).c_str(), EncodeXml(content).c_str());
 
         return *this;
     }
 
     winrt::Microsoft::Windows::AppNotifications::Builder::AppNotificationComboBox AppNotificationComboBox::SetTitle(winrt::hstring const& value)
     {
-        m_title = value;
+        m_title = EncodeXml(value).c_str();
 
         return *this;
     }
@@ -34,7 +35,7 @@ namespace winrt::Microsoft::Windows::AppNotifications::Builder::implementation
     {
         THROW_HR_IF_MSG(E_INVALIDARG, id.empty(), "You must provide an id for the selected item");
 
-        m_selectedItem = id;
+        m_selectedItem = EncodeXml(id).c_str();
 
         return *this;
     }

--- a/dev/AppNotifications/AppNotificationBuilder/AppNotificationProgressBar.cpp
+++ b/dev/AppNotifications/AppNotificationBuilder/AppNotificationProgressBar.cpp
@@ -4,6 +4,7 @@
 #include "pch.h"
 #include "AppNotificationProgressBar.h"
 #include "Microsoft.Windows.AppNotifications.Builder.AppNotificationProgressBar.g.cpp"
+#include "AppNotificationBuilderUtility.h"
 
 namespace winrt::Microsoft::Windows::AppNotifications::Builder::implementation
 {
@@ -16,13 +17,13 @@ namespace winrt::Microsoft::Windows::AppNotifications::Builder::implementation
 
     void AppNotificationProgressBar::Title(winrt::hstring const& value)
     {
-        m_title = value;
+        m_title = EncodeXml(value).c_str();
         m_titleBindMode = BindMode::Value;
     }
 
     void AppNotificationProgressBar::Status(winrt::hstring const& value)
     {
-        m_status = value;
+        m_status = EncodeXml(value).c_str();
         m_statusBindMode = BindMode::Value;
     }
 
@@ -36,7 +37,7 @@ namespace winrt::Microsoft::Windows::AppNotifications::Builder::implementation
 
     void AppNotificationProgressBar::ValueStringOverride(winrt::hstring const& value)
     {
-        m_valueStringOverride = value;
+        m_valueStringOverride = EncodeXml(value).c_str();
         m_valueStringOverrideBindMode = BindMode::Value;
     }
 

--- a/dev/AppNotifications/AppNotifications.idl
+++ b/dev/AppNotifications/AppNotifications.idl
@@ -4,7 +4,7 @@ import "..\AppLifecycle\AppLifecycle.idl";
 
 namespace Microsoft.Windows.AppNotifications
 {
-    [contractversion(2)]
+    [contractversion(3)]
     apicontract AppNotificationsContract {}
 
     // Event args for the Notification Activation
@@ -16,6 +16,10 @@ namespace Microsoft.Windows.AppNotifications
 
         // The data from the input elements of a Notification like a TextBox
         Windows.Foundation.Collections.IMap<String, String> UserInput{ get; };
+
+        // Arguments from the invoked button built from AppNotificationBuilder
+        [contract(AppNotificationsContract, 3)]
+        Windows.Foundation.Collections.IMap<String, String> Arguments{ get; };
     }
 
     // Notification Progress Data

--- a/dev/AppNotifications/AppNotifications.vcxitems
+++ b/dev/AppNotifications/AppNotifications.vcxitems
@@ -26,6 +26,7 @@
     <ClInclude Include="$(MSBuildThisFileDirectory)ShellLocalization.h" />
   </ItemGroup>
   <ItemGroup>
+    <ClCompile Include="$(MSBuildThisFileDirectory)AppNotificationActivatedEventArgs.cpp" />
     <ClCompile Include="$(MSBuildThisFileDirectory)AppNotificationManager.cpp" />
     <ClCompile Include="$(MSBuildThisFileDirectory)AppNotification.cpp" />
     <ClCompile Include="$(MSBuildThisFileDirectory)AppNotificationProgressData.cpp" />

--- a/test/AppNotificationBuilderTests/APITests.cpp
+++ b/test/AppNotificationBuilderTests/APITests.cpp
@@ -421,41 +421,41 @@ namespace Test::AppNotification::Builder
 
         TEST_METHOD(AppNotificationBuilderBuildNotificationWithTooLargePayload)
         {
-            VERIFY_THROWS_HR(AppNotificationBuilder()
+            VERIFY_THROWS_HR(winrt::AppNotificationBuilder()
                 .AddText(std::wstring(5120, 'A').c_str())
                 .BuildNotification(), E_INVALIDARG);
         }
 
         TEST_METHOD(AppNotificationAddProgressBar)
         {
-            auto builder{ AppNotificationBuilder()
+            auto builder{ winrt::AppNotificationBuilder()
                 .AddText(L"Downloading this week's new music...")
-                .AddProgressBar(AppNotificationProgressBar()
+                .AddProgressBar(winrt::AppNotificationProgressBar()
                     .BindTitle()
                     .BindValueStringOverride()) };
-            auto expected{ L"<toast><visual><binding template='ToastGeneric'><text>Downloading this week's new music...</text><progress title='{progressTitle}' status='{progressStatus}' value='{progressValue}' valueStringOverride='{progressValueString}'/></binding></visual></toast>" };
-
+            auto expected{ L"<toast><visual><binding template='ToastGeneric'><text>Downloading this week&apos;s new music...</text><progress title='{progressTitle}' status='{progressStatus}' value='{progressValue}' valueStringOverride='{progressValueString}'/></binding></visual></toast>" };
+            WEX::Logging::Log::Comment(builder.BuildNotification().Payload().c_str());
             VERIFY_ARE_EQUAL(builder.BuildNotification().Payload(), expected);
         }
 
         TEST_METHOD(AppNotificationAddMoreThanOneProgressBar)
         {
-            auto builder{ AppNotificationBuilder()
+            auto builder{ winrt::AppNotificationBuilder()
                 .AddText(L"Downloading this week's new music...")
-                .AddProgressBar(AppNotificationProgressBar()
+                .AddProgressBar(winrt::AppNotificationProgressBar()
                     .BindTitle()
                     .BindValueStringOverride())
-                .AddProgressBar(AppNotificationProgressBar()
+                .AddProgressBar(winrt::AppNotificationProgressBar()
                     .SetValue(0.8)
                     .SetStatus(L"Still downloading...")) };
-            auto expected{ L"<toast><visual><binding template='ToastGeneric'><text>Downloading this week's new music...</text><progress title='{progressTitle}' status='{progressStatus}' value='{progressValue}' valueStringOverride='{progressValueString}'/><progress status='Still downloading...' value='0.8'/></binding></visual></toast>" };
+            auto expected{ L"<toast><visual><binding template='ToastGeneric'><text>Downloading this week&apos;s new music...</text><progress title='{progressTitle}' status='{progressStatus}' value='{progressValue}' valueStringOverride='{progressValueString}'/><progress status='Still downloading...' value='0.8'/></binding></visual></toast>" };
 
             VERIFY_ARE_EQUAL(builder.BuildNotification().Payload(), expected);
         }
 
         TEST_METHOD(AppNotificationProgressBarDefaults)
         {
-            auto progressBar{ AppNotificationProgressBar() };
+            auto progressBar{ winrt::AppNotificationProgressBar() };
             auto expected{ L"<progress status='{progressStatus}' value='{progressValue}'/>" };
 
             VERIFY_ARE_EQUAL(progressBar.as<winrt::Windows::Foundation::IStringable>().ToString(), expected);
@@ -463,7 +463,7 @@ namespace Test::AppNotification::Builder
 
         TEST_METHOD(AppNotificationProgressBarSetSpecificValue)
         {
-            auto progressBar{ AppNotificationProgressBar() };
+            auto progressBar{ winrt::AppNotificationProgressBar() };
             progressBar.Value(0.8);
             auto expected{ L"<progress status='{progressStatus}' value='0.8'/>" };
 
@@ -472,23 +472,23 @@ namespace Test::AppNotification::Builder
 
         TEST_METHOD(AppNotificationProgressBarSetValueLargerThanOne)
         {
-            auto progressBar{ AppNotificationProgressBar() };
+            auto progressBar{ winrt::AppNotificationProgressBar() };
             VERIFY_THROWS_HR(progressBar.Value(1.01), E_INVALIDARG);
 
-            VERIFY_THROWS_HR(AppNotificationProgressBar().SetValue(1.01), E_INVALIDARG);
+            VERIFY_THROWS_HR(winrt::AppNotificationProgressBar().SetValue(1.01), E_INVALIDARG);
         }
 
         TEST_METHOD(AppNotificationProgressBarSetValueSmallerThanZero)
         {
-            auto progressBar{ AppNotificationProgressBar() };
+            auto progressBar{ winrt::AppNotificationProgressBar() };
             VERIFY_THROWS_HR(progressBar.Value(-0.1), E_INVALIDARG);
 
-            VERIFY_THROWS_HR(AppNotificationProgressBar().SetValue(-0.1), E_INVALIDARG);
+            VERIFY_THROWS_HR(winrt::AppNotificationProgressBar().SetValue(-0.1), E_INVALIDARG);
         }
 
         TEST_METHOD(AppNotificationProgressBarSetSpecificValueThenChangeToBind)
         {
-            auto progressBar{ AppNotificationProgressBar() };
+            auto progressBar{ winrt::AppNotificationProgressBar() };
             progressBar.Value(0.8);
             progressBar.BindValue();
             auto expected{ L"<progress status='{progressStatus}' value='{progressValue}'/>" };
@@ -498,7 +498,7 @@ namespace Test::AppNotification::Builder
 
         TEST_METHOD(AppNotificationProgressBarBindTitleThenChangeToSpecificText)
         {
-            auto progressBar{ AppNotificationProgressBar()
+            auto progressBar{ winrt::AppNotificationProgressBar()
                 .BindTitle()
                 .SetTitle(L"Specific title") };
             auto expected{ L"<progress title='Specific title' status='{progressStatus}' value='{progressValue}'/>" };
@@ -508,7 +508,7 @@ namespace Test::AppNotification::Builder
 
         TEST_METHOD(AppNotificationBuilderAddTextBox)
         {
-            auto builder{ AppNotificationBuilder()
+            auto builder{ winrt::AppNotificationBuilder()
                 .AddTextBox(L"input1") };
             auto expected{ L"<toast><visual><binding template='ToastGeneric'></binding></visual><actions><input id='input1' type='text'/></actions></toast>" };
 
@@ -517,19 +517,19 @@ namespace Test::AppNotification::Builder
 
         TEST_METHOD(AppNotificationBuilderAddTextBoxWithEmptyId)
         {
-            VERIFY_THROWS_HR(AppNotificationBuilder()
+            VERIFY_THROWS_HR(winrt::AppNotificationBuilder()
                 .AddTextBox(L""), E_INVALIDARG);
         }
 
         TEST_METHOD(AppNotificationBuilderAddTextBoxWithEmptyIdAndPlaceHolderTextAndTitle)
         {
-            VERIFY_THROWS_HR(AppNotificationBuilder()
+            VERIFY_THROWS_HR(winrt::AppNotificationBuilder()
                 .AddTextBox(L"", L"placeholder text", L"title"), E_INVALIDARG);
         }
 
         TEST_METHOD(AppNotificationBuilderAddTooManyTextBoxes)
         {
-            VERIFY_THROWS_HR(AppNotificationBuilder()
+            VERIFY_THROWS_HR(winrt::AppNotificationBuilder()
                 .AddTextBox(L"input1")
                 .AddTextBox(L"input2")
                 .AddTextBox(L"input3")
@@ -540,7 +540,7 @@ namespace Test::AppNotification::Builder
 
         TEST_METHOD(AppNotificationBuilderAddTextBoxWithPlaceHolderTextAndTitle)
         {
-            auto builder{ AppNotificationBuilder()
+            auto builder{ winrt::AppNotificationBuilder()
                 .AddTextBox(L"some input id", L"Some placeholder text", L"A Title")};
             auto expected{ L"<toast><visual><binding template='ToastGeneric'></binding></visual><actions><input id='some input id' type='text' placeHolderContent='Some placeholder text' title='A Title'/></actions></toast>" };
 
@@ -549,8 +549,8 @@ namespace Test::AppNotification::Builder
 
         TEST_METHOD(AppNotificationBuilderAddComboBox)
         {
-            auto builder{ AppNotificationBuilder()
-                .AddComboBox(AppNotificationComboBox(L"comboBox1")
+            auto builder{ winrt::AppNotificationBuilder()
+                .AddComboBox(winrt::AppNotificationComboBox(L"comboBox1")
                     .AddItem(L"item1", L"item1 text")
                     .AddItem(L"item2", L"item2 text")
                     .AddItem(L"item3", L"item3 text")
@@ -563,38 +563,38 @@ namespace Test::AppNotification::Builder
 
         TEST_METHOD(AppNotificationBuilderAddTooManyComboBox)
         {
-            VERIFY_THROWS_HR(AppNotificationBuilder()
+            VERIFY_THROWS_HR(winrt::AppNotificationBuilder()
                 .AddTextBox(L"input1")
                 .AddTextBox(L"input2")
                 .AddTextBox(L"input3")
-                .AddComboBox(AppNotificationComboBox(L"comboBox1")
+                .AddComboBox(winrt::AppNotificationComboBox(L"comboBox1")
                     .AddItem(L"item1", L"item1 text"))
-                .AddComboBox(AppNotificationComboBox(L"comboBox2")
+                .AddComboBox(winrt::AppNotificationComboBox(L"comboBox2")
                     .AddItem(L"item1", L"item1 text"))
-                .AddComboBox(AppNotificationComboBox(L"comboBox3")
+                .AddComboBox(winrt::AppNotificationComboBox(L"comboBox3")
                     .AddItem(L"item1", L"item1 text")), E_INVALIDARG);
         }
 
         TEST_METHOD(AppNotificationBuilderAddTooManyInputElements)
         {
-            VERIFY_THROWS_HR(AppNotificationBuilder()
-                .AddComboBox(AppNotificationComboBox(L"comboBox1")
+            VERIFY_THROWS_HR(winrt::AppNotificationBuilder()
+                .AddComboBox(winrt::AppNotificationComboBox(L"comboBox1")
                     .AddItem(L"item1", L"item1 text"))
-                .AddComboBox(AppNotificationComboBox(L"comboBox2")
+                .AddComboBox(winrt::AppNotificationComboBox(L"comboBox2")
                     .AddItem(L"item1", L"item1 text"))
-                .AddComboBox(AppNotificationComboBox(L"comboBox3")
+                .AddComboBox(winrt::AppNotificationComboBox(L"comboBox3")
                     .AddItem(L"item1", L"item1 text"))
-                .AddComboBox(AppNotificationComboBox(L"comboBox4")
+                .AddComboBox(winrt::AppNotificationComboBox(L"comboBox4")
                     .AddItem(L"item1", L"item1 text"))
-                .AddComboBox(AppNotificationComboBox(L"comboBox5")
+                .AddComboBox(winrt::AppNotificationComboBox(L"comboBox5")
                     .AddItem(L"item1", L"item1 text"))
-                .AddComboBox(AppNotificationComboBox(L"comboBox6")
+                .AddComboBox(winrt::AppNotificationComboBox(L"comboBox6")
                     .AddItem(L"item1", L"item1 text")), E_INVALIDARG);
         }
 
         TEST_METHOD(AppNotificationComboBoxAddTooManySelectionItems)
         {
-            VERIFY_THROWS_HR(AppNotificationComboBox(L"comboBox1")
+            VERIFY_THROWS_HR(winrt::AppNotificationComboBox(L"comboBox1")
                     .AddItem(L"item1", L"item1 text")
                     .AddItem(L"item2", L"item2 text")
                     .AddItem(L"item3", L"item3 text")
@@ -605,7 +605,7 @@ namespace Test::AppNotification::Builder
 
         TEST_METHOD(AppNotificationComboBoxAddFiveSelectionItems)
         {
-            auto comboBox{ AppNotificationComboBox(L"comboBox1")
+            auto comboBox{ winrt::AppNotificationComboBox(L"comboBox1")
                     .AddItem(L"item1", L"item1 text")
                     .AddItem(L"item2", L"item2 text")
                     .AddItem(L"item3", L"item3 text")
@@ -618,13 +618,13 @@ namespace Test::AppNotification::Builder
 
         TEST_METHOD(AppNotificationComboBoxAddSelectionItemWithoutAnId)
         {
-            VERIFY_THROWS_HR(AppNotificationComboBox(L"comboBox1")
+            VERIFY_THROWS_HR(winrt::AppNotificationComboBox(L"comboBox1")
                 .AddItem(L"", L"item text"), E_INVALIDARG);
         }
 
         TEST_METHOD(AppNotificationComboBoxAddTwoSelectionItemsWithSameId)
         {
-            auto comboBox{ AppNotificationComboBox(L"comboBox1")
+            auto comboBox{ winrt::AppNotificationComboBox(L"comboBox1")
                     .AddItem(L"item1", L"item1 text")
                     .AddItem(L"item1", L"item2 text") };
             auto expected{ L"<input id='comboBox1' type='selection'><selection id='item1' content='item2 text'/></input>" };
@@ -634,13 +634,13 @@ namespace Test::AppNotification::Builder
 
         TEST_METHOD(AppNotificationComboBoxSetSelectedItemWithoutAnId)
         {
-            VERIFY_THROWS_HR(AppNotificationComboBox(L"comboBox1")
+            VERIFY_THROWS_HR(winrt::AppNotificationComboBox(L"comboBox1")
                 .SetSelectedItem(L""), E_INVALIDARG);
         }
 
         TEST_METHOD(AppNotificationCreateComboBoxWithoutAnId)
         {
-            VERIFY_THROWS_HR(AppNotificationComboBox(L""), E_INVALIDARG);
+            VERIFY_THROWS_HR(winrt::AppNotificationComboBox(L""), E_INVALIDARG);
         }
     };
 }

--- a/test/AppNotificationBuilderTests/APITests.cpp
+++ b/test/AppNotificationBuilderTests/APITests.cpp
@@ -92,6 +92,29 @@ namespace Test::AppNotification::Builder
             VERIFY_ARE_EQUAL(builder.BuildNotification().Payload(), expected);
         }
 
+        TEST_METHOD(AppNotificationBuilderAddArgumentWithPercentChar)
+        {
+            auto builder{ AppNotificationBuilder().AddArgument(L"k%ey", L"") };
+            auto expected{ L"<toast launch='k%25ey'><visual><binding template='ToastGeneric'></binding></visual></toast>" };
+
+            VERIFY_ARE_EQUAL(builder.BuildNotification().Payload(), expected);
+        }
+
+        TEST_METHOD(AppNotificationBuilderAddArgumentWithEqualChar)
+        {
+            auto builder{ AppNotificationBuilder().AddArgument(L"k=ey", L"") };
+            auto expected{ L"<toast launch='k%3Dey'><visual><binding template='ToastGeneric'></binding></visual></toast>" };
+
+            VERIFY_ARE_EQUAL(builder.BuildNotification().Payload(), expected);
+        }
+
+        TEST_METHOD(AppNotificationBuilderAddArgumentWithSemicolonChar)
+        {
+            auto builder{ AppNotificationBuilder().AddArgument(L"k;ey", L"") };
+            auto expected{ L"<toast launch='k%3Bey'><visual><binding template='ToastGeneric'></binding></visual></toast>" };
+
+            VERIFY_ARE_EQUAL(builder.BuildNotification().Payload(), expected);
+        }
         TEST_METHOD(AppNotificationBuilderAddArgumentEmptyKey)
         {
             VERIFY_THROWS_HR(AppNotificationBuilder().AddArgument(L"", L""), E_INVALIDARG);

--- a/test/AppNotificationBuilderTests/APITests.cpp
+++ b/test/AppNotificationBuilderTests/APITests.cpp
@@ -125,6 +125,8 @@ namespace Test::AppNotification::Builder
             VERIFY_ARE_EQUAL(Decode(L"key%3D"), L"key=");
             VERIFY_ARE_EQUAL(Decode(L"key%25"), L"key%");
             VERIFY_ARE_EQUAL(Decode(L"key%3B%3D%25"), L"key;=%");
+            VERIFY_ARE_EQUAL(Decode(L"%25%25%25"), L"%%%");
+
         }
 
         TEST_METHOD(AppNotificationBuilderAddArgumentEmptyKey)

--- a/test/AppNotificationBuilderTests/APITests.cpp
+++ b/test/AppNotificationBuilderTests/APITests.cpp
@@ -3,7 +3,10 @@
 
 #include "pch.h"
 
-using namespace winrt::Microsoft::Windows::AppNotifications::Builder;
+namespace winrt
+{
+    using namespace winrt::Microsoft::Windows::AppNotifications::Builder;
+}
 
 namespace Test::AppNotification::Builder
 {
@@ -47,7 +50,7 @@ namespace Test::AppNotification::Builder
 
         TEST_METHOD(AppNotificationBuilderDefault)
         {
-            auto builder{ AppNotificationBuilder() };
+            auto builder{ winrt::AppNotificationBuilder() };
             auto expected{ L"<toast><visual><binding template='ToastGeneric'></binding></visual></toast>"};
             VERIFY_ARE_EQUAL(builder.BuildNotification().Payload(), expected);
         }
@@ -62,7 +65,7 @@ namespace Test::AppNotification::Builder
             std::time_t time{ mktime(&dateTime) };
             auto timeStamp{ winrt::clock::from_time_t(time) };
 
-            auto builder{ AppNotificationBuilder().SetTimeStamp(timeStamp) };
+            auto builder{ winrt::AppNotificationBuilder().SetTimeStamp(timeStamp) };
             auto expected{ L"<toast displayTimestamp='2016-12-22T09:12:10Z'><visual><binding template='ToastGeneric'></binding></visual></toast>" };
 
             VERIFY_ARE_EQUAL(builder.BuildNotification().Payload(), expected);
@@ -70,7 +73,7 @@ namespace Test::AppNotification::Builder
 
         TEST_METHOD(AppNotificationBuilderAddOneArgument)
         {
-            auto builder{ AppNotificationBuilder().AddArgument(L"key", L"value") };
+            auto builder{ winrt::AppNotificationBuilder().AddArgument(L"key", L"value") };
             auto expected{ L"<toast launch='key=value'><visual><binding template='ToastGeneric'></binding></visual></toast>" };
 
             VERIFY_ARE_EQUAL(builder.BuildNotification().Payload(), expected);
@@ -78,7 +81,7 @@ namespace Test::AppNotification::Builder
 
         TEST_METHOD(AppNotificationBuilderAddTwoArguments)
         {
-            auto builder{ AppNotificationBuilder().AddArgument(L"key1", L"value1").AddArgument(L"key2", L"value2") };
+            auto builder{ winrt::AppNotificationBuilder().AddArgument(L"key1", L"value1").AddArgument(L"key2", L"value2") };
             auto expected{ L"<toast launch='key1=value1;key2=value2'><visual><binding template='ToastGeneric'></binding></visual></toast>" };
 
             VERIFY_ARE_EQUAL(builder.BuildNotification().Payload(), expected);
@@ -86,7 +89,7 @@ namespace Test::AppNotification::Builder
 
         TEST_METHOD(AppNotificationBuilderAddArgumentEmptyValue)
         {
-            auto builder{ AppNotificationBuilder().AddArgument(L"key", L"") };
+            auto builder{ winrt::AppNotificationBuilder().AddArgument(L"key", L"") };
             auto expected{ L"<toast launch='key'><visual><binding template='ToastGeneric'></binding></visual></toast>" };
 
             VERIFY_ARE_EQUAL(builder.BuildNotification().Payload(), expected);
@@ -94,35 +97,44 @@ namespace Test::AppNotification::Builder
 
         TEST_METHOD(AppNotificationBuilderAddArgumentWithPercentChar)
         {
-            auto builder{ AppNotificationBuilder().AddArgument(L"k%ey", L"") };
-            auto expected{ L"<toast launch='k%25ey'><visual><binding template='ToastGeneric'></binding></visual></toast>" };
+            auto builder{ winrt::AppNotificationBuilder().AddArgument(L"k%ey", L"v%alue") };
+            auto expected{ L"<toast launch='k%25ey=v%25alue'><visual><binding template='ToastGeneric'></binding></visual></toast>" };
 
             VERIFY_ARE_EQUAL(builder.BuildNotification().Payload(), expected);
         }
 
         TEST_METHOD(AppNotificationBuilderAddArgumentWithEqualChar)
         {
-            auto builder{ AppNotificationBuilder().AddArgument(L"k=ey", L"") };
-            auto expected{ L"<toast launch='k%3Dey'><visual><binding template='ToastGeneric'></binding></visual></toast>" };
+            auto builder{ winrt::AppNotificationBuilder().AddArgument(L"k=ey", L"v=alue") };
+            auto expected{ L"<toast launch='k%3Dey=v%3Dalue'><visual><binding template='ToastGeneric'></binding></visual></toast>" };
 
             VERIFY_ARE_EQUAL(builder.BuildNotification().Payload(), expected);
         }
 
         TEST_METHOD(AppNotificationBuilderAddArgumentWithSemicolonChar)
         {
-            auto builder{ AppNotificationBuilder().AddArgument(L"k;ey", L"") };
-            auto expected{ L"<toast launch='k%3Bey'><visual><binding template='ToastGeneric'></binding></visual></toast>" };
+            auto builder{ winrt::AppNotificationBuilder().AddArgument(L"k;ey", L"v;alue") };
+            auto expected{ L"<toast launch='k%3Bey=v%3Balue'><visual><binding template='ToastGeneric'></binding></visual></toast>" };
 
             VERIFY_ARE_EQUAL(builder.BuildNotification().Payload(), expected);
         }
+
+        TEST_METHOD(DecodeArguments)
+        {
+            VERIFY_ARE_EQUAL(Decode(L"key%3B"), L"key;");
+            VERIFY_ARE_EQUAL(Decode(L"key%3D"), L"key=");
+            VERIFY_ARE_EQUAL(Decode(L"key%25"), L"key%");
+            VERIFY_ARE_EQUAL(Decode(L"key%3B%3D%25"), L"key;=%");
+        }
+
         TEST_METHOD(AppNotificationBuilderAddArgumentEmptyKey)
         {
-            VERIFY_THROWS_HR(AppNotificationBuilder().AddArgument(L"", L""), E_INVALIDARG);
+            VERIFY_THROWS_HR(winrt::AppNotificationBuilder().AddArgument(L"", L""), E_INVALIDARG);
         }
 
         TEST_METHOD(AppNotificationBuilderSetReminderScenario)
         {
-            auto builder{ AppNotificationBuilder().SetScenario(AppNotificationScenario::Reminder) };
+            auto builder{ winrt::AppNotificationBuilder().SetScenario(winrt::AppNotificationScenario::Reminder) };
             auto expected{ L"<toast scenario='reminder'><visual><binding template='ToastGeneric'></binding></visual></toast>" };
 
             VERIFY_ARE_EQUAL(builder.BuildNotification().Payload(), expected);
@@ -130,7 +142,7 @@ namespace Test::AppNotification::Builder
 
         TEST_METHOD(AppNotificationBuilderSetAlarmScenario)
         {
-            auto builder{ AppNotificationBuilder().SetScenario(AppNotificationScenario::Alarm) };
+            auto builder{ winrt::AppNotificationBuilder().SetScenario(winrt::AppNotificationScenario::Alarm) };
             auto expected{ L"<toast scenario='alarm'><visual><binding template='ToastGeneric'></binding></visual></toast>" };
 
             VERIFY_ARE_EQUAL(builder.BuildNotification().Payload(), expected);
@@ -138,7 +150,7 @@ namespace Test::AppNotification::Builder
 
         TEST_METHOD(AppNotificationBuilderSetIncomingCallScenario)
         {
-            auto builder{ AppNotificationBuilder().SetScenario(AppNotificationScenario::IncomingCall) };
+            auto builder{ winrt::AppNotificationBuilder().SetScenario(winrt::AppNotificationScenario::IncomingCall) };
             auto expected{ L"<toast scenario='incomingCall'><visual><binding template='ToastGeneric'></binding></visual></toast>" };
 
             VERIFY_ARE_EQUAL(builder.BuildNotification().Payload(), expected);
@@ -146,7 +158,7 @@ namespace Test::AppNotification::Builder
 
         TEST_METHOD(AppNotificationBuilderSetUrgentScenario)
         {
-            auto builder{ AppNotificationBuilder().SetScenario(AppNotificationScenario::Urgent) };
+            auto builder{ winrt::AppNotificationBuilder().SetScenario(winrt::AppNotificationScenario::Urgent) };
             auto expected{ L"<toast scenario='urgent'><visual><binding template='ToastGeneric'></binding></visual></toast>" };
 
             VERIFY_ARE_EQUAL(builder.BuildNotification().Payload(), expected);
@@ -154,7 +166,7 @@ namespace Test::AppNotification::Builder
 
         TEST_METHOD(AppNotificationBuilderAddText)
         {
-            auto builder{ AppNotificationBuilder().AddText(L"content") };
+            auto builder{ winrt::AppNotificationBuilder().AddText(L"content") };
             auto expected{ L"<toast><visual><binding template='ToastGeneric'><text>content</text></binding></visual></toast>" };
 
             VERIFY_ARE_EQUAL(builder.BuildNotification().Payload(), expected);
@@ -162,8 +174,8 @@ namespace Test::AppNotification::Builder
 
         TEST_METHOD(AppNotificationBuilderAddTextWithLanguage)
         {
-            auto builder{ AppNotificationBuilder()
-                            .AddText(L"content", AppNotificationTextProperties()
+            auto builder{ winrt::AppNotificationBuilder()
+                            .AddText(L"content", winrt::AppNotificationTextProperties()
                                 .SetLanguage(L"en-US"))
             };
             auto expected{ L"<toast><visual><binding template='ToastGeneric'><text lang='en-US'>content</text></binding></visual></toast>" };
@@ -173,8 +185,8 @@ namespace Test::AppNotification::Builder
 
         TEST_METHOD(AppNotificationBuilderAddTextWithMaxLines)
         {
-            auto builder{ AppNotificationBuilder()
-                            .AddText(L"content", AppNotificationTextProperties()
+            auto builder{ winrt::AppNotificationBuilder()
+                            .AddText(L"content", winrt::AppNotificationTextProperties()
                                 .SetMaxLines(2))
             };
             auto expected{ L"<toast><visual><binding template='ToastGeneric'><text hint-maxLines='2'>content</text></binding></visual></toast>" };
@@ -184,8 +196,8 @@ namespace Test::AppNotification::Builder
 
         TEST_METHOD(AppNotificationBuilderAddTextWithCallScenarioAlign)
         {
-            auto builder{ AppNotificationBuilder()
-                            .AddText(L"content", AppNotificationTextProperties()
+            auto builder{ winrt::AppNotificationBuilder()
+                            .AddText(L"content", winrt::AppNotificationTextProperties()
                                 .SetIncomingCallAlignment())
             };
             auto expected{ L"<toast scenario='incomingCall'><visual><binding template='ToastGeneric'><text hint-callScenarioCenterAlign='true'>content</text></binding></visual></toast>" };
@@ -195,8 +207,8 @@ namespace Test::AppNotification::Builder
 
         TEST_METHOD(AppNotificationBuilderAddTextWithAllProperties)
         {
-            auto builder{ AppNotificationBuilder()
-                            .AddText(L"content", AppNotificationTextProperties()
+            auto builder{ winrt::AppNotificationBuilder()
+                            .AddText(L"content", winrt::AppNotificationTextProperties()
                                 .SetLanguage(L"en-US")
                                 .SetMaxLines(2)
                                 .SetIncomingCallAlignment())
@@ -208,7 +220,7 @@ namespace Test::AppNotification::Builder
 
         TEST_METHOD(AppNotificationBuilderAddTextThrows)
         {
-            VERIFY_THROWS_HR(AppNotificationBuilder()
+            VERIFY_THROWS_HR(winrt::AppNotificationBuilder()
                 .AddText(L"content")
                 .AddText(L"content")
                 .AddText(L"content")
@@ -217,7 +229,7 @@ namespace Test::AppNotification::Builder
 
         TEST_METHOD(AppNotificationBuilderAddAttributionText)
         {
-            auto builder{ AppNotificationBuilder().SetAttributionText(L"content") };
+            auto builder{ winrt::AppNotificationBuilder().SetAttributionText(L"content") };
             auto expected{ L"<toast><visual><binding template='ToastGeneric'><text placement='attribution'>content</text></binding></visual></toast>" };
 
             VERIFY_ARE_EQUAL(builder.BuildNotification().Payload(), expected);
@@ -225,7 +237,7 @@ namespace Test::AppNotification::Builder
 
         TEST_METHOD(AppNotificationBuilderAddAttributionTextWithLanguage)
         {
-            auto builder{ AppNotificationBuilder().SetAttributionText(L"content", L"en-US")};
+            auto builder{ winrt::AppNotificationBuilder().SetAttributionText(L"content", L"en-US")};
             auto expected{ L"<toast><visual><binding template='ToastGeneric'><text placement='attribution' lang='en-US'>content</text></binding></visual></toast>" };
 
             VERIFY_ARE_EQUAL(builder.BuildNotification().Payload(), expected);
@@ -233,7 +245,7 @@ namespace Test::AppNotification::Builder
 
         TEST_METHOD(AppNotificationBuilderSetInlineImage)
         {
-            auto builder{ AppNotificationBuilder().SetInlineImage(c_sampleUri) };
+            auto builder{ winrt::AppNotificationBuilder().SetInlineImage(c_sampleUri) };
             auto expected{ L"<toast><visual><binding template='ToastGeneric'><image src='http://www.microsoft.com/'/></binding></visual></toast>" };
 
             VERIFY_ARE_EQUAL(builder.BuildNotification().Payload(), expected);
@@ -241,7 +253,7 @@ namespace Test::AppNotification::Builder
 
         TEST_METHOD(AppNotificationBuilderSetInlineImageWithProperties)
         {
-            auto builder{ AppNotificationBuilder().SetInlineImage(c_sampleUri, AppNotificationImageCrop::Circle, L"altText")};
+            auto builder{ winrt::AppNotificationBuilder().SetInlineImage(c_sampleUri, winrt::AppNotificationImageCrop::Circle, L"altText")};
             auto expected{ L"<toast><visual><binding template='ToastGeneric'><image src='http://www.microsoft.com/' alt='altText' hint-crop='circle'/></binding></visual></toast>" };
 
             VERIFY_ARE_EQUAL(builder.BuildNotification().Payload(), expected);
@@ -249,7 +261,7 @@ namespace Test::AppNotification::Builder
 
         TEST_METHOD(AppNotificationBuilderSetAppLogoOverride)
         {
-            auto builder{ AppNotificationBuilder().SetAppLogoOverride(c_sampleUri) };
+            auto builder{ winrt::AppNotificationBuilder().SetAppLogoOverride(c_sampleUri) };
             auto expected{ L"<toast><visual><binding template='ToastGeneric'><image placement='appLogoOverride' src='http://www.microsoft.com/'/></binding></visual></toast>" };
 
             VERIFY_ARE_EQUAL(builder.BuildNotification().Payload(), expected);
@@ -257,7 +269,7 @@ namespace Test::AppNotification::Builder
 
         TEST_METHOD(AppNotificationBuilderSetAppLogoOverrideProperties)
         {
-            auto builder{ AppNotificationBuilder().SetAppLogoOverride(c_sampleUri, AppNotificationImageCrop::Circle, L"altText") };
+            auto builder{ winrt::AppNotificationBuilder().SetAppLogoOverride(c_sampleUri, winrt::AppNotificationImageCrop::Circle, L"altText") };
             auto expected{ L"<toast><visual><binding template='ToastGeneric'><image placement='appLogoOverride' src='http://www.microsoft.com/' alt='altText' hint-crop='circle'/></binding></visual></toast>" };
 
             VERIFY_ARE_EQUAL(builder.BuildNotification().Payload(), expected);
@@ -265,7 +277,7 @@ namespace Test::AppNotification::Builder
 
         TEST_METHOD(AppNotificationBuilderSetHeroImage)
         {
-            auto builder{ AppNotificationBuilder().SetHeroImage(c_sampleUri) };
+            auto builder{ winrt::AppNotificationBuilder().SetHeroImage(c_sampleUri) };
             auto expected{ L"<toast><visual><binding template='ToastGeneric'><image placement='hero' src='http://www.microsoft.com/'/></binding></visual></toast>" };
 
             VERIFY_ARE_EQUAL(builder.BuildNotification().Payload(), expected);
@@ -273,7 +285,7 @@ namespace Test::AppNotification::Builder
 
         TEST_METHOD(AppNotificationBuilderSetHeroImageWithAlt)
         {
-            auto builder{ AppNotificationBuilder().SetHeroImage(c_sampleUri, L"altText") };
+            auto builder{ winrt::AppNotificationBuilder().SetHeroImage(c_sampleUri, L"altText") };
             auto expected{ L"<toast><visual><binding template='ToastGeneric'><image placement='hero' src='http://www.microsoft.com/' alt='altText'/></binding></visual></toast>" };
 
             VERIFY_ARE_EQUAL(builder.BuildNotification().Payload(), expected);
@@ -281,8 +293,8 @@ namespace Test::AppNotification::Builder
 
         TEST_METHOD(AppNotificationBuilderAddButton)
         {
-            auto builder{ AppNotificationBuilder()
-                .AddButton(AppNotificationButton(L"content")
+            auto builder{ winrt::AppNotificationBuilder()
+                .AddButton(winrt::AppNotificationButton(L"content")
                 .AddArgument(L"key", L"value"))
             };
             auto expected{ L"<toast><visual><binding template='ToastGeneric'></binding></visual><actions><action content='content' arguments='key=value'/></actions></toast>" };
@@ -292,8 +304,8 @@ namespace Test::AppNotification::Builder
 
         TEST_METHOD(AppNotificationBuilderAddButtonWithPlacement)
         {
-            auto builder{ AppNotificationBuilder()
-                .AddButton(AppNotificationButton(L"content")
+            auto builder{ winrt::AppNotificationBuilder()
+                .AddButton(winrt::AppNotificationButton(L"content")
                 .AddArgument(L"key", L"value")
                 .SetContextMenuPlacement())
             };
@@ -304,19 +316,19 @@ namespace Test::AppNotification::Builder
 
         TEST_METHOD(AppNotificationBuilderTooManyButtons)
         {
-            VERIFY_THROWS_HR(AppNotificationBuilder()
-                .AddButton(AppNotificationButton(L"content").AddArgument(L"key1", L"value1"))
-                .AddButton(AppNotificationButton(L"content").AddArgument(L"key2", L"value2"))
-                .AddButton(AppNotificationButton(L"content").AddArgument(L"key3", L"value3"))
-                .AddButton(AppNotificationButton(L"content").AddArgument(L"key4", L"value4"))
-                .AddButton(AppNotificationButton(L"content").AddArgument(L"key5", L"value5"))
-                .AddButton(AppNotificationButton(L"content").AddArgument(L"key6", L"value6")), E_INVALIDARG);
+            VERIFY_THROWS_HR(winrt::AppNotificationBuilder()
+                .AddButton(winrt::AppNotificationButton(L"content").AddArgument(L"key1", L"value1"))
+                .AddButton(winrt::AppNotificationButton(L"content").AddArgument(L"key2", L"value2"))
+                .AddButton(winrt::AppNotificationButton(L"content").AddArgument(L"key3", L"value3"))
+                .AddButton(winrt::AppNotificationButton(L"content").AddArgument(L"key4", L"value4"))
+                .AddButton(winrt::AppNotificationButton(L"content").AddArgument(L"key5", L"value5"))
+                .AddButton(winrt::AppNotificationButton(L"content").AddArgument(L"key6", L"value6")), E_INVALIDARG);
         }
 
         TEST_METHOD(AppNotificationBuilderAddButtonWithProtocolActivation)
         {
-            auto builder{ AppNotificationBuilder()
-                .AddButton(AppNotificationButton(L"content")
+            auto builder{ winrt::AppNotificationBuilder()
+                .AddButton(winrt::AppNotificationButton(L"content")
                 .SetInvokeUri(c_sampleUri))
             };
             auto expected{ L"<toast><visual><binding template='ToastGeneric'></binding></visual><actions><action content='content' arguments='http://www.microsoft.com/' activationType='protocol'/></actions></toast>" };
@@ -326,10 +338,10 @@ namespace Test::AppNotification::Builder
 
         TEST_METHOD(AppNotificationBuilderAddButtonWithProperties)
         {
-            auto builder{ AppNotificationBuilder()
-                .AddButton(AppNotificationButton(L"content")
+            auto builder{ winrt::AppNotificationBuilder()
+                .AddButton(winrt::AppNotificationButton(L"content")
                 .AddArgument(L"key", L"value")
-                .SetButtonStyle(AppNotificationButtonStyle::Success)
+                .SetButtonStyle(winrt::AppNotificationButtonStyle::Success)
                 .SetIcon(c_sampleUri)
                 .SetInputId(L"inputId")
                 .SetToolTip(L"toolTip"))
@@ -341,27 +353,27 @@ namespace Test::AppNotification::Builder
 
         TEST_METHOD(AppNotificationBuilderAddButtonWithEmptyKey)
         {
-            VERIFY_THROWS_HR(AppNotificationBuilder()
-                .AddButton(AppNotificationButton(L"content")
+            VERIFY_THROWS_HR(winrt::AppNotificationBuilder()
+                .AddButton(winrt::AppNotificationButton(L"content")
                     .AddArgument(L"", L"value")), E_INVALIDARG);
         }
 
         TEST_METHOD(AppNotificationBuilderAddButtonWithArgumentAndProtocol)
         {
-            VERIFY_THROWS_HR(AppNotificationBuilder()
-                .AddButton(AppNotificationButton(L"content")
+            VERIFY_THROWS_HR(winrt::AppNotificationBuilder()
+                .AddButton(winrt::AppNotificationButton(L"content")
                     .AddArgument(L"key", L"value")
                     .SetInvokeUri(c_sampleUri)), E_INVALIDARG);
 
-            VERIFY_THROWS_HR(AppNotificationBuilder()
-                .AddButton(AppNotificationButton(L"content")
+            VERIFY_THROWS_HR(winrt::AppNotificationBuilder()
+                .AddButton(winrt::AppNotificationButton(L"content")
                     .SetInvokeUri(c_sampleUri)
                     .AddArgument(L"key", L"value")), E_INVALIDARG);
         }
 
         TEST_METHOD(AppNotificationBuilderSetAudioWithUri)
         {
-            auto builder{ AppNotificationBuilder()
+            auto builder{ winrt::AppNotificationBuilder()
                     .SetAudioUri(c_sampleUri) };
             auto expected{ L"<toast><visual><binding template='ToastGeneric'></binding></visual><audio src='http://www.microsoft.com/'/></toast>" };
 
@@ -370,9 +382,9 @@ namespace Test::AppNotification::Builder
 
         TEST_METHOD(AppNotificationBuilderSetAudioWithUriAndDuration)
         {
-            auto builder{ AppNotificationBuilder()
-                    .SetDuration(AppNotificationDuration::Long)
-                    .SetAudioUri(c_sampleUri, AppNotificationAudioLooping::Loop) };
+            auto builder{ winrt::AppNotificationBuilder()
+                    .SetDuration(winrt::AppNotificationDuration::Long)
+                    .SetAudioUri(c_sampleUri, winrt::AppNotificationAudioLooping::Loop) };
             auto expected{ L"<toast duration='long'><visual><binding template='ToastGeneric'></binding></visual><audio src='http://www.microsoft.com/' loop='true'/></toast>" };
 
             VERIFY_ARE_EQUAL(builder.BuildNotification().Payload(), expected);
@@ -380,8 +392,8 @@ namespace Test::AppNotification::Builder
 
         TEST_METHOD(AppNotificationBuilderSetAudioWithSoundEvent)
         {
-            auto builder{ AppNotificationBuilder()
-                    .SetAudioEvent(AppNotificationSoundEvent::Reminder) };
+            auto builder{ winrt::AppNotificationBuilder()
+                    .SetAudioEvent(winrt::AppNotificationSoundEvent::Reminder) };
             auto expected{ L"<toast><visual><binding template='ToastGeneric'></binding></visual><audio src='ms-winsoundevent:Notification.Reminder'/></toast>" };
 
             VERIFY_ARE_EQUAL(builder.BuildNotification().Payload(), expected);
@@ -389,9 +401,9 @@ namespace Test::AppNotification::Builder
 
         TEST_METHOD(AppNotificationBuilderSetAudioWithSoundEventAndDuration)
         {
-            auto builder{ AppNotificationBuilder()
-                    .SetDuration(AppNotificationDuration::Long)
-                    .SetAudioEvent(AppNotificationSoundEvent::Reminder, AppNotificationAudioLooping::Loop) };
+            auto builder{ winrt::AppNotificationBuilder()
+                    .SetDuration(winrt::AppNotificationDuration::Long)
+                    .SetAudioEvent(winrt::AppNotificationSoundEvent::Reminder, winrt::AppNotificationAudioLooping::Loop) };
             auto expected{ L"<toast duration='long'><visual><binding template='ToastGeneric'></binding></visual><audio src='ms-winsoundevent:Notification.Reminder' loop='true'/></toast>" };
 
             VERIFY_ARE_EQUAL(builder.BuildNotification().Payload(), expected);
@@ -399,7 +411,7 @@ namespace Test::AppNotification::Builder
 
         TEST_METHOD(AppNotificationBuilderMuteAudio)
         {
-            auto builder{ AppNotificationBuilder().MuteAudio() };
+            auto builder{ winrt::AppNotificationBuilder().MuteAudio() };
             auto expected{ L"<toast><visual><binding template='ToastGeneric'></binding></visual><audio silent='true'/></toast>" };
 
             VERIFY_ARE_EQUAL(builder.BuildNotification().Payload(), expected);

--- a/test/AppNotificationBuilderTests/AppNotificationBuilderTests.vcxproj
+++ b/test/AppNotificationBuilderTests/AppNotificationBuilderTests.vcxproj
@@ -75,7 +75,7 @@
       <PrecompiledHeader>Use</PrecompiledHeader>
       <UseFullPaths>true</UseFullPaths>
       <PrecompiledHeaderFile>pch.h</PrecompiledHeaderFile>
-      <AdditionalIncludeDirectories>$(RepoRoot)\test\inc;$(RepoRoot)\Dev\Common;$(VCInstallDir)UnitTest\include;%(AdditionalIncludeDirectories);$(OutDir)\..\WindowsAppRuntime_DLL;$(OutDir)\..\WindowsAppRuntime_BootstrapDLL</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(RepoRoot)\test\inc;$(RepoRoot)\Dev\Common;$(RepoRoot)\Dev\AppNotifications\AppNotificationBuilder;$(VCInstallDir)UnitTest\include;%(AdditionalIncludeDirectories);$(OutDir)\..\WindowsAppRuntime_DLL;$(OutDir)\..\WindowsAppRuntime_BootstrapDLL</AdditionalIncludeDirectories>
       <AdditionalIncludeDirectories Condition="$(WindowsAppSDKBuildPipeline) == '1'">$(RepoRoot);%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ClCompile>
     <Link>

--- a/test/AppNotificationBuilderTests/AppNotificationBuilderTests.vcxproj.filters
+++ b/test/AppNotificationBuilderTests/AppNotificationBuilderTests.vcxproj.filters
@@ -5,15 +5,27 @@
       <UniqueIdentifier>{67DA6AB6-F800-4c08-8B7A-83BB121AAD01}</UniqueIdentifier>
       <Extensions>rc;ico;cur;bmp;dlg;rc2;rct;bin;rgs;gif;jpg;jpeg;jpe;resx;tga;tiff;tif;png;wav;mfcribbon-ms</Extensions>
     </Filter>
+    <Filter Include="Source Files">
+      <UniqueIdentifier>{4b514c96-7ee8-44e5-aeb3-64c1bc0d6b91}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Header Files">
+      <UniqueIdentifier>{9f96baa5-3d60-4ef4-9ff2-5a5fe8d7367b}</UniqueIdentifier>
+    </Filter>
   </ItemGroup>
   <ItemGroup>
-    <ClCompile Include="pch.cpp" />
-    <ClCompile Include="APITests.cpp" />
-  </ItemGroup>
-  <ItemGroup>
-    <ClInclude Include="pch.h" />
+    <ClCompile Include="APITests.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="pch.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <None Include="packages.config" />
+  </ItemGroup>
+  <ItemGroup>
+    <ClInclude Include="pch.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
   </ItemGroup>
 </Project>

--- a/test/AppNotificationBuilderTests/pch.h
+++ b/test/AppNotificationBuilderTests/pch.h
@@ -43,7 +43,7 @@
 
 #include <winrt/Microsoft.Windows.AppNotifications.h>
 #include <winrt/Microsoft.Windows.AppNotifications.Builder.h>
-#include "../../dev/AppNotifications/AppNotificationBuilder/AppNotificationBuilderUtility.h"
+#include <AppNotificationBuilderUtility.h>
 #include <WindowsAppRuntime.SelfContained.h>
 #include <WindowsAppRuntime.VersionInfo.h>
 

--- a/test/AppNotificationBuilderTests/pch.h
+++ b/test/AppNotificationBuilderTests/pch.h
@@ -43,6 +43,7 @@
 
 #include <winrt/Microsoft.Windows.AppNotifications.h>
 #include <winrt/Microsoft.Windows.AppNotifications.Builder.h>
+#include "../../dev/AppNotifications/AppNotificationBuilder/AppNotificationBuilderUtility.h"
 #include <WindowsAppRuntime.SelfContained.h>
 #include <WindowsAppRuntime.VersionInfo.h>
 

--- a/test/TestApps/ToastNotificationsDemoApp/ToastNotificationsDemoApp.vcxproj
+++ b/test/TestApps/ToastNotificationsDemoApp/ToastNotificationsDemoApp.vcxproj
@@ -211,6 +211,11 @@
       <IsWinMDFile>true</IsWinMDFile>
       <Implementation>$(OutDir)\..\WindowsAppRuntime_DLL\Microsoft.WindowsAppRuntime.dll</Implementation>
     </Reference>
+    <Reference Include="Microsoft.Windows.AppNotifications.Builder">
+      <HintPath>$(OutDir)\..\WindowsAppRuntime_DLL\Microsoft.Windows.AppNotifications.Builder.winmd</HintPath>
+      <IsWinMDFile>true</IsWinMDFile>
+      <Implementation>$(OutDir)\..\WindowsAppRuntime_DLL\Microsoft.WindowsAppRuntime.dll</Implementation>
+    </Reference>
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\..\dev\WindowsAppRuntime_BootstrapDLL\WindowsAppRuntime_BootstrapDLL.vcxproj">

--- a/test/TestApps/ToastNotificationsDemoApp/main.cpp
+++ b/test/TestApps/ToastNotificationsDemoApp/main.cpp
@@ -18,6 +18,7 @@ namespace winrt
     using namespace winrt::Microsoft::Windows::AppLifecycle;
     using namespace winrt::Microsoft::Windows::PushNotifications;
     using namespace winrt::Microsoft::Windows::AppNotifications;
+    using namespace winrt::Microsoft::Windows::AppNotifications::Builder;
     using namespace winrt::Windows::ApplicationModel::Activation;
     using namespace winrt::Windows::ApplicationModel::Background; // BackgroundTask APIs
     using namespace winrt::Windows::Foundation;
@@ -124,7 +125,9 @@ bool PostToastHelper(std::wstring const& tag, std::wstring const& group)
     toast.Tag(tag.c_str());
     toast.Group(group.c_str());
 
-    winrt::AppNotificationManager::Default().Show(toast);
+    auto builder{ winrt::AppNotificationBuilder().AddArgument(L"key", L"value").AddArgument(L"key", L"value").SetTag(tag.c_str()).SetGroup(group.c_str())};
+
+    winrt::AppNotificationManager::Default().Show(builder.BuildNotification());
 
     if (toast.Id() == 0)
     {
@@ -170,11 +173,11 @@ int main()
     winrt::event_token token = appNotificationManager.NotificationInvoked([](const auto&, winrt::AppNotificationActivatedEventArgs const& toastArgs)
         {
             std::wcout << L"AppNotification received foreground!\n";
-            winrt::hstring arguments{ toastArgs.Argument() };
-            std::wcout << arguments.c_str() << L"\n\n";
+            winrt::hstring argument{ toastArgs.Argument() };
+            std::wcout << argument.c_str() << L"\n\n";
 
-            winrt::IMap<winrt::hstring, winrt::hstring> userInput{ toastArgs.UserInput() };
-            for (auto pair : userInput)
+            winrt::IMap<winrt::hstring, winrt::hstring> arguments{ toastArgs.Arguments() };
+            for (auto pair : arguments)
             {
                 std::wcout << "Key= " << pair.Key().c_str() << " " << "Value= " << pair.Value().c_str() << L"\n";
             }
@@ -200,11 +203,11 @@ int main()
     {
         std::wcout << L"Activated by AppNotification from background.\n";
         winrt::AppNotificationActivatedEventArgs appNotificationArgs{ args.Data().as<winrt::AppNotificationActivatedEventArgs>() };
-        winrt::hstring arguments{ appNotificationArgs.Argument() };
-        std::wcout << arguments.c_str() << std::endl << std::endl;
+        winrt::hstring argument{ appNotificationArgs.Argument() };
+        std::wcout << argument.c_str() << std::endl << std::endl;
 
-        winrt::IMap<winrt::hstring, winrt::hstring> userInput = appNotificationArgs.UserInput();
-        for (auto pair : userInput)
+        winrt::IMap<winrt::hstring, winrt::hstring> arguments = appNotificationArgs.Arguments();
+        for (auto pair : arguments)
         {
             std::wcout << "Key= " << pair.Key().c_str() << " " << "Value= " << pair.Value().c_str() << L"\n";
         }

--- a/test/TestApps/ToastNotificationsDemoApp/pch.h
+++ b/test/TestApps/ToastNotificationsDemoApp/pch.h
@@ -17,3 +17,4 @@
 #include <winrt/Microsoft.Windows.AppLifecycle.h>
 #include <winrt/Microsoft.Windows.PushNotifications.h>
 #include <winrt/Microsoft.Windows.AppNotifications.h>
+#include <winrt/Microsoft.Windows.AppNotifications.Builder.h>


### PR DESCRIPTION
This PR contains the implementation of encoding special characters into the activation arguments for AppNotification/Button activation.

The encoded args can be retrieved in the App through AppNotificationActivatedEventArgs.Arguments which returns a decoded mapping of key/values pairs.

Added unit tests to verify correct encoding and manual testing to verify decoding from app activation was returning key/value mapping correctly.