### PR TITLE
Add SDK Build Tools package reference, for when full Windows SDK isn't installed

### DIFF
--- a/dev/VSIX/ProjectTemplates/Desktop/CSharp/PackagedApp/WapProj/WinUI.Desktop.Cs.WapProj.vstemplate
+++ b/dev/VSIX/ProjectTemplates/Desktop/CSharp/PackagedApp/WapProj/WinUI.Desktop.Cs.WapProj.vstemplate
@@ -51,5 +51,7 @@
   <WizardData>
     <MinSupportedVersion>10.0.17763.0</MinSupportedVersion>
     <SkipXamlCompilerCheck>true</SkipXamlCompilerCheck>
+    <UseWindowsSdkBuildToolsPackage>true</UseWindowsSdkBuildToolsPackage>
+    <UseSdkFallbackFile>true</UseSdkFallbackFile>
   </WizardData>
 </VSTemplate>


### PR DESCRIPTION
http://task.ms/41236875