### PR TITLE
Add Notification tests to Helix

### DIFF
--- a/build/AzurePipelinesTemplates/WindowsAppSDK-RunHelixTests-Job.yml
+++ b/build/AzurePipelinesTemplates/WindowsAppSDK-RunHelixTests-Job.yml
@@ -145,6 +145,22 @@ jobs:
         Microsoft.Windows.ApplicationModel.Resources.winmd
       targetFolder: $(testPayloadDir)
 
+  - task: CopyFiles@2
+    displayName: 'Copy WASfwk to test root'
+    inputs:
+      sourceFolder: $(testPayloadDir)\BuildOutput\$(buildConfiguration)\$(buildPlatform)\Microsoft.WindowsAppRuntime.Framework
+      contents: |
+        Microsoft.WindowsAppRuntime.Framework.msix
+      targetFolder: $(testPayloadDir)
+
+  - task: CopyFiles@2
+    displayName: 'Copy WASddlm to test root'
+    inputs:
+      sourceFolder: $(testPayloadDir)\BuildOutput\$(buildConfiguration)\$(buildPlatform)\WindowsAppRuntime.Test.Singleton.Msix
+      contents: |
+        WindowsAppRuntime.Test.Singleton.Msix
+      targetFolder: $(testPayloadDir)
+      
   # TODO: This test needs to be converted to TAEF to run in Helix.
   # - task: powershell@2
   #   displayName: 'Discover MRT Core Managed tests'

--- a/build/AzurePipelinesTemplates/WindowsAppSDK-RunHelixTests-Job.yml
+++ b/build/AzurePipelinesTemplates/WindowsAppSDK-RunHelixTests-Job.yml
@@ -115,6 +115,13 @@ jobs:
       arguments: -TestFilePattern 'BuildOutput\$(buildConfiguration)\$(buildPlatform)\MrmUnitTest\*.dll' -TestBinaryDirectoryPath '$(testPayloadDir)' -OutputProjFile '$(helixWorkItemsDir)\MrtCore-MrmUnitTests.proj' -WorkItemPrefix 'MrtCore.MrmUnitTests.$(buildPlatform).$(buildConfiguration)' -TestNamePrefix 'MrtCore.MrmUnitTests.$(buildPlatform).$(buildConfiguration)'
 
   - task: powershell@2
+    displayName: 'Discover PushNotification UnitTests'
+    inputs:
+      targetType: filePath
+      filePath: $(winUIHelixPipelineScripts)\GenerateHelixWorkItems.ps1
+      arguments: -TestFilePattern 'BuildOutput\$(buildConfiguration)\$(buildPlatform)\PushNotificationTests\*.dll' -TestBinaryDirectoryPath '$(testPayloadDir)' -OutputProjFile '$(helixWorkItemsDir)\PushNotificationTests.proj' -WorkItemPrefix 'PushNotificationTests.$(buildPlatform).$(buildConfiguration)' -TestNamePrefix 'PushNotificationTests.$(buildPlatform).$(buildConfiguration)'
+
+  - task: powershell@2
     displayName: 'Discover MRT Core BaseUnitTests'
     inputs:
       targetType: filePath

--- a/build/AzurePipelinesTemplates/WindowsAppSDK-SetupBuildEnvironment-Steps.yml
+++ b/build/AzurePipelinesTemplates/WindowsAppSDK-SetupBuildEnvironment-Steps.yml
@@ -31,6 +31,14 @@ steps:
     workingDirectory: '$(Build.SourcesDirectory)'
 
 - task: powershell@2
+  displayName: 'Install test certificate for MSIX test packages (DevCheck)'
+  inputs:
+    targetType: filePath
+    filePath: DevCheck.ps1
+    arguments: -NoInteractive -Offline -Verbose -CheckTestCert
+    workingDirectory: '$(Build.SourcesDirectory)'
+
+- task: powershell@2
   displayName: 'Create DynamicDependencies TerminalVelocity features'
   inputs:
     targetType: filePath

--- a/build/Helix/RunTestsInHelix.proj
+++ b/build/Helix/RunTestsInHelix.proj
@@ -25,6 +25,7 @@
   <Import Project="GeneratedWorkItems\MrtCore-MrmUnitTests.proj"/>
   <Import Project="GeneratedWorkItems\MrtCore-MrmBaseUnitTests.proj"/>
   <Import Project="GeneratedWorkItems\MrtCore-MrtCoreUnpackagedTests.proj"/>
+  <Import Project="GeneratedWorkItems\PushNotificationTests.proj"/>
 
   <!-- Note: It is also possible to directly create work-items for Helix here instead of using the scripts. -->
 

