### PR TITLE
AppNotificationBuilder returning a payload instead of an AppNotification

### DIFF
--- a/WindowsAppRuntime.sln
+++ b/WindowsAppRuntime.sln
@@ -354,6 +354,8 @@ Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "AppNotificationBuilderTests
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.Windows.Security.AccessControl.Projection", "dev\Projections\CS\Microsoft.Windows.Security.AccessControl.Projection\Microsoft.Windows.Security.AccessControl.Projection.csproj", "{E6D59245-696F-4D13-ACF6-7ECE6E653367}"
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.Windows.AppNotifications.Builder.Projection", "dev\Projections\CS\Microsoft.Windows.AppNotifications.Builder.Projection\Microsoft.Windows.AppNotifications.Builder.Projection.csproj", "{50BF3E96-3050-4053-B012-BF6993483DA5}"
+EndProject
 Global
 	GlobalSection(SharedMSBuildProjectFiles) = preSolution
 		test\inc\inc.vcxitems*{08bc78e0-63c6-49a7-81b3-6afc3deac4de}*SharedItemsImports = 4
@@ -1390,6 +1392,20 @@ Global
 		{E6D59245-696F-4D13-ACF6-7ECE6E653367}.Release|x64.Build.0 = Release|x64
 		{E6D59245-696F-4D13-ACF6-7ECE6E653367}.Release|x86.ActiveCfg = Release|x86
 		{E6D59245-696F-4D13-ACF6-7ECE6E653367}.Release|x86.Build.0 = Release|x86
+		{50BF3E96-3050-4053-B012-BF6993483DA5}.Debug|Any CPU.ActiveCfg = Debug|x86
+		{50BF3E96-3050-4053-B012-BF6993483DA5}.Debug|ARM64.ActiveCfg = Debug|arm64
+		{50BF3E96-3050-4053-B012-BF6993483DA5}.Debug|ARM64.Build.0 = Debug|arm64
+		{50BF3E96-3050-4053-B012-BF6993483DA5}.Debug|x64.ActiveCfg = Debug|x64
+		{50BF3E96-3050-4053-B012-BF6993483DA5}.Debug|x64.Build.0 = Debug|x64
+		{50BF3E96-3050-4053-B012-BF6993483DA5}.Debug|x86.ActiveCfg = Debug|x86
+		{50BF3E96-3050-4053-B012-BF6993483DA5}.Debug|x86.Build.0 = Debug|x86
+		{50BF3E96-3050-4053-B012-BF6993483DA5}.Release|Any CPU.ActiveCfg = Release|x86
+		{50BF3E96-3050-4053-B012-BF6993483DA5}.Release|ARM64.ActiveCfg = Release|arm64
+		{50BF3E96-3050-4053-B012-BF6993483DA5}.Release|ARM64.Build.0 = Release|arm64
+		{50BF3E96-3050-4053-B012-BF6993483DA5}.Release|x64.ActiveCfg = Release|x64
+		{50BF3E96-3050-4053-B012-BF6993483DA5}.Release|x64.Build.0 = Release|x64
+		{50BF3E96-3050-4053-B012-BF6993483DA5}.Release|x86.ActiveCfg = Release|x86
+		{50BF3E96-3050-4053-B012-BF6993483DA5}.Release|x86.Build.0 = Release|x86
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -1507,6 +1523,7 @@ Global
 		{E49329F3-5196-4BBA-B5C4-E11CE7EFB07A} = {1C9A0791-2BAA-420B-84B6-C0721F22A6E8}
 		{131DE0C4-AA1E-4649-B5BC-7B43508FA93A} = {8630F7AA-2969-4DC9-8700-9B468C1DC21D}
 		{E6D59245-696F-4D13-ACF6-7ECE6E653367} = {716C26A0-E6B0-4981-8412-D14A4D410531}
+		{50BF3E96-3050-4053-B012-BF6993483DA5} = {716C26A0-E6B0-4981-8412-D14A4D410531}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {4B3D7591-CFEC-4762-9A07-ABE99938FB77}

--- a/build/CopyFilesToStagingDir.ps1
+++ b/build/CopyFilesToStagingDir.ps1
@@ -40,6 +40,7 @@ PublishFile $FullBuildOutput\WindowsAppRuntime_DLL\Microsoft.WindowsAppRuntime.d
 PublishFile $FullBuildOutput\WindowsAppRuntime_DLL\Microsoft.WindowsAppRuntime.lib $FullPublishDir\Microsoft.WindowsAppRuntime\
 PublishFile $FullBuildOutput\WindowsAppRuntime_DLL\StrippedWinMD\Microsoft.Windows.AppLifecycle.winmd $FullPublishDir\Microsoft.WindowsAppRuntime\
 PublishFile $FullBuildOutput\WindowsAppRuntime_DLL\StrippedWinMD\Microsoft.Windows.AppNotifications.winmd $FullPublishDir\Microsoft.WindowsAppRuntime\
+PublishFile $FullBuildOutput\WindowsAppRuntime_DLL\StrippedWinMD\Microsoft.Windows.AppNotifications.Builder.winmd $FullPublishDir\Microsoft.WindowsAppRuntime\
 PublishFile $FullBuildOutput\WindowsAppRuntime_DLL\StrippedWinMD\Microsoft.Windows.PushNotifications.winmd $FullPublishDir\Microsoft.WindowsAppRuntime\
 PublishFile $FullBuildOutput\WindowsAppRuntime_DLL\StrippedWinMD\Microsoft.Windows.ApplicationModel.DynamicDependency.winmd $FullPublishDir\Microsoft.WindowsAppRuntime\
 PublishFile $FullBuildOutput\WindowsAppRuntime_DLL\StrippedWinMD\Microsoft.Windows.ApplicationModel.WindowsAppRuntime.winmd $FullPublishDir\Microsoft.WindowsAppRuntime\
