### PR TITLE
Introducing WIL activities for AppNotifications

### DIFF
--- a/dev/AppNotifications/AppNotificationManager.cpp
+++ b/dev/AppNotifications/AppNotificationManager.cpp
@@ -38,7 +38,7 @@ namespace winrt
     using namespace winrt::Windows::Foundation;
     using namespace winrt::Windows::Foundation::Collections;
     using namespace winrt::Microsoft::Windows::AppNotifications;
-	using namespace Windows::ApplicationModel::Core;
+    using namespace Windows::ApplicationModel::Core;
 }
 
 namespace ToastABI
@@ -115,48 +115,38 @@ namespace winrt::Microsoft::Windows::AppNotifications::implementation
             return;
         }
 
-        HRESULT hr{ S_OK };
+        auto logTelemetry{ AppNotificationTelemetry::Register::Start(g_telemetryHelper, m_appId) };
 
-        auto logTelemetry{ wil::scope_exit([&]() {
-            AppNotificationTelemetry::LogRegister(hr, m_appId);
+        {
+            auto lock{ m_lock.lock_exclusive() };
+            THROW_HR_IF_MSG(HRESULT_FROM_WIN32(ERROR_OPERATION_IN_PROGRESS), m_registering, "Registration is in progress!");
+            m_registering = true;
+        }
+
+        auto registeringScopeExit{ wil::scope_exit([&]()
+        {
+            auto lock { m_lock.lock_exclusive() };
+            m_registering = false;
         }) };
 
-        try
+        winrt::guid registeredClsid{};
+        if (AppModel::Identity::IsPackagedProcess())
         {
-            {
-                auto lock{ m_lock.lock_exclusive() };
-                THROW_HR_IF_MSG(HRESULT_FROM_WIN32(ERROR_OPERATION_IN_PROGRESS), m_registering, "Registration is in progress!");
-                m_registering = true;
-            }
-
-            auto registeringScopeExit{ wil::scope_exit([&]()
-            {
-                auto lock { m_lock.lock_exclusive() };
-                m_registering = false;
-            }) };
-
-            winrt::guid registeredClsid{};
-            if (AppModel::Identity::IsPackagedProcess())
-            {
-                registeredClsid = RegisterPackagedApp();
-            }
-            else
-            {
-                AppNotificationAssets assets{ GetAssets() };
-                registeredClsid = RegisterUnpackagedApp(assets);
-            }
-
-            // Create event handle before COM Registration otherwise if a notification arrives will lead to race condition
-            m_waitHandleForArgs.create();
-
-            // Register the AppNotificationManager as a COM server for Shell to Activate and Invoke
-            RegisterComServer(registeredClsid);
+            registeredClsid = RegisterPackagedApp();
         }
-        catch (...)
+        else
         {
-            hr = wil::ResultFromCaughtException();
-            throw;
+            AppNotificationAssets assets{ GetAssets() };
+            registeredClsid = RegisterUnpackagedApp(assets);
         }
+
+        // Create event handle before COM Registration otherwise if a notification arrives will lead to race condition
+        m_waitHandleForArgs.create();
+
+        // Register the AppNotificationManager as a COM server for Shell to Activate and Invoke
+        RegisterComServer(registeredClsid);
+
+        logTelemetry.Stop();
     }
 
     void AppNotificationManager::Register(hstring const& displayName, winrt::Windows::Foundation::Uri const& iconUri)
@@ -166,45 +156,35 @@ namespace winrt::Microsoft::Windows::AppNotifications::implementation
             return;
         }
 
-        HRESULT hr{ S_OK };
+        auto logTelemetry{ AppNotificationTelemetry::Register::Start(g_telemetryHelper, m_appId) };
 
-        auto logTelemetry{ wil::scope_exit([&]() {
-            AppNotificationTelemetry::LogRegister(hr, m_appId);
+        THROW_HR_IF_MSG(E_ILLEGAL_METHOD_CALL, AppModel::Identity::IsPackagedProcess(), "Not applicable for packaged applications");
+
+        THROW_HR_IF(E_INVALIDARG, displayName.empty() || (iconUri == nullptr));
+
+        AppNotificationAssets assets{ ValidateAssets(displayName, iconUri.RawUri().c_str()) };
+
+        {
+            auto lock{ m_lock.lock_exclusive() };
+            THROW_HR_IF_MSG(HRESULT_FROM_WIN32(ERROR_OPERATION_IN_PROGRESS), m_registering, "Registration is in progress!");
+            m_registering = true;
+        }
+
+        auto registeringScopeExit{ wil::scope_exit([&]()
+        {
+            auto lock { m_lock.lock_exclusive() };
+            m_registering = false;
         }) };
 
-        try
-        {
-            THROW_HR_IF_MSG(E_ILLEGAL_METHOD_CALL, AppModel::Identity::IsPackagedProcess(), "Not applicable for packaged applications");
+        winrt::guid registeredClsid{ RegisterUnpackagedApp(assets) };
 
-            THROW_HR_IF(E_INVALIDARG, displayName.empty() || (iconUri == nullptr));
+        // Create event handle before COM Registration otherwise if a notification arrives will lead to race condition
+        m_waitHandleForArgs.create();
 
-            AppNotificationAssets assets{ ValidateAssets(displayName, iconUri.RawUri().c_str()) };
+        // Register the AppNotificationManager as a COM server for Shell to Activate and Invoke
+        RegisterComServer(registeredClsid);
 
-            {
-                auto lock{ m_lock.lock_exclusive() };
-                THROW_HR_IF_MSG(HRESULT_FROM_WIN32(ERROR_OPERATION_IN_PROGRESS), m_registering, "Registration is in progress!");
-                m_registering = true;
-            }
-
-            auto registeringScopeExit{ wil::scope_exit([&]()
-            {
-                auto lock { m_lock.lock_exclusive() };
-                m_registering = false;
-            }) };
-
-            winrt::guid registeredClsid{ RegisterUnpackagedApp(assets) };
-
-            // Create event handle before COM Registration otherwise if a notification arrives will lead to race condition
-            m_waitHandleForArgs.create();
-
-            // Register the AppNotificationManager as a COM server for Shell to Activate and Invoke
-            RegisterComServer(registeredClsid);
-        }
-        catch (...)
-        {
-            hr = wil::ResultFromCaughtException();
-            throw;
-        }
+        logTelemetry.Stop();
     }
 
     void AppNotificationManager::RegisterComServer(winrt::guid const& registeredClsid)
@@ -276,30 +256,20 @@ namespace winrt::Microsoft::Windows::AppNotifications::implementation
             return;
         }
 
-        HRESULT hr{ S_OK };
+        auto logTelemetry{ AppNotificationTelemetry::Unregister::Start(g_telemetryHelper, m_appId) };
 
-        auto logTelemetry{ wil::scope_exit([&]() {
-            AppNotificationTelemetry::LogUnregister(hr, m_appId);
-        }) };
+        auto lock{ m_lock.lock_exclusive() };
+        THROW_HR_IF_MSG(HRESULT_FROM_WIN32(ERROR_OPERATION_IN_PROGRESS), m_registering, "Register or Unregister currently in progress!");
+        m_registering = true;
+        auto scope_exit = wil::scope_exit(
+            [&] {
+                m_registering = false;
+            });
 
-        try
-        {
-            auto lock{ m_lock.lock_exclusive() };
-            THROW_HR_IF_MSG(HRESULT_FROM_WIN32(ERROR_OPERATION_IN_PROGRESS), m_registering, "Register or Unregister currently in progress!");
-            m_registering = true;
-            auto scope_exit = wil::scope_exit(
-                [&] {
-                    m_registering = false;
-                });
+        THROW_HR_IF_MSG(HRESULT_FROM_WIN32(ERROR_NOT_FOUND), !m_notificationComActivatorRegistration, "Not Registered for App Notifications!");
+        UnregisterHelper();
 
-            THROW_HR_IF_MSG(HRESULT_FROM_WIN32(ERROR_NOT_FOUND), !m_notificationComActivatorRegistration, "Not Registered for App Notifications!");
-            UnregisterHelper();
-        }
-        catch (...)
-        {
-            hr = wil::ResultFromCaughtException();
-            throw;
-        }
+        logTelemetry.Stop();
     }
 
     void AppNotificationManager::UnregisterAll()
@@ -309,55 +279,45 @@ namespace winrt::Microsoft::Windows::AppNotifications::implementation
             return;
         }
 
