### PR TITLE
Microsoft.WindowsAppRuntime.dll!DllMain fails if exe has resources but no SxS manifest

### DIFF
--- a/dev/UndockedRegFreeWinRT/urfw.cpp
+++ b/dev/UndockedRegFreeWinRT/urfw.cpp
@@ -343,9 +343,11 @@ HRESULT ExtRoLoadCatalog()
     if ((hActCtx == INVALID_HANDLE_VALUE) || (hActCtx == nullptr))
     {
         const auto lastError{ GetLastError() };
-        if (lastError == ERROR_RESOURCE_DATA_NOT_FOUND)
+        if ((lastError == ERROR_RESOURCE_DATA_NOT_FOUND) || (lastError == ERROR_RESOURCE_TYPE_NOT_FOUND))
         {
-            // Not found == Nothing to do!
+            // No resources in the executable (ERROR_RESOURCE_DATA_NOT_FOUND) or there are resources
+            // but not an embedded SxS manifest we're looking for (ERROR_RESOURCE_TYPE_NOT_FOUND).
+            // Either way it's Not Found == Nothing to do!
             return S_OK;
         }
         RETURN_WIN32(lastError);


### PR DESCRIPTION
Microsoft.WindowsAppRuntime.dll fails in DllMain if loaded by a process whose exe has resources but not an embedded SxS fusion manifest. Those are distinct error codes from `CreateActCtxW()` but we only trapped for one. Updated to trap for both conditions.

https://task.ms/41853965