@@ -93,6 +94,8 @@ PublishFile $FullBuildOutput\Microsoft.Windows.AppLifecycle.Projection\Microsoft
 PublishFile $FullBuildOutput\Microsoft.Windows.AppLifecycle.Projection\Microsoft.Windows.AppLifecycle.Projection.pdb $NugetDir\lib\net5.0-windows10.0.17763.0
 PublishFile $FullBuildOutput\Microsoft.Windows.AppNotifications.Projection\Microsoft.Windows.AppNotifications.Projection.dll $NugetDir\lib\net5.0-windows10.0.17763.0
 PublishFile $FullBuildOutput\Microsoft.Windows.AppNotifications.Projection\Microsoft.Windows.AppNotifications.Projection.pdb $NugetDir\lib\net5.0-windows10.0.17763.0
+PublishFile $FullBuildOutput\Microsoft.Windows.AppNotifications.Builder.Projection\Microsoft.Windows.AppNotifications.Builder.Projection.dll $NugetDir\lib\net5.0-windows10.0.17763.0
+PublishFile $FullBuildOutput\Microsoft.Windows.AppNotifications.Builder.Projection\Microsoft.Windows.AppNotifications.Builder.Projection.pdb $NugetDir\lib\net5.0-windows10.0.17763.0
 PublishFile $FullBuildOutput\Microsoft.Windows.PushNotifications.Projection\Microsoft.Windows.PushNotifications.Projection.dll $NugetDir\lib\net5.0-windows10.0.17763.0
 PublishFile $FullBuildOutput\Microsoft.Windows.PushNotifications.Projection\Microsoft.Windows.PushNotifications.Projection.pdb $NugetDir\lib\net5.0-windows10.0.17763.0
 PublishFile $FullBuildOutput\Microsoft.Windows.System.Projection\Microsoft.Windows.System.Projection.dll $NugetDir\lib\net5.0-windows10.0.17763.0
@@ -159,6 +162,7 @@ PublishFile $FullBuildOutput\WindowsAppRuntime_MSIXInstallFromPath\WindowsAppRun
 # WinMD for UWP apps
 PublishFile $FullBuildOutput\WindowsAppRuntime_DLL\StrippedWinMD\Microsoft.Windows.AppLifecycle.winmd $NugetDir\lib\uap10.0
 PublishFile $FullBuildOutput\WindowsAppRuntime_DLL\StrippedWinMD\Microsoft.Windows.AppNotifications.winmd $NugetDir\lib\uap10.0
+PublishFile $FullBuildOutput\WindowsAppRuntime_DLL\StrippedWinMD\Microsoft.Windows.AppNotifications.Builder.winmd $NugetDir\lib\uap10.0
 PublishFile $FullBuildOutput\WindowsAppRuntime_DLL\StrippedWinMD\Microsoft.Windows.PushNotifications.winmd $NugetDir\lib\uap10.0
 PublishFile $FullBuildOutput\WindowsAppRuntime_DLL\StrippedWinMD\Microsoft.Windows.ApplicationModel.DynamicDependency.winmd $NugetDir\lib\uap10.0
 PublishFile $FullBuildOutput\WindowsAppRuntime_DLL\StrippedWinMD\Microsoft.Windows.ApplicationModel.WindowsAppRuntime.winmd $NugetDir\lib\uap10.0

--- a/build/NuSpecs/AppxManifest.xml
+++ b/build/NuSpecs/AppxManifest.xml
@@ -63,6 +63,13 @@
           <ActivatableClass ActivatableClassId="Microsoft.Windows.AppNotifications.AppNotificationProgressData" ThreadingModel="both" />
           <ActivatableClass ActivatableClassId="Microsoft.Windows.AppNotifications.AppNotificationActivatedEventArgs" ThreadingModel="both" />
 
+          <!-- AppNotificationBuilder -->
+          <ActivatableClass ActivatableClassId="Microsoft.Windows.AppNotifications.Builder.AppNotificationBuilder" ThreadingModel="both" />
+          <ActivatableClass ActivatableClassId="Microsoft.Windows.AppNotifications.Builder.AppNotificationTextProperties" ThreadingModel="both" />
+          <ActivatableClass ActivatableClassId="Microsoft.Windows.AppNotifications.Builder.AppNotificationButton" ThreadingModel="both" />
+          <ActivatableClass ActivatableClassId="Microsoft.Windows.AppNotifications.Builder.AppNotificationProgressBar" ThreadingModel="both" />
+          <ActivatableClass ActivatableClassId="Microsoft.Windows.AppNotifications.Builder.AppNotificationComboBox" ThreadingModel="both" />
+
           <!-- AccessControl -->
           <ActivatableClass ActivatableClassId="Microsoft.Windows.Security.AccessControl.SecurityDescriptorHelpers" ThreadingModel="both" />
       </InProcessServer>

--- a/dev/AppNotifications/AppNotificationBuilder/AppNotificationBuilder.cpp
+++ b/dev/AppNotifications/AppNotificationBuilder/AppNotificationBuilder.cpp
@@ -244,7 +244,7 @@ namespace winrt::Microsoft::Windows::AppNotifications::Builder::implementation
 
         return *this;
     }
-
+#if 0
     winrt::Microsoft::Windows::AppNotifications::Builder::AppNotificationBuilder AppNotificationBuilder::SetTag(hstring const& value)
     {
         m_tag = value;
@@ -256,7 +256,7 @@ namespace winrt::Microsoft::Windows::AppNotifications::Builder::implementation
         m_group = value;
         return *this;
     }
-
+#endif
     std::wstring AppNotificationBuilder::GetDuration()
     {
         return m_duration == AppNotificationDuration::Default ? L"" : L" duration='long'";
@@ -366,7 +366,7 @@ namespace winrt::Microsoft::Windows::AppNotifications::Builder::implementation
 
         return result;
     }