-        HRESULT hr{ S_OK };
+        auto logTelemetry{ AppNotificationTelemetry::UnregisterAll::Start(g_telemetryHelper, m_appId) };
 
-        auto logTelemetry{ wil::scope_exit([&]() {
-            AppNotificationTelemetry::LogUnregisterAll(hr, m_appId);
-        }) };
-
-        try
         {
-            {
+            auto lock{ m_lock.lock_exclusive() };
+            UnregisterHelper();
+            THROW_HR_IF_MSG(HRESULT_FROM_WIN32(ERROR_OPERATION_IN_PROGRESS), m_registering, "Register or Unregister currently in progress!");
+            m_registering = true;
+        }
+
+        auto scope_exit = wil::scope_exit(
+            [&] {
                 auto lock{ m_lock.lock_exclusive() };
-                UnregisterHelper();
-                THROW_HR_IF_MSG(HRESULT_FROM_WIN32(ERROR_OPERATION_IN_PROGRESS), m_registering, "Register or Unregister currently in progress!");
-                m_registering = true;
-            }
+                m_registering = false;
+            });
 
-            auto scope_exit = wil::scope_exit(
-                [&] {
-                    auto lock{ m_lock.lock_exclusive() };
-                    m_registering = false;
-                });
-
-            // Remove any Registrations from the Long Running Process that are necessary for Cloud toasts
-            if (!PushNotificationHelpers::IsPackagedAppScenario() && !WindowsAppRuntime::SelfContained::IsSelfContained())
-            {
-                auto notificationPlatform{ NotificationPlatform::GetNotificationPlatform() };
-                THROW_IF_FAILED(notificationPlatform->RemoveToastRegistrationMapping(m_processName.c_str()));
-            }
-
-            if (!AppModel::Identity::IsPackagedProcess())
-            {
-                // If the app icon was inferred from process, then we should clean it up.
-                // Do not fail this function if such a file doesn't exist,
-                // which is the case if the icon was retrieved from shortcut or there is no IconUri in registry.
-                winrt::hresult deleteIconResult{ DeleteIconFromCache() };
-                THROW_HR_IF(deleteIconResult, FAILED(deleteIconResult) && deleteIconResult != HRESULT_FROM_WIN32(ERROR_FILE_NOT_FOUND));
-
-                std::wstring storedComActivatorString;
-                THROW_IF_FAILED(GetActivatorGuid(storedComActivatorString));
-                UnRegisterComServer(storedComActivatorString);
-
-                UnRegisterNotificationAppIdentifierFromRegistry();
-                THROW_IF_FAILED(PushNotifications_UnregisterFullTrustApplication(m_appId.c_str()));
-            }
-        }
-        catch (...)
+        // Remove any Registrations from the Long Running Process that are necessary for Cloud toasts
+        if (!PushNotificationHelpers::IsPackagedAppScenario() && !WindowsAppRuntime::SelfContained::IsSelfContained())
         {
-            hr = wil::ResultFromCaughtException();
-            throw;
+            auto notificationPlatform{ NotificationPlatform::GetNotificationPlatform() };
+            THROW_IF_FAILED(notificationPlatform->RemoveToastRegistrationMapping(m_processName.c_str()));
         }
+
+        if (!AppModel::Identity::IsPackagedProcess())
+        {
+            // If the app icon was inferred from process, then we should clean it up.
+            // Do not fail this function if such a file doesn't exist,
+            // which is the case if the icon was retrieved from shortcut or there is no IconUri in registry.
+            winrt::hresult deleteIconResult{ DeleteIconFromCache() };
+            THROW_HR_IF(deleteIconResult, FAILED(deleteIconResult) && deleteIconResult != HRESULT_FROM_WIN32(ERROR_FILE_NOT_FOUND));
+
+            std::wstring storedComActivatorString;
+            THROW_IF_FAILED(GetActivatorGuid(storedComActivatorString));
+            UnRegisterComServer(storedComActivatorString);
+
+            UnRegisterNotificationAppIdentifierFromRegistry();
+            THROW_IF_FAILED(PushNotifications_UnregisterFullTrustApplication(m_appId.c_str()));
+        }
+
+        logTelemetry.Stop();
     }
 
     winrt::event_token AppNotificationManager::NotificationInvoked(winrt::Windows::Foundation::TypedEventHandler<winrt::Microsoft::Windows::AppNotifications::AppNotificationManager, winrt::Microsoft::Windows::AppNotifications::AppNotificationActivatedEventArgs> const& handler)
