### PR TITLE
User/sachinta/fix installer for windows10 arm64 on release 1.1 stable

### DIFF
--- a/dev/Common/IsWindowsVersion.h
+++ b/dev/Common/IsWindowsVersion.h
@@ -13,15 +13,22 @@ inline bool IsExportPresent(
     PCSTR functionName)
 {
     wil::unique_hmodule dll{ LoadLibraryExW(filename, nullptr, 0) };
-    if (dll)
+    if (!dll)
     {
-        auto function{ GetProcAddress(dll.get(), functionName) };
-        if (function)
-        {
-            return true;
-        }
+        const DWORD rcLoadLibraryError = GetLastError();
+        THROW_HR_IF(HRESULT_FROM_WIN32(rcLoadLibraryError), rcLoadLibraryError != ERROR_MOD_NOT_FOUND);
+        return false;
     }
-    return false;
+
+    auto function{ GetProcAddress(dll.get(), functionName) };
+    if (!function)
+    {
+        const DWORD rcGetProcAddressError = GetLastError();
+        THROW_HR_IF(HRESULT_FROM_WIN32(rcGetProcAddressError), rcGetProcAddressError != ERROR_PROC_NOT_FOUND);
+        return false;
+    }
+
+    return true;
 }
 
 inline bool IsWindows10_19H1OrGreater()

--- a/dev/Common/IsWindowsVersion.h
+++ b/dev/Common/IsWindowsVersion.h
@@ -35,6 +35,11 @@ inline bool IsWindows10_20H1OrGreater()
     // GetPackageInfo3() added to kernelbase.dll in NTDDI_WIN10_VB (aka 20H1)
     return IsExportPresent(L"kernelbase.dll", "GetPackageInfo3");
 }
+inline bool IsWindows11_21H2OrGreater()
+{
+    // GetMachineTypeAttributes() added to kernelbase.dll in NTDDI_WIN10_CO (aka Windows 11 21H2)
+    return IsExportPresent(L"kernelbase.dll", "GetMachineTypeAttributes");
+}
 }
 
 #endif // __ISWINDOWSVERSION_H

--- a/installer/dev/MachineTypeAttributes.h
+++ b/installer/dev/MachineTypeAttributes.h
@@ -1,0 +1,43 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+#pragma once
+
+#include "pch.h"
+
+namespace MachineTypeAttributes
+{
+    // On systems running Windows 11, this inline function returns if given architecture is supported on the system in user mode.
+    // On systems running down level Windows versions (ex: Windows 10), this inline function will return false, always.
+    // NOTE: If in case, the GetMachineTypeAttributes API that is currently only available on Windows 11 get serviced to down level Windows versions as well,
+    // then on systems running down level Windows versions (ex: Windows 10), this inline function will function the same as on Windows 11.
+    inline bool IsWindows11_IsArchitectureSupportedInUserMode(USHORT architecture)
+    {
+        // GetMachineTypeAttributes() added to kernelbase.dll in NTDDI_WIN10_CO (aka Windows 11 21H2, the first market release version of Windows 11).
+        // So, if that API is available, it indicates current system is running Windows 11.
+        wil::unique_hmodule kernelbaseDll{ LoadLibraryExW(L"kernelbase.dll", nullptr, 0) };
+        if (!kernelbaseDll)
+        {
+            THROW_LAST_ERROR();
+        }
+        else
+        {
+            auto getMachineTypeAttributes{ GetProcAddressByFunctionDeclaration(kernelbaseDll.get(), GetMachineTypeAttributes) };
+            if (!getMachineTypeAttributes)
+            {
+                // For now, GetMachineTypeAttributes API is available only on Windows 11 (i.e. builds 22000+).
+                THROW_LAST_ERROR();
+                return false;
+            }
+            else
+            {
+                // If execution entered this block, it means that the current system is running Windows 11
+                // until if and when GetMachineTypeAttributes API is serviced down level Windows versions (ex: Windows 10).
+                // For defense against such possible future changes, also check explicitly if given architecture is supported on the current system.
+                MACHINE_ATTRIBUTES machineAttributes{};
+                THROW_IF_FAILED(getMachineTypeAttributes(architecture, &machineAttributes));
+                return WI_IsFlagSet(machineAttributes, MACHINE_ATTRIBUTES::UserEnabled);
+            }
+        }
+        return false;
+    }
+}

--- a/installer/dev/WindowsAppRuntimeInstall.vcxproj
+++ b/installer/dev/WindowsAppRuntimeInstall.vcxproj
@@ -11,7 +11,7 @@
     <ProjectGuid>{e6e59b30-9f55-4550-aa73-3b3b3dc89872}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>WindowsAppRuntimeInstall</RootNamespace>