-
+#if 0
     winrt::Microsoft::Windows::AppNotifications::AppNotification AppNotificationBuilder::BuildNotification()
     {
         // Build the actions string and fill m_useButtonStyle
@@ -392,5 +392,30 @@ namespace winrt::Microsoft::Windows::AppNotifications::Builder::implementation
         appNotification.Group(m_group);
         
         return appNotification;
+    }
+#endif
+
+    hstring AppNotificationBuilder::GetXmlPayload()
+    {
+        // Build the actions string and fill m_useButtonStyle
+        std::wstring actions{ GetActions() };
+
+        auto xmlResult{ wil::str_printf<std::wstring>(L"<toast%ls%ls%ls%ls%ls><visual><binding template='ToastGeneric'>%ls%ls%ls%ls</binding></visual>%ls%ls</toast>",
+            m_timeStamp.c_str(),
+            GetDuration().c_str(),
+            GetScenario().c_str(),
+            GetArguments().c_str(),
+            GetButtonStyle().c_str(),
+            GetText().c_str(),
+            m_attributionText.c_str(),
+            GetImages().c_str(),
+            GetProgressBars().c_str(),
+            m_audio.c_str(),
+            actions.c_str()) };
+
+        THROW_HR_IF_MSG(E_FAIL, xmlResult.size() > c_maxAppNotificationPayload, "Maximum payload size exceeded");
+
+        return xmlResult.c_str();
+
     }
 }

--- a/dev/AppNotifications/AppNotificationBuilder/AppNotificationBuilder.h
+++ b/dev/AppNotifications/AppNotificationBuilder/AppNotificationBuilder.h
@@ -58,10 +58,11 @@ namespace winrt::Microsoft::Windows::AppNotifications::Builder::implementation
 
         winrt::Microsoft::Windows::AppNotifications::Builder::AppNotificationBuilder AddComboBox(AppNotificationComboBox const& value);
 
-        winrt::Microsoft::Windows::AppNotifications::Builder::AppNotificationBuilder SetTag(winrt::hstring const& value);
-        winrt::Microsoft::Windows::AppNotifications::Builder::AppNotificationBuilder SetGroup(winrt::hstring const& value);
+        //winrt::Microsoft::Windows::AppNotifications::Builder::AppNotificationBuilder SetTag(winrt::hstring const& value);
+        //winrt::Microsoft::Windows::AppNotifications::Builder::AppNotificationBuilder SetGroup(winrt::hstring const& value);
 
-        winrt::Microsoft::Windows::AppNotifications::AppNotification BuildNotification();
+        //winrt::Microsoft::Windows::AppNotifications::AppNotification BuildNotification();
+        hstring GetXmlPayload();
 
         static bool IsUrgentScenarioSupported();
 
@@ -91,8 +92,8 @@ namespace winrt::Microsoft::Windows::AppNotifications::Builder::implementation
         std::vector<AppNotificationProgressBar> m_progressBarList{};
         std::vector<std::wstring> m_textBoxList{};
         std::vector<AppNotificationComboBox> m_comboBoxList{};
-        winrt::hstring m_tag{};
-        winrt::hstring m_group{};
+        //winrt::hstring m_tag{};
+        //winrt::hstring m_group{};
     };
 }
 namespace winrt::Microsoft::Windows::AppNotifications::Builder::factory_implementation

--- a/dev/AppNotifications/AppNotificationBuilder/AppNotificationBuilder.idl
+++ b/dev/AppNotifications/AppNotificationBuilder/AppNotificationBuilder.idl
@@ -5,6 +5,10 @@ import "..\AppNotifications\AppNotifications.idl";
 
 namespace Microsoft.Windows.AppNotifications.Builder
 {
+    [contractversion(1)]
+    apicontract AppNotificationBuilderContract {}
+
+    [contract(AppNotificationBuilderContract, 1)]
     runtimeclass AppNotificationTextProperties
     {
         // Contains the set of <text> attributes
@@ -19,6 +23,7 @@ namespace Microsoft.Windows.AppNotifications.Builder
         AppNotificationTextProperties SetMaxLines(Int32 value);
     };
 
+    [contract(AppNotificationBuilderContract, 1)]
     enum AppNotificationButtonStyle
     {
         Default,
@@ -26,6 +31,7 @@ namespace Microsoft.Windows.AppNotifications.Builder
         Critical,
     };
 
+    [contract(AppNotificationBuilderContract, 1)]
     runtimeclass AppNotificationButton
     {
         AppNotificationButton();
@@ -65,6 +71,7 @@ namespace Microsoft.Windows.AppNotifications.Builder
         AppNotificationButton SetInvokeUri(Windows.Foundation.Uri protocolUri, String targetAppId);
     };
 
+    [contract(AppNotificationBuilderContract, 1)]
     runtimeclass AppNotificationProgressBar
     {
         // AppNotificationProgressBar binds to AppNotificationProgressData so the AppNotification will
@@ -92,6 +99,7 @@ namespace Microsoft.Windows.AppNotifications.Builder
         AppNotificationProgressBar BindValueStringOverride();
     };
 
+    [contract(AppNotificationBuilderContract, 1)]
     runtimeclass AppNotificationComboBox
     {
         AppNotificationComboBox(String id);
@@ -110,6 +118,7 @@ namespace Microsoft.Windows.AppNotifications.Builder
         AppNotificationComboBox SetSelectedItem(String id);
     };
 
+    [contract(AppNotificationBuilderContract, 1)]
     enum AppNotificationSoundEvent
     {
         Default,
@@ -139,6 +148,7 @@ namespace Microsoft.Windows.AppNotifications.Builder
         Call10,
     };
 
+    [contract(AppNotificationBuilderContract, 1)]
     enum AppNotificationScenario
     {
         Default, // The normal AppNotification behavior. The AppNotification appears for a short duration, and then automatically dismisses into Notification Center.
@@ -148,24 +158,28 @@ namespace Microsoft.Windows.AppNotifications.Builder
         Urgent, // Important notifications allow users to have more control over what 1st party and 3rd party apps can send them high-priority AppNotifications (urgent/important) that can break through Focus Assist.
     };
 
+    [contract(AppNotificationBuilderContract, 1)]
     enum AppNotificationAudioLooping
     {
         None, // Audio will not loop
         Loop, // Audio will loop for the duration of the AppNotification
     };
 
+    [contract(AppNotificationBuilderContract, 1)]
     enum AppNotificationDuration
     {
         Default, // Default value. AppNotification appears for a short while and then goes into Notification Center.
         Long, // AppNotification stays on-screen for longer, and then goes into Notification Center.
     };
 
+    [contract(AppNotificationBuilderContract, 1)]
     enum AppNotificationImageCrop
     {
         Default, // Uses the default renderer to display the image
         Circle, // Crops the image as a circle.
     };
 
+    [contract(AppNotificationBuilderContract, 1)]
     runtimeclass AppNotificationBuilder
     {
         AppNotificationBuilder();

--- a/dev/AppNotifications/AppNotificationBuilder/AppNotificationBuilder.idl
+++ b/dev/AppNotifications/AppNotificationBuilder/AppNotificationBuilder.idl
@@ -223,10 +223,11 @@ namespace Microsoft.Windows.AppNotifications.Builder
         AppNotificationBuilder AddProgressBar(AppNotificationProgressBar value);
 
         // Constructs a WindowsAppSDK AppNotification object with the XML payload
-        Microsoft.Windows.AppNotifications.AppNotification BuildNotification();
+        //Microsoft.Windows.AppNotifications.AppNotification BuildNotification();
+        String GetXmlPayload();
 
         // AppNotification properties
-        AppNotificationBuilder SetTag(String value);
-        AppNotificationBuilder SetGroup(String group);
+        //AppNotificationBuilder SetTag(String value);
+        //AppNotificationBuilder SetGroup(String group);
     };
 }