@@ -389,6 +349,12 @@ namespace winrt::Microsoft::Windows::AppNotifications::implementation
         [[maybe_unused]] NOTIFICATION_USER_INPUT_DATA const* data,
         [[maybe_unused]] ULONG dataCount) noexcept try
     {
+        auto logTelemetry{ AppNotificationTelemetry::Activated::Start(
+            g_telemetryHelper,
+            m_appId,
+            invokedArgs,
+            m_firstNotificationReceived,
+            !!m_notificationHandlers) };
 
         winrt::IMap<winrt::hstring, winrt::hstring> userInput{ winrt::single_threaded_map<winrt::hstring, winrt::hstring>() };
         for (unsigned long i = 0; i < dataCount; i++)
@@ -398,109 +364,92 @@ namespace winrt::Microsoft::Windows::AppNotifications::implementation
 
         winrt::AppNotificationActivatedEventArgs activatedEventArgs = winrt::make<implementation::AppNotificationActivatedEventArgs>(invokedArgs, userInput);
 
-        HRESULT hr{ S_OK };
+        // Need to store the first notification in the case of ToastActivation
 
-        auto logTelemetry{ wil::scope_exit([&]() {
-            AppNotificationTelemetry::LogActivated(hr, m_appId, invokedArgs, m_firstNotificationReceived, !!m_notificationHandlers);
-        }) };
-
-        try
+        auto lock{ m_lock.lock_exclusive() };
+        if (!m_firstNotificationReceived)
         {
-            // Need to store the first notification in the case of ToastActivation
+            m_firstNotificationReceived = true;
 
-            auto lock{ m_lock.lock_exclusive() };
-            if (!m_firstNotificationReceived)
+            std::wstring commandLine{ GetCommandLine() };
+
+            // If the app was not launched due to ToastActivation, we will launch a new instance or invoke the foreground handlers.
+            // Otherwise we store the EventArgs and signal to the Main thread
+            auto pos{ commandLine.find(c_notificationActivatedArgument) };
+            if (pos == std::wstring::npos) // Any launch kind that is not AppNotification
             {
-                m_firstNotificationReceived = true;
-
-                std::wstring commandLine{ GetCommandLine() };
-
-                // If the app was not launched due to ToastActivation, we will launch a new instance or invoke the foreground handlers.
-                // Otherwise we store the EventArgs and signal to the Main thread
-                auto pos{ commandLine.find(c_notificationActivatedArgument) };
-                if (pos == std::wstring::npos) // Any launch kind that is not AppNotification
+                // If the Process was launched due to other Activation Kinds, we will need to
+                // re-route the payload to a new process if there are no registered event handlers.
+                if (!m_notificationHandlers)
                 {
-                    // If the Process was launched due to other Activation Kinds, we will need to
-                    // re-route the payload to a new process if there are no registered event handlers.
-                    if (!m_notificationHandlers)
+                    winrt::guid registeredClsid{ GUID_NULL };
+                    if (AppModel::Identity::IsPackagedProcess())
                     {
-                        winrt::guid registeredClsid{ GUID_NULL };
-                        if (AppModel::Identity::IsPackagedProcess())
-                        {
-                            registeredClsid = PushNotificationHelpers::GetComRegistrationFromRegistry(c_expectedAppServerArgs.data());
-                        }
-                        else
-                        {
-                            std::wstring registeredClsidString;
-                            THROW_IF_FAILED(GetActivatorGuid(registeredClsidString));
-
-                            // Remove braces around the guid string
-                            registeredClsid = winrt::guid(registeredClsidString.substr(1, registeredClsidString.size() - 2));
-                        }
-
-                        auto notificationCallback{ winrt::create_instance<INotificationActivationCallback>(registeredClsid, CLSCTX_ALL) };
-                        THROW_IF_FAILED(notificationCallback->Activate(appUserModelId, invokedArgs, data, dataCount));
+                        registeredClsid = PushNotificationHelpers::GetComRegistrationFromRegistry(c_expectedAppServerArgs.data());
                     }
                     else
                     {
-                        m_notificationHandlers(Default(), activatedEventArgs);
+                        std::wstring registeredClsidString;
+                        THROW_IF_FAILED(GetActivatorGuid(registeredClsidString));
+
+                        // Remove braces around the guid string
+                        registeredClsid = winrt::guid(registeredClsidString.substr(1, registeredClsidString.size() - 2));
                     }
+
+                    auto notificationCallback{ winrt::create_instance<INotificationActivationCallback>(registeredClsid, CLSCTX_ALL) };
+                    THROW_IF_FAILED(notificationCallback->Activate(appUserModelId, invokedArgs, data, dataCount));
                 }
                 else
                 {
-                    m_activatedEventArgs = activatedEventArgs;
-                    SetEvent(m_waitHandleForArgs.get());
+                    m_notificationHandlers(Default(), activatedEventArgs);
                 }
             }
             else
             {
-                m_notificationHandlers(Default(), activatedEventArgs);
+                m_activatedEventArgs = activatedEventArgs;
+                SetEvent(m_waitHandleForArgs.get());
             }
-
-            return hr;
         }
-        catch (...)
+        else
         {
-            hr = wil::ResultFromCaughtException();
-            throw;
+            m_notificationHandlers(Default(), activatedEventArgs);
         }
+
+        logTelemetry.Stop();
+
+        return S_OK;
     }
     CATCH_RETURN()
 
-    void AppNotificationManager::Show(winrt::Microsoft::Windows::AppNotifications::AppNotification const& notification)
+        void AppNotificationManager::Show(winrt::Microsoft::Windows::AppNotifications::AppNotification const& notification)
     {
         if (!IsSupported())
         {
             return;
         }
 
+        auto logTelemetry{ AppNotificationTelemetry::Show::Start(
+            g_telemetryHelper,
+            m_appId,
+            notification.Payload(),
+            notification.Tag(),
+            notification.Group()) };
+
         THROW_HR_IF(WPN_E_NOTIFICATION_POSTED, notification.Id() != 0);
 
-        HRESULT hr{ S_OK };
+        winrt::com_ptr<::ABI::Microsoft::Internal::ToastNotifications::INotificationProperties> notificationProperties = winrt::make_self<NotificationProperties>(notification);
 
-        auto logTelemetry{ wil::scope_exit([&]() {
-            AppNotificationTelemetry::LogShow(hr, m_appId, notification.Payload(), notification.Tag(), notification.Group());
-        }) };
+        winrt::com_ptr<::ABI::Microsoft::Internal::ToastNotifications::INotificationTransientProperties> notificationTransientProperties = winrt::make_self<NotificationTransientProperties>(notification);
 
-        try
-        {
-            winrt::com_ptr<::ABI::Microsoft::Internal::ToastNotifications::INotificationProperties> notificationProperties = winrt::make_self<NotificationProperties>(notification);
+        DWORD notificationId = 0;
+        THROW_IF_FAILED(ToastNotifications_PostToast(m_appId.c_str(), notificationProperties.get(), notificationTransientProperties.get(), &notificationId));
 
-            winrt::com_ptr<::ABI::Microsoft::Internal::ToastNotifications::INotificationTransientProperties> notificationTransientProperties = winrt::make_self<NotificationTransientProperties>(notification);
+        THROW_HR_IF(E_UNEXPECTED, notificationId == 0);
 
-            DWORD notificationId = 0;
-            THROW_IF_FAILED(ToastNotifications_PostToast(m_appId.c_str(), notificationProperties.get(), notificationTransientProperties.get(), &notificationId));
+        implementation::AppNotification* notificationImpl = get_self<implementation::AppNotification>(notification);
+        notificationImpl->SetNotificationId(notificationId);
 
-            THROW_HR_IF(E_UNEXPECTED, notificationId == 0);
-
-            implementation::AppNotification* notificationImpl = get_self<implementation::AppNotification>(notification);
-            notificationImpl->SetNotificationId(notificationId);
-        }
-        catch (...)
-        {
-            hr = wil::ResultFromCaughtException();
-            throw;
-        }
+        logTelemetry.Stop();
     }
 
     winrt::Windows::Foundation::IAsyncOperation<winrt::Microsoft::Windows::AppNotifications::AppNotificationProgressResult> AppNotificationManager::UpdateAsync(winrt::Microsoft::Windows::AppNotifications::AppNotificationProgressData const data, hstring const tag, hstring const group)
@@ -513,39 +462,30 @@ namespace winrt::Microsoft::Windows::AppNotifications::implementation
         THROW_HR_IF_MSG(E_INVALIDARG, tag == winrt::hstring(L""), "Update operation isn't guaranteed to find a specific notification to replace correctly.");
         THROW_HR_IF_MSG(E_INVALIDARG, data.SequenceNumber() == 0, "Sequence Number for Updates should be greater than 0!");
 
-        HRESULT hr{ S_OK };
-
         auto strong = get_strong();
         co_await resume_background();
 
-        auto logTelemetry{ wil::scope_exit([&]() {
-            AppNotificationTelemetry::LogUpdateAsync(hr, m_appId, tag, group);
-        }) };
+        auto logTelemetry{ AppNotificationTelemetry::UpdateAsync::Start(g_telemetryHelper, m_appId, tag, group) };
 
-        try
+        winrt::com_ptr<ToastABI::IToastProgressData> toastProgressData{ winrt::make_self<NotificationProgressData>(data) };
+
+        HRESULT hr{ S_OK };
+        hr = ToastNotifications_UpdateNotificationData(m_appId.c_str(), tag.c_str(), group.c_str(), toastProgressData.get());
+
+        if (SUCCEEDED(hr))
         {
-            winrt::com_ptr<ToastABI::IToastProgressData> toastProgressData{ winrt::make_self<NotificationProgressData>(data) };
-
-            hr = ToastNotifications_UpdateNotificationData(m_appId.c_str(), tag.c_str(), group.c_str(), toastProgressData.get());
-
-            if (SUCCEEDED(hr))
-            {
-                co_return winrt::AppNotificationProgressResult::Succeeded;
-            }
-            else if (hr == E_NOT_SET)
-            {
-                co_return winrt::AppNotificationProgressResult::AppNotificationNotFound;
-            }
-            else
-            {
-                THROW_HR(hr);
-            }
+            co_return winrt::AppNotificationProgressResult::Succeeded;
         }
-        catch (...)
+        else if (hr == E_NOT_SET)
         {
-            hr = wil::ResultFromCaughtException();
-            throw;
+            co_return winrt::AppNotificationProgressResult::AppNotificationNotFound;
         }
