### PR TITLE
Fix Installer to work on ARM64 on Windows 10

### DIFF
--- a/dev/Common/IsWindowsVersion.h
+++ b/dev/Common/IsWindowsVersion.h
@@ -20,8 +20,17 @@ inline bool IsExportPresent(
         {
             return true;
         }
+        else
+        {
+            DWORD getProcAddressError = GetLastError();
+            if (getProcAddressError != ERROR_PROC_NOT_FOUND)
+            {
+                THROW_HR(HRESULT_FROM_WIN32(getProcAddressError));
+            }
+            return false;
+        }
     }
-    return false;
+    THROW_LAST_ERROR();
 }
 
 inline bool IsWindows10_19H1OrGreater()

--- a/dev/Common/IsWindowsVersion.h
+++ b/dev/Common/IsWindowsVersion.h
@@ -13,24 +13,20 @@ inline bool IsExportPresent(
     PCSTR functionName)
 {
     wil::unique_hmodule dll{ LoadLibraryExW(filename, nullptr, 0) };
-    if (dll)
+    if (!dll)
     {
-        auto function{ GetProcAddress(dll.get(), functionName) };
-        if (function)
-        {
-            return true;
-        }
-        else
-        {
-            DWORD getProcAddressError = GetLastError();
-            if (getProcAddressError != ERROR_PROC_NOT_FOUND)
-            {
-                THROW_HR(HRESULT_FROM_WIN32(getProcAddressError));
-            }
-            return false;
-        }
+        THROW_LAST_ERROR();
     }
-    THROW_LAST_ERROR();
+
+    auto function{ GetProcAddress(dll.get(), functionName) };
+    if (!function)
+    {
+        DWORD getProcAddressError = GetLastError();
+        THROW_HR_IF(HRESULT_FROM_WIN32(getProcAddressError), getProcAddressError != ERROR_PROC_NOT_FOUND);
+        return false;
+    }
+
+    return true;
 }
 
 inline bool IsWindows10_19H1OrGreater()