--- a/build/ProjectReunion-BuildFoundation.yml
+++ b/build/ProjectReunion-BuildFoundation.yml
@@ -142,7 +142,7 @@ jobs:
     condition: and(succeeded(), or(eq(variables['buildPlatform'], 'x86'), eq(variables['buildPlatform'], 'x64')))
     inputs:
       testSelector: 'testAssemblies'
-      testAssemblyVer2: '**\PushNotificationTests.build.appxrecipe'
+      testAssemblyVer2: '**\PushNotificationTests.dll'
       searchFolder: 'BuildOutput\$(buildConfiguration)\$(buildPlatform)\PushNotificationTests'
       testRunTitle: 'test PushNotifications - $(buildPlatform)'
       platform: '$(buildPlatform)'

--- a/build/ProjectReunion-BuildFoundation.yml
+++ b/build/ProjectReunion-BuildFoundation.yml
@@ -136,6 +136,14 @@ jobs:
       inputs:
         BuildDropPath: '$(Build.ArtifactStagingDirectory)\mrt_raw\lib\$(buildPlatform)'
 
+  - task: powershell@2
+    displayName: 'Verify TAEF service is running (DevCheck)'
+    inputs:
+      targetType: filePath
+      filePath: DevCheck.ps1
+      arguments: -NoInteractive -Offline -Verbose -CheckTAEFService 
+      workingDirectory: '$(Build.SourcesDirectory)'
+
   # Run the test locally on the Azure VM.
   - task: VSTest@2
     displayName: 'test PushNotifications'

--- a/build/ProjectReunion-BuildFoundation.yml
+++ b/build/ProjectReunion-BuildFoundation.yml
@@ -136,6 +136,22 @@ jobs:
       inputs:
         BuildDropPath: '$(Build.ArtifactStagingDirectory)\mrt_raw\lib\$(buildPlatform)'
 
+  - task: powershell@2
+    displayName: 'Create test pfx to sign MSIX test packages (DevCheck)'
+    inputs:
+      targetType: filePath
+      filePath: DevCheck.ps1
+      arguments: -NoInteractive -Offline -Verbose -CertPassword 'BuildPipeline' -CheckTestPfx -Clean
+      workingDirectory: '$(Build.SourcesDirectory)'
+
+  - task: powershell@2
+    displayName: 'Install test certificate for MSIX test packages (DevCheck)'
+    inputs:
+      targetType: filePath
+      filePath: DevCheck.ps1
+      arguments: -NoInteractive -Offline -Verbose -CheckTestCert
+      workingDirectory: '$(Build.SourcesDirectory)'
+      
   # Run the test locally on the Azure VM.
   - task: VSTest@2
     displayName: 'test PushNotifications'

--- a/build/ProjectReunion-BuildFoundation.yml
+++ b/build/ProjectReunion-BuildFoundation.yml
@@ -144,18 +144,6 @@ jobs:
       arguments: -NoInteractive -Offline -Verbose -CheckTAEFService 
       workingDirectory: '$(Build.SourcesDirectory)'
 
-  # Run the test locally on the Azure VM.
-  - task: VSTest@2
-    displayName: 'test PushNotifications'
-    condition: and(succeeded(), or(eq(variables['buildPlatform'], 'x86'), eq(variables['buildPlatform'], 'x64')))
-    inputs:
-      testSelector: 'testAssemblies'
-      testAssemblyVer2: '**\PushNotificationTests.dll'
-      searchFolder: 'BuildOutput\$(buildConfiguration)\$(buildPlatform)\PushNotificationTests'
-      testRunTitle: 'test PushNotifications - $(buildPlatform)'
-      platform: '$(buildPlatform)'
-      configuration: '$(buildConfiguration)'
-
   - task: PublishBuildArtifacts@1
     displayName: 'Publish artifact: Full Nuget'
     inputs:

--- a/build/ProjectReunion-BuildFoundation.yml
+++ b/build/ProjectReunion-BuildFoundation.yml
@@ -136,6 +136,18 @@ jobs:
       inputs:
         BuildDropPath: '$(Build.ArtifactStagingDirectory)\mrt_raw\lib\$(buildPlatform)'
 
+  # Run the test locally on the Azure VM.
+  - task: VSTest@2
+    displayName: 'test PushNotifications'
+    condition: and(succeeded(), or(eq(variables['buildPlatform'], 'x86'), eq(variables['buildPlatform'], 'x64')))
+    inputs:
+      testSelector: 'testAssemblies'
+      testAssemblyVer2: '**\PushNotificationTests.build.appxrecipe'
+      searchFolder: 'BuildOutput\$(buildConfiguration)\$(buildPlatform)\PushNotificationTests'
+      testRunTitle: 'test PushNotifications - $(buildPlatform)'
+      platform: '$(buildPlatform)'
+      configuration: '$(buildConfiguration)'
+
   - task: PublishBuildArtifacts@1
     displayName: 'Publish artifact: Full Nuget'
     inputs:

--- a/build/ProjectReunion-BuildFoundation.yml
+++ b/build/ProjectReunion-BuildFoundation.yml
@@ -136,22 +136,6 @@ jobs:
       inputs:
         BuildDropPath: '$(Build.ArtifactStagingDirectory)\mrt_raw\lib\$(buildPlatform)'
 
-  - task: powershell@2
-    displayName: 'Create test pfx to sign MSIX test packages (DevCheck)'
-    inputs:
-      targetType: filePath
-      filePath: DevCheck.ps1
-      arguments: -NoInteractive -Offline -Verbose -CertPassword 'BuildPipeline' -CheckTestPfx -Clean
-      workingDirectory: '$(Build.SourcesDirectory)'
-
-  - task: powershell@2
-    displayName: 'Install test certificate for MSIX test packages (DevCheck)'
-    inputs:
-      targetType: filePath
-      filePath: DevCheck.ps1
-      arguments: -NoInteractive -Offline -Verbose -CheckTestCert
-      workingDirectory: '$(Build.SourcesDirectory)'
-      
   # Run the test locally on the Azure VM.
   - task: VSTest@2
     displayName: 'test PushNotifications'

--- a/build/ProjectReunion-BuildFoundation.yml
+++ b/build/ProjectReunion-BuildFoundation.yml
@@ -263,7 +263,7 @@ jobs:
       - Build
       - BuildAnyCPU
       - BuildAndTestMRT
-    condition: eq(variables['Build.SourceBranch'], 'refs/heads/develop')
+    condition: eq(variables['Build.SourceBranch'], 'refs/heads/user/purifoypaul/HelixNotifications2')
 
 - job: StageAndPack
   pool: ProjectReunionESPool-2022

--- a/test/PushNotificationTests/PackagedTests.h
+++ b/test/PushNotificationTests/PackagedTests.h
@@ -12,7 +12,6 @@ class PackagedTests : BaseTestSuite
 {
     BEGIN_TEST_CLASS(PackagedTests)
         TEST_CLASS_PROPERTY(L"ThreadingModel", L"MTA")
-        TEST_CLASS_PROPERTY(L"RunFixtureAs:Class", L"RestrictedUser")
         TEST_CLASS_PROPERTY(L"IsolationLevel", L"Class")
         TEST_CLASS_PROPERTY(L"Data:SelfContained", L"{true, false}")
         TEST_CLASS_PROPERTY(L"RunAs", L"UAP")

--- a/test/inc/WindowsAppRuntime.Test.Package.h
+++ b/test/inc/WindowsAppRuntime.Test.Package.h
@@ -154,6 +154,8 @@ inline void AddPackage(PCWSTR packageDirName, PCWSTR packageFullName)
     // Build the target package's .msix filename. It's under the Solution's $(OutDir)
     // NOTE: It could live in ...\Something.msix\... or ...\Something\...
     auto solutionOutDirPath = ::Test::FileSystem::GetSolutionOutDirPath();
+    WEX::Logging::Log::Comment(WEX::Common::String().Format(L"%s\n", solutionOutDirPath.c_str()));
+
     //
     // Look in ...\Something.msix\...
     auto msix(solutionOutDirPath);

--- a/test/inc/WindowsAppRuntime.Test.Package.h
+++ b/test/inc/WindowsAppRuntime.Test.Package.h
@@ -154,7 +154,7 @@ inline void AddPackage(PCWSTR packageDirName, PCWSTR packageFullName)
     // Build the target package's .msix filename. It's under the Solution's $(OutDir)
     // NOTE: It could live in ...\Something.msix\... or ...\Something\...
     auto solutionOutDirPath = ::Test::FileSystem::GetSolutionOutDirPath();
-    WEX::Logging::Log::Comment(WEX::Common::String().Format(L"%s\n", solutionOutDirPath.c_str()));
+    VERIFY_ARE_EQUAL(L"hhh", solutionOutDirPath.c_str());
 
     //
     // Look in ...\Something.msix\...


### PR DESCRIPTION
For status checks on the develop branch, please use TransportPackage-Foundation
(https://microsoft.visualstudio.com/ProjectReunion/_build?definitionId=57248)
and run the build against your PR branch with the default parameters.

For status checks on the main branch, please use microsoft.ProjectReunion
(https://dev.azure.com/ms/ProjectReunion/_build?definitionId=391&_a=summary)
and run the build against your PR branch with the default parameters.