### PR TITLE
Don't install x64 framework package on Windows 10 ARM64 devices as it…

### DIFF
--- a/dev/Common/IsWindowsVersion.h
+++ b/dev/Common/IsWindowsVersion.h
@@ -37,7 +37,7 @@ inline bool IsWindows10_20H1OrGreater()
 }
 inline bool IsWindows11_21H2OrGreater()
 {
-    // GetPackageInfo3() added to kernelbase.dll in NTDDI_WIN10_VB (aka 20H1)
+    // GetMachineTypeAttributes() added to kernelbase.dll in NTDDI_WIN10_CO (aka Windows 11 21H2)
     return IsExportPresent(L"kernelbase.dll", "GetMachineTypeAttributes");
 }
 }

--- a/dev/Common/IsWindowsVersion.h
+++ b/dev/Common/IsWindowsVersion.h
@@ -35,6 +35,11 @@ inline bool IsWindows10_20H1OrGreater()
     // GetPackageInfo3() added to kernelbase.dll in NTDDI_WIN10_VB (aka 20H1)
     return IsExportPresent(L"kernelbase.dll", "GetPackageInfo3");
 }
+inline bool IsWindows11_21H2OrGreater()
+{
+    // GetPackageInfo3() added to kernelbase.dll in NTDDI_WIN10_VB (aka 20H1)
+    return IsExportPresent(L"kernelbase.dll", "GetMachineTypeAttributes");
+}
 }
 
 #endif // __ISWINDOWSVERSION_H

--- a/installer/dev/MachineTypeAttributes.h
+++ b/installer/dev/MachineTypeAttributes.h
@@ -9,7 +9,7 @@ namespace MachineTypeAttributes
     // On systems running Windows 11, this inline function returns if given architecture is supported on the system in user mode.
     // On systems running down level Windows versions (ex: Windows 10), this inline function will return false, always.
     // NOTE: If in case, the GetMachineTypeAttributes API that is currently only available on Windows 11 get serviced to down level Windows versions as well,
