### PR TITLE
Update WindowsAppSDK-RunHelixTests-Job.yml

### DIFF
--- a/build/AzurePipelinesTemplates/WindowsAppSDK-RunHelixTests-Job.yml
+++ b/build/AzurePipelinesTemplates/WindowsAppSDK-RunHelixTests-Job.yml
@@ -30,8 +30,8 @@ jobs:
 
     # The target queues to run the tests on.
     # Note: %3b is the escape sequence for ';' which is used as the delimiter
-    helixTargetQueuesOpen: 'Windows.10.Amd64.ClientRS5.Open.reunion%3bWindows.10.Amd64.Client20h2.Open.reunion%3bwindows.10.amd64.client21h1.open.reunion%3bwindows.11.amd64.client.open.reunion'
-    helixTargetQueuesClosed: 'windows.10.amd64.client20h2.reunion%3bwindows.10.amd64.clientrs5.reunion%3bwindows.10.amd64.client21h1.reunion%3bWindows.11.Amd64.client.Reunion'
+    helixTargetQueuesOpen: 'Windows.10.Amd64.ClientRS5.Open.reunion%3bWindows.10.Amd64.Client20h2.Open.reunion%3bWindows.10.Amd64.Client.Open.reunion%3bwindows.11.amd64.client.open.reunion'
+    helixTargetQueuesClosed: 'windows.10.amd64.client20h2.reunion%3bwindows.10.amd64.clientrs5.reunion%3bWindows.10.Amd64.Client.reunion%3bWindows.11.Amd64.client.Reunion'
 
     # When a test fails, it is re-run 10 times. This variable specifies how many times out of 10 it is required to pass
     rerunPassesRequiredToAvoidFailure: 8


### PR DESCRIPTION
Replacing the Helix queues for 21h1 with corresponding new Windows 10 Helix queues, because 21h1 is becoming out of service, so we can stop running tests on it. The new Windows 10 Helix queues will be kept up to date, always pointing to the latest public Windows 10 release.
---
For status checks on the develop branch, please use TransportPackage-Foundation
(https://microsoft.visualstudio.com/ProjectReunion/_build?definitionId=57248)
and run the build against your PR branch with the default parameters.

For status checks on the main branch, please use microsoft.ProjectReunion
(https://dev.azure.com/ms/ProjectReunion/_build?definitionId=391&_a=summary)
and run the build against your PR branch with the default parameters.