--- a/dev/Projections/CS/Microsoft.Windows.AppNotifications.Builder.Projection/Microsoft.Windows.AppNotifications.Builder.Projection.csproj
+++ b/dev/Projections/CS/Microsoft.Windows.AppNotifications.Builder.Projection/Microsoft.Windows.AppNotifications.Builder.Projection.csproj
@@ -1,0 +1,44 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net5.0-windows10.0.17763.0</TargetFramework>
+    <TargetPlatformMinVersion>10.0.17763.0</TargetPlatformMinVersion>
+    <Platforms>x64;x86;arm64</Platforms>
+    <PlatformTarget>AnyCPU</PlatformTarget>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.SourceLink.Common" Version="1.1.0-beta-21055-01">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.0-beta-20204-02">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="Microsoft.Windows.CsWinRT" Version="$(MicrosoftWindowsCsWinRTPackageVersion)" />
+  </ItemGroup>
+
+  <PropertyGroup>
+    <CSWinRTIncludes>Microsoft.Windows.AppNotifications.Builder</CSWinRTIncludes>
+    <CSWinRTWindowsMetadata>10.0.17763.0</CSWinRTWindowsMetadata>
+    <WindowsSdkPackageVersion>10.0.17763.$(CsWinRTDependencyWindowsSdkVersionSuffixPackageVersion)</WindowsSdkPackageVersion>
+  </PropertyGroup>
+
+  <!-- Configure the release build binary to be as required by internal API scanning tools. -->
+  <PropertyGroup Condition="'$(Configuration)'=='Release'">
+    <DebugType>pdbonly</DebugType>
+    <DebugSymbols>true</DebugSymbols>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <CsWinRTInputs Include="$(OutDir)/**/*.winmd" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Reference Include="Microsoft.Windows.AppNotifications.Builder">
+      <HintPath>$(OutDir)..\WindowsAppRuntime_DLL\StrippedWinMD\Microsoft.Windows.AppNotifications.Builder.winmd</HintPath>
+      <IsWinMDFile>true</IsWinMDFile>
+    </Reference>
+  </ItemGroup>
+
+</Project>

--- a/test/AppNotificationBuilderTests/APITests.cpp
+++ b/test/AppNotificationBuilderTests/APITests.cpp
@@ -52,7 +52,7 @@ namespace Test::AppNotification::Builder
         {
             auto builder{ winrt::AppNotificationBuilder() };
             auto expected{ L"<toast><visual><binding template='ToastGeneric'></binding></visual></toast>"};
-            VERIFY_ARE_EQUAL(builder.BuildNotification().Payload(), expected);
+            VERIFY_ARE_EQUAL(builder.GetXmlPayload(), expected);
         }
 
         TEST_METHOD(AppNotificationBuilderSetTimeStamp)
@@ -71,7 +71,7 @@ namespace Test::AppNotification::Builder
             expectedTimestamp.insert(expectedTimestamp.size() - c_offsetIndexValue, L":");
             std::wstring expected{ wil::str_printf<std::wstring>(L"<toast displayTimestamp='%ls'><visual><binding template='ToastGeneric'></binding></visual></toast>", expectedTimestamp.c_str()) };
 
-            VERIFY_ARE_EQUAL(builder.BuildNotification().Payload(), expected);
+            VERIFY_ARE_EQUAL(builder.GetXmlPayload(), expected);
         }
 
         TEST_METHOD(AppNotificationBuilderAddOneArgument)
@@ -79,7 +79,7 @@ namespace Test::AppNotification::Builder
             auto builder{ winrt::AppNotificationBuilder().AddArgument(L"key", L"value") };
             auto expected{ L"<toast launch='key=value'><visual><binding template='ToastGeneric'></binding></visual></toast>" };
 
-            VERIFY_ARE_EQUAL(builder.BuildNotification().Payload(), expected);
+            VERIFY_ARE_EQUAL(builder.GetXmlPayload(), expected);
         }
 
         TEST_METHOD(AppNotificationBuilderAddTwoArguments)
@@ -87,7 +87,7 @@ namespace Test::AppNotification::Builder
             auto builder{ winrt::AppNotificationBuilder().AddArgument(L"key1", L"value1").AddArgument(L"key2", L"value2") };
             auto expected{ L"<toast launch='key1=value1;key2=value2'><visual><binding template='ToastGeneric'></binding></visual></toast>" };
 
-            VERIFY_ARE_EQUAL(builder.BuildNotification().Payload(), expected);
+            VERIFY_ARE_EQUAL(builder.GetXmlPayload(), expected);
         }
 
         TEST_METHOD(AppNotificationBuilderAddArgumentEmptyValue)
@@ -95,7 +95,7 @@ namespace Test::AppNotification::Builder
             auto builder{ winrt::AppNotificationBuilder().AddArgument(L"key", L"") };
             auto expected{ L"<toast launch='key'><visual><binding template='ToastGeneric'></binding></visual></toast>" };
 