-    // then on systems running down level Windows versions (ex: Windows 10), this inline function will function same as on Windows 11.
+    // then on systems running down level Windows versions (ex: Windows 10), this inline function will function the same as on Windows 11.
     inline bool IsWindows11_IsArchitectureSupportedInUserMode(USHORT architecture)
     {
         // GetMachineTypeAttributes() added to kernelbase.dll in NTDDI_WIN10_CO (aka Windows 11 21H2, the first market release version of Windows 11).
@@ -25,9 +25,7 @@ namespace MachineTypeAttributes
             if (!getMachineTypeAttributes)
             {
                 // For now, GetMachineTypeAttributes API is available only on Windows 11 (i.e. builds 22000+).
-                // TODO: If GetMachineTypeAttributes API gets serviced downlevel to Windows versions (ex: Windows 10), then we have to THROW_LAST_ERROR
-                // if GetProcAddressByFunctionDeclaration returned NULL, instead of logging last error and returning false here.
-                LOG_LAST_ERROR();
+                THROW_LAST_ERROR();
                 return false;
             }
             else

--- a/installer/dev/MachineTypeAttributes.h
+++ b/installer/dev/MachineTypeAttributes.h
@@ -6,28 +6,39 @@
 
 namespace MachineTypeAttributes
 {
-    using GetMachineTypeAttributesPtr = HRESULT(WINAPI*)(USHORT Machine, MACHINE_ATTRIBUTES* MachineTypeAttributes);
-
     // On systems running Windows 11, this inline function returns if given architecture is supported on the system in user mode.
     // On systems running down level Windows versions (ex: Windows 10), this inline function will return false, always.
+    // NOTE: If in case, the GetMachineTypeAttributes API that is currently only available on Windows 11 get serviced to down level Windows versions as well,
+    // then on systems running down level Windows versions (ex: Windows 10), this inline function will function same as on Windows 11.
     inline bool IsWindows11_IsArchitectureSupportedInUserMode(USHORT architecture)
     {
         // GetMachineTypeAttributes() added to kernelbase.dll in NTDDI_WIN10_CO (aka Windows 11 21H2, the first market release version of Windows 11).
         // So, if that API is available, it indicates current system is running Windows 11.
         wil::unique_hmodule kernelbaseDll{ LoadLibraryExW(L"kernelbase.dll", nullptr, 0) };
-        if (kernelbaseDll)
+        if (!kernelbaseDll)
         {
-            // GetMachineTypeAttributes API is available only on Windows 11 (i.e. builds 22000+)
-            auto getMachineTypeAttributes{ reinterpret_cast<GetMachineTypeAttributesPtr>(GetProcAddress(kernelbaseDll.get(), "GetMachineTypeAttributes")) };
-            if (getMachineTypeAttributes)
+            THROW_LAST_ERROR();
+        }
+        else
+        {
+            auto getMachineTypeAttributes{ GetProcAddressByFunctionDeclaration(kernelbaseDll.get(), GetMachineTypeAttributes) };
+            if (!getMachineTypeAttributes)
             {
-                // If execution entered this block, it means that the current system is running Windows 11.
-                // Further, check explicitly if given architecture is supported on the current system.
+                // For now, GetMachineTypeAttributes API is available only on Windows 11 (i.e. builds 22000+).
+                // TODO: If GetMachineTypeAttributes API gets serviced downlevel to Windows versions (ex: Windows 10), then we have to THROW_LAST_ERROR
+                // if GetProcAddressByFunctionDeclaration returned NULL, instead of logging last error and returning false here.
+                LOG_LAST_ERROR();
+                return false;
+            }
+            else
+            {
+                // If execution entered this block, it means that the current system is running Windows 11
+                // until if and when GetMachineTypeAttributes API is serviced down level Windows versions (ex: Windows 10).
+                // For defense against such possible future changes, also check explicitly if given architecture is supported on the current system.
                 MACHINE_ATTRIBUTES machineAttributes{};
                 THROW_IF_FAILED(getMachineTypeAttributes(architecture, &machineAttributes));
                 return WI_IsFlagSet(machineAttributes, MACHINE_ATTRIBUTES::UserEnabled);
             }
-            return false;
         }
         return false;
     }

--- a/installer/dev/MachineTypeAttributes.h
+++ b/installer/dev/MachineTypeAttributes.h
@@ -1,0 +1,34 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+#pragma once
+
+#include "pch.h"
+
+namespace MachineTypeAttributes
+{
+    using GetMachineTypeAttributesPtr = HRESULT(WINAPI*)(USHORT Machine, MACHINE_ATTRIBUTES* MachineTypeAttributes);
+
+    // On systems running Windows 11, this inline function returns if given architecture is supported on the system in user mode.
+    // On systems running down level Windows versions (ex: Windows 10), this inline function will return false, always.
+    inline bool IsWindows11_IsArchitectureSupportedInUserMode(USHORT architecture)
+    {
+        // GetMachineTypeAttributes() added to kernelbase.dll in NTDDI_WIN10_CO (aka Windows 11 21H2, the first market release version of Windows 11).
+        // So, if that API is available, it indicates current system is running Windows 11.
+        wil::unique_hmodule kernelbaseDll{ LoadLibraryExW(L"kernelbase.dll", nullptr, 0) };
+        if (kernelbaseDll)
+        {
+            // GetMachineTypeAttributes API is available only on Windows 11 (i.e. builds 22000+)
+            auto getMachineTypeAttributes{ reinterpret_cast<GetMachineTypeAttributesPtr>(GetProcAddress(kernelbaseDll.get(), "GetMachineTypeAttributes")) };
+            if (getMachineTypeAttributes)
+            {
+                // If execution entered this block, it means that the current system is running Windows 11.
+                // Further, check explicitly if given architecture is supported on the current system.
+                MACHINE_ATTRIBUTES machineAttributes{};
+                THROW_IF_FAILED(getMachineTypeAttributes(architecture, &machineAttributes));
+                return WI_IsFlagSet(machineAttributes, MACHINE_ATTRIBUTES::UserEnabled);
+            }
+            return false;
+        }
+        return false;
+    }
+}

--- a/installer/dev/WindowsAppRuntimeInstall.vcxproj
+++ b/installer/dev/WindowsAppRuntimeInstall.vcxproj
@@ -43,7 +43,6 @@
   <PropertyGroup Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <PlatformToolset>v143</PlatformToolset>
-    <PlatformToolset Condition="'$(VisualStudioVersion)' == '16.0'">v142</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)'=='Debug'" Label="Configuration">

--- a/installer/dev/WindowsAppRuntimeInstall.vcxproj
+++ b/installer/dev/WindowsAppRuntimeInstall.vcxproj
@@ -11,7 +11,7 @@
     <ProjectGuid>{e6e59b30-9f55-4550-aa73-3b3b3dc89872}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>WindowsAppRuntimeInstall</RootNamespace>
-    <WindowsTargetPlatformVersion Condition=" '$(WindowsTargetPlatformVersion)' == '' ">10.0.19041.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion Condition=" '$(WindowsTargetPlatformVersion)' == '' ">10.0.22000.0</WindowsTargetPlatformVersion>
     <WindowsTargetPlatformMinVersion>10.0.17763.0</WindowsTargetPlatformMinVersion>
   </PropertyGroup>
   <ItemGroup Label="ProjectConfigurations">
@@ -42,7 +42,8 @@
   </ItemGroup>
   <PropertyGroup Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
-    <PlatformToolset>v142</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
+    <PlatformToolset Condition="'$(VisualStudioVersion)' == '16.0'">v142</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)'=='Debug'" Label="Configuration">
@@ -114,6 +115,7 @@
   </ItemDefinitionGroup>
   <ItemGroup>
     <ClInclude Include="console.h" />