+        else
+        {
+            THROW_HR(hr);
+        }
+
+        logTelemetry.Stop();
     }
 
     winrt::Windows::Foundation::IAsyncOperation<winrt::Microsoft::Windows::AppNotifications::AppNotificationProgressResult> AppNotificationManager::UpdateAsync(winrt::Microsoft::Windows::AppNotifications::AppNotificationProgressData const data, hstring const tag)
@@ -560,23 +500,14 @@ namespace winrt::Microsoft::Windows::AppNotifications::implementation
             return AppNotificationSetting::Unsupported;
         }
 
-        HRESULT hr{ S_OK };
+        auto logTelemetry{ AppNotificationTelemetry::Setting::Start(g_telemetryHelper, m_appId) };
 
-        auto logTelemetry{ wil::scope_exit([&]() {
-            AppNotificationTelemetry::LogSetting(hr, m_appId);
-        }) };
+        DWORD appNotificationSetting{ 0 };
+        ToastNotifications_QuerySettings(m_appId.c_str(), &appNotificationSetting);
 
-        try
-        {
-            DWORD appNotificationSetting{ 0 };
-            ToastNotifications_QuerySettings(m_appId.c_str(), &appNotificationSetting);
-            return static_cast<winrt::Microsoft::Windows::AppNotifications::AppNotificationSetting>(appNotificationSetting);
-        }
-        catch (...)
-        {
-            hr = wil::ResultFromCaughtException();
-            throw;
-        }
+        logTelemetry.Stop();
+
+        return static_cast<winrt::Microsoft::Windows::AppNotifications::AppNotificationSetting>(appNotificationSetting);
     }
 
     winrt::Windows::Foundation::IAsyncAction AppNotificationManager::RemoveByIdAsync(uint32_t notificationId)
@@ -586,26 +517,19 @@ namespace winrt::Microsoft::Windows::AppNotifications::implementation
             return;
         }
 
+        auto logTelemetry{ AppNotificationTelemetry::RemoveByIdAsync::Start(g_telemetryHelper, m_appId, notificationId) };
+
         THROW_HR_IF(E_INVALIDARG, notificationId == 0);
 
-        HRESULT hr{ S_OK };
-
         auto strong = get_strong();
+        logTelemetry.IgnoreCurrentThread();
         co_await winrt::resume_background();
 
-        auto logTelemetry{ wil::scope_exit([&]() {
-            AppNotificationTelemetry::LogRemoveByIdAsync(hr, m_appId, notificationId);
-        }) };
+        auto logTelemetryContinuation = logTelemetry.ContinueOnCurrentThread();
 
-        try
-        {
-            THROW_IF_FAILED(ToastNotifications_RemoveToast(m_appId.c_str(), notificationId));
-        }
-        catch (...)
-        {
-            hr = wil::ResultFromCaughtException();
-            throw;
-        }
+        THROW_IF_FAILED(ToastNotifications_RemoveToast(m_appId.c_str(), notificationId));
+
+        logTelemetry.Stop();
     }
 
     winrt::Windows::Foundation::IAsyncAction AppNotificationManager::RemoveByTagAsync(hstring const tag)
@@ -615,26 +539,19 @@ namespace winrt::Microsoft::Windows::AppNotifications::implementation
             return;
         }
 
+        auto logTelemetry{ AppNotificationTelemetry::RemoveByTagAsync::Start(g_telemetryHelper, m_appId, tag) };
+
         THROW_HR_IF(E_INVALIDARG, tag == winrt::hstring(L""));
 
-        HRESULT hr{ S_OK };
-
         auto strong = get_strong();
+        logTelemetry.IgnoreCurrentThread();
         co_await winrt::resume_background();
 
-        auto logTelemetry{ wil::scope_exit([&]() {
-            AppNotificationTelemetry::LogRemoveByTagAsync(hr, m_appId, tag);
-        }) };
+        auto logTelemetryContinuation = logTelemetry.ContinueOnCurrentThread();
 
-        try
-        {
-            THROW_IF_FAILED(ToastNotifications_RemoveToastsWithTagAndGroup(m_appId.c_str(), tag.c_str(), nullptr));
-        }
-        catch (...)
-        {
-            hr = wil::ResultFromCaughtException();
-            throw;
-        }
+        THROW_IF_FAILED(ToastNotifications_RemoveToastsWithTagAndGroup(m_appId.c_str(), tag.c_str(), nullptr));
+
+        logTelemetry.Stop();
     }
 
     winrt::Windows::Foundation::IAsyncAction AppNotificationManager::RemoveByTagAndGroupAsync(hstring const tag, hstring const group)
@@ -644,27 +561,20 @@ namespace winrt::Microsoft::Windows::AppNotifications::implementation
             return;
         }
 
+        auto logTelemetry{ AppNotificationTelemetry::RemoveByTagAndGroupAsync::Start(g_telemetryHelper, m_appId, tag, group) };
+
         THROW_HR_IF(E_INVALIDARG, tag == winrt::hstring(L""));
         THROW_HR_IF(E_INVALIDARG, group == winrt::hstring(L""));
 
-        HRESULT hr{ S_OK };
-
         auto strong = get_strong();
+        logTelemetry.IgnoreCurrentThread();
         co_await winrt::resume_background();
 
-        auto logTelemetry{ wil::scope_exit([&]() {
-            AppNotificationTelemetry::LogRemoveByTagAndGroupAsync(hr, m_appId, tag, group);
-        }) };
+        auto logTelemetryContinuation = logTelemetry.ContinueOnCurrentThread();
 
-        try
-        {
-            THROW_IF_FAILED(ToastNotifications_RemoveToastsWithTagAndGroup(m_appId.c_str(), tag.c_str(), group.c_str()));
-        }
-        catch (...)
-        {
-            hr = wil::ResultFromCaughtException();
-            throw;
-        }
+        THROW_IF_FAILED(ToastNotifications_RemoveToastsWithTagAndGroup(m_appId.c_str(), tag.c_str(), group.c_str()));
+
+        logTelemetry.Stop();
     }
 
     winrt::Windows::Foundation::IAsyncAction AppNotificationManager::RemoveByGroupAsync(hstring const group)
@@ -674,26 +584,19 @@ namespace winrt::Microsoft::Windows::AppNotifications::implementation
             return;
         }
 
+        auto logTelemetry{ AppNotificationTelemetry::RemoveByGroupAsync::Start(g_telemetryHelper, m_appId, group) };
+
         THROW_HR_IF(E_INVALIDARG, group == winrt::hstring(L""));
 
-        HRESULT hr{ S_OK };
-
         auto strong = get_strong();
+        logTelemetry.IgnoreCurrentThread();
         co_await winrt::resume_background();
 
-        auto logTelemetry{ wil::scope_exit([&]() {
-            AppNotificationTelemetry::LogRemoveByGroupAsync(hr, m_appId);
-        }) };
+        auto logTelemetryContinuation = logTelemetry.ContinueOnCurrentThread();
 
-        try
-        {
-            THROW_IF_FAILED(ToastNotifications_RemoveToastsWithTagAndGroup(m_appId.c_str(), nullptr, group.c_str()));
-        }
-        catch (...)
-        {
-            hr = wil::ResultFromCaughtException();
-            throw;
-        }
+        THROW_IF_FAILED(ToastNotifications_RemoveToastsWithTagAndGroup(m_appId.c_str(), nullptr, group.c_str()));
+
+        logTelemetry.Stop();
     }
 
     winrt::Windows::Foundation::IAsyncAction AppNotificationManager::RemoveAllAsync()
@@ -703,73 +606,53 @@ namespace winrt::Microsoft::Windows::AppNotifications::implementation
             return;
         }
 