--- a/dev/Common/IsWindowsVersion.h
+++ b/dev/Common/IsWindowsVersion.h
@@ -15,16 +15,16 @@ inline bool IsExportPresent(
     wil::unique_hmodule dll{ LoadLibraryExW(filename, nullptr, 0) };
     if (!dll)
     {
-        DWORD getLoadLibraryError = GetLastError();
-        THROW_HR_IF(HRESULT_FROM_WIN32(getLoadLibraryError), getLoadLibraryError != ERROR_MOD_NOT_FOUND);
+        const DWORD rcLoadLibraryError = GetLastError();
+        THROW_HR_IF(HRESULT_FROM_WIN32(rcLoadLibraryError), rcLoadLibraryError != ERROR_MOD_NOT_FOUND);
         return false;
     }
 
     auto function{ GetProcAddress(dll.get(), functionName) };
     if (!function)
     {
-        DWORD getProcAddressError = GetLastError();
-        THROW_HR_IF(HRESULT_FROM_WIN32(getProcAddressError), getProcAddressError != ERROR_PROC_NOT_FOUND);
+        const DWORD rcGetProcAddressError = GetLastError();
+        THROW_HR_IF(HRESULT_FROM_WIN32(rcGetProcAddressError), rcGetProcAddressError != ERROR_PROC_NOT_FOUND);
         return false;
     }
 

--- a/dev/Common/IsWindowsVersion.h
+++ b/dev/Common/IsWindowsVersion.h
@@ -15,7 +15,9 @@ inline bool IsExportPresent(
     wil::unique_hmodule dll{ LoadLibraryExW(filename, nullptr, 0) };
     if (!dll)
     {
-        THROW_LAST_ERROR();
+        DWORD getLoadLibraryError = GetLastError();
+        THROW_HR_IF(HRESULT_FROM_WIN32(getLoadLibraryError), getLoadLibraryError != ERROR_MOD_NOT_FOUND);
+        return false;
     }
 
     auto function{ GetProcAddress(dll.get(), functionName) };

--- a/installer/dev/MachineTypeAttributes.h
+++ b/installer/dev/MachineTypeAttributes.h
@@ -17,16 +17,16 @@ namespace MachineTypeAttributes
         wil::unique_hmodule kernelbaseDll{ LoadLibraryExW(L"kernelbase.dll", nullptr, 0) };
         if (!kernelbaseDll)
         {
-            DWORD getLoadLibraryError = GetLastError();
-            THROW_HR_IF(HRESULT_FROM_WIN32(getLoadLibraryError), getLoadLibraryError != ERROR_MOD_NOT_FOUND);
+            const DWORD rcLoadLibraryError = GetLastError();
+            THROW_HR_IF(HRESULT_FROM_WIN32(rcLoadLibraryError), rcLoadLibraryError != ERROR_MOD_NOT_FOUND);
             return false;
         }
 
         auto getMachineTypeAttributes{ GetProcAddressByFunctionDeclaration(kernelbaseDll.get(), GetMachineTypeAttributes) };
         if (!getMachineTypeAttributes)
         {
-            DWORD getProcAddressError = GetLastError();
-            THROW_HR_IF(HRESULT_FROM_WIN32(getProcAddressError), getProcAddressError != ERROR_PROC_NOT_FOUND);
+            const DWORD rcGetProcAddressError = GetLastError();
+            THROW_HR_IF(HRESULT_FROM_WIN32(rcGetProcAddressError), rcGetProcAddressError != ERROR_PROC_NOT_FOUND);
             // If execution comes here, it means the current system is not running Windows 11.
             return false;
         }

--- a/installer/dev/MachineTypeAttributes.h
+++ b/installer/dev/MachineTypeAttributes.h
@@ -17,7 +17,9 @@ namespace MachineTypeAttributes
         wil::unique_hmodule kernelbaseDll{ LoadLibraryExW(L"kernelbase.dll", nullptr, 0) };
         if (!kernelbaseDll)
         {
-            THROW_LAST_ERROR();
+            DWORD getLoadLibraryError = GetLastError();
+            THROW_HR_IF(HRESULT_FROM_WIN32(getLoadLibraryError), getLoadLibraryError != ERROR_MOD_NOT_FOUND);
+            return false;
         }
 
         auto getMachineTypeAttributes{ GetProcAddressByFunctionDeclaration(kernelbaseDll.get(), GetMachineTypeAttributes) };

--- a/installer/dev/main.cpp
+++ b/installer/dev/main.cpp
@@ -80,7 +80,7 @@ int wmain(int argc, wchar_t *argv[])
         }
         else
         {
-            if (WI_IsFlagSet(options, WindowsAppRuntimeInstaller::Options::Quiet))
+            if (WI_IsFlagClear(options, WindowsAppRuntimeInstaller::Options::Quiet))
             {
                 std::wcerr << "Unknown argument: " << arg.data() << std::endl;
                 DisplayHelp();
@@ -100,19 +100,17 @@ int wmain(int argc, wchar_t *argv[])
     LOG_IF_WIN32_BOOL_FALSE(installActivityContext.LogInstallerCommandLineArgs(args.str().c_str()));
     args.clear();
 
-    if (!isElevated)
+    const bool quiet{ WI_IsFlagSet(options, WindowsAppRuntimeInstaller::Options::Quiet) };
+    if (!isElevated && !quiet)
     {
-        if (WI_IsFlagSet(options, WindowsAppRuntimeInstaller::Options::Quiet))
-        {
-            std::wcout << "INFO: Provisioning of WindowsAppSDK packages will be skipped as it requires elevation." << std::endl;
-        }
+        std::wcout << "INFO: Provisioning of WindowsAppSDK packages will be skipped as it requires elevation." << std::endl;
     }
 
     const HRESULT deployPackagesResult{ WindowsAppRuntimeInstaller::Deploy(options) };
 
     if (SUCCEEDED(deployPackagesResult))
     {
-        if (WI_IsFlagSet(options, WindowsAppRuntimeInstaller::Options::Quiet))
+        if (!quiet)
         {
             std::wcout << "All install operations successful." << std::endl;
         }
@@ -132,7 +130,7 @@ int wmain(int argc, wchar_t *argv[])
     }
     else
     {
-        if (WI_IsFlagSet(options, WindowsAppRuntimeInstaller::Options::Quiet))
+        if (!quiet)
         {
             std::wcerr << "One or more install operations failed. Result: 0x" << std::hex << deployPackagesResult << std::endl;
         }

--- a/installer/dev/main.cpp
+++ b/installer/dev/main.cpp
@@ -80,8 +80,12 @@ int wmain(int argc, wchar_t *argv[])
         }
         else
         {
-            std::wcerr << "Unknown argument: " << arg.data() << std::endl;
-            DisplayHelp();
+            if (WI_IsFlagSet(options, WindowsAppRuntimeInstaller::Options::Quiet))
+            {
+                std::wcerr << "Unknown argument: " << arg.data() << std::endl;
+                DisplayHelp();
+            }
+
             installActivityContext.SetActivity(WindowsAppRuntimeInstaller_TraceLogger::Install::Start(args.str().c_str(), static_cast<UINT32>(options), isElevated));
             LOG_IF_WIN32_BOOL_FALSE(installActivityContext.LogInstallerCommandLineArgs(args.str().c_str()));
             LOG_IF_WIN32_BOOL_FALSE(installActivityContext.LogInstallerFailureEvent(HRESULT_FROM_WIN32(ERROR_BAD_ARGUMENTS)));
@@ -98,48 +102,53 @@ int wmain(int argc, wchar_t *argv[])
 
     if (!isElevated)
     {
-        std::wcout << "INFO: Provisioning of WindowsAppSDK packages will be skipped as it requires elevation." << std::endl;
+        if (WI_IsFlagSet(options, WindowsAppRuntimeInstaller::Options::Quiet))
+        {
+            std::wcout << "INFO: Provisioning of WindowsAppSDK packages will be skipped as it requires elevation." << std::endl;
+        }
     }
 
     const HRESULT deployPackagesResult{ WindowsAppRuntimeInstaller::Deploy(options) };
-    if (WI_IsFlagClear(options, WindowsAppRuntimeInstaller::Options::Quiet))
+
+    if (SUCCEEDED(deployPackagesResult))
     {
-        if (SUCCEEDED(deployPackagesResult))
+        if (WI_IsFlagSet(options, WindowsAppRuntimeInstaller::Options::Quiet))
         {
             std::wcout << "All install operations successful." << std::endl;
-
-            LOG_IF_WIN32_BOOL_FALSE(installActivityContext.LogInstallerSuccess());
-
-            installActivityContext.GetActivity().StopWithResult(
-                deployPackagesResult,
-                static_cast <UINT32>(0),
-                static_cast<PCSTR>(nullptr),
-                static_cast <unsigned int>(0),
-                static_cast<PCWSTR>(nullptr),
-                static_cast<UINT32>(WindowsAppRuntimeInstaller::InstallActivity::InstallStage::None),
-                static_cast<PCWSTR>(nullptr),
-                S_OK,
-                static_cast<PCWSTR>(nullptr),
-                GUID_NULL);
         }
-        else
+        LOG_IF_WIN32_BOOL_FALSE(installActivityContext.LogInstallerSuccess());
+
+        installActivityContext.GetActivity().StopWithResult(
+            deployPackagesResult,
+            static_cast <UINT32>(0),
+            static_cast<PCSTR>(nullptr),
+            static_cast <unsigned int>(0),
+            static_cast<PCWSTR>(nullptr),
+            static_cast<UINT32>(WindowsAppRuntimeInstaller::InstallActivity::InstallStage::None),
+            static_cast<PCWSTR>(nullptr),
+            S_OK,
+            static_cast<PCWSTR>(nullptr),
+            GUID_NULL);
+    }
+    else
+    {
+        if (WI_IsFlagSet(options, WindowsAppRuntimeInstaller::Options::Quiet))
         {
             std::wcerr << "One or more install operations failed. Result: 0x" << std::hex << deployPackagesResult << std::endl;
-
-            LOG_IF_WIN32_BOOL_FALSE(installActivityContext.LogInstallerFailureEvent(deployPackagesResult));
-
-            installActivityContext.GetActivity().StopWithResult(
-                deployPackagesResult,
-                static_cast<UINT32>(installActivityContext.GetLastFailure().type),
-                installActivityContext.GetLastFailure().file.c_str(),
-                installActivityContext.GetLastFailure().lineNumber,
-                installActivityContext.GetLastFailure().message.c_str(),
-                static_cast<UINT32>(installActivityContext.GetInstallStage()),
-                installActivityContext.GetCurrentResourceId().c_str(),
-                installActivityContext.GetDeploymentErrorHresult(),
-                installActivityContext.GetDeploymentErrorText().c_str(),
-                installActivityContext.GetDeploymentErrorActivityId());
         }
+        LOG_IF_WIN32_BOOL_FALSE(installActivityContext.LogInstallerFailureEvent(deployPackagesResult));
+
+        installActivityContext.GetActivity().StopWithResult(
+            deployPackagesResult,
+            static_cast<UINT32>(installActivityContext.GetLastFailure().type),
+            installActivityContext.GetLastFailure().file.c_str(),
+            installActivityContext.GetLastFailure().lineNumber,
+            installActivityContext.GetLastFailure().message.c_str(),
+            static_cast<UINT32>(installActivityContext.GetInstallStage()),
+            installActivityContext.GetCurrentResourceId().c_str(),
+            installActivityContext.GetDeploymentErrorHresult(),
+            installActivityContext.GetDeploymentErrorText().c_str(),
+            installActivityContext.GetDeploymentErrorActivityId());
     }
 
     LOG_IF_WIN32_BOOL_FALSE(WindowsAppRuntimeInstaller::InstallActivity::Context::Get().DeregisterInstallerEventSourceW());


### PR DESCRIPTION
1. Fix the logic in determining whether a given Procedure is found in the given library or not.
2. Fix console output that wasn't respecting quiet option.
3. Fix Push notifications LRP restart decision logic to be inclusive of ARM64 architecture as well.

Tested and validated the Installer on a real arm64 devices on both Windows 10 and Windows 11 versions.