### PR TITLE
 Separate Maestro dependencies and manual dependencies into two xml files

### DIFF
--- a/DevCheck.ps1
+++ b/DevCheck.ps1
@@ -696,9 +696,9 @@ function Get-DependencyVersions
     {
         ForEach ($list in @($dependencies.AutoMagic, $dependencies.Manual))
         {
-            ForEach ($name in $versions.Keys)
+            ForEach ($name in $list.Keys)
             {
-                Write-Verbose "...$($name) = $($versions[$name])"
+                Write-Verbose "...$($name) = $($list[$name])"
             }
         }
     }
@@ -764,11 +764,12 @@ function Build-Dependencies
   <PropertyGroup>
     <VersionDetailsXmlFilename>`$(MSBuildThisFileDirectory)Version.Details.xml</VersionDetailsXmlFilename>
     <VersionDetailsXml>`$([System.IO.File]::ReadAllText(`"`$(VersionDetailsXmlFilename)`"))</VersionDetailsXml>
-    <VersionDependenciesXmlFilename>`$(MSBuildThisFileDirectory)Version.Details.xml</VersionDependenciesXmlFilename>
-    <VersionDependenciesXml>`$([System.IO.File]::ReadAllText("`$(VersionDetailsXmlFilename)"))</VersionDependenciesXml>
+    <VersionDependenciesXmlFilename>`$(MSBuildThisFileDirectory)Version.Dependencies.xml</VersionDependenciesXmlFilename>
+    <VersionDependenciesXml>`$([System.IO.File]::ReadAllText("`$(VersionDependenciesXmlFilename)"))</VersionDependenciesXml>
+
 "@
 
-    $output = $output + "    <!-- Dependencies: Automagic -->`r`n"
+    $output = $output + "    <!-- Dependencies: Maestro -->`r`n"
     $lines = @{}
     ForEach ($name in $automagic.Keys)
     {
@@ -789,7 +790,7 @@ function Build-Dependencies
         # NOTE: Create macros per name.Replace(".","").Append("Version")=value
         $macro = $name.Replace(".","") + "Version"
         $value = $manual[$name]
-        $lines.Add("    <$($macro)>`$([System.Text.RegularExpressions.Regex]::Match(`$(VersionDetailsXml), 'Name=`"$($name)`"\s+Version=`"(.*?)`"').Groups[1].Value)</$macro>`r`n", $null)
+        $lines.Add("    <$($macro)>`$([System.Text.RegularExpressions.Regex]::Match(`$(VersionDependenciesXml), 'Name=`"$($name)`"\s+Version=`"(.*?)`"').Groups[1].Value)</$macro>`r`n", $null)
     }
     $sortedLines = $lines.Keys | Sort-Object
     $output = $output + [String]::Join("", $sortedLines)

--- a/DevCheck.ps1
+++ b/DevCheck.ps1
@@ -650,16 +650,16 @@ function Start-TAEFService
 function Get-DependencyVersions
 {
     # Dependencies are defined in Version.Details.xml
-    #   Automagically updated by Maestro
+    #   - Automagically updated by Maestro
     # Dependencies are defined in Version.Dependencies.xml
-    #   Manually updated by human beings
+    #   - Manually updated by human beings
     # Return the pair of lists
     $dependencies = @{ Automagic=$null; Manual=$null }
 
     $root = Get-ProjectRoot
     $path = Join-Path $root 'eng'
 
-    # Parse the VersionDetails dependencies
+    # Parse the Version.Details.xml dependencies
     $versionDetailsFileName = Join-Path $path 'Version.Details.xml'
     Write-Host "Reading $($versionDetailsFileName)..."
     $automagicXml = [xml](Get-Content $versionDetailsFileName -EA:Stop)
@@ -678,11 +678,11 @@ function Get-DependencyVersions
     }
     $dependencies.Automagic = $automagicVersions
 
-    # Parse The VersionDependencies dependencies
+    # Parse The Version.Dependencies.xml dependencies
     $versionDependenciesFileName = Join-Path $path 'Version.Dependencies.xml'
     Write-Host "Reading $($versionDependenciesFileName)..."
     $manualXml = [xml](Get-Content $versionDependenciesFileName -EA:Stop)
-    # Parse the VersionDependencies dependencies
+    # Parse the Version.Dependencies.xml dependencies
     $manualVersions = [ordered]@{}
     ForEach ($dependency in $manualXml.SelectNodes("/Dependencies/Dependency"))
     {

--- a/DevCheck.ps1
+++ b/DevCheck.ps1
@@ -941,14 +941,14 @@ Write-Verbose("Processor...$cpu")
 $project_root = Get-ProjectRoot
 Write-Output "Windows App SDK location...$project_root"
 
-# if (($CheckAll -ne $false) -Or ($CheckVisualStudio -ne $false))
-# {
-#     $ok = Test-VisualStudio2022Install
-#     if ($ok -eq $true)
-#     {
-#         $null = Test-VisualStudioComponents
-#     }
-# }
+if (($CheckAll -ne $false) -Or ($CheckVisualStudio -ne $false))
+{
+    $ok = Test-VisualStudio2022Install
+    if ($ok -eq $true)
+    {
+        $null = Test-VisualStudioComponents
+    }
+}
 
 if (($CheckAll -ne $false) -Or ($CheckTestPfx -ne $false))
 {

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -9,7 +9,7 @@
 -->
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup>
-    <PackageVersion Include="Microsoft.Windows.CsWinRT" Version="$(MicrosoftWindowsCsWinRTVersion)" />
+    <PackageVersion Include="Microsoft.Windows.CsWinRT" Version="$(MicrosoftWindowsCsWinRTPackageVersion)" />
     <PackageVersion Include="Microsoft.SourceLink.Common" Version="$(MicrosoftSourceLinkCommonVersion)" />
     <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="$(MicrosoftSourceLinkGitHubVersion)" />
   </ItemGroup>

--- a/dev/MRTCore/mrt/Microsoft.Windows.ApplicationModel.Resources/projection/Microsoft.Windows.ApplicationModel.Resources.Projection.csproj
+++ b/dev/MRTCore/mrt/Microsoft.Windows.ApplicationModel.Resources/projection/Microsoft.Windows.ApplicationModel.Resources.Projection.csproj
@@ -22,7 +22,7 @@
   <PropertyGroup>
     <CSWinRTIncludes>Microsoft.Windows.ApplicationModel.Resources</CSWinRTIncludes>
     <CSWinRTWindowsMetadata>10.0.17763.0</CSWinRTWindowsMetadata>
-    <WindowsSdkPackageVersion>10.0.17763.$(CsWinRTDependencyWindowsSdkVersionSuffixVersion)</WindowsSdkPackageVersion>
+    <WindowsSdkPackageVersion>10.0.17763.$(CsWinRTDependencyWindowsSdkVersionSuffixPackageVersion)</WindowsSdkPackageVersion>
     <NoWarn>MSB3271</NoWarn>
   </PropertyGroup>
 

--- a/dev/Projections/CS/Microsoft.Windows.AppLifecycle/Microsoft.Windows.AppLifecycle.Projection.csproj
+++ b/dev/Projections/CS/Microsoft.Windows.AppLifecycle/Microsoft.Windows.AppLifecycle.Projection.csproj
@@ -26,7 +26,7 @@
   <PropertyGroup>
     <CSWinRTIncludes>Microsoft.Windows.AppLifecycle</CSWinRTIncludes>
     <CSWinRTWindowsMetadata>10.0.17763.0</CSWinRTWindowsMetadata>
-    <WindowsSdkPackageVersion>10.0.17763.$(CsWinRTDependencyWindowsSdkVersionSuffixVersion)</WindowsSdkPackageVersion>
+    <WindowsSdkPackageVersion>10.0.17763.$(CsWinRTDependencyWindowsSdkVersionSuffixPackageVersion)</WindowsSdkPackageVersion>
     <ProduceReferenceAssembly>false</ProduceReferenceAssembly>
   </PropertyGroup>
 

--- a/dev/Projections/CS/Microsoft.Windows.AppNotifications.Builder.Projection/Microsoft.Windows.AppNotifications.Builder.Projection.csproj
+++ b/dev/Projections/CS/Microsoft.Windows.AppNotifications.Builder.Projection/Microsoft.Windows.AppNotifications.Builder.Projection.csproj
@@ -26,7 +26,7 @@
   <PropertyGroup>
     <CSWinRTIncludes>Microsoft.Windows.AppNotifications.Builder</CSWinRTIncludes>
     <CSWinRTWindowsMetadata>10.0.17763.0</CSWinRTWindowsMetadata>
-    <WindowsSdkPackageVersion>10.0.17763.$(CsWinRTDependencyWindowsSdkVersionSuffixVersion)</WindowsSdkPackageVersion>
+    <WindowsSdkPackageVersion>10.0.17763.$(CsWinRTDependencyWindowsSdkVersionSuffixPackageVersion)</WindowsSdkPackageVersion>
   </PropertyGroup>
 
   <!-- Configure the release build binary to be as required by internal API scanning tools. -->

--- a/dev/Projections/CS/Microsoft.Windows.AppNotifications.Projection/Microsoft.Windows.AppNotifications.Projection.csproj
+++ b/dev/Projections/CS/Microsoft.Windows.AppNotifications.Projection/Microsoft.Windows.AppNotifications.Projection.csproj
@@ -26,7 +26,7 @@
   <PropertyGroup>
     <CSWinRTIncludes>Microsoft.Windows.AppNotifications</CSWinRTIncludes>
     <CSWinRTWindowsMetadata>10.0.17763.0</CSWinRTWindowsMetadata>
-    <WindowsSdkPackageVersion>10.0.17763.$(CsWinRTDependencyWindowsSdkVersionSuffixVersion)</WindowsSdkPackageVersion>
+    <WindowsSdkPackageVersion>10.0.17763.$(CsWinRTDependencyWindowsSdkVersionSuffixPackageVersion)</WindowsSdkPackageVersion>
     <ProduceReferenceAssembly>false</ProduceReferenceAssembly>
   </PropertyGroup>
 

--- a/dev/Projections/CS/Microsoft.Windows.ApplicationModel.DynamicDependency/Microsoft.Windows.ApplicationModel.DynamicDependency.Projection.csproj
+++ b/dev/Projections/CS/Microsoft.Windows.ApplicationModel.DynamicDependency/Microsoft.Windows.ApplicationModel.DynamicDependency.Projection.csproj
@@ -26,7 +26,7 @@
   <PropertyGroup>
     <CSWinRTIncludes>Microsoft.Windows.ApplicationModel.DynamicDependency</CSWinRTIncludes>
     <CSWinRTWindowsMetadata>10.0.17763.0</CSWinRTWindowsMetadata>
-    <WindowsSdkPackageVersion>10.0.17763.$(CsWinRTDependencyWindowsSdkVersionSuffixVersion)</WindowsSdkPackageVersion>
+    <WindowsSdkPackageVersion>10.0.17763.$(CsWinRTDependencyWindowsSdkVersionSuffixPackageVersion)</WindowsSdkPackageVersion>
     <ProduceReferenceAssembly>false</ProduceReferenceAssembly>
   </PropertyGroup>
 

--- a/dev/Projections/CS/Microsoft.Windows.ApplicationModel.WindowsAppRuntime/Microsoft.Windows.ApplicationModel.WindowsAppRuntime.Projection.csproj
+++ b/dev/Projections/CS/Microsoft.Windows.ApplicationModel.WindowsAppRuntime/Microsoft.Windows.ApplicationModel.WindowsAppRuntime.Projection.csproj
@@ -26,7 +26,7 @@
   <PropertyGroup>
     <CSWinRTIncludes>Microsoft.Windows.ApplicationModel.WindowsAppRuntime</CSWinRTIncludes>
     <CSWinRTWindowsMetadata>10.0.17763.0</CSWinRTWindowsMetadata>
-    <WindowsSdkPackageVersion>10.0.17763.$(CsWinRTDependencyWindowsSdkVersionSuffixVersion)</WindowsSdkPackageVersion>
+    <WindowsSdkPackageVersion>10.0.17763.$(CsWinRTDependencyWindowsSdkVersionSuffixPackageVersion)</WindowsSdkPackageVersion>
     <ProduceReferenceAssembly>false</ProduceReferenceAssembly>
   </PropertyGroup>
 

--- a/dev/Projections/CS/Microsoft.Windows.PushNotifications.Projection/Microsoft.Windows.PushNotifications.Projection.csproj
+++ b/dev/Projections/CS/Microsoft.Windows.PushNotifications.Projection/Microsoft.Windows.PushNotifications.Projection.csproj
@@ -26,7 +26,7 @@
   <PropertyGroup>
     <CSWinRTIncludes>Microsoft.Windows.PushNotifications</CSWinRTIncludes>
     <CSWinRTWindowsMetadata>10.0.17763.0</CSWinRTWindowsMetadata>
-    <WindowsSdkPackageVersion>10.0.17763.$(CsWinRTDependencyWindowsSdkVersionSuffixVersion)</WindowsSdkPackageVersion>
+    <WindowsSdkPackageVersion>10.0.17763.$(CsWinRTDependencyWindowsSdkVersionSuffixPackageVersion)</WindowsSdkPackageVersion>
     <ProduceReferenceAssembly>false</ProduceReferenceAssembly>
   </PropertyGroup>
 

--- a/dev/Projections/CS/Microsoft.Windows.Security.AccessControl.Projection/Microsoft.Windows.Security.AccessControl.Projection.csproj
+++ b/dev/Projections/CS/Microsoft.Windows.Security.AccessControl.Projection/Microsoft.Windows.Security.AccessControl.Projection.csproj
@@ -26,7 +26,7 @@
   <PropertyGroup>
     <CSWinRTIncludes>Microsoft.Windows.Security.AccessControl</CSWinRTIncludes>
     <CSWinRTWindowsMetadata>10.0.17763.0</CSWinRTWindowsMetadata>
-    <WindowsSdkPackageVersion>10.0.17763.$(CsWinRTDependencyWindowsSdkVersionSuffixVersion)</WindowsSdkPackageVersion>
+    <WindowsSdkPackageVersion>10.0.17763.$(CsWinRTDependencyWindowsSdkVersionSuffixPackageVersion)</WindowsSdkPackageVersion>
     <ProduceReferenceAssembly>false</ProduceReferenceAssembly>
   </PropertyGroup>
 

--- a/dev/Projections/CS/Microsoft.Windows.System.Power/Microsoft.Windows.System.Power.Projection.csproj
+++ b/dev/Projections/CS/Microsoft.Windows.System.Power/Microsoft.Windows.System.Power.Projection.csproj
@@ -26,7 +26,7 @@
   <PropertyGroup>
     <CSWinRTIncludes>Microsoft.Windows.System.Power</CSWinRTIncludes>
     <CSWinRTWindowsMetadata>10.0.17763.0</CSWinRTWindowsMetadata>
-    <WindowsSdkPackageVersion>10.0.17763.$(CsWinRTDependencyWindowsSdkVersionSuffixVersion)</WindowsSdkPackageVersion>
+    <WindowsSdkPackageVersion>10.0.17763.$(CsWinRTDependencyWindowsSdkVersionSuffixPackageVersion)</WindowsSdkPackageVersion>
     <ProduceReferenceAssembly>false</ProduceReferenceAssembly>
   </PropertyGroup>
 

--- a/dev/Projections/CS/Microsoft.Windows.System/Microsoft.Windows.System.Projection.csproj
+++ b/dev/Projections/CS/Microsoft.Windows.System/Microsoft.Windows.System.Projection.csproj
@@ -26,7 +26,7 @@
   <PropertyGroup>
     <CSWinRTIncludes>Microsoft.Windows.System</CSWinRTIncludes>
     <CSWinRTWindowsMetadata>10.0.17763.0</CSWinRTWindowsMetadata>
-    <WindowsSdkPackageVersion>10.0.17763.$(CsWinRTDependencyWindowsSdkVersionSuffixVersion)</WindowsSdkPackageVersion>
+    <WindowsSdkPackageVersion>10.0.17763.$(CsWinRTDependencyWindowsSdkVersionSuffixPackageVersion)</WindowsSdkPackageVersion>
     <ProduceReferenceAssembly>false</ProduceReferenceAssembly>
   </PropertyGroup>
 

--- a/eng/Version.Dependencies.props
+++ b/eng/Version.Dependencies.props
@@ -4,23 +4,24 @@
   <PropertyGroup>
     <VersionDetailsXmlFilename>$(MSBuildThisFileDirectory)Version.Details.xml</VersionDetailsXmlFilename>
     <VersionDetailsXml>$([System.IO.File]::ReadAllText("$(VersionDetailsXmlFilename)"))</VersionDetailsXml>
-
-    <!-- Dependencies: Automagic -->
+    <VersionDependenciesXmlFilename>$(MSBuildThisFileDirectory)Version.Details.xml</VersionDependenciesXmlFilename>
+    <VersionDependenciesXml>$([System.IO.File]::ReadAllText("$(VersionDetailsXmlFilename)"))</VersionDependenciesXml>
+    <!-- Dependencies: Version.Details.xml -->
     <MicrosoftFrameworkUdkPackageVersion>$([System.Text.RegularExpressions.Regex]::Match($(VersionDetailsXml), 'Name="Microsoft.FrameworkUdk"\s+Version="(.*?)"').Groups[1].Value)</MicrosoftFrameworkUdkPackageVersion>
     <MicrosoftWindowsAppSDKAppLicensingInternalTransportPackagePackageVersion>$([System.Text.RegularExpressions.Regex]::Match($(VersionDetailsXml), 'Name="Microsoft.WindowsAppSDK.AppLicensingInternal.TransportPackage"\s+Version="(.*?)"').Groups[1].Value)</MicrosoftWindowsAppSDKAppLicensingInternalTransportPackagePackageVersion>
 
-    <!-- Dependencies: Manual -->
-    <CsWinRTDependencyDotNetCoreRuntimeVersion>$([System.Text.RegularExpressions.Regex]::Match($(VersionDetailsXml), 'Name="CsWinRT.Dependency.DotNetCoreRuntime"\s+Version="(.*?)"').Groups[1].Value)</CsWinRTDependencyDotNetCoreRuntimeVersion>
-    <CsWinRTDependencyDotNetCoreSdkVersion>$([System.Text.RegularExpressions.Regex]::Match($(VersionDetailsXml), 'Name="CsWinRT.Dependency.DotNetCoreSdk"\s+Version="(.*?)"').Groups[1].Value)</CsWinRTDependencyDotNetCoreSdkVersion>
-    <CsWinRTDependencyWindowsSdkVersionSuffixVersion>$([System.Text.RegularExpressions.Regex]::Match($(VersionDetailsXml), 'Name="CsWinRT.Dependency.WindowsSdkVersionSuffix"\s+Version="(.*?)"').Groups[1].Value)</CsWinRTDependencyWindowsSdkVersionSuffixVersion>
-    <MicrosoftBuildTasksGitVersion>$([System.Text.RegularExpressions.Regex]::Match($(VersionDetailsXml), 'Name="Microsoft.Build.Tasks.Git"\s+Version="(.*?)"').Groups[1].Value)</MicrosoftBuildTasksGitVersion>
-    <MicrosoftSourceLinkCommonVersion>$([System.Text.RegularExpressions.Regex]::Match($(VersionDetailsXml), 'Name="Microsoft.SourceLink.Common"\s+Version="(.*?)"').Groups[1].Value)</MicrosoftSourceLinkCommonVersion>
-    <MicrosoftSourceLinkGitHubVersion>$([System.Text.RegularExpressions.Regex]::Match($(VersionDetailsXml), 'Name="Microsoft.SourceLink.GitHub"\s+Version="(.*?)"').Groups[1].Value)</MicrosoftSourceLinkGitHubVersion>
-    <MicrosoftTaefVersion>$([System.Text.RegularExpressions.Regex]::Match($(VersionDetailsXml), 'Name="Microsoft.Taef"\s+Version="(.*?)"').Groups[1].Value)</MicrosoftTaefVersion>
-    <MicrosoftTelemetryInboxNativeVersion>$([System.Text.RegularExpressions.Regex]::Match($(VersionDetailsXml), 'Name="Microsoft.Telemetry.Inbox.Native"\s+Version="(.*?)"').Groups[1].Value)</MicrosoftTelemetryInboxNativeVersion>
-    <MicrosoftWinAppSDKEngCommonVersion>$([System.Text.RegularExpressions.Regex]::Match($(VersionDetailsXml), 'Name="Microsoft.WinAppSDK.EngCommon"\s+Version="(.*?)"').Groups[1].Value)</MicrosoftWinAppSDKEngCommonVersion>
-    <MicrosoftWindowsCppWinRTVersion>$([System.Text.RegularExpressions.Regex]::Match($(VersionDetailsXml), 'Name="Microsoft.Windows.CppWinRT"\s+Version="(.*?)"').Groups[1].Value)</MicrosoftWindowsCppWinRTVersion>
-    <MicrosoftWindowsCsWinRTVersion>$([System.Text.RegularExpressions.Regex]::Match($(VersionDetailsXml), 'Name="Microsoft.Windows.CsWinRT"\s+Version="(.*?)"').Groups[1].Value)</MicrosoftWindowsCsWinRTVersion>
-    <MicrosoftWindowsImplementationLibraryVersion>$([System.Text.RegularExpressions.Regex]::Match($(VersionDetailsXml), 'Name="Microsoft.Windows.ImplementationLibrary"\s+Version="(.*?)"').Groups[1].Value)</MicrosoftWindowsImplementationLibraryVersion>
+    <!-- Dependencies: Version.Dependencies.xml -->
+    <CsWinRTDependencyDotNetCoreRuntimeVersion>$([System.Text.RegularExpressions.Regex]::Match($(VersionDependenciesXml), 'Name="CsWinRT.Dependency.DotNetCoreRuntime"\s+Version="(.*?)"').Groups[1].Value)</CsWinRTDependencyDotNetCoreRuntimeVersion>
+    <CsWinRTDependencyDotNetCoreSdkVersion>$([System.Text.RegularExpressions.Regex]::Match($(VersionDependenciesXml), 'Name="CsWinRT.Dependency.DotNetCoreSdk"\s+Version="(.*?)"').Groups[1].Value)</CsWinRTDependencyDotNetCoreSdkVersion>
+    <CsWinRTDependencyWindowsSdkVersionSuffixVersion>$([System.Text.RegularExpressions.Regex]::Match($(VersionDependenciesXml), 'Name="CsWinRT.Dependency.WindowsSdkVersionSuffix"\s+Version="(.*?)"').Groups[1].Value)</CsWinRTDependencyWindowsSdkVersionSuffixVersion>
+    <MicrosoftBuildTasksGitVersion>$([System.Text.RegularExpressions.Regex]::Match($(VersionDependenciesXml), 'Name="Microsoft.Build.Tasks.Git"\s+Version="(.*?)"').Groups[1].Value)</MicrosoftBuildTasksGitVersion>
+    <MicrosoftSourceLinkCommonVersion>$([System.Text.RegularExpressions.Regex]::Match($(VersionDependenciesXml), 'Name="Microsoft.SourceLink.Common"\s+Version="(.*?)"').Groups[1].Value)</MicrosoftSourceLinkCommonVersion>
+    <MicrosoftSourceLinkGitHubVersion>$([System.Text.RegularExpressions.Regex]::Match($(VersionDependenciesXml), 'Name="Microsoft.SourceLink.GitHub"\s+Version="(.*?)"').Groups[1].Value)</MicrosoftSourceLinkGitHubVersion>
+    <MicrosoftTaefVersion>$([System.Text.RegularExpressions.Regex]::Match($(VersionDependenciesXml), 'Name="Microsoft.Taef"\s+Version="(.*?)"').Groups[1].Value)</MicrosoftTaefVersion>
+    <MicrosoftTelemetryInboxNativeVersion>$([System.Text.RegularExpressions.Regex]::Match($(VersionDependenciesXml), 'Name="Microsoft.Telemetry.Inbox.Native"\s+Version="(.*?)"').Groups[1].Value)</MicrosoftTelemetryInboxNativeVersion>
+    <MicrosoftWinAppSDKEngCommonVersion>$([System.Text.RegularExpressions.Regex]::Match($(VersionDependenciesXml), 'Name="Microsoft.WinAppSDK.EngCommon"\s+Version="(.*?)"').Groups[1].Value)</MicrosoftWinAppSDKEngCommonVersion>
+    <MicrosoftWindowsCppWinRTVersion>$([System.Text.RegularExpressions.Regex]::Match($(VersionDependenciesXml), 'Name="Microsoft.Windows.CppWinRT"\s+Version="(.*?)"').Groups[1].Value)</MicrosoftWindowsCppWinRTVersion>
+    <MicrosoftWindowsCsWinRTVersion>$([System.Text.RegularExpressions.Regex]::Match($(VersionDependenciesXml), 'Name="Microsoft.Windows.CsWinRT"\s+Version="(.*?)"').Groups[1].Value)</MicrosoftWindowsCsWinRTVersion>
+    <MicrosoftWindowsImplementationLibraryVersion>$([System.Text.RegularExpressions.Regex]::Match($(VersionDependenciesXml), 'Name="Microsoft.Windows.ImplementationLibrary"\s+Version="(.*?)"').Groups[1].Value)</MicrosoftWindowsImplementationLibraryVersion>
   </PropertyGroup>
 </Project>

--- a/eng/Version.Dependencies.props
+++ b/eng/Version.Dependencies.props
@@ -7,20 +7,21 @@
     <VersionDependenciesXmlFilename>$(MSBuildThisFileDirectory)Version.Dependencies.xml</VersionDependenciesXmlFilename>
     <VersionDependenciesXml>$([System.IO.File]::ReadAllText("$(VersionDependenciesXmlFilename)"))</VersionDependenciesXml>
     <!-- Dependencies: Maestro -->
+    <CsWinRTDependencyDotNetCoreRuntimePackageVersion>$([System.Text.RegularExpressions.Regex]::Match($(VersionDetailsXml), 'Name="CsWinRT.Dependency.DotNetCoreRuntime"\s+Version="(.*?)"').Groups[1].Value)</CsWinRTDependencyDotNetCoreRuntimePackageVersion>
+    <CsWinRTDependencyDotNetCoreSdkPackageVersion>$([System.Text.RegularExpressions.Regex]::Match($(VersionDetailsXml), 'Name="CsWinRT.Dependency.DotNetCoreSdk"\s+Version="(.*?)"').Groups[1].Value)</CsWinRTDependencyDotNetCoreSdkPackageVersion>
+    <CsWinRTDependencyWindowsSdkVersionSuffixPackageVersion>$([System.Text.RegularExpressions.Regex]::Match($(VersionDetailsXml), 'Name="CsWinRT.Dependency.WindowsSdkVersionSuffix"\s+Version="(.*?)"').Groups[1].Value)</CsWinRTDependencyWindowsSdkVersionSuffixPackageVersion>
     <MicrosoftFrameworkUdkPackageVersion>$([System.Text.RegularExpressions.Regex]::Match($(VersionDetailsXml), 'Name="Microsoft.FrameworkUdk"\s+Version="(.*?)"').Groups[1].Value)</MicrosoftFrameworkUdkPackageVersion>
+    <MicrosoftWinAppSDKEngCommonPackageVersion>$([System.Text.RegularExpressions.Regex]::Match($(VersionDetailsXml), 'Name="Microsoft.WinAppSDK.EngCommon"\s+Version="(.*?)"').Groups[1].Value)</MicrosoftWinAppSDKEngCommonPackageVersion>
     <MicrosoftWindowsAppSDKAppLicensingInternalTransportPackagePackageVersion>$([System.Text.RegularExpressions.Regex]::Match($(VersionDetailsXml), 'Name="Microsoft.WindowsAppSDK.AppLicensingInternal.TransportPackage"\s+Version="(.*?)"').Groups[1].Value)</MicrosoftWindowsAppSDKAppLicensingInternalTransportPackagePackageVersion>
+    <MicrosoftWindowsCsWinRTPackageVersion>$([System.Text.RegularExpressions.Regex]::Match($(VersionDetailsXml), 'Name="Microsoft.Windows.CsWinRT"\s+Version="(.*?)"').Groups[1].Value)</MicrosoftWindowsCsWinRTPackageVersion>
 
     <!-- Dependencies: Manual -->
-    <CsWinRTDependencyDotNetCoreRuntimeVersion>$([System.Text.RegularExpressions.Regex]::Match($(VersionDependenciesXml), 'Name="CsWinRT.Dependency.DotNetCoreRuntime"\s+Version="(.*?)"').Groups[1].Value)</CsWinRTDependencyDotNetCoreRuntimeVersion>
-    <CsWinRTDependencyDotNetCoreSdkVersion>$([System.Text.RegularExpressions.Regex]::Match($(VersionDependenciesXml), 'Name="CsWinRT.Dependency.DotNetCoreSdk"\s+Version="(.*?)"').Groups[1].Value)</CsWinRTDependencyDotNetCoreSdkVersion>
-    <CsWinRTDependencyWindowsSdkVersionSuffixVersion>$([System.Text.RegularExpressions.Regex]::Match($(VersionDependenciesXml), 'Name="CsWinRT.Dependency.WindowsSdkVersionSuffix"\s+Version="(.*?)"').Groups[1].Value)</CsWinRTDependencyWindowsSdkVersionSuffixVersion>
     <MicrosoftBuildTasksGitVersion>$([System.Text.RegularExpressions.Regex]::Match($(VersionDependenciesXml), 'Name="Microsoft.Build.Tasks.Git"\s+Version="(.*?)"').Groups[1].Value)</MicrosoftBuildTasksGitVersion>
     <MicrosoftSourceLinkCommonVersion>$([System.Text.RegularExpressions.Regex]::Match($(VersionDependenciesXml), 'Name="Microsoft.SourceLink.Common"\s+Version="(.*?)"').Groups[1].Value)</MicrosoftSourceLinkCommonVersion>
     <MicrosoftSourceLinkGitHubVersion>$([System.Text.RegularExpressions.Regex]::Match($(VersionDependenciesXml), 'Name="Microsoft.SourceLink.GitHub"\s+Version="(.*?)"').Groups[1].Value)</MicrosoftSourceLinkGitHubVersion>
     <MicrosoftTaefVersion>$([System.Text.RegularExpressions.Regex]::Match($(VersionDependenciesXml), 'Name="Microsoft.Taef"\s+Version="(.*?)"').Groups[1].Value)</MicrosoftTaefVersion>
     <MicrosoftTelemetryInboxNativeVersion>$([System.Text.RegularExpressions.Regex]::Match($(VersionDependenciesXml), 'Name="Microsoft.Telemetry.Inbox.Native"\s+Version="(.*?)"').Groups[1].Value)</MicrosoftTelemetryInboxNativeVersion>
     <MicrosoftWindowsCppWinRTVersion>$([System.Text.RegularExpressions.Regex]::Match($(VersionDependenciesXml), 'Name="Microsoft.Windows.CppWinRT"\s+Version="(.*?)"').Groups[1].Value)</MicrosoftWindowsCppWinRTVersion>
-    <MicrosoftWindowsCsWinRTVersion>$([System.Text.RegularExpressions.Regex]::Match($(VersionDependenciesXml), 'Name="Microsoft.Windows.CsWinRT"\s+Version="(.*?)"').Groups[1].Value)</MicrosoftWindowsCsWinRTVersion>
     <MicrosoftWindowsImplementationLibraryVersion>$([System.Text.RegularExpressions.Regex]::Match($(VersionDependenciesXml), 'Name="Microsoft.Windows.ImplementationLibrary"\s+Version="(.*?)"').Groups[1].Value)</MicrosoftWindowsImplementationLibraryVersion>
   </PropertyGroup>
 </Project>

--- a/eng/Version.Dependencies.props
+++ b/eng/Version.Dependencies.props
@@ -4,13 +4,13 @@
   <PropertyGroup>
     <VersionDetailsXmlFilename>$(MSBuildThisFileDirectory)Version.Details.xml</VersionDetailsXmlFilename>
     <VersionDetailsXml>$([System.IO.File]::ReadAllText("$(VersionDetailsXmlFilename)"))</VersionDetailsXml>
-    <VersionDependenciesXmlFilename>$(MSBuildThisFileDirectory)Version.Details.xml</VersionDependenciesXmlFilename>
-    <VersionDependenciesXml>$([System.IO.File]::ReadAllText("$(VersionDetailsXmlFilename)"))</VersionDependenciesXml>
-    <!-- Dependencies: Version.Details.xml -->
+    <VersionDependenciesXmlFilename>$(MSBuildThisFileDirectory)Version.Dependencies.xml</VersionDependenciesXmlFilename>
+    <VersionDependenciesXml>$([System.IO.File]::ReadAllText("$(VersionDependenciesXmlFilename)"))</VersionDependenciesXml>
+    <!-- Dependencies: Maestro -->
     <MicrosoftFrameworkUdkPackageVersion>$([System.Text.RegularExpressions.Regex]::Match($(VersionDetailsXml), 'Name="Microsoft.FrameworkUdk"\s+Version="(.*?)"').Groups[1].Value)</MicrosoftFrameworkUdkPackageVersion>
     <MicrosoftWindowsAppSDKAppLicensingInternalTransportPackagePackageVersion>$([System.Text.RegularExpressions.Regex]::Match($(VersionDetailsXml), 'Name="Microsoft.WindowsAppSDK.AppLicensingInternal.TransportPackage"\s+Version="(.*?)"').Groups[1].Value)</MicrosoftWindowsAppSDKAppLicensingInternalTransportPackagePackageVersion>
 
-    <!-- Dependencies: Version.Dependencies.xml -->
+    <!-- Dependencies: Manual -->
     <CsWinRTDependencyDotNetCoreRuntimeVersion>$([System.Text.RegularExpressions.Regex]::Match($(VersionDependenciesXml), 'Name="CsWinRT.Dependency.DotNetCoreRuntime"\s+Version="(.*?)"').Groups[1].Value)</CsWinRTDependencyDotNetCoreRuntimeVersion>
     <CsWinRTDependencyDotNetCoreSdkVersion>$([System.Text.RegularExpressions.Regex]::Match($(VersionDependenciesXml), 'Name="CsWinRT.Dependency.DotNetCoreSdk"\s+Version="(.*?)"').Groups[1].Value)</CsWinRTDependencyDotNetCoreSdkVersion>
     <CsWinRTDependencyWindowsSdkVersionSuffixVersion>$([System.Text.RegularExpressions.Regex]::Match($(VersionDependenciesXml), 'Name="CsWinRT.Dependency.WindowsSdkVersionSuffix"\s+Version="(.*?)"').Groups[1].Value)</CsWinRTDependencyWindowsSdkVersionSuffixVersion>
@@ -19,7 +19,6 @@
     <MicrosoftSourceLinkGitHubVersion>$([System.Text.RegularExpressions.Regex]::Match($(VersionDependenciesXml), 'Name="Microsoft.SourceLink.GitHub"\s+Version="(.*?)"').Groups[1].Value)</MicrosoftSourceLinkGitHubVersion>
     <MicrosoftTaefVersion>$([System.Text.RegularExpressions.Regex]::Match($(VersionDependenciesXml), 'Name="Microsoft.Taef"\s+Version="(.*?)"').Groups[1].Value)</MicrosoftTaefVersion>
     <MicrosoftTelemetryInboxNativeVersion>$([System.Text.RegularExpressions.Regex]::Match($(VersionDependenciesXml), 'Name="Microsoft.Telemetry.Inbox.Native"\s+Version="(.*?)"').Groups[1].Value)</MicrosoftTelemetryInboxNativeVersion>
-    <MicrosoftWinAppSDKEngCommonVersion>$([System.Text.RegularExpressions.Regex]::Match($(VersionDependenciesXml), 'Name="Microsoft.WinAppSDK.EngCommon"\s+Version="(.*?)"').Groups[1].Value)</MicrosoftWinAppSDKEngCommonVersion>
     <MicrosoftWindowsCppWinRTVersion>$([System.Text.RegularExpressions.Regex]::Match($(VersionDependenciesXml), 'Name="Microsoft.Windows.CppWinRT"\s+Version="(.*?)"').Groups[1].Value)</MicrosoftWindowsCppWinRTVersion>
     <MicrosoftWindowsCsWinRTVersion>$([System.Text.RegularExpressions.Regex]::Match($(VersionDependenciesXml), 'Name="Microsoft.Windows.CsWinRT"\s+Version="(.*?)"').Groups[1].Value)</MicrosoftWindowsCsWinRTVersion>
     <MicrosoftWindowsImplementationLibraryVersion>$([System.Text.RegularExpressions.Regex]::Match($(VersionDependenciesXml), 'Name="Microsoft.Windows.ImplementationLibrary"\s+Version="(.*?)"').Groups[1].Value)</MicrosoftWindowsImplementationLibraryVersion>

--- a/eng/Version.Dependencies.xml
+++ b/eng/Version.Dependencies.xml
@@ -24,16 +24,15 @@
        20. POLICY: Update Version.Dependencies.props via "DevCheck -CheckDependencies -SyncDependencies". NOTE: This is required when adding or removing a dependency
     -->
 <Dependencies>
-  <ProductDependencies>
-    <Dependency Name="Microsoft.FrameworkUdk" Version="1.3.0-CI-25260.1001.221205-1000.0">
-      <Uri>https://dev.azure.com/microsoft/LiftedIXP/_git/DCPP</Uri>
-      <Sha>f4a7f5a1ff6b473f3c55560d80bfd3d4c80da6a7</Sha>
-    </Dependency>
-    <Dependency Name="Microsoft.WindowsAppSDK.AppLicensingInternal.TransportPackage" Version="1.2.0-main.20221103.4">
-      <Uri>https://dev.azure.com/microsoft/ProjectReunion/_git/ProjectReunionClosed</Uri>
-      <Sha>cc4045b6190f44ed55e10700cc9f0d25a7a60341</Sha>
-    </Dependency>
-  </ProductDependencies>
-  <ToolsetDependencies>
-  </ToolsetDependencies>
+  <Dependency Name="CsWinRT.Dependency.DotNetCoreRuntime" Version="6.0.6"/>
+  <Dependency Name="CsWinRT.Dependency.DotNetCoreSdk" Version="6.0.301"/>
+  <Dependency Name="CsWinRT.Dependency.WindowsSdkVersionSuffix" Version="27"/>
+  <Dependency Name="Microsoft.Windows.CsWinRT" Version="2.0.0"/>
+  <Dependency Name="Microsoft.Build.Tasks.Git"                Version="1.1.1"/>
+  <Dependency Name="Microsoft.SourceLink.Common"              Version="1.1.1"/>
+  <Dependency Name="Microsoft.SourceLink.GitHub"              Version="1.1.1"/>
+  <Dependency Name="Microsoft.Taef"                           Version="10.58.210222006-develop"/>
+  <Dependency Name="Microsoft.Telemetry.Inbox.Native"         Version="10.0.19041.1-191206-1406.vb-release.x86fre" />
+  <Dependency Name="Microsoft.Windows.CppWinRT"               Version="2.0.220929.3"/>
+  <Dependency Name="Microsoft.Windows.ImplementationLibrary"  Version="1.0.220914.1"/>
 </Dependencies>

--- a/eng/Version.Dependencies.xml
+++ b/eng/Version.Dependencies.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
   <!-- Rules for Dependency Management:
-        1. Dependencies in Version.Details.xml are utomagically propogated via Maestro
+        1. Dependencies in Version.Details.xml are automagically propogated via Maestro
            e.g. if B depends on A v1 and A v2 is published, Maestro updates B's Version.Details.xml to A v2
         2. Dependencies in Version.Dependencies.xml are only changed by explicit (manual) developer action
            e.g. if B depends on A v1 and A v2 is published, B is unchanged
@@ -26,10 +26,6 @@
             NOTE: This is required when adding or removing a dependency
     -->
 <Dependencies>
-  <Dependency Name="CsWinRT.Dependency.DotNetCoreRuntime" Version="6.0.6"/>
-  <Dependency Name="CsWinRT.Dependency.DotNetCoreSdk" Version="6.0.301"/>
-  <Dependency Name="CsWinRT.Dependency.WindowsSdkVersionSuffix" Version="27"/>
-  <Dependency Name="Microsoft.Windows.CsWinRT" Version="2.0.0"/>
   <Dependency Name="Microsoft.Build.Tasks.Git"                Version="1.1.1"/>
   <Dependency Name="Microsoft.SourceLink.Common"              Version="1.1.1"/>
   <Dependency Name="Microsoft.SourceLink.GitHub"              Version="1.1.1"/>

--- a/eng/Version.Dependencies.xml
+++ b/eng/Version.Dependencies.xml
@@ -1,10 +1,11 @@
 <?xml version="1.0" encoding="utf-8"?>
   <!-- Rules for Dependency Management:
-        1. <ProductDependencies> are automagically propogated via Maestro
+        1. Dependencies in Version.Details.xml are utomagically propogated via Maestro
            e.g. if B depends on A v1 and A v2 is published, Maestro updates B's Version.Details.xml to A v2
-        2. <ToolsetDependencies> are only changed by explicit (manual) developer action
+        2. Dependencies in Version.Dependencies.xml are only changed by explicit (manual) developer action
            e.g. if B depends on A v1 and A v2 is published, B is unchanged
-        3. Dependencies' versions in Version.Details.xml are TheMasterSourceOfTruth(TM). These are literal values. No macro expansion or magic substitution will occur
+        3. Dependencies' versions in Version.Details.xml and Version.Dependencies.xml are TheMasterSourceOfTruth(TM). 
+            These are literal values. No macro expansion or magic substitution will occur
         4. <ProductDependencies><Dependency> are listed in sorted order (alphabetically, case-insensitive)
         5. <ToolsetDependencies><Dependency> are listed in sorted order (alphabetically, case-insensitive)
         6. <ProductDependencies> appears before <ToolsetDependencies> (aka sorted order, alphabetically, case-insensitive)
@@ -21,7 +22,8 @@
        17. Version.Dependencies.props is a generated file. DO NOT EDIT. Use DevCheck -SyncDependencies
        18. POLICY: Dependencies on Transport Packages are expressed as <ProductDependencies> in Version.Details.xml
        19. POLICY: Dependencies on non-Transport Packages are expressed as <ToolsetDependencies> in Version.Dependencies.xml
-       20. POLICY: Update Version.Dependencies.props via "DevCheck -CheckDependencies -SyncDependencies". NOTE: This is required when adding or removing a dependency
+       20. POLICY: Update Version.Dependencies.props via "DevCheck -CheckDependencies -SyncDependencies". 
+            NOTE: This is required when adding or removing a dependency
     -->
 <Dependencies>
   <Dependency Name="CsWinRT.Dependency.DotNetCoreRuntime" Version="6.0.6"/>

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
   <!-- Rules for Dependency Management:
-        1. Dependencies in Version.Details.xml are utomagically propogated via Maestro
+        1. Dependencies in Version.Details.xml are automagically propogated via Maestro
            e.g. if B depends on A v1 and A v2 is published, Maestro updates B's Version.Details.xml to A v2
         2. Dependencies in Version.Dependencies.xml are only changed by explicit (manual) developer action
            e.g. if B depends on A v1 and A v2 is published, B is unchanged
@@ -37,5 +37,9 @@
     </Dependency>
   </ProductDependencies>
   <ToolsetDependencies>
+    <Dependency Name="Microsoft.WinAppSDK.EngCommon" Version="1.3.221209100">
+      <Uri>https://dev.azure.com/microsoft/ProjectReunion/_git/WindowsAppSDKAggregator</Uri>
+      <Sha>f595a1e3c825d944ff5f097cd1941dfe27447d7e</Sha>
+    </Dependency>
   </ToolsetDependencies>
 </Dependencies>

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -1,10 +1,11 @@
 <?xml version="1.0" encoding="utf-8"?>
   <!-- Rules for Dependency Management:
-        1. <ProductDependencies> are automagically propogated via Maestro
+        1. Dependencies in Version.Details.xml are utomagically propogated via Maestro
            e.g. if B depends on A v1 and A v2 is published, Maestro updates B's Version.Details.xml to A v2
-        2. <ToolsetDependencies> are only changed by explicit (manual) developer action
+        2. Dependencies in Version.Dependencies.xml are only changed by explicit (manual) developer action
            e.g. if B depends on A v1 and A v2 is published, B is unchanged
-        3. Dependencies' versions in Version.Details.xml are TheMasterSourceOfTruth(TM). These are literal values. No macro expansion or magic substitution will occur
+        3. Dependencies' versions in Version.Details.xml and Version.Dependencies.xml are TheMasterSourceOfTruth(TM). 
+            These are literal values. No macro expansion or magic substitution will occur
         4. <ProductDependencies><Dependency> are listed in sorted order (alphabetically, case-insensitive)
         5. <ToolsetDependencies><Dependency> are listed in sorted order (alphabetically, case-insensitive)
         6. <ProductDependencies> appears before <ToolsetDependencies> (aka sorted order, alphabetically, case-insensitive)
@@ -21,7 +22,8 @@
        17. Version.Dependencies.props is a generated file. DO NOT EDIT. Use DevCheck -SyncDependencies
        18. POLICY: Dependencies on Transport Packages are expressed as <ProductDependencies> in Version.Details.xml
        19. POLICY: Dependencies on non-Transport Packages are expressed as <ToolsetDependencies> in Version.Dependencies.xml
-       20. POLICY: Update Version.Dependencies.props via "DevCheck -CheckDependencies -SyncDependencies". NOTE: This is required when adding or removing a dependency
+       20. POLICY: Update Version.Dependencies.props via "DevCheck -CheckDependencies -SyncDependencies". 
+            NOTE: This is required when adding or removing a dependency
     -->
 <Dependencies>
   <ProductDependencies>

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -41,5 +41,21 @@
       <Uri>https://dev.azure.com/microsoft/ProjectReunion/_git/WindowsAppSDKAggregator</Uri>
       <Sha>f595a1e3c825d944ff5f097cd1941dfe27447d7e</Sha>
     </Dependency>
+    <Dependency Name="Microsoft.Windows.CsWinRT" Version="2.0.0">
+      <Uri>https://github.com/microsoft/CsWinRT</Uri>
+      <Sha>fa7f5565cb53353dc15c28a09ebd500577dc0b72</Sha>
+    </Dependency>
+    <Dependency Name="CsWinRT.Dependency.DotNetCoreSdk" Version="6.0.301">
+      <Uri>https://github.com/microsoft/CsWinRT</Uri>
+      <Sha>fa7f5565cb53353dc15c28a09ebd500577dc0b72</Sha>
+    </Dependency>
+    <Dependency Name="CsWinRT.Dependency.DotNetCoreRuntime" Version="6.0.6">
+      <Uri>https://github.com/microsoft/CsWinRT</Uri>
+      <Sha>fa7f5565cb53353dc15c28a09ebd500577dc0b72</Sha>
+    </Dependency>
+    <Dependency Name="CsWinRT.Dependency.WindowsSdkVersionSuffix" Version="27">
+      <Uri>https://github.com/microsoft/CsWinRT</Uri>
+      <Sha>fa7f5565cb53353dc15c28a09ebd500577dc0b72</Sha>
+    </Dependency>
   </ToolsetDependencies>
 </Dependencies>


### PR DESCRIPTION
Unfortunately, Maestro is not happy with how we format our manual dependencies in version.details.xml. 
We need to leave version.details.xml alone and move our manual dependencies into a version.dependencies.xml. 