### PR TITLE
Include wil/result_originate for much better error origination

### DIFF
--- a/dev/WindowsAppRuntime_DLL/dllmain.cpp
+++ b/dev/WindowsAppRuntime_DLL/dllmain.cpp
@@ -6,6 +6,10 @@
 #include <MddDetourPackageGraph.h>
 #include <urfw.h>
 
+// Including this file once per binary will automatically opt WIL error handling macros into calling RoOriginateError when they
+// begin logging a new error.  This greatly improves the debuggability of errors that propagate before a failfast.
+#include <wil/result_originate.h>
+
 #include <../Detours/detours.h>
 
 static HRESULT DetoursInitialize()


### PR DESCRIPTION
Closes: #3096 

## Why is this change being made?
Prior to the fix for #3093 the error output in the debugger was worse than I expected.  WIL should have been logging the error when it was first observed, not just the failfast.  

## Briefly summarize what changed
The change is to include <wil/result_originate.h> in the Microsoft.WindowsAppRuntime.dll binary's dllmain.cpp so that WIL will call `RoOriginateError` automatically whenever it first observes an error.  This vastly improves the debug output for this same crash.

## How was this change tested?
I can replicate the crash fixed by 3093 at will.  I made the edits and compared the debugger output before and after.

### Before
```
STACK_TEXT:  
0000003a`b289cfc0 00007fff`fd359859     : 00000000`00000000 00007ff8`08d4f3b0 00000000`00000000 0000003a`b289d620 : KERNELBASE!RaiseFailFastException+0x152
0000003a`b289d5a0 00007fff`fd2e5a68     : 0000003a`b289d6f0 00000000`00000022 00000214`980d4630 00007ff8`0b396f31 : Microsoft_WindowsAppRuntime!wil::details::WilDynamicLoadRaiseFailFastException+0x49
0000003a`b289d5d0 00007fff`fd2e5b1c     : 0000003a`b289d7d0 00000000`00000000 00000000`00000000 00000214`980b0000 : Microsoft_WindowsAppRuntime!wil::details::WilRaiseFailFastException+0x18
0000003a`b289d600 00007fff`fd2e4c87     : 0000003a`00000000 00000000`00000800 00000000`00000022 00000000`00000800 : Microsoft_WindowsAppRuntime!wil::details::WilFailFast+0xa8
0000003a`b289d6d0 00007fff`fd2e4cb8     : 00007fff`fd364e80 00000000`00000000 00000000`00000000 00000000`00000001 : Microsoft_WindowsAppRuntime!wil::details::ReportFailure_NoReturn<3>+0x273
0000003a`b289ebd0 00007fff`fd30147e     : 0000003a`b289ec60 00000000`00000000 00000000`00000000 00000000`00000000 : Microsoft_WindowsAppRuntime!wil::details::ReportFailure_Base<3,0>+0x30
0000003a`b289ec30 00007fff`fd30fd4c     : 00007fff`80070715 00000214`980b7540 0000003a`b289f0f8 00007fff`fd3441e7 : Microsoft_WindowsAppRuntime!wil::details::ReportFailure_Hr<3>+0x5a
0000003a`b289ecb0 00007fff`fd358c2d     : 00000000`00000001 00007fff`00000008 00000214`980c5f50 00007fff`e8c5155b : Microsoft_WindowsAppRuntime!wil::details::in1diag3::_FailFast_Hr+0x18
0000003a`b289ed00 00007fff`fd358d41     : 00000000`7ffe0300 00000000`00000001 0000003a`b289f0f8 00007ff8`0b3b7423 : Microsoft_WindowsAppRuntime!DetoursInitialize+0xad
0000003a`b289ed30 00007fff`fd364ddb     : 00000000`00000001 00000000`00000000 00000000`00000000 00000000`00000001 : Microsoft_WindowsAppRuntime!DllMain+0x25
<TRUNCATED>
0000003a`b289f990 00007ff8`0b3d7558     : 00000000`00000000 00000000`00000000 00000000`00000000 00000000`00000000 : KERNEL32!BaseThreadInitThunk+0x1d
0000003a`b289f9c0 00000000`00000000     : 00000000`00000000 00000000`00000000 00000000`00000000 00000000`00000000 : ntdll!RtlUserThreadStart+0x28

FAULTING_SOURCE_FILE:  V:\T\WinAppSDKGitHub\dev\WindowsAppRuntime_DLL\dllmain.cpp

FAULTING_SOURCE_LINE_NUMBER:  34
```

### After
```
STACK_TEXT:  
000001a2`f6ff6040 00007ff8`0adee871 combase!RoOriginateError+0x51
000001a2`f6ff6048 00007fff`fd358d4e Microsoft_WindowsAppRuntime!wil::details::RaiseRoOriginateOnWilExceptions+0x10e
000001a2`f6ff6050 00007fff`fd2e4efc Microsoft_WindowsAppRuntime!wil::details::ReportFailure_Return<1>+0x180
000001a2`f6ff6058 00007fff`fd33cd35 Microsoft_WindowsAppRuntime!wil::details::ReportFailure_Win32<1>+0x71
000001a2`f6ff6060 00007fff`fd33cd58 Microsoft_WindowsAppRuntime!wil::details::in1diag3::Return_Win32+0x18
000001a2`f6ff6068 00007fff`fd3441d1 Microsoft_WindowsAppRuntime!ExtRoLoadCatalog+0x3ed
000001a2`f6ff6070 00007fff`fd344288 Microsoft_WindowsAppRuntime!UrfwInitialize+0x58
000001a2`f6ff6078 00007fff`fd358eca Microsoft_WindowsAppRuntime!DetoursInitialize+0x32
000001a2`f6ff6080 00007fff`fd359059 Microsoft_WindowsAppRuntime!DllMain+0x25
000001a2`f6ff6088 00007fff`fd3650eb Microsoft_WindowsAppRuntime!dllmain_dispatch+0x8f
<TRUNCATED>
000001a2`f6ff60e8 00007ff8`0a99335d KERNEL32!BaseThreadInitThunk+0x1d
000001a2`f6ff60f0 00007ff8`0b3d7558 ntdll!RtlUserThreadStart+0x28

FAULTING_SOURCE_FILE:  V:\T\WinAppSDKGitHub\dev\UndockedRegFreeWinRT\urfw.cpp

FAULTING_SOURCE_LINE_NUMBER:  401
```
(Note that for some reason it is blaming line 401 (the return at the end of the function) instead of line 351.  I think the optimizer might be playing games here but either way this is still a huge improvement)



For status checks on the develop branch, please use TransportPackage-Foundation
(https://microsoft.visualstudio.com/ProjectReunion/_build?definitionId=57248)
and run the build against your PR branch with the default parameters.

For status checks on the main branch, please use microsoft.ProjectReunion
(https://dev.azure.com/ms/ProjectReunion/_build?definitionId=391&_a=summary)
and run the build against your PR branch with the default parameters.