### PR TITLE
Update WindowsAppSDK.Build.Cpp.props

### DIFF
--- a/WindowsAppSDK.Build.Cpp.props
+++ b/WindowsAppSDK.Build.Cpp.props
@@ -39,7 +39,8 @@
 
       <!-- /Brepro Enables deterministic output from the compiler toolchain -->
       <!-- /PDBALTPATH Stops pdb's basepath from appearing in the Debug Directories of the image header -->
-      <AdditionalOptions>%(AdditionalOptions) /Brepro /PDBALTPATH:$(TargetName).pdb</AdditionalOptions>
+      <!-- /CETCOMPAT enables Control-flow Enforcement Technology (CET) Shadow Stack mitigation. BinSkim asks for this. -->
+      <AdditionalOptions>%(AdditionalOptions) /Brepro /PDBALTPATH:$(TargetName).pdb /CETCOMPAT</AdditionalOptions>
     </Link>
   </ItemDefinitionGroup>
 


### PR DESCRIPTION
Added linker flag /CETCOMPAT as global default, per BinSkim's ask.