-        HRESULT hr{ S_OK };
-
         auto strong = get_strong();
         co_await winrt::resume_background();
 
-        auto logTelemetry{ wil::scope_exit([&]() {
-            AppNotificationTelemetry::LogRemoveAllAsync(hr, m_appId);
-        }) };
+        auto logTelemetry{ AppNotificationTelemetry::RemoveAllAsync::Start(g_telemetryHelper, m_appId) };
 
-        try
-        {
-            THROW_IF_FAILED(ToastNotifications_RemoveAllToastsForApp(m_appId.c_str()));
-        }
-        catch (...)
-        {
-            hr = wil::ResultFromCaughtException();
-            throw;
-        }
+        THROW_IF_FAILED(ToastNotifications_RemoveAllToastsForApp(m_appId.c_str()));
+
+        logTelemetry.Stop();
     }
 
     winrt::Windows::Foundation::IAsyncOperation<winrt::Windows::Foundation::Collections::IVector<winrt::Microsoft::Windows::AppNotifications::AppNotification>> AppNotificationManager::GetAllAsync()
     {
         if (!IsSupported())
         {
-            co_return {};
+            co_return{};
         }
-
-        HRESULT hr{ S_OK };
 
         auto strong = get_strong();
         co_await winrt::resume_background();
 
-        auto logTelemetry{ wil::scope_exit([&](){
-            AppNotificationTelemetry::LogGetAllAsync(hr, m_appId);
-        }) };
+        auto logTelemetry{ AppNotificationTelemetry::GetAllAsync::Start(g_telemetryHelper, m_appId) };
 
-        try
+        winrt::com_ptr<ToastABI::IVector<ToastABI::INotificationProperties*>> toastPropertiesCollection{};
+        auto result{ ToastNotifications_GetHistory(m_appId.c_str(), toastPropertiesCollection.put()) };
+
+        THROW_HR_IF(result, result != S_OK && result != E_NOT_SET); // Swallow E_NOT_SET and return an empty properties vector to signal that there are no active toasts
+
+        unsigned int count{};
+        if (toastPropertiesCollection)
         {
-            winrt::com_ptr<ToastABI::IVector<ToastABI::INotificationProperties*>> toastPropertiesCollection{};
-            auto result{ ToastNotifications_GetHistory(m_appId.c_str(), toastPropertiesCollection.put()) };
-
-            THROW_HR_IF(result, result != S_OK && result != E_NOT_SET); // Swallow E_NOT_SET and return an empty properties vector to signal that there are no active toasts
-
-            unsigned int count{};
-            if (toastPropertiesCollection)
-            {
-                THROW_IF_FAILED(toastPropertiesCollection->get_Size(&count));
-            }
-
-            winrt::IVector<winrt::Microsoft::Windows::AppNotifications::AppNotification> toastNotifications{ winrt::single_threaded_vector<winrt::Microsoft::Windows::AppNotifications::AppNotification>() };
-
-            for (unsigned i = 0; i < count; ++i)
-            {
-                ToastABI::INotificationProperties* toastProperties;
-                THROW_IF_FAILED(toastPropertiesCollection->GetAt(i, &toastProperties));
-
-                auto toastNotification{ ToastNotificationFromToastProperties(toastProperties) };
-
-                toastNotifications.Append(toastNotification);
-            }
-
-            co_return toastNotifications;
+            THROW_IF_FAILED(toastPropertiesCollection->get_Size(&count));
         }
-        catch (...)
+
+        winrt::IVector<winrt::Microsoft::Windows::AppNotifications::AppNotification> toastNotifications{ winrt::single_threaded_vector<winrt::Microsoft::Windows::AppNotifications::AppNotification>() };
+
+        for (unsigned i = 0; i < count; ++i)
         {
-            hr = wil::ResultFromCaughtException();
-            throw;
+            ToastABI::INotificationProperties* toastProperties;
+            THROW_IF_FAILED(toastPropertiesCollection->GetAt(i, &toastProperties));
+
+            auto toastNotification{ ToastNotificationFromToastProperties(toastProperties) };
+
+            toastNotifications.Append(toastNotification);
         }
+
+        logTelemetry.Stop();
+
+        co_return toastNotifications;
     }
 }

