### PR TITLE
UrfwInitialize() fails if exe lacks a Fusion manifest

### DIFF
--- a/dev/UndockedRegFreeWinRT/urfw.cpp
+++ b/dev/UndockedRegFreeWinRT/urfw.cpp
@@ -317,13 +317,13 @@ HRESULT WINAPI RoResolveNamespaceDetour(
 
 HRESULT ExtRoLoadCatalog()
 {
-    WCHAR filePath[MAX_PATH];
+    WCHAR filePath[MAX_PATH]{};
     if (!GetModuleFileNameW(nullptr, filePath, _countof(filePath)))
     {
         return HRESULT_FROM_WIN32(GetLastError());
     }
     std::wstring manifestPath(filePath);
-    HANDLE hActCtx = INVALID_HANDLE_VALUE;
+    HANDLE hActCtx{ INVALID_HANDLE_VALUE };
     auto exit = wil::scope_exit([&]
     {
         if (hActCtx != INVALID_HANDLE_VALUE)
@@ -333,22 +333,26 @@ HRESULT ExtRoLoadCatalog()
     });
     wil::unique_hmodule exeModule;
     RETURN_IF_WIN32_BOOL_FALSE(GetModuleHandleExW(0, nullptr, &exeModule));
-    ACTCTXW acw = { sizeof(acw) };
+    ACTCTXW acw{ sizeof(acw) };
     acw.lpSource = manifestPath.c_str();
     acw.hModule = exeModule.get();
     acw.lpResourceName = MAKEINTRESOURCEW(1);
     acw.dwFlags = ACTCTX_FLAG_HMODULE_VALID | ACTCTX_FLAG_RESOURCE_NAME_VALID;
 
     hActCtx = CreateActCtxW(&acw);
-    RETURN_LAST_ERROR_IF(!hActCtx);
-    if (hActCtx == INVALID_HANDLE_VALUE)
+    if ((hActCtx == INVALID_HANDLE_VALUE) || (hActCtx == nullptr))
     {
-        SetLastError(ERROR_OUTOFMEMORY);
-        return HRESULT_FROM_WIN32(GetLastError());
+        const auto lastError{ GetLastError() };
+        if (lastError == ERROR_RESOURCE_DATA_NOT_FOUND)
+        {
+            // Not found == Nothing to do!
+            return S_OK;
+        }
+        RETURN_WIN32(lastError);
     }
 
     PACTIVATION_CONTEXT_DETAILED_INFORMATION actCtxInfo = nullptr;
-    SIZE_T bufferSize = 0;
+    SIZE_T bufferSize{};
     (void)QueryActCtxW(0,
         hActCtx,
         nullptr,
@@ -357,13 +361,9 @@ HRESULT ExtRoLoadCatalog()
         0,
         &bufferSize);
     RETURN_HR_IF(HRESULT_FROM_WIN32(GetLastError()), bufferSize == 0);
-    auto actCtxInfoBuffer = std::make_unique<BYTE[]>(bufferSize);
+    auto actCtxInfoBuffer{ std::make_unique<BYTE[]>(bufferSize) };
+    RETURN_IF_NULL_ALLOC(actCtxInfoBuffer);
     actCtxInfo = reinterpret_cast<PACTIVATION_CONTEXT_DETAILED_INFORMATION>(actCtxInfoBuffer.get());
-    if (!actCtxInfo)
-    {
-        SetLastError(ERROR_OUTOFMEMORY);
-        return HRESULT_FROM_WIN32(GetLastError());
-    }
 
     RETURN_IF_WIN32_BOOL_FALSE(QueryActCtxW(0,
         hActCtx,
@@ -385,13 +385,9 @@ HRESULT ExtRoLoadCatalog()
             0,
             &bufferSize);
         RETURN_HR_IF(HRESULT_FROM_WIN32(GetLastError()), bufferSize == 0);
-        auto asmInfobuffer = std::make_unique<BYTE[]>(bufferSize);
+        auto asmInfobuffer{ std::make_unique<BYTE[]>(bufferSize) };
+        RETURN_IF_NULL_ALLOC(asmInfobuffer);
         asmInfo = reinterpret_cast<PACTIVATION_CONTEXT_ASSEMBLY_DETAILED_INFORMATION>(asmInfobuffer.get());
-        if (!asmInfo)
-        {
-            SetLastError(ERROR_OUTOFMEMORY);
-            return HRESULT_FROM_WIN32(GetLastError());
-        }
 
         RETURN_IF_WIN32_BOOL_FALSE(QueryActCtxW(0,
             hActCtx,


### PR DESCRIPTION
UrfwInitialize() fails if exe lacks a Fusion manifest

UrfwInitialize() calls ExtRoLoadCatalog() calls CreateActCtxW() to create an activation context with the executable's Fusion manifest. If the exe has no manifest CreateActCtxW() returns ERROR_INVALID_HANDLE with GetLastError=ERROR_RESOURCE_DATA_NOT_FOUND. ExtRoLoadCatalog() detects the failure but (1) `SetLastError(ERROR_OUTOFMEMORY)` due to a developer mistake copy-pasta error handling from a wil::make_unique call (i.e. memory allocation) and (2) treats not-found as an error.

Executables aren't required to have Fusion manfiests. Requiring one is an error.

To repro, create a tiny trivial exe with NO Fusion manifest and 

```
int main()
{
    LoadLibrary("Microsoft.WindowsAppRuntime.dll")
    return 0;
}
```

Run under the debugger you'll see Microsoft.WindowsAppRuntime.dll's DllMain() calls into this code and FAIL_FAST on the error.

https://task.ms/40349008 