-            VERIFY_ARE_EQUAL(builder.BuildNotification().Payload(), expected);
+            VERIFY_ARE_EQUAL(builder.GetXmlPayload(), expected);
         }
 
         TEST_METHOD(AppNotificationBuilderAddArgumentWithPercentChar)
@@ -103,7 +103,7 @@ namespace Test::AppNotification::Builder
             auto builder{ winrt::AppNotificationBuilder().AddArgument(L"k%ey", L"v%alue") };
             auto expected{ L"<toast launch='k%25ey=v%25alue'><visual><binding template='ToastGeneric'></binding></visual></toast>" };
 
-            VERIFY_ARE_EQUAL(builder.BuildNotification().Payload(), expected);
+            VERIFY_ARE_EQUAL(builder.GetXmlPayload(), expected);
         }
 
         TEST_METHOD(AppNotificationBuilderAddArgumentWithEqualChar)
@@ -111,7 +111,7 @@ namespace Test::AppNotification::Builder
             auto builder{ winrt::AppNotificationBuilder().AddArgument(L"k=ey", L"v=alue") };
             auto expected{ L"<toast launch='k%3Dey=v%3Dalue'><visual><binding template='ToastGeneric'></binding></visual></toast>" };
 
-            VERIFY_ARE_EQUAL(builder.BuildNotification().Payload(), expected);
+            VERIFY_ARE_EQUAL(builder.GetXmlPayload(), expected);
         }
 
         TEST_METHOD(AppNotificationBuilderAddArgumentWithSemicolonChar)
@@ -119,7 +119,7 @@ namespace Test::AppNotification::Builder
             auto builder{ winrt::AppNotificationBuilder().AddArgument(L"k;ey", L"v;alue") };
             auto expected{ L"<toast launch='k%3Bey=v%3Balue'><visual><binding template='ToastGeneric'></binding></visual></toast>" };
 
-            VERIFY_ARE_EQUAL(builder.BuildNotification().Payload(), expected);
+            VERIFY_ARE_EQUAL(builder.GetXmlPayload(), expected);
         }
 
         TEST_METHOD(DecodeArguments)
@@ -142,7 +142,7 @@ namespace Test::AppNotification::Builder
             auto builder{ winrt::AppNotificationBuilder().SetScenario(winrt::AppNotificationScenario::Reminder) };
             auto expected{ L"<toast scenario='reminder'><visual><binding template='ToastGeneric'></binding></visual></toast>" };
 
-            VERIFY_ARE_EQUAL(builder.BuildNotification().Payload(), expected);
+            VERIFY_ARE_EQUAL(builder.GetXmlPayload(), expected);
         }
 
         TEST_METHOD(AppNotificationBuilderSetAlarmScenario)
@@ -150,7 +150,7 @@ namespace Test::AppNotification::Builder
             auto builder{ winrt::AppNotificationBuilder().SetScenario(winrt::AppNotificationScenario::Alarm) };
             auto expected{ L"<toast scenario='alarm'><visual><binding template='ToastGeneric'></binding></visual></toast>" };
 
-            VERIFY_ARE_EQUAL(builder.BuildNotification().Payload(), expected);
+            VERIFY_ARE_EQUAL(builder.GetXmlPayload(), expected);
         }
 
         TEST_METHOD(AppNotificationBuilderSetIncomingCallScenario)
@@ -158,7 +158,7 @@ namespace Test::AppNotification::Builder
             auto builder{ winrt::AppNotificationBuilder().SetScenario(winrt::AppNotificationScenario::IncomingCall) };
             auto expected{ L"<toast scenario='incomingCall'><visual><binding template='ToastGeneric'></binding></visual></toast>" };
 
-            VERIFY_ARE_EQUAL(builder.BuildNotification().Payload(), expected);
+            VERIFY_ARE_EQUAL(builder.GetXmlPayload(), expected);
         }
 
         TEST_METHOD(AppNotificationBuilderSetUrgentScenario)
@@ -166,7 +166,7 @@ namespace Test::AppNotification::Builder
             auto builder{ winrt::AppNotificationBuilder().SetScenario(winrt::AppNotificationScenario::Urgent) };
             auto expected{ L"<toast scenario='urgent'><visual><binding template='ToastGeneric'></binding></visual></toast>" };
 
-            VERIFY_ARE_EQUAL(builder.BuildNotification().Payload(), expected);
+            VERIFY_ARE_EQUAL(builder.GetXmlPayload(), expected);
         }
 
         TEST_METHOD(AppNotificationBuilderAddText)
@@ -174,7 +174,7 @@ namespace Test::AppNotification::Builder
             auto builder{ winrt::AppNotificationBuilder().AddText(L"content") };
             auto expected{ L"<toast><visual><binding template='ToastGeneric'><text>content</text></binding></visual></toast>" };
 
-            VERIFY_ARE_EQUAL(builder.BuildNotification().Payload(), expected);
+            VERIFY_ARE_EQUAL(builder.GetXmlPayload(), expected);
         }
 
         TEST_METHOD(AppNotificationBuilderAddTextWithLanguage)
@@ -185,7 +185,7 @@ namespace Test::AppNotification::Builder
             };
             auto expected{ L"<toast><visual><binding template='ToastGeneric'><text lang='en-US'>content</text></binding></visual></toast>" };
 
-            VERIFY_ARE_EQUAL(builder.BuildNotification().Payload(), expected);
+            VERIFY_ARE_EQUAL(builder.GetXmlPayload(), expected);
         }
 
         TEST_METHOD(AppNotificationBuilderAddTextWithMaxLines)
@@ -196,7 +196,7 @@ namespace Test::AppNotification::Builder
             };
             auto expected{ L"<toast><visual><binding template='ToastGeneric'><text hint-maxLines='2'>content</text></binding></visual></toast>" };
 
-            VERIFY_ARE_EQUAL(builder.BuildNotification().Payload(), expected);
+            VERIFY_ARE_EQUAL(builder.GetXmlPayload(), expected);
         }
 
         TEST_METHOD(AppNotificationBuilderAddTextWithCallScenarioAlign)
