### PR TITLE
Add MddGetPackageGraphRevisionId() and PackageGraphRevisionId property

### DIFF
--- a/dev/Common/IsWindowsVersion.h
+++ b/dev/Common/IsWindowsVersion.h
@@ -40,6 +40,11 @@ inline bool IsWindows11_21H2OrGreater()
     // GetMachineTypeAttributes() added to kernelbase.dll in NTDDI_WIN10_CO (aka Windows 11 21H2)
     return IsExportPresent(L"kernelbase.dll", "GetMachineTypeAttributes");
 }
+inline bool IsWindows11_22H2OrGreater()
+{
+    // GetPackageGraphRevisionId() added to kernelbase.dll in NTDDI_WIN10_NI (aka Windows 11 22H2)
+    return IsExportPresent(L"kernelbase.dll", "GetPackageGraphRevisionId");
+}
 }
 
 #endif // __ISWINDOWSVERSION_H

--- a/dev/DynamicDependency/API/M.AM.DD.PackageDependency.cpp
+++ b/dev/DynamicDependency/API/M.AM.DD.PackageDependency.cpp
@@ -76,9 +76,14 @@ namespace winrt::Microsoft::Windows::ApplicationModel::DynamicDependency::implem
         return Create(nullptr, packageFamilyName.c_str(), mddMinVersion, mddArchitectures, mddLifetimeKind, mddLifetimeArtifact, mddOptions);
     }
 
+    uint32_t PackageDependency::PackageGraphRevisionId()
+    {
+        return MddGetPackageGraphRevisionId();
+    }
+
     uint32_t PackageDependency::GenerationId()
     {
-        return MddGetGenerationId();
+        return PackageGraphRevisionId();
     }
 
     hstring PackageDependency::Id()

--- a/dev/DynamicDependency/API/M.AM.DD.PackageDependency.h
+++ b/dev/DynamicDependency/API/M.AM.DD.PackageDependency.h
@@ -20,6 +20,7 @@ namespace winrt::Microsoft::Windows::ApplicationModel::DynamicDependency::implem
         static winrt::PackageDependency Create(hstring const& packageFamilyName, winrt::Windows::ApplicationModel::PackageVersion const& minVersion);
         static winrt::PackageDependency Create(hstring const& packageFamilyName, winrt::Windows::ApplicationModel::PackageVersion const& minVersion, winrt::CreatePackageDependencyOptions const& options);
         static winrt::PackageDependency CreateForSystem(hstring const& packageFamilyName, winrt::Windows::ApplicationModel::PackageVersion const& minVersion, winrt::CreatePackageDependencyOptions const& options);
+        static uint32_t PackageGraphRevisionId();
         static uint32_t GenerationId();
         hstring Id();
         void Delete();

--- a/dev/DynamicDependency/API/M.AM.DynamicDependency.idl
+++ b/dev/DynamicDependency/API/M.AM.DynamicDependency.idl
@@ -3,7 +3,7 @@
 
 namespace Microsoft.Windows.ApplicationModel.DynamicDependency
 {
-    [contractversion(1)]
+    [contractversion(2)]
     apicontract DynamicDependencyContract{};
 
     /// CPU architectures to optionally filter available packages against a package dependency.
@@ -242,6 +242,10 @@ namespace Microsoft.Windows.ApplicationModel.DynamicDependency
         ///
         /// Calls to Add() can be balanced by a PackageDependencyContext.Remove()
         /// to remove the entry from the package graph.
+        ///
+        /// Successful calls change the package graph's current revision id.
+        ///
+        /// @see PackageGraphRevisionId
         PackageDependencyContext Add();
 
         /// Resolve a previously pinned PackageDependency to a specific package and
@@ -277,10 +281,20 @@ namespace Microsoft.Windows.ApplicationModel.DynamicDependency
         ///
         /// Calls to Add() can be balanced by a PackageDependencyContext.Remove() (or object destruction)
         /// to remove the entry from the package graph.
+        ///
+        /// Successful calls change the package graph's current revision id.
+        ///
+        /// @see PackageGraphRevisionId
         PackageDependencyContext Add(AddPackageDependencyOptions options);
 
-        /// Return the package graph's current generation id.
-        /*[experimental]*/
+        /// Return the package graph's current revision id.
+        [contract(DynamicDependencyContract, 2)]
+        static UInt32 PackageGraphRevisionId{ get; };
+
+        /// Return the package graph's current revision id.
+        ///
+        /// @note This API is deprecated and will be removed in a future release.
+        ///       Use the PackageGraphRevisionId property.
         static UInt32 GenerationId{ get; };
     };
 

