### PR TITLE
Update WindowsAppSDK.Build.Cpp.props to add /Qspectre flag

### DIFF
--- a/WindowsAppSDK.Build.Cpp.props
+++ b/WindowsAppSDK.Build.Cpp.props
@@ -29,7 +29,9 @@
       <!-- /ZH:SHA_256 Hash algorithm for file checksums in debug info -->
       <!-- /d1trimfile:$(RepoRoot) If the prefix for a source file path name string matches "trim-string", 
       then the prefix is removed and is replaced with the mapping-identifier (if present). Requires /Brepro. -->
-      <AdditionalOptions>%(AdditionalOptions) /d1trimfile:$(RepoRoot) /ZH:SHA_256</AdditionalOptions>
+      <!-- /Qspectre Specifies compiler generation of instructions to mitigate certain Spectre variant 1 
+      security vulnerabilities. BinSkim asks for this. -->
+      <AdditionalOptions>%(AdditionalOptions) /d1trimfile:$(RepoRoot) /ZH:SHA_256 /Qspectre</AdditionalOptions>
     </ClCompile>
     <Link>
       <!-- /DEBUG:FULL Create PDF containing full debug information -->


### PR DESCRIPTION
Added the /Qspectre compiler flag, as suggested by BinSkim, as a project wide default setting.