@@ -207,7 +207,7 @@ namespace Test::AppNotification::Builder
             };
             auto expected{ L"<toast scenario='incomingCall'><visual><binding template='ToastGeneric'><text hint-callScenarioCenterAlign='true'>content</text></binding></visual></toast>" };
 
-            VERIFY_ARE_EQUAL(builder.BuildNotification().Payload(), expected);
+            VERIFY_ARE_EQUAL(builder.GetXmlPayload(), expected);
         }
 
         TEST_METHOD(AppNotificationBuilderAddTextWithAllProperties)
@@ -220,7 +220,7 @@ namespace Test::AppNotification::Builder
             };
             auto expected{ L"<toast scenario='incomingCall'><visual><binding template='ToastGeneric'><text lang='en-US' hint-maxLines='2' hint-callScenarioCenterAlign='true'>content</text></binding></visual></toast>" };
 
-            VERIFY_ARE_EQUAL(builder.BuildNotification().Payload(), expected);
+            VERIFY_ARE_EQUAL(builder.GetXmlPayload(), expected);
         }
 
         TEST_METHOD(AppNotificationBuilderAddTextThrows)
@@ -237,7 +237,7 @@ namespace Test::AppNotification::Builder
             auto builder{ winrt::AppNotificationBuilder().SetAttributionText(L"content") };
             auto expected{ L"<toast><visual><binding template='ToastGeneric'><text placement='attribution'>content</text></binding></visual></toast>" };
 
-            VERIFY_ARE_EQUAL(builder.BuildNotification().Payload(), expected);
+            VERIFY_ARE_EQUAL(builder.GetXmlPayload(), expected);
         }
 
         TEST_METHOD(AppNotificationBuilderAddAttributionTextWithLanguage)
@@ -245,7 +245,7 @@ namespace Test::AppNotification::Builder
             auto builder{ winrt::AppNotificationBuilder().SetAttributionText(L"content", L"en-US")};
             auto expected{ L"<toast><visual><binding template='ToastGeneric'><text placement='attribution' lang='en-US'>content</text></binding></visual></toast>" };
 
-            VERIFY_ARE_EQUAL(builder.BuildNotification().Payload(), expected);
+            VERIFY_ARE_EQUAL(builder.GetXmlPayload(), expected);
         }
 
         TEST_METHOD(AppNotificationBuilderSetInlineImage)
@@ -253,7 +253,7 @@ namespace Test::AppNotification::Builder
             auto builder{ winrt::AppNotificationBuilder().SetInlineImage(c_sampleUri) };
             auto expected{ L"<toast><visual><binding template='ToastGeneric'><image src='http://www.microsoft.com/'/></binding></visual></toast>" };
 
-            VERIFY_ARE_EQUAL(builder.BuildNotification().Payload(), expected);
+            VERIFY_ARE_EQUAL(builder.GetXmlPayload(), expected);
         }
 
         TEST_METHOD(AppNotificationBuilderSetInlineImageWithProperties)
@@ -261,7 +261,7 @@ namespace Test::AppNotification::Builder
             auto builder{ winrt::AppNotificationBuilder().SetInlineImage(c_sampleUri, winrt::AppNotificationImageCrop::Circle, L"altText")};
             auto expected{ L"<toast><visual><binding template='ToastGeneric'><image src='http://www.microsoft.com/' alt='altText' hint-crop='circle'/></binding></visual></toast>" };
 
-            VERIFY_ARE_EQUAL(builder.BuildNotification().Payload(), expected);
+            VERIFY_ARE_EQUAL(builder.GetXmlPayload(), expected);
         }
 
         TEST_METHOD(AppNotificationBuilderSetAppLogoOverride)
@@ -269,7 +269,7 @@ namespace Test::AppNotification::Builder
             auto builder{ winrt::AppNotificationBuilder().SetAppLogoOverride(c_sampleUri) };
             auto expected{ L"<toast><visual><binding template='ToastGeneric'><image placement='appLogoOverride' src='http://www.microsoft.com/'/></binding></visual></toast>" };
 
-            VERIFY_ARE_EQUAL(builder.BuildNotification().Payload(), expected);
+            VERIFY_ARE_EQUAL(builder.GetXmlPayload(), expected);
         }
 
         TEST_METHOD(AppNotificationBuilderSetAppLogoOverrideProperties)
@@ -277,7 +277,7 @@ namespace Test::AppNotification::Builder
             auto builder{ winrt::AppNotificationBuilder().SetAppLogoOverride(c_sampleUri, winrt::AppNotificationImageCrop::Circle, L"altText") };
             auto expected{ L"<toast><visual><binding template='ToastGeneric'><image placement='appLogoOverride' src='http://www.microsoft.com/' alt='altText' hint-crop='circle'/></binding></visual></toast>" };
 
-            VERIFY_ARE_EQUAL(builder.BuildNotification().Payload(), expected);
+            VERIFY_ARE_EQUAL(builder.GetXmlPayload(), expected);
         }
 
         TEST_METHOD(AppNotificationBuilderSetHeroImage)
@@ -285,7 +285,7 @@ namespace Test::AppNotification::Builder
             auto builder{ winrt::AppNotificationBuilder().SetHeroImage(c_sampleUri) };
             auto expected{ L"<toast><visual><binding template='ToastGeneric'><image placement='hero' src='http://www.microsoft.com/'/></binding></visual></toast>" };
 
-            VERIFY_ARE_EQUAL(builder.BuildNotification().Payload(), expected);
+            VERIFY_ARE_EQUAL(builder.GetXmlPayload(), expected);
         }
 
         TEST_METHOD(AppNotificationBuilderSetHeroImageWithAlt)
@@ -293,7 +293,7 @@ namespace Test::AppNotification::Builder
             auto builder{ winrt::AppNotificationBuilder().SetHeroImage(c_sampleUri, L"altText") };
             auto expected{ L"<toast><visual><binding template='ToastGeneric'><image placement='hero' src='http://www.microsoft.com/' alt='altText'/></binding></visual></toast>" };
 
-            VERIFY_ARE_EQUAL(builder.BuildNotification().Payload(), expected);
+            VERIFY_ARE_EQUAL(builder.GetXmlPayload(), expected);
         }
 
         TEST_METHOD(AppNotificationBuilderAddButton)