--- a/dev/DynamicDependency/API/MsixDynamicDependency.cpp
+++ b/dev/DynamicDependency/API/MsixDynamicDependency.cpp
@@ -108,7 +108,12 @@ STDAPI MddGetIdForPackageDependencyContext(
 }
 CATCH_RETURN();
 
+STDAPI_(UINT32) MddGetPackageGraphRevisionId() noexcept
+{
+    return MddCore::PackageGraphManager::GetPackageGraphRevisionId();
+}
+
 STDAPI_(UINT32) MddGetGenerationId() noexcept
 {
-    return MddCore::PackageGraphManager::GetGenerationId();
+    return MddGetPackageGraphRevisionId();
 }

--- a/dev/DynamicDependency/API/MsixDynamicDependency.h
+++ b/dev/DynamicDependency/API/MsixDynamicDependency.h
@@ -29,6 +29,8 @@
 /// MSIX Dynamic Dependency: Bootstrap initialization request is incompatible with current Bootstrap initialization state.
 #define MDD_E_BOOTSTRAP_INITIALIZE_INCOMPATIBLE         _HRESULT_TYPEDEF_(0x80040014L)
 
+#if defined(__cplusplus)
+
 enum class MddCreatePackageDependencyOptions : uint32_t
 {
     None = 0,
@@ -210,7 +212,15 @@ STDAPI MddGetIdForPackageDependencyContext(
     _In_ MDD_PACKAGEDEPENDENCY_CONTEXT packageDependencyContext,
     _Outptr_result_maybenull_ PWSTR* packageDependencyId) noexcept;
 
-/// Return the package graph's current generation id.
+/// Return the package graph's current revision id.
+STDAPI_(UINT32) MddGetPackageGraphRevisionId() noexcept;
+
+/// Return the package graph's current revision id.
+///
+/// @note This API is deprecated and will be removed in a future release.
+///       Use MddGetPackageGraphRevisionId().
 STDAPI_(UINT32) MddGetGenerationId() noexcept;
+
+#endif // defined(__cplusplus)
 
 #endif // MSIXDYNAMICDEPENDENCY_H

--- a/dev/DynamicDependency/API/PackageGraphManager.cpp
+++ b/dev/DynamicDependency/API/PackageGraphManager.cpp
@@ -9,21 +9,21 @@
 
 std::recursive_mutex MddCore::PackageGraphManager::s_lock;
 MddCore::PackageGraph MddCore::PackageGraphManager::s_packageGraph;
-volatile ULONG MddCore::PackageGraphManager::s_generationId{};
+volatile ULONG MddCore::PackageGraphManager::s_packageGraphRevisionId{};
 
-UINT32 MddCore::PackageGraphManager::GetGenerationId()
+UINT32 MddCore::PackageGraphManager::GetPackageGraphRevisionId()
 {
-    return static_cast<UINT32>(ReadULongAcquire(&s_generationId));
+    return static_cast<UINT32>(ReadULongAcquire(&s_packageGraphRevisionId));
 }
 
-UINT32 MddCore::PackageGraphManager::IncrementGenerationId()
+UINT32 MddCore::PackageGraphManager::IncrementPackageGraphRevisionId()
 {
-    return static_cast<UINT32>(InterlockedIncrement(&s_generationId));
+    return static_cast<UINT32>(InterlockedIncrement(&s_packageGraphRevisionId));
 }
 
-UINT32 MddCore::PackageGraphManager::SetGenerationId(const UINT32 value)
+UINT32 MddCore::PackageGraphManager::SetPackageGraphRevisionId(const UINT32 value)
 {
-    return static_cast<UINT32>(InterlockedExchange(&s_generationId, value));
+    return static_cast<UINT32>(InterlockedExchange(&s_packageGraphRevisionId, value));
 }
 
 HRESULT MddCore::PackageGraphManager::ResolvePackageDependency(
@@ -47,7 +47,7 @@ HRESULT MddCore::PackageGraphManager::AddToPackageGraph(
 
     RETURN_IF_FAILED(s_packageGraph.Add(packageDependencyId, rank, options, *context, packageFullName));
 
-    IncrementGenerationId();
+    IncrementPackageGraphRevisionId();
     return S_OK;
 }
 
@@ -63,7 +63,7 @@ void MddCore::PackageGraphManager::RemoveFromPackageGraph(
 
     (void) LOG_IF_FAILED(s_packageGraph.Remove(context));
 
-    IncrementGenerationId();
+    IncrementPackageGraphRevisionId();
 }
 
 HRESULT MddCore::PackageGraphManager::GetPackageDependencyForContext(
@@ -80,7 +80,7 @@ HRESULT MddCore::PackageGraphManager::GetPackageDependencyForContext(
 //     buffer is a byte[] containing PACKAGE_INFO[count] followed by all variable length data.
 // Pointers in PACKAGE_INFO (all PWSTR) are null or point to their value in the variable length data.
 //   * PackageInfoType_PackageInfoGeneration
-//     buffer is a UINT32 containing the GenerationId. count is unused (always set to zero if not null).
+//     buffer is a UINT32 containing the RevisionId (aka GenerationId). count is unused (always set to zero if not null).
 //
 // On success but \c bufferLength is too small to hold all the data, we still set bufferLength to the
 // size needed for all this data but return ERROR_INSUFFICIENT_BUFFER (as an HRESULT).
@@ -94,7 +94,7 @@ HRESULT MddCore::PackageGraphManager::GetCurrentPackageInfo3(
     // Check parameter(s) per GetCurrentPackageInfo3 compatibility
     //   * bufferLength is required
     //   * buffer is required if bufferLength >0
-    //   * count is required if buffer is not nullptr, unless caller is getting the generation
+    //   * count is required if buffer is not nullptr, unless caller is getting the revision (aka generation)
     RETURN_HR_IF(E_INVALIDARG, (bufferLength == nullptr) || (*bufferLength > 0 && buffer == nullptr) || ((count == nullptr) && (buffer != nullptr) && (packageInfoType != PackageInfoType_PackageInfoGeneration)));
 
     if (count)
@@ -124,15 +124,15 @@ HRESULT MddCore::PackageGraphManager::GetCurrentPackageInfo3(
         return HRESULT_FROM_WIN32(APPMODEL_ERROR_NO_PACKAGE);
     }
 
-    // Are we asked for the GenerationId?
+    // Are we asked for the RevisionId (aka GenerationId)?
     if (packageInfoType == PackageInfoType_PackageInfoGeneration)
     {
         const bool insufficientSpace{ *bufferLength < sizeof(UINT32) };
         *bufferLength = sizeof(UINT32);
         RETURN_HR_IF_EXPECTED(HRESULT_FROM_WIN32(ERROR_INSUFFICIENT_BUFFER), insufficientSpace);
 
-        UINT32* generationId{ reinterpret_cast<UINT32*>(buffer) };
-        *generationId = GetGenerationId();
+        UINT32* revisionId{ reinterpret_cast<UINT32*>(buffer) };
+        *revisionId = GetPackageGraphRevisionId();
         return S_OK;
     }
     else if ((packageInfoType != PackageInfoType_PackageInfoInstallPath) &&

--- a/dev/DynamicDependency/API/PackageGraphManager.h
+++ b/dev/DynamicDependency/API/PackageGraphManager.h
@@ -13,11 +13,11 @@ namespace MddCore
 class PackageGraphManager
 {
 public:
-    static UINT32 GetGenerationId();
+    static UINT32 GetPackageGraphRevisionId();
 
-    static UINT32 IncrementGenerationId();
+    static UINT32 IncrementPackageGraphRevisionId();
 
-    static UINT32 SetGenerationId(const UINT32 value);
+    static UINT32 SetPackageGraphRevisionId(const UINT32 value);
 
 public:
     static HRESULT ResolvePackageDependency(
@@ -80,7 +80,7 @@ private:
 private:
     static std::recursive_mutex s_lock;
     static MddCore::PackageGraph s_packageGraph;
-    static volatile ULONG s_generationId;
+    static volatile ULONG s_packageGraphRevisionId;
 };
 }
 

--- a/dev/WindowsAppRuntime_DLL/WindowsAppRuntime.def
+++ b/dev/WindowsAppRuntime_DLL/WindowsAppRuntime.def
@@ -14,6 +14,7 @@ EXPORTS
     MddTryCreatePackageDependency
     MddLifetimeManagementGC
     MddLifetimeManagementTestInitialize
+    MddGetPackageGraphRevisionId
     MddGetGenerationId
 
     MsixInstallLicenses

--- a/test/DynamicDependency/Test_Win32/Test_GetCurrentPackageInfo.cpp
+++ b/test/DynamicDependency/Test_Win32/Test_GetCurrentPackageInfo.cpp
@@ -252,6 +252,15 @@ namespace Test::DynamicDependency
 
             const auto actualGenerationId{ MddGetGenerationId() };
             VERIFY_ARE_EQUAL(expectedGenerationId, actualGenerationId);
+
+            if (!IsGetPackageGraphRevisionIdSupported())
+            {
+                return;
+            }
+
+            const auto actualPackageGraphRevisionId{ MddGetPackageGraphRevisionId() };
+            const auto expectedPackageGraphRevisionId{ actualGenerationId };
+            VERIFY_ARE_EQUAL(expectedPackageGraphRevisionId, actualPackageGraphRevisionId);
         }
 
         void PrintGetCurrentPackageInfoHeader()
@@ -343,14 +352,27 @@ namespace Test::DynamicDependency
             _Out_opt_ UINT32* count);
         GetCurrentPackageInfo3Function m_getCurrentPackageInfo3{};
 
-        void EnsureGetCurrentPackageInfo3IsIniitalizedIfExists()
+        typedef UINT32 (WINAPI* GetPackageGraphRevisionIdFunction)();
+        GetPackageGraphRevisionIdFunction m_getPackageGraphRevisionId{};
+
+        void EnsureKernelbaseDllIsLoaded()
         {
             if (!m_kernelbaseDll)
             {
                 wil::unique_hmodule dll{ LoadLibraryW(L"kernelbase.dll") };
                 FAIL_FAST_HR_IF_NULL(E_UNEXPECTED, dll);
 
-                auto function{ reinterpret_cast<GetCurrentPackageInfo3Function>(GetProcAddress(dll.get(), "GetCurrentPackageInfo3")) };
+                m_kernelbaseDll = std::move(dll);
+            }
+        }
+
+        void EnsureGetCurrentPackageInfo3IsInitializedIfExists()
+        {
+            EnsureKernelbaseDllIsLoaded();
+
+            if (!m_getCurrentPackageInfo3)
+            {
+                auto function{ reinterpret_cast<GetCurrentPackageInfo3Function>(GetProcAddress(m_kernelbaseDll.get(), "GetCurrentPackageInfo3")) };
                 if (!function)
                 {
                     const auto lastError{ GetLastError() };
@@ -360,15 +382,40 @@ namespace Test::DynamicDependency
                     }
                 }
 
-                m_kernelbaseDll = std::move(dll);
                 m_getCurrentPackageInfo3 = std::move(function);
             }
         }
 
         bool IsGetCurrentPackageInfo3Supported()
         {
-            EnsureGetCurrentPackageInfo3IsIniitalizedIfExists();
+            EnsureGetCurrentPackageInfo3IsInitializedIfExists();
             return m_getCurrentPackageInfo3 != nullptr;
+        }
+
+        void EnsureGetPackageGraphRevisionIdIsInitializedIfExists()
+        {
+            EnsureKernelbaseDllIsLoaded();
+
+            if (!m_getPackageGraphRevisionId)
+            {
+                auto function{ reinterpret_cast<GetPackageGraphRevisionIdFunction>(GetProcAddress(m_kernelbaseDll.get(), "GetPackageGraphRevisionId")) };
+                if (!function)
+                {
+                    const auto lastError{ GetLastError() };
+                    if (lastError != ERROR_PROC_NOT_FOUND)
+                    {
+                        FAIL_FAST_WIN32(lastError);
+                    }
+                }
+
+                m_getPackageGraphRevisionId = std::move(function);
+            }
+        }
+
+        bool IsGetPackageGraphRevisionIdSupported()
+        {
+            EnsureGetPackageGraphRevisionIdIsInitializedIfExists();
+            return m_getPackageGraphRevisionId != nullptr;
         }
 
     private:

--- a/test/DynamicDependency/Test_Win32/Test_Win32.cpp
+++ b/test/DynamicDependency/Test_Win32/Test_Win32.cpp
@@ -82,7 +82,7 @@ bool Test::DynamicDependency::Test_Win32::Cleanup()
 void Test::DynamicDependency::Test_Win32::Create_Delete()
 {
     // The process starts at GenerationId=0 but the bootstrap API was called which calls DynamicDependencies so it's now 1
-    VerifyGenerationId(1);
+    VerifyPackageGraphRevisionId(1);
 
     PCWSTR packageFamilyName{ TP::FrameworkMathAdd::c_PackageFamilyName };
     const PACKAGE_VERSION minVersion{};
@@ -95,7 +95,7 @@ void Test::DynamicDependency::Test_Win32::Create_Delete()
 
     MddDeletePackageDependency(packageDependencyId.get());
 
-    VerifyGenerationId(1);
+    VerifyPackageGraphRevisionId(1);
 }
 
 void Test::DynamicDependency::Test_Win32::Delete_Null()
@@ -113,7 +113,7 @@ void Test::DynamicDependency::Test_Win32::Delete_NotFound()
 void Test::DynamicDependency::Test_Win32::FullLifecycle_ProcessLifetime_Framework_WindowsAppRuntime()
 {
     // The process starts at GenerationId=0 but the bootstrap API was called which calls DynamicDependencies so it's now 1
-    VerifyGenerationId(1);
+    VerifyPackageGraphRevisionId(1);
 
     // Setup our dynamic dependencies
 
@@ -125,7 +125,7 @@ void Test::DynamicDependency::Test_Win32::FullLifecycle_ProcessLifetime_Framewor
     auto pathEnvironmentVariable{ GetPathEnvironmentVariableMinusWindowsAppRuntimeFramework() };
     auto packagePath_WindowsAppRuntimeFramework{ TP::GetPackagePath(expectedPackageFullName_WindowsAppRuntimeFramework) };
     VerifyPathEnvironmentVariable(packagePath_WindowsAppRuntimeFramework, pathEnvironmentVariable.c_str());
-    VerifyGenerationId(1);
+    VerifyPackageGraphRevisionId(1);
 
     // -- TryCreate
 
@@ -135,7 +135,7 @@ void Test::DynamicDependency::Test_Win32::FullLifecycle_ProcessLifetime_Framewor
     VerifyPackageNotInPackageGraph(expectedPackageFullName_FrameworkMathAdd, S_OK);
     VerifyPathEnvironmentVariable(packagePath_WindowsAppRuntimeFramework, pathEnvironmentVariable.c_str());
     VerifyPackageDependency(packageDependencyId_FrameworkMathAdd.get(), S_OK, expectedPackageFullName_FrameworkMathAdd);
-    VerifyGenerationId(1);
+    VerifyPackageGraphRevisionId(1);
 
     // -- Add
 
@@ -150,7 +150,7 @@ void Test::DynamicDependency::Test_Win32::FullLifecycle_ProcessLifetime_Framewor
     auto packagePath_FrameworkMathAdd{ TP::GetPackagePath(expectedPackageFullName_FrameworkMathAdd) };
     VerifyPathEnvironmentVariable(packagePath_WindowsAppRuntimeFramework, packagePath_FrameworkMathAdd, pathEnvironmentVariable.c_str());
     VerifyPackageDependency(packageDependencyId_FrameworkMathAdd.get(), S_OK, expectedPackageFullName_FrameworkMathAdd);
-    VerifyGenerationId(2);
+    VerifyPackageGraphRevisionId(2);
 
     // -- Use it
 
@@ -172,7 +172,7 @@ void Test::DynamicDependency::Test_Win32::FullLifecycle_ProcessLifetime_Framewor
     std::wstring actualResolvedPackageFullName{ resolvedPackageFullName.get() };
     const auto& expectedResolvedPackageFullName{ expectedPackageFullName_FrameworkMathAdd };
     VERIFY_ARE_EQUAL(expectedResolvedPackageFullName, actualResolvedPackageFullName);
-    VerifyGenerationId(2);
+    VerifyPackageGraphRevisionId(2);
 
     // Tear down our dynamic dependencies
 
@@ -184,7 +184,7 @@ void Test::DynamicDependency::Test_Win32::FullLifecycle_ProcessLifetime_Framewor
     VerifyPackageNotInPackageGraph(expectedPackageFullName_FrameworkMathAdd, S_OK);
     VerifyPathEnvironmentVariable(packagePath_WindowsAppRuntimeFramework, pathEnvironmentVariable.c_str());
     VerifyPackageDependency(packageDependencyId_FrameworkMathAdd.get(), S_OK, expectedPackageFullName_FrameworkMathAdd);
-    VerifyGenerationId(3);
+    VerifyPackageGraphRevisionId(3);
 
     // -- Delete
 
@@ -194,7 +194,7 @@ void Test::DynamicDependency::Test_Win32::FullLifecycle_ProcessLifetime_Framewor
     VerifyPackageNotInPackageGraph(expectedPackageFullName_FrameworkMathAdd, S_OK);
     VerifyPathEnvironmentVariable(packagePath_WindowsAppRuntimeFramework, pathEnvironmentVariable.c_str());
     VerifyPackageDependency(packageDependencyId_FrameworkMathAdd.get(), HRESULT_FROM_WIN32(ERROR_NOT_FOUND));
-    VerifyGenerationId(3);
+    VerifyPackageGraphRevisionId(3);
 }
 
 void Test::DynamicDependency::Test_Win32::GetResolvedPackageFullName_Null()
@@ -647,6 +647,16 @@ MddPackageDependencyProcessorArchitectures Test::DynamicDependency::Test_Win32::
 #else
 #   error "Unknown processor architecture"
 #endif
+}
+
+void Test::DynamicDependency::Test_Win32::VerifyPackageGraphRevisionId(
+    const UINT32 expectedPackageGraphRevisionId)
+{
+    const auto actualPackageGraphRevisionId{ MddGetPackageGraphRevisionId() };
+    VERIFY_ARE_EQUAL(expectedPackageGraphRevisionId, actualPackageGraphRevisionId);
+
+    // GenerationId is deprecated but verify until removed
+    VerifyGenerationId(expectedPackageGraphRevisionId);
 }
 
 void Test::DynamicDependency::Test_Win32::VerifyGenerationId(

--- a/test/DynamicDependency/Test_Win32/Test_Win32.h
+++ b/test/DynamicDependency/Test_Win32/Test_Win32.h
@@ -224,6 +224,9 @@ namespace Test::DynamicDependency
         static MddPackageDependencyProcessorArchitectures GetCurrentArchitectureAsFilter();
 
     private:
+        static void VerifyPackageGraphRevisionId(
+            const UINT32 expectedPackageGraphRevisionId);
+
         static void VerifyGenerationId(
             const UINT32 expectedGenerationId);
 


### PR DESCRIPTION
Add MddGetPackageGraphRevisionId() and PackageGraphRevisionId property.

Detour GetPackageGraphRevisionId() (new in recent Windows previews).

Detach Detour'd functions in reverse order that we Detour'd them.

Moar Tests!

https://task.ms/41077943