### PR TITLE
Update Newtonsoft.Json explicit reference in VSIX projects

### DIFF
--- a/dev/VSIX/Extension/Cpp/Dev16/WindowsAppSDK.Cpp.Extension.Dev16.csproj
+++ b/dev/VSIX/Extension/Cpp/Dev16/WindowsAppSDK.Cpp.Extension.Dev16.csproj
@@ -60,6 +60,7 @@
     <PackageReference Include="Microsoft.VisualStudio.SDK" Version="16.0.206" ExcludeAssets="runtime">
       <IncludeAssets>compile; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
     <PackageReference Include="System.Net.Http" Version="4.3.4" />
     <PackageReference Include="Microsoft.VSSDK.BuildTools" Version="17.0.3177-preview3">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/dev/VSIX/Extension/Cpp/Dev17/WindowsAppSDK.Cpp.Extension.Dev17.csproj
+++ b/dev/VSIX/Extension/Cpp/Dev17/WindowsAppSDK.Cpp.Extension.Dev17.csproj
@@ -60,6 +60,7 @@
     <PackageReference Include="Microsoft.VisualStudio.SDK" Version="17.0.0-previews-4-31709-430" ExcludeAssets="runtime">
       <IncludeAssets>compile; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
     <PackageReference Include="System.Net.Http" Version="4.3.4" />
     <PackageReference Include="Microsoft.VSSDK.BuildTools" Version="17.0.4207-preview4">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/dev/VSIX/Extension/Cs/Dev16/WindowsAppSDK.Cs.Extension.Dev16.csproj
+++ b/dev/VSIX/Extension/Cs/Dev16/WindowsAppSDK.Cs.Extension.Dev16.csproj
@@ -61,6 +61,7 @@
     <PackageReference Include="Microsoft.VisualStudio.SDK" Version="16.0.206" ExcludeAssets="runtime">
       <IncludeAssets>compile; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
     <PackageReference Include="System.Net.Http" Version="4.3.4" />
     <PackageReference Include="Microsoft.VSSDK.BuildTools" Version="17.0.3177-preview3">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/dev/VSIX/Extension/Cs/Dev17/WindowsAppSDK.Cs.Extension.Dev17.csproj
+++ b/dev/VSIX/Extension/Cs/Dev17/WindowsAppSDK.Cs.Extension.Dev17.csproj
@@ -60,6 +60,7 @@
     <PackageReference Include="Microsoft.VisualStudio.SDK" Version="17.0.0-previews-4-31709-430" ExcludeAssets="runtime">
       <IncludeAssets>compile; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
     <PackageReference Include="System.Net.Http" Version="4.3.4" />
     <PackageReference Include="Microsoft.VSSDK.BuildTools" Version="17.0.4207-preview4">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>


### PR DESCRIPTION
Component Governance Checks failing due to expired NewtonSoft.Json version