@@ -304,7 +304,7 @@ namespace Test::AppNotification::Builder
             };
             auto expected{ L"<toast><visual><binding template='ToastGeneric'></binding></visual><actions><action content='content' arguments='key=value'/></actions></toast>" };
 
-            VERIFY_ARE_EQUAL(builder.BuildNotification().Payload(), expected);
+            VERIFY_ARE_EQUAL(builder.GetXmlPayload(), expected);
         }
 
         TEST_METHOD(AppNotificationBuilderAddButtonWithPlacement)
@@ -316,7 +316,7 @@ namespace Test::AppNotification::Builder
             };
             auto expected{ L"<toast><visual><binding template='ToastGeneric'></binding></visual><actions><action content='content' arguments='key=value' placement='contextMenu'/></actions></toast>" };
 
-            VERIFY_ARE_EQUAL(builder.BuildNotification().Payload(), expected);
+            VERIFY_ARE_EQUAL(builder.GetXmlPayload(), expected);
         }
 
         TEST_METHOD(AppNotificationBuilderTooManyButtons)
@@ -338,7 +338,7 @@ namespace Test::AppNotification::Builder
             };
             auto expected{ L"<toast><visual><binding template='ToastGeneric'></binding></visual><actions><action content='content' arguments='http://www.microsoft.com/' activationType='protocol'/></actions></toast>" };
 
-            VERIFY_ARE_EQUAL(builder.BuildNotification().Payload(), expected);
+            VERIFY_ARE_EQUAL(builder.GetXmlPayload(), expected);
         }
 
         TEST_METHOD(AppNotificationBuilderAddButtonWithProperties)
@@ -353,7 +353,7 @@ namespace Test::AppNotification::Builder
             };
             auto expected{ L"<toast useButtonStyle='true'><visual><binding template='ToastGeneric'></binding></visual><actions><action content='content' arguments='key=value' imageUri='http://www.microsoft.com/' hint-inputId='inputId' hint-buttonStyle='Success' hint-toolTip='toolTip'/></actions></toast>"};
 
-            VERIFY_ARE_EQUAL(builder.BuildNotification().Payload(), expected);
+            VERIFY_ARE_EQUAL(builder.GetXmlPayload(), expected);
         }
 
         TEST_METHOD(AppNotificationBuilderAddButtonWithEmptyKey)
@@ -382,7 +382,7 @@ namespace Test::AppNotification::Builder
                     .SetAudioUri(c_sampleUri) };
             auto expected{ L"<toast><visual><binding template='ToastGeneric'></binding></visual><audio src='http://www.microsoft.com/'/></toast>" };
 
-            VERIFY_ARE_EQUAL(builder.BuildNotification().Payload(), expected);
+            VERIFY_ARE_EQUAL(builder.GetXmlPayload(), expected);
         }
 
         TEST_METHOD(AppNotificationBuilderSetAudioWithUriAndDuration)
@@ -392,7 +392,7 @@ namespace Test::AppNotification::Builder
                     .SetAudioUri(c_sampleUri, winrt::AppNotificationAudioLooping::Loop) };
             auto expected{ L"<toast duration='long'><visual><binding template='ToastGeneric'></binding></visual><audio src='http://www.microsoft.com/' loop='true'/></toast>" };
 
-            VERIFY_ARE_EQUAL(builder.BuildNotification().Payload(), expected);
+            VERIFY_ARE_EQUAL(builder.GetXmlPayload(), expected);
         }
 
         TEST_METHOD(AppNotificationBuilderSetAudioWithSoundEvent)
@@ -401,7 +401,7 @@ namespace Test::AppNotification::Builder
                     .SetAudioEvent(winrt::AppNotificationSoundEvent::Reminder) };
             auto expected{ L"<toast><visual><binding template='ToastGeneric'></binding></visual><audio src='ms-winsoundevent:Notification.Reminder'/></toast>" };
 
-            VERIFY_ARE_EQUAL(builder.BuildNotification().Payload(), expected);
+            VERIFY_ARE_EQUAL(builder.GetXmlPayload(), expected);
         }
 
         TEST_METHOD(AppNotificationBuilderSetAudioWithSoundEventAndDuration)
@@ -411,7 +411,7 @@ namespace Test::AppNotification::Builder
                     .SetAudioEvent(winrt::AppNotificationSoundEvent::Reminder, winrt::AppNotificationAudioLooping::Loop) };
             auto expected{ L"<toast duration='long'><visual><binding template='ToastGeneric'></binding></visual><audio src='ms-winsoundevent:Notification.Reminder' loop='true'/></toast>" };
 
-            VERIFY_ARE_EQUAL(builder.BuildNotification().Payload(), expected);
+            VERIFY_ARE_EQUAL(builder.GetXmlPayload(), expected);
         }
 
         TEST_METHOD(AppNotificationBuilderMuteAudio)
@@ -419,14 +419,14 @@ namespace Test::AppNotification::Builder
             auto builder{ winrt::AppNotificationBuilder().MuteAudio() };
             auto expected{ L"<toast><visual><binding template='ToastGeneric'></binding></visual><audio silent='true'/></toast>" };
 
-            VERIFY_ARE_EQUAL(builder.BuildNotification().Payload(), expected);
+            VERIFY_ARE_EQUAL(builder.GetXmlPayload(), expected);
         }
 
         TEST_METHOD(AppNotificationBuilderBuildNotificationWithTooLargePayload)
         {
             VERIFY_THROWS_HR(winrt::AppNotificationBuilder()
                 .AddText(std::wstring(5120, 'A').c_str())
-                .BuildNotification(), E_FAIL);
+                .GetXmlPayload(), E_FAIL);
         }
 
         TEST_METHOD(AppNotificationAddProgressBar)
@@ -438,7 +438,7 @@ namespace Test::AppNotification::Builder
                     .BindValueStringOverride()) };
             auto expected{ L"<toast><visual><binding template='ToastGeneric'><text>Downloading this week&apos;s new music...</text><progress title='{progressTitle}' status='{progressStatus}' value='{progressValue}' valueStringOverride='{progressValueString}'/></binding></visual></toast>" };
 