+    <ClInclude Include="MachineTypeAttributes.h" />
     <ClInclude Include="InstallActivityContext.h" />
     <ClInclude Include="tracelogging.h" />
     <ClInclude Include="install.h" />

--- a/installer/dev/WindowsAppRuntimeInstall.vcxproj
+++ b/installer/dev/WindowsAppRuntimeInstall.vcxproj
@@ -42,7 +42,7 @@
   </ItemGroup>
   <PropertyGroup Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
-    <PlatformToolset>v143</PlatformToolset>
+    <PlatformToolset>v142</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)'=='Debug'" Label="Configuration">

--- a/installer/dev/WindowsAppRuntimeInstall.vcxproj.filters
+++ b/installer/dev/WindowsAppRuntimeInstall.vcxproj.filters
@@ -42,6 +42,9 @@
     <ClInclude Include="InstallActivityContext.h">
       <Filter>Header Files</Filter>
     </ClInclude>
+    <ClInclude Include="MachineTypeAttributes.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="pch.cpp">

--- a/installer/dev/install.cpp
+++ b/installer/dev/install.cpp
@@ -190,19 +190,12 @@ namespace WindowsAppRuntimeInstaller
         }
 
         // On Windows 11 (i.e. builds 22000+) ARM64 systems, all framework package architectures are applicable.
-        // On Windows 10 (i.e. builds 17763-190**) ARM64 systems (which don't support X64 apps), all but x64 framework package architecture is not applicable.
+        // On Windows 10 (i.e. builds 17763-190**) ARM64 systems (which don't support X64 apps), all x64 framework package architectures, except x64, are applicable.
         if (systemArchitecture == ProcessorArchitecture::Arm64)
         {
             if (packageProperties->architecture == ProcessorArchitecture::X64)
             {
-                if (WindowsVersion::IsWindows11_21H2OrGreater())
-                {
-                    return true;
-                }
-                else
-                {
-                    return false;
-                }
+                return WindowsVersion::IsWindows11_21H2OrGreater();
             }
 
             return true;

--- a/installer/dev/install.cpp
+++ b/installer/dev/install.cpp
@@ -49,7 +49,7 @@ namespace WindowsAppRuntimeInstaller
             winrt::Windows::Management::Deployment::DeploymentOptions::None };
 
         PackageManager packageManager;
-        const auto deploymentOperation{ packageManager.AddPackageAsync(packageUri, nullptr, DeploymentOptions::None) };
+        const auto deploymentOperation{ packageManager.AddPackageAsync(packageUri, nullptr, deploymentOptions) };
         deploymentOperation.get();
         if (deploymentOperation.Status() != AsyncStatus::Completed)
         {
@@ -81,8 +81,6 @@ namespace WindowsAppRuntimeInstaller
         WindowsAppRuntimeInstaller::InstallActivity::Context& installActivityContext,
         const Uri& packageUri)
     {
-        const auto deploymentOptions{ winrt::Windows::Management::Deployment::DeploymentOptions::None };
-
         PackageManager packageManager;
         const auto deploymentOperation{ packageManager.StagePackageAsync(packageUri, nullptr, DeploymentOptions::None) };
         deploymentOperation.get();
@@ -191,9 +189,22 @@ namespace WindowsAppRuntimeInstaller
             return true;
         }
 
