### PR TITLE
Updating BuildTools version

### DIFF
--- a/dev/VSIX/Directory.Build.props
+++ b/dev/VSIX/Directory.Build.props
@@ -7,7 +7,7 @@
             https://pkgs.dev.azure.com/microsoft/ProjectReunion/_packaging/Project.Reunion.nuget.internal/nuget/v3/index.json
         </RestoreSources>
         <CppWinRTVersion Condition="'$(CppWinRTVersion)' == ''">2.0.210806.1</CppWinRTVersion>
-        <WindowsSDKBuildToolsVersion Condition="'$(WindowsSDKBuildToolsVersion)' == ''">10.0.22000.194</WindowsSDKBuildToolsVersion>
+        <WindowsSDKBuildToolsVersion Condition="'$(WindowsSDKBuildToolsVersion)' == ''">10.0.22621.1</WindowsSDKBuildToolsVersion>
         <WILVersion Condition="'$(WILVersion)' == ''">1.0.211019.2</WILVersion>
         <!-- Provides a default package version in order to simplify dev inner loop testing -->
         <WindowsAppSdkVersion Condition="'$(WindowsAppSdkVersion)' == ''">1.0.0-preview1</WindowsAppSdkVersion>


### PR DESCRIPTION
Updating BuildTools version to enable WindowsAppSDK updates. This was already made in main. Needs to be made in release/1.1-stable to support WinAppSDK 1.1.5 servicing.

main fix: https://github.com/microsoft/WindowsAppSDK/pull/2902/files