-            VERIFY_ARE_EQUAL(builder.BuildNotification().Payload(), expected);
+            VERIFY_ARE_EQUAL(builder.GetXmlPayload(), expected);
         }
 
         TEST_METHOD(AppNotificationAddMoreThanOneProgressBar)
@@ -453,7 +453,7 @@ namespace Test::AppNotification::Builder
                     .SetStatus(L"Still downloading...")) };
             auto expected{ L"<toast><visual><binding template='ToastGeneric'><text>Downloading this week&apos;s new music...</text><progress title='{progressTitle}' status='{progressStatus}' value='{progressValue}' valueStringOverride='{progressValueString}'/><progress status='Still downloading...' value='0.8'/></binding></visual></toast>" };
 
-            VERIFY_ARE_EQUAL(builder.BuildNotification().Payload(), expected);
+            VERIFY_ARE_EQUAL(builder.GetXmlPayload(), expected);
         }
 
         TEST_METHOD(AppNotificationProgressBarDefaults)
@@ -515,7 +515,7 @@ namespace Test::AppNotification::Builder
                 .AddTextBox(L"input1") };
             auto expected{ L"<toast><visual><binding template='ToastGeneric'></binding></visual><actions><input id='input1' type='text'/></actions></toast>" };
 
-            VERIFY_ARE_EQUAL(builder.BuildNotification().Payload(), expected);
+            VERIFY_ARE_EQUAL(builder.GetXmlPayload(), expected);
         }
 
         TEST_METHOD(AppNotificationBuilderAddTextBoxWithEmptyId)
@@ -547,7 +547,7 @@ namespace Test::AppNotification::Builder
                 .AddTextBox(L"some input id", L"Some placeholder text", L"A Title")};
             auto expected{ L"<toast><visual><binding template='ToastGeneric'></binding></visual><actions><input id='some input id' type='text' placeHolderContent='Some placeholder text' title='A Title'/></actions></toast>" };
 
-            VERIFY_ARE_EQUAL(builder.BuildNotification().Payload(), expected);
+            VERIFY_ARE_EQUAL(builder.GetXmlPayload(), expected);
         }
 
         TEST_METHOD(AppNotificationBuilderAddComboBox)
@@ -561,7 +561,7 @@ namespace Test::AppNotification::Builder
                     .SetSelectedItem(L"item2"))};
             auto expected{ L"<toast><visual><binding template='ToastGeneric'></binding></visual><actions><input id='comboBox1' type='selection' title='ComboBox Title' defaultInput='item2'><selection id='item1' content='item1 text'/><selection id='item2' content='item2 text'/><selection id='item3' content='item3 text'/></input></actions></toast>" };
 
-            VERIFY_ARE_EQUAL(builder.BuildNotification().Payload(), expected);
+            VERIFY_ARE_EQUAL(builder.GetXmlPayload(), expected);
         }
 
         TEST_METHOD(AppNotificationBuilderAddTooManyComboBox)
@@ -651,7 +651,7 @@ namespace Test::AppNotification::Builder
             auto builder{ winrt::AppNotificationBuilder().AddText(LR"(&"'<>)") };
             std::wstring expected{ L"<toast><visual><binding template='ToastGeneric'><text>&amp;&quot;&apos;&lt;&gt;</text></binding></visual></toast>"};
 
-            VERIFY_ARE_EQUAL(builder.BuildNotification().Payload(), expected);
+            VERIFY_ARE_EQUAL(builder.GetXmlPayload(), expected);
         }
 
         TEST_METHOD(AppNotificationBuilderArgumentsWithXmlCharacters)
@@ -661,7 +661,7 @@ namespace Test::AppNotification::Builder
                             .AddArgument(LR"(&"'<>)", L";=%")};
 
             std::wstring expected{ L"<toast launch='&amp;%3B&quot;%3D&apos;%25&lt;&gt;;&amp;&quot;&apos;&lt;&gt;=%3B%3D%25'><visual><binding template='ToastGeneric'></binding></visual></toast>" };
-            VERIFY_ARE_EQUAL(builder.BuildNotification().Payload(), expected);
+            VERIFY_ARE_EQUAL(builder.GetXmlPayload(), expected);
 
             VERIFY_ARE_EQUAL(Decode(LR"(&%3B"%3D'%25<>)"), LR"(&;"='%<>)");
             VERIFY_ARE_EQUAL(Decode(L"%3B%3D%25"), L";=%");

--- a/test/TestApps/ToastNotificationsDemoApp/main.cpp
+++ b/test/TestApps/ToastNotificationsDemoApp/main.cpp
@@ -120,16 +120,18 @@ winrt::AppNotification CreateToastNotification()
 
 bool PostToastHelper(std::wstring const& tag, std::wstring const& group)
 {
-    winrt::AppNotification toast{ CreateToastNotification() };
+    //winrt::AppNotification toast{ CreateToastNotification() };
 
-    toast.Tag(tag.c_str());
-    toast.Group(group.c_str());
+    //toast.Tag(tag.c_str());
+    //toast.Group(group.c_str());
 
-    auto builder{ winrt::AppNotificationBuilder().AddArgument(L"key", L"value").AddArgument(L"key", L"value").SetTag(tag.c_str()).SetGroup(group.c_str())};
+    auto builder{ winrt::AppNotificationBuilder().AddArgument(L"key", L"value").AddArgument(L"key", L"value") };
+    auto appNotification{ winrt::AppNotification(builder.GetXmlPayload()) };
+    appNotification.Tag(tag.c_str());
+    appNotification.Group(group.c_str());
+    winrt::AppNotificationManager::Default().Show(appNotification);
 
-    winrt::AppNotificationManager::Default().Show(builder.BuildNotification());
-
-    if (toast.Id() == 0)
+    if (appNotification.Id() == 0)
     {
         return false;
     }


### PR DESCRIPTION
Alternative to https://github.com/microsoft/WindowsAppSDK/pull/2834 in case no-one can figure out how to set dependencies between AppNotificationBuilder and AppNotification.