--- a/dev/AppNotifications/AppNotificationTelemetry.h
+++ b/dev/AppNotifications/AppNotificationTelemetry.h
@@ -177,7 +177,7 @@ public:
         std::wstring const& appId)
     {
         TraceLoggingClassWriteStart(
-            RemoveAllAsyncActivity,
+            RemoveAllAsync,
             _GENERIC_PARTB_FIELDS_ENABLED,
             TraceLoggingWideString(appId.c_str(), "AppId"),
             TraceLoggingBool(notificationTelemetryHelper.IsPackagedApp(), "IsAppPackaged"),

--- a/dev/AppNotifications/AppNotificationTelemetry.h
+++ b/dev/AppNotifications/AppNotificationTelemetry.h
@@ -11,270 +11,211 @@ DECLARE_TRACELOGGING_CLASS(AppNotificationTelemetryProvider,
     // {1825c850-a487-537d-b768-f0ab298d2565}
     (0x1825c850, 0xa487, 0x537d, 0xb7, 0x68, 0xf0, 0xab, 0x29, 0x8d, 0x25, 0x65));
 
-
 class AppNotificationTelemetry : public wil::TraceLoggingProvider
 {
     IMPLEMENT_TELEMETRY_CLASS(AppNotificationTelemetry, AppNotificationTelemetryProvider);
 
 public:
-    DEFINE_EVENT_METHOD(LogRegister)(
-        winrt::hresult hr,
-        std::wstring const& appId) noexcept try
-    {
-        if (m_telemetryHelper.ShouldLogEvent())
-        {
-            TraceLoggingClassWriteMeasure(
-                "Register",
-                TelemetryPrivacyDataTag(PDT_ProductAndServicePerformance),
-                _GENERIC_PARTB_FIELDS_ENABLED,
-                TraceLoggingHexUInt32(hr, "OperationResult"),
-                TraceLoggingWideString(appId.c_str(), "AppId"),
-                TraceLoggingBool(m_telemetryHelper.IsPackagedApp(), "IsAppPackaged"),
-                TraceLoggingWideString(m_telemetryHelper.GetAppName().c_str(), "AppName"));
-        }
-    }
-    CATCH_LOG()
 
-    DEFINE_EVENT_METHOD(LogUnregister)(
-        winrt::hresult hr,
-        std::wstring const& appId) noexcept try
+    BEGIN_COMPLIANT_MEASURES_ACTIVITY_CLASS(Register, PDT_ProductAndServicePerformance);
+    DEFINE_ACTIVITY_START(NotificationTelemetryHelper& notificationTelemetryHelper, std::wstring const& appId)
     {
-        if (m_telemetryHelper.ShouldLogEvent())
-        {
-            TraceLoggingClassWriteMeasure(
-                "Unregister",
-                TelemetryPrivacyDataTag(PDT_ProductAndServicePerformance),
-                _GENERIC_PARTB_FIELDS_ENABLED,
-                TraceLoggingHexUInt32(hr, "OperationResult"),
-                TraceLoggingWideString(appId.c_str(), "AppId"),
-                TraceLoggingBool(m_telemetryHelper.IsPackagedApp(), "IsAppPackaged"),
-                TraceLoggingWideString(m_telemetryHelper.GetAppName().c_str(), "AppName"));
-        }
+        TraceLoggingClassWriteStart(
+            Register,
+            _GENERIC_PARTB_FIELDS_ENABLED,
+            TraceLoggingWideString(appId.c_str(), "AppId"),
+            TraceLoggingBool(notificationTelemetryHelper.IsPackagedApp(), "IsAppPackaged"),
+            TraceLoggingWideString(notificationTelemetryHelper.GetAppName().c_str(), "AppName"));
     }
-    CATCH_LOG()
+    END_ACTIVITY_CLASS();
 
-    DEFINE_EVENT_METHOD(LogUnregisterAll)(
-        winrt::hresult hr,
-        std::wstring const& appId) noexcept try
+    BEGIN_COMPLIANT_MEASURES_ACTIVITY_CLASS(Unregister, PDT_ProductAndServicePerformance);
+    DEFINE_ACTIVITY_START(NotificationTelemetryHelper& notificationTelemetryHelper, std::wstring const& appId)
     {
-        if (m_telemetryHelper.ShouldLogEvent())
-        {
-            TraceLoggingClassWriteMeasure(
-                "UnregisterAll",
-                TelemetryPrivacyDataTag(PDT_ProductAndServicePerformance),
-                _GENERIC_PARTB_FIELDS_ENABLED,
-                TraceLoggingHexUInt32(hr, "OperationResult"),
-                TraceLoggingWideString(appId.c_str(), "AppId"),
-                TraceLoggingBool(m_telemetryHelper.IsPackagedApp(), "IsAppPackaged"),
-                TraceLoggingWideString(m_telemetryHelper.GetAppName().c_str(), "AppName"));
-        }
+        TraceLoggingClassWriteStart(
+            Unregister,
+            _GENERIC_PARTB_FIELDS_ENABLED,
+            TraceLoggingWideString(appId.c_str(), "AppId"),
+            TraceLoggingBool(notificationTelemetryHelper.IsPackagedApp(), "IsAppPackaged"),
+            TraceLoggingWideString(notificationTelemetryHelper.GetAppName().c_str(), "AppName"));
     }
-    CATCH_LOG()
+    END_ACTIVITY_CLASS();
 
-    DEFINE_EVENT_METHOD(LogShow)(
-        winrt::hresult hr,
+    BEGIN_COMPLIANT_MEASURES_ACTIVITY_CLASS(UnregisterAll, PDT_ProductAndServicePerformance);
+    DEFINE_ACTIVITY_START(NotificationTelemetryHelper& notificationTelemetryHelper, std::wstring const& appId)
+    {
+        TraceLoggingClassWriteStart(
+            UnregisterAll,
+            _GENERIC_PARTB_FIELDS_ENABLED,
+            TraceLoggingWideString(appId.c_str(), "AppId"),
+            TraceLoggingBool(notificationTelemetryHelper.IsPackagedApp(), "IsAppPackaged"),
+            TraceLoggingWideString(notificationTelemetryHelper.GetAppName().c_str(), "AppName"));
+    }
+    END_ACTIVITY_CLASS();
+
+    BEGIN_COMPLIANT_MEASURES_ACTIVITY_CLASS(Show, PDT_ProductAndServicePerformance);
+    DEFINE_ACTIVITY_START(
+        NotificationTelemetryHelper& notificationTelemetryHelper,
         std::wstring const& appId,
         winrt::hstring const& payload,
         winrt::hstring const& tag,
-        winrt::hstring const& group) noexcept try
+        winrt::hstring const& group)
     {
-        if (m_telemetryHelper.ShouldLogEvent())
-        {
-            TraceLoggingClassWriteMeasure(
-                "Show",
-                TelemetryPrivacyDataTag(PDT_ProductAndServicePerformance),
-                _GENERIC_PARTB_FIELDS_ENABLED,
-                TraceLoggingHexUInt32(hr, "OperationResult"),
-                TraceLoggingWideString(appId.c_str(), "AppId"),
-                TraceLoggingUInt32(payload.size(), "PayloadSize"),
-                TraceLoggingUInt32(tag.size(), "TagSize"),
-                TraceLoggingUInt32(group.size(), "GroupSize"),
-                TraceLoggingBool(m_telemetryHelper.IsPackagedApp(), "IsAppPackaged"),
-                TraceLoggingWideString(m_telemetryHelper.GetAppName().c_str(), "AppName"));
-        }
+        TraceLoggingClassWriteStart(
+            Show,
+            _GENERIC_PARTB_FIELDS_ENABLED,
+            TraceLoggingWideString(appId.c_str(), "AppId"),
+            TraceLoggingUInt32(payload.size(), "PayloadSize"),
+            TraceLoggingUInt32(tag.size(), "TagSize"),
+            TraceLoggingUInt32(group.size(), "GroupSize"),
+            TraceLoggingBool(notificationTelemetryHelper.IsPackagedApp(), "IsAppPackaged"),
+            TraceLoggingWideString(notificationTelemetryHelper.GetAppName().c_str(), "AppName"));
     }
-    CATCH_LOG()
+    END_ACTIVITY_CLASS();
 
-    DEFINE_EVENT_METHOD(LogUpdateAsync)(
-            winrt::hresult hr,
-            std::wstring const& appId,
-            winrt::hstring const& tag,
-            winrt::hstring const& group) noexcept try
-    {
-        if (m_telemetryHelper.ShouldLogEvent())
-        {
-            TraceLoggingClassWriteMeasure(
-                "UpdateAsync",
-                TelemetryPrivacyDataTag(PDT_ProductAndServicePerformance),
-                _GENERIC_PARTB_FIELDS_ENABLED,
-                TraceLoggingHexUInt32(hr, "OperationResult"),
-                TraceLoggingWideString(appId.c_str(), "AppId"),
-                TraceLoggingUInt32(tag.size(), "TagSize"),
-                TraceLoggingUInt32(group.size(), "GroupSize"),
-                TraceLoggingBool(m_telemetryHelper.IsPackagedApp(), "IsAppPackaged"),
-                TraceLoggingWideString(m_telemetryHelper.GetAppName().c_str(), "AppName"));
-        }
-    }
-    CATCH_LOG()
-
-    DEFINE_EVENT_METHOD(LogSetting)(
-        winrt::hresult hr,
-        std::wstring const& appId) noexcept try
-    {
-        if (m_telemetryHelper.ShouldLogEvent())
-        {
-            TraceLoggingClassWriteMeasure(
-                "Setting",
-                TelemetryPrivacyDataTag(PDT_ProductAndServicePerformance),
-                _GENERIC_PARTB_FIELDS_ENABLED,
-                TraceLoggingHexUInt32(hr, "OperationResult"),
-                TraceLoggingWideString(appId.c_str(), "AppId"),
-                TraceLoggingBool(m_telemetryHelper.IsPackagedApp(), "IsAppPackaged"),
-                TraceLoggingWideString(m_telemetryHelper.GetAppName().c_str(), "AppName"));
-        }
-    }
-    CATCH_LOG()
-
-    DEFINE_EVENT_METHOD(LogRemoveByIdAsync)(
-        winrt::hresult hr,
-        std::wstring const& appId,
-        uint32_t notificationId) noexcept try
-    {
-        if (m_telemetryHelper.ShouldLogEvent())
-        {
-            TraceLoggingClassWriteMeasure(
-                "RemoveByIdAsync",
-                TelemetryPrivacyDataTag(PDT_ProductAndServicePerformance),
-                _GENERIC_PARTB_FIELDS_ENABLED,
-                TraceLoggingHexUInt32(hr, "OperationResult"),
-                TraceLoggingWideString(appId.c_str(), "AppId"),
-                TraceLoggingHexUInt32(notificationId, "NotificationId"),
-                TraceLoggingBool(m_telemetryHelper.IsPackagedApp(), "IsAppPackaged"),
-                TraceLoggingWideString(m_telemetryHelper.GetAppName().c_str(), "AppName"));
-        }
-    }
-    CATCH_LOG()
-
-    DEFINE_EVENT_METHOD(LogRemoveByTagAsync)(
-        winrt::hresult hr,
-        std::wstring const& appId,
-        winrt::hstring const& tag) noexcept try
-    {
-        if (m_telemetryHelper.ShouldLogEvent())
-        {
-            TraceLoggingClassWriteMeasure(
-                "RemoveByTagAsync",
-                TelemetryPrivacyDataTag(PDT_ProductAndServicePerformance),
-                _GENERIC_PARTB_FIELDS_ENABLED,
-                TraceLoggingHexUInt32(hr, "OperationResult"),
-                TraceLoggingWideString(appId.c_str(), "AppId"),
-                TraceLoggingUInt32(tag.size(), "TagSize"),
-                TraceLoggingBool(m_telemetryHelper.IsPackagedApp(), "IsAppPackaged"),
-                TraceLoggingWideString(m_telemetryHelper.GetAppName().c_str(), "AppName"));
-        }
-    }
-    CATCH_LOG()
-
-    DEFINE_EVENT_METHOD(LogRemoveByTagAndGroupAsync)(
-        winrt::hresult hr,
+    BEGIN_COMPLIANT_MEASURES_ACTIVITY_CLASS(UpdateAsync, PDT_ProductAndServicePerformance);
+    DEFINE_ACTIVITY_START(
+        NotificationTelemetryHelper& notificationTelemetryHelper,
         std::wstring const& appId,
         winrt::hstring const& tag,
-        winrt::hstring const& group) noexcept try
+        winrt::hstring const& group)
     {
-        if (m_telemetryHelper.ShouldLogEvent())
-        {
-            TraceLoggingClassWriteMeasure(
-                "RemoveByTagAndGroupAsync",
-                TelemetryPrivacyDataTag(PDT_ProductAndServicePerformance),
-                _GENERIC_PARTB_FIELDS_ENABLED,
-                TraceLoggingHexUInt32(hr, "OperationResult"),
-                TraceLoggingWideString(appId.c_str(), "AppId"),
-                TraceLoggingUInt32(tag.size(), "TagSize"),
-                TraceLoggingUInt32(group.size(), "GroupSize"),
-                TraceLoggingBool(m_telemetryHelper.IsPackagedApp(), "IsAppPackaged"),
-                TraceLoggingWideString(m_telemetryHelper.GetAppName().c_str(), "AppName"));
-        }
+        TraceLoggingClassWriteStart(
+            UpdateAsync,
+            _GENERIC_PARTB_FIELDS_ENABLED,
+            TraceLoggingWideString(appId.c_str(), "AppId"),
+            TraceLoggingUInt32(tag.size(), "TagSize"),
+            TraceLoggingUInt32(group.size(), "GroupSize"),
+            TraceLoggingBool(notificationTelemetryHelper.IsPackagedApp(), "IsAppPackaged"),
+            TraceLoggingWideString(notificationTelemetryHelper.GetAppName().c_str(), "AppName"));
     }
-    CATCH_LOG()
+    END_ACTIVITY_CLASS();
 
-    DEFINE_EVENT_METHOD(LogRemoveByGroupAsync)(
-        winrt::hresult hr,
-        std::wstring const& appId) noexcept try
+    BEGIN_COMPLIANT_MEASURES_ACTIVITY_CLASS(Setting, PDT_ProductAndServicePerformance);
+    DEFINE_ACTIVITY_START(
+        NotificationTelemetryHelper& notificationTelemetryHelper,
+        std::wstring const& appId)
     {
-        if (m_telemetryHelper.ShouldLogEvent())
-        {
-            TraceLoggingClassWriteMeasure(
-                "RemoveByGroupAsync",
-                TelemetryPrivacyDataTag(PDT_ProductAndServicePerformance),
-                _GENERIC_PARTB_FIELDS_ENABLED,
-                TraceLoggingHexUInt32(hr, "OperationResult"),
-                TraceLoggingWideString(appId.c_str(), "AppId"),
-                TraceLoggingBool(m_telemetryHelper.IsPackagedApp(), "IsAppPackaged"),
-                TraceLoggingWideString(m_telemetryHelper.GetAppName().c_str(), "AppName"));
-        }
+        TraceLoggingClassWriteStart(
+            Setting,
+            _GENERIC_PARTB_FIELDS_ENABLED,
+            TraceLoggingWideString(appId.c_str(), "AppId"),
+            TraceLoggingBool(notificationTelemetryHelper.IsPackagedApp(), "IsAppPackaged"),
+            TraceLoggingWideString(notificationTelemetryHelper.GetAppName().c_str(), "AppName"));
     }
-    CATCH_LOG()
+    END_ACTIVITY_CLASS();
 
-    DEFINE_EVENT_METHOD(LogRemoveAllAsync)(
-        winrt::hresult hr,
-        std::wstring const& appId) noexcept try
+    BEGIN_COMPLIANT_MEASURES_ACTIVITY_CLASS(RemoveByIdAsync, PDT_ProductAndServicePerformance);
+    DEFINE_ACTIVITY_START(
+        NotificationTelemetryHelper& notificationTelemetryHelper,
+        std::wstring const& appId,
+        uint32_t notificationId)
     {
-        if (m_telemetryHelper.ShouldLogEvent())
-        {
-            TraceLoggingClassWriteMeasure(
-                "RemoveAllAsync",
-                TelemetryPrivacyDataTag(PDT_ProductAndServicePerformance),
-                _GENERIC_PARTB_FIELDS_ENABLED,
-                TraceLoggingHexUInt32(hr, "OperationResult"),
-                TraceLoggingWideString(appId.c_str(), "AppId"),
-                TraceLoggingBool(m_telemetryHelper.IsPackagedApp(), "IsAppPackaged"),
-                TraceLoggingWideString(m_telemetryHelper.GetAppName().c_str(), "AppName"));
-        }
+        TraceLoggingClassWriteStart(
+            RemoveByIdAsync,
+            _GENERIC_PARTB_FIELDS_ENABLED,
+            TraceLoggingWideString(appId.c_str(), "AppId"),
+            TraceLoggingHexUInt32(notificationId, "NotificationId"),
+            TraceLoggingBool(notificationTelemetryHelper.IsPackagedApp(), "IsAppPackaged"),
+            TraceLoggingWideString(notificationTelemetryHelper.GetAppName().c_str(), "AppName"));
     }
-    CATCH_LOG()
+    END_ACTIVITY_CLASS();
 
-    DEFINE_EVENT_METHOD(LogGetAllAsync)(
-        winrt::hresult hr,
-        std::wstring const& appId) noexcept try
+    BEGIN_COMPLIANT_MEASURES_ACTIVITY_CLASS(RemoveByTagAsync, PDT_ProductAndServicePerformance);
+    DEFINE_ACTIVITY_START(
+        NotificationTelemetryHelper& notificationTelemetryHelper,
+        std::wstring const& appId,
+        winrt::hstring const& tag)
     {
-        if (m_telemetryHelper.ShouldLogEvent())
-        {
-            TraceLoggingClassWriteMeasure(
-                "GetAllAsync",
-                TelemetryPrivacyDataTag(PDT_ProductAndServicePerformance),
-                _GENERIC_PARTB_FIELDS_ENABLED,
-                TraceLoggingHexUInt32(hr, "OperationResult"),
-                TraceLoggingWideString(appId.c_str(), "AppId"),
-                TraceLoggingBool(m_telemetryHelper.IsPackagedApp(), "IsAppPackaged"),
-                TraceLoggingWideString(m_telemetryHelper.GetAppName().c_str(), "AppName"));
-        }
+        TraceLoggingClassWriteStart(
+            RemoveByTagAsync,
+            _GENERIC_PARTB_FIELDS_ENABLED,
+            TraceLoggingWideString(appId.c_str(), "AppId"),
+            TraceLoggingUInt32(tag.size(), "TagSize"),
+            TraceLoggingBool(notificationTelemetryHelper.IsPackagedApp(), "IsAppPackaged"),
+            TraceLoggingWideString(notificationTelemetryHelper.GetAppName().c_str(), "AppName"));
     }
-    CATCH_LOG()
+    END_ACTIVITY_CLASS();
 
-    DEFINE_EVENT_METHOD(LogActivated)(
-        winrt::hresult hr,
+    BEGIN_COMPLIANT_MEASURES_ACTIVITY_CLASS(RemoveByTagAndGroupAsync, PDT_ProductAndServicePerformance);
+    DEFINE_ACTIVITY_START(
+        NotificationTelemetryHelper& notificationTelemetryHelper,
+        std::wstring const& appId,
+        winrt::hstring const& tag,
+        winrt::hstring const& group)
+    {
+        TraceLoggingClassWriteStart(
+            RemoveByTagAndGroupAsync,
+            _GENERIC_PARTB_FIELDS_ENABLED,
+            TraceLoggingWideString(appId.c_str(), "AppId"),
+            TraceLoggingUInt32(tag.size(), "TagSize"),
+            TraceLoggingUInt32(group.size(), "GroupSize"),
+            TraceLoggingBool(notificationTelemetryHelper.IsPackagedApp(), "IsAppPackaged"),
+            TraceLoggingWideString(notificationTelemetryHelper.GetAppName().c_str(), "AppName"));
+    }
+    END_ACTIVITY_CLASS();
+
+    BEGIN_COMPLIANT_MEASURES_ACTIVITY_CLASS(RemoveByGroupAsync, PDT_ProductAndServicePerformance);
+    DEFINE_ACTIVITY_START(
+        NotificationTelemetryHelper& notificationTelemetryHelper,
+        std::wstring const& appId,
+        winrt::hstring const& group)
+    {
+        TraceLoggingClassWriteStart(
+            RemoveByGroupAsync,
+            _GENERIC_PARTB_FIELDS_ENABLED,
+            TraceLoggingWideString(appId.c_str(), "AppId"),
+            TraceLoggingUInt32(group.size(), "GroupSize"),
+            TraceLoggingBool(notificationTelemetryHelper.IsPackagedApp(), "IsAppPackaged"),
+            TraceLoggingWideString(notificationTelemetryHelper.GetAppName().c_str(), "AppName"));
+    }
+    END_ACTIVITY_CLASS();
+
+    BEGIN_COMPLIANT_MEASURES_ACTIVITY_CLASS(RemoveAllAsync, PDT_ProductAndServicePerformance);
+    DEFINE_ACTIVITY_START(
+        NotificationTelemetryHelper& notificationTelemetryHelper,
+        std::wstring const& appId)
+    {
+        TraceLoggingClassWriteStart(
+            RemoveAllAsyncActivity,
+            _GENERIC_PARTB_FIELDS_ENABLED,
+            TraceLoggingWideString(appId.c_str(), "AppId"),
+            TraceLoggingBool(notificationTelemetryHelper.IsPackagedApp(), "IsAppPackaged"),
+            TraceLoggingWideString(notificationTelemetryHelper.GetAppName().c_str(), "AppName"));
+    }
+    END_ACTIVITY_CLASS();
+
+    BEGIN_COMPLIANT_MEASURES_ACTIVITY_CLASS(GetAllAsync, PDT_ProductAndServicePerformance);
+    DEFINE_ACTIVITY_START(
+        NotificationTelemetryHelper& notificationTelemetryHelper,
+        std::wstring const& appId)
+    {
+        TraceLoggingClassWriteStart(
+            GetAllAsync,
+            _GENERIC_PARTB_FIELDS_ENABLED,
+            TraceLoggingWideString(appId.c_str(), "AppId"),
+            TraceLoggingBool(notificationTelemetryHelper.IsPackagedApp(), "IsAppPackaged"),
+            TraceLoggingWideString(notificationTelemetryHelper.GetAppName().c_str(), "AppName"));
+    }
+    END_ACTIVITY_CLASS();
+
+    BEGIN_COMPLIANT_MEASURES_ACTIVITY_CLASS(Activated, PDT_ProductAndServicePerformance);
+    DEFINE_ACTIVITY_START(
+        NotificationTelemetryHelper& notificationTelemetryHelper,
         std::wstring const& appId,
         winrt::hstring const& arguments,
         bool firstNotificationReceived,
-        bool hasNotificationHandlers) noexcept try
+        bool hasNotificationHandlers)
     {
-        if (m_telemetryHelper.ShouldLogEvent())
-        {
-            TraceLoggingClassWriteMeasure(
-                "Activated",
-                TelemetryPrivacyDataTag(PDT_ProductAndServicePerformance),
-                _GENERIC_PARTB_FIELDS_ENABLED,
-                TraceLoggingHexUInt32(hr, "OperationResult"),
-                TraceLoggingWideString(appId.c_str(), "AppId"),
-                TraceLoggingUInt32(arguments.size(), "ArgumentsSize"),
-                TraceLoggingBool(firstNotificationReceived, "FirstNotificationReceived"),
-                TraceLoggingBool(hasNotificationHandlers, "HasNotificationHandlers"),
-                TraceLoggingBool(m_telemetryHelper.IsPackagedApp(), "IsAppPackaged"),
-                TraceLoggingWideString(m_telemetryHelper.GetAppName().c_str(), "AppName"));
-        }
+        TraceLoggingClassWriteStart(
+            Activated,
+            _GENERIC_PARTB_FIELDS_ENABLED,
+            TraceLoggingWideString(appId.c_str(), "AppId"),
+            TraceLoggingUInt32(arguments.size(), "ArgumentsSize"),
+            TraceLoggingBool(firstNotificationReceived, "FirstNotificationReceived"),
+            TraceLoggingBool(hasNotificationHandlers, "HasNotificationHandlers"),
+            TraceLoggingBool(notificationTelemetryHelper.IsPackagedApp(), "IsAppPackaged"),
+            TraceLoggingWideString(notificationTelemetryHelper.GetAppName().c_str(), "AppName"));
     }
-    CATCH_LOG()
-
-private:
-    NotificationTelemetryHelper m_telemetryHelper;
+    END_ACTIVITY_CLASS();
 };

--- a/test/AppNotificationTests/AppNotifications.Test.h
+++ b/test/AppNotificationTests/AppNotifications.Test.h
@@ -129,8 +129,9 @@ namespace AppNotifications::Test
             break;
 
         case ExpectedTransientProperties::DEFAULT:
+            // The default priority value is Default, and the default for SuppressDisplay is false.
             VERIFY_ARE_EQUAL(winrt::Microsoft::Windows::AppNotifications::AppNotificationPriority::Default, actual.Priority());
-            VERIFY_IS_TRUE(actual.SuppressDisplay());
+            VERIFY_IS_FALSE(actual.SuppressDisplay());
             break;
 
         case ExpectedTransientProperties::UNKNOWN:

--- a/test/AppNotificationTests/UnpackagedTests.cpp
+++ b/test/AppNotificationTests/UnpackagedTests.cpp
@@ -110,7 +110,7 @@ void UnpackagedTests::VerifyGetAllAsyncWithZeroActiveToast()
 
 void UnpackagedTests::VerifyGetAllAsyncWithOneActiveToast()
 {
-    BaseTestSuite::VerifyGetAllAsyncWithZeroActiveToast();
+    BaseTestSuite::VerifyGetAllAsyncWithOneActiveToast();
 }
 
 void UnpackagedTests::VerifyGetAllAsyncWithMultipleActiveToasts()


### PR DESCRIPTION
Now it's time to bring WIL activities goodness to App Notifications.

**How verified:** While running the AppNotificationTests suite, I recorded AppNotificationTelemetry traces in an etl file and I was able to see the new activities there.

**Bonus:** I fixed a couple of minor test bugs on AppNotificationTests.