-    <WindowsTargetPlatformVersion Condition=" '$(WindowsTargetPlatformVersion)' == '' ">10.0.19041.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion Condition=" '$(WindowsTargetPlatformVersion)' == '' ">10.0.22000.0</WindowsTargetPlatformVersion>
     <WindowsTargetPlatformMinVersion>10.0.17763.0</WindowsTargetPlatformMinVersion>
   </PropertyGroup>
   <ItemGroup Label="ProjectConfigurations">
@@ -124,6 +124,7 @@
   </ItemDefinitionGroup>
   <ItemGroup>
     <ClInclude Include="console.h" />
+    <ClInclude Include="MachineTypeAttributes.h" />
     <ClInclude Include="InstallActivityContext.h" />
     <ClInclude Include="tracelogging.h" />
     <ClInclude Include="install.h" />

--- a/installer/dev/WindowsAppRuntimeInstall.vcxproj.filters
+++ b/installer/dev/WindowsAppRuntimeInstall.vcxproj.filters
@@ -42,6 +42,9 @@
     <ClInclude Include="InstallActivityContext.h">
       <Filter>Header Files</Filter>
     </ClInclude>
+    <ClInclude Include="MachineTypeAttributes.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="pch.cpp">

--- a/installer/dev/install.cpp
+++ b/installer/dev/install.cpp
@@ -4,6 +4,7 @@
 #include "pch.h"
 #include "packages.h"
 #include "install.h"
+#include "MachineTypeAttributes.h"
 
 EXTERN_C IMAGE_DOS_HEADER __ImageBase;
 
@@ -49,7 +50,7 @@ namespace WindowsAppRuntimeInstaller
             winrt::Windows::Management::Deployment::DeploymentOptions::None };
 
         PackageManager packageManager;
-        const auto deploymentOperation{ packageManager.AddPackageAsync(packageUri, nullptr, DeploymentOptions::None) };
+        const auto deploymentOperation{ packageManager.AddPackageAsync(packageUri, nullptr, deploymentOptions) };
         deploymentOperation.get();
         if (deploymentOperation.Status() != AsyncStatus::Completed)
         {
@@ -81,8 +82,6 @@ namespace WindowsAppRuntimeInstaller
         WindowsAppRuntimeInstaller::InstallActivity::Context& installActivityContext,
         const Uri& packageUri)
     {
-        const auto deploymentOptions{ winrt::Windows::Management::Deployment::DeploymentOptions::None };
-
         PackageManager packageManager;
         const auto deploymentOperation{ packageManager.StagePackageAsync(packageUri, nullptr, DeploymentOptions::None) };
         deploymentOperation.get();
@@ -191,9 +190,15 @@ namespace WindowsAppRuntimeInstaller
             return true;
         }
 
-        // On Arm64 systems, all current package architectures are applicable.
+        // On Windows 11 (i.e. builds 22000+) ARM64 systems, all framework package architectures are applicable.
+        // On Windows 10 (i.e. builds 17763-190**) ARM64 systems (which don't support X64 apps), all x64 framework package architectures, except x64, are applicable.
         if (systemArchitecture == ProcessorArchitecture::Arm64)
         {
+            if (packageProperties->architecture == ProcessorArchitecture::X64)
+            {
+                return MachineTypeAttributes::IsWindows11_IsArchitectureSupportedInUserMode(IMAGE_FILE_MACHINE_AMD64);
+            }
+
             return true;
         }
 