-        // On Arm64 systems, all current package architectures are applicable.
+        // On Windows 11 (i.e. builds 22000+) ARM64 systems, all framework package architectures are applicable.
+        // On Windows 10 (i.e. builds 17763-190**) ARM64 systems (which don't support X64 apps), all but x64 framework package architecture is not applicable.
         if (systemArchitecture == ProcessorArchitecture::Arm64)
         {
+            if (packageProperties->architecture == ProcessorArchitecture::X64)
+            {
+                if (WindowsVersion::IsWindows11_21H2OrGreater())
+                {
+                    return true;
+                }
+                else
+                {
+                    return false;
+                }
+            }
+
             return true;
         }
 

--- a/installer/dev/install.cpp
+++ b/installer/dev/install.cpp
@@ -4,6 +4,7 @@
 #include "pch.h"
 #include "packages.h"
 #include "install.h"
+#include "MachineTypeAttributes.h"
 
 EXTERN_C IMAGE_DOS_HEADER __ImageBase;
 
@@ -195,7 +196,7 @@ namespace WindowsAppRuntimeInstaller
         {
             if (packageProperties->architecture == ProcessorArchitecture::X64)
             {
-                return WindowsVersion::IsWindows11_21H2OrGreater();
+                return MachineTypeAttributes::IsWindows11_IsArchitectureSupportedInUserMode(IMAGE_FILE_MACHINE_AMD64);
             }
 
             return true;

--- a/installer/dev/pch.h
+++ b/installer/dev/pch.h
@@ -19,7 +19,7 @@
 #include <shlwapi.h>
 #include <WinBase.h>
 #include <AppxPackaging.h>
-
+#include <processthreadsapi.h>
 #include <string_view>
 
 #include <winrt/Windows.ApplicationModel.h>
@@ -32,7 +32,6 @@
 #include <Security.IntegrityLevel.h>
 #include <Security.User.h>
 #include <PushNotifications-Constants.h>
-#include <IsWindowsVersion.h>
 
 #include "tracelogging.h"
 #include "InstallActivityContext.h"

--- a/installer/dev/pch.h
+++ b/installer/dev/pch.h
@@ -32,6 +32,7 @@
 #include <Security.IntegrityLevel.h>
 #include <Security.User.h>
 #include <PushNotifications-Constants.h>
+#include <IsWindowsVersion.h>
 
 #include "tracelogging.h"
 #include "InstallActivityContext.h"

--- a/installer/test/InstallerFunctionalTests/InstallerFunctionalTests.vcxproj
+++ b/installer/test/InstallerFunctionalTests/InstallerFunctionalTests.vcxproj
@@ -40,7 +40,6 @@
     <ConfigurationType>DynamicLibrary</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
     <PlatformToolset>v143</PlatformToolset>
-    <PlatformToolset Condition="'$(VisualStudioVersion)' == '16.0'">v142</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
     <UseOfMfc>false</UseOfMfc>
   </PropertyGroup>

--- a/installer/test/InstallerFunctionalTests/InstallerFunctionalTests.vcxproj
+++ b/installer/test/InstallerFunctionalTests/InstallerFunctionalTests.vcxproj
@@ -39,7 +39,7 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>v143</PlatformToolset>
+    <PlatformToolset>v142</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
     <UseOfMfc>false</UseOfMfc>
   </PropertyGroup>

--- a/installer/test/InstallerFunctionalTests/InstallerFunctionalTests.vcxproj
+++ b/installer/test/InstallerFunctionalTests/InstallerFunctionalTests.vcxproj
@@ -39,7 +39,8 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>v142</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
+    <PlatformToolset Condition="'$(VisualStudioVersion)' == '16.0'">v142</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
     <UseOfMfc>false</UseOfMfc>
   </PropertyGroup>


### PR DESCRIPTION
Don't install x64 framework package on Windows 10 ARM64 devices. Win 10 ARM64 doesn't support x64 apps.
Tested IsWindows10_21H2OrGreater API on Windows 10 and Windows 11 and works as expected.

And fixed an unused variable deploymentOptions in two places (in one place, it is used now. In another, it is removed altogether).

https://github.com/microsoft/WindowsAppSDK/issues/2564