--- a/installer/dev/main.cpp
+++ b/installer/dev/main.cpp
@@ -80,8 +80,12 @@ int wmain(int argc, wchar_t *argv[])
         }
         else
         {
-            std::wcerr << "Unknown argument: " << arg.data() << std::endl;
-            DisplayHelp();
+            if (WI_IsFlagClear(options, WindowsAppRuntimeInstaller::Options::Quiet))
+            {
+                std::wcerr << "Unknown argument: " << arg.data() << std::endl;
+                DisplayHelp();
+            }
+
             installActivityContext.SetActivity(WindowsAppRuntimeInstaller_TraceLogger::Install::Start(args.str().c_str(), static_cast<UINT32>(options), isElevated));
             LOG_IF_WIN32_BOOL_FALSE(installActivityContext.LogInstallerCommandLineArgs(args.str().c_str()));
             LOG_IF_WIN32_BOOL_FALSE(installActivityContext.LogInstallerFailureEvent(HRESULT_FROM_WIN32(ERROR_BAD_ARGUMENTS)));
@@ -96,50 +100,53 @@ int wmain(int argc, wchar_t *argv[])
     LOG_IF_WIN32_BOOL_FALSE(installActivityContext.LogInstallerCommandLineArgs(args.str().c_str()));
     args.clear();
 
-    if (!isElevated)
+    const bool quiet{ WI_IsFlagSet(options, WindowsAppRuntimeInstaller::Options::Quiet) };
+    if (!isElevated && !quiet)
     {
         std::wcout << "INFO: Provisioning of WindowsAppSDK packages will be skipped as it requires elevation." << std::endl;
     }
 
     const HRESULT deployPackagesResult{ WindowsAppRuntimeInstaller::Deploy(options) };
-    if (WI_IsFlagClear(options, WindowsAppRuntimeInstaller::Options::Quiet))
+
+    if (SUCCEEDED(deployPackagesResult))
     {
-        if (SUCCEEDED(deployPackagesResult))
+        if (!quiet)
         {
             std::wcout << "All install operations successful." << std::endl;
-
-            LOG_IF_WIN32_BOOL_FALSE(installActivityContext.LogInstallerSuccess());
-
-            installActivityContext.GetActivity().StopWithResult(
-                deployPackagesResult,
-                static_cast <UINT32>(0),
-                static_cast<PCSTR>(nullptr),
-                static_cast <unsigned int>(0),
-                static_cast<PCWSTR>(nullptr),
-                static_cast<UINT32>(WindowsAppRuntimeInstaller::InstallActivity::InstallStage::None),
-                static_cast<PCWSTR>(nullptr),
-                S_OK,
-                static_cast<PCWSTR>(nullptr),
-                GUID_NULL);
         }
-        else
+        LOG_IF_WIN32_BOOL_FALSE(installActivityContext.LogInstallerSuccess());
+
+        installActivityContext.GetActivity().StopWithResult(
+            deployPackagesResult,
+            static_cast <UINT32>(0),
+            static_cast<PCSTR>(nullptr),
+            static_cast <unsigned int>(0),
+            static_cast<PCWSTR>(nullptr),
+            static_cast<UINT32>(WindowsAppRuntimeInstaller::InstallActivity::InstallStage::None),
+            static_cast<PCWSTR>(nullptr),
+            S_OK,
+            static_cast<PCWSTR>(nullptr),
+            GUID_NULL);
+    }
+    else
+    {
+        if (!quiet)
         {
             std::wcerr << "One or more install operations failed. Result: 0x" << std::hex << deployPackagesResult << std::endl;
-
-            LOG_IF_WIN32_BOOL_FALSE(installActivityContext.LogInstallerFailureEvent(deployPackagesResult));
-
-            installActivityContext.GetActivity().StopWithResult(
-                deployPackagesResult,
-                static_cast<UINT32>(installActivityContext.GetLastFailure().type),
-                installActivityContext.GetLastFailure().file.c_str(),
-                installActivityContext.GetLastFailure().lineNumber,
-                installActivityContext.GetLastFailure().message.c_str(),
-                static_cast<UINT32>(installActivityContext.GetInstallStage()),
-                installActivityContext.GetCurrentResourceId().c_str(),
-                installActivityContext.GetDeploymentErrorHresult(),
-                installActivityContext.GetDeploymentErrorText().c_str(),
-                installActivityContext.GetDeploymentErrorActivityId());
         }
+        LOG_IF_WIN32_BOOL_FALSE(installActivityContext.LogInstallerFailureEvent(deployPackagesResult));
+
+        installActivityContext.GetActivity().StopWithResult(
+            deployPackagesResult,
+            static_cast<UINT32>(installActivityContext.GetLastFailure().type),
+            installActivityContext.GetLastFailure().file.c_str(),
+            installActivityContext.GetLastFailure().lineNumber,
+            installActivityContext.GetLastFailure().message.c_str(),
+            static_cast<UINT32>(installActivityContext.GetInstallStage()),
+            installActivityContext.GetCurrentResourceId().c_str(),
+            installActivityContext.GetDeploymentErrorHresult(),
+            installActivityContext.GetDeploymentErrorText().c_str(),
+            installActivityContext.GetDeploymentErrorActivityId());
     }
 
     LOG_IF_WIN32_BOOL_FALSE(WindowsAppRuntimeInstaller::InstallActivity::Context::Get().DeregisterInstallerEventSourceW());

--- a/installer/dev/pch.h
+++ b/installer/dev/pch.h
@@ -19,7 +19,7 @@
 #include <shlwapi.h>
 #include <WinBase.h>
 #include <AppxPackaging.h>
-
+#include <processthreadsapi.h>
 #include <string_view>
 
 #include <winrt/Windows.ApplicationModel.h>


### PR DESCRIPTION
Cherry-picked from https://github.com/microsoft/WindowsAppSDK/pull/2901 and https://github.com/microsoft/WindowsAppSDK/pull/2841

Fix installer to not attempt to install x64 framework package on Windows 10 ARM64 systems.
Fix console output that wasn't respecting quiet option.
Fix Push notifications LRP restart decision logic to be inclusive of ARM64 architecture as well.