### PR TITLE
Updated versions of TAEF and C++/WinRT. Fixed DevCheck -SyncDependencies

### DIFF
--- a/DevCheck.ps1
+++ b/DevCheck.ps1
@@ -109,7 +109,7 @@ $ErrorActionPreference = "Stop"
 $global:issues = 0
 
 $remove_any = ($RemoveAll -eq $true) -or ($RemoveTestCert -eq $true) -or ($RemoveTestCert -eq $true)
-if (($remove_any -eq $false) -And ($CheckTAEFService -eq $false) -And ($CheckTestCert -eq $false) -And ($CheckTestPfx -eq $false) -And ($CheckVisualStudio -eq $false) -And ($CheckDependencies -eq $false) -And ($CheckDeveloperMode -eq $false))
+if (($remove_any -eq $false) -And ($CheckTAEFService -eq $false) -And ($CheckTestCert -eq $false) -And ($CheckTestPfx -eq $false) -And ($CheckVisualStudio -eq $false) -And ($CheckDependencies -eq $false) -And ($SyncDependencies -eq $false) -And ($CheckDeveloperMode -eq $false))
 {
     $CheckAll = $true
 }

--- a/build/AzurePipelinesTemplates/WindowsAppSDK-RunHelixTests-Job.yml
+++ b/build/AzurePipelinesTemplates/WindowsAppSDK-RunHelixTests-Job.yml
@@ -66,11 +66,11 @@ jobs:
   - task: NuGetAuthenticate@1
 
   - task: powershell@2
-    displayName: 'DevCheck: Setup development environment'
+    displayName: 'DevCheck: Setup/Verify development environment'
     inputs:
       targetType: filePath
       filePath: DevCheck.ps1
-      arguments: -NoInteractive -Offline -Verbose -CertPassword 'BuildPipeline' -CheckTestPfx -Clean
+      arguments: -NoInteractive -Offline -Verbose -CertPassword 'BuildPipeline' -CheckTestPfx -Clean -CheckDependencies
       workingDirectory: '$(Build.SourcesDirectory)'
 
   - task: powershell@2

--- a/build/AzurePipelinesTemplates/WindowsAppSDK-SetupBuildEnvironment-Steps.yml
+++ b/build/AzurePipelinesTemplates/WindowsAppSDK-SetupBuildEnvironment-Steps.yml
@@ -23,11 +23,11 @@ steps:
 - template: WindowsAppSDK-InstallWindowsSDK-Steps.yml
 
 - task: powershell@2
-  displayName: 'DevCheck: Setup development environment'
+  displayName: 'DevCheck: Setup/Verify development environment'
   inputs:
     targetType: filePath
     filePath: DevCheck.ps1
-    arguments: -NoInteractive -Offline -Verbose -CertPassword 'BuildPipeline' -CheckTestPfx -Clean
+    arguments: -NoInteractive -Offline -Verbose -CertPassword 'BuildPipeline' -CheckTestPfx -Clean -CheckDependencies
     workingDirectory: '$(Build.SourcesDirectory)'
 
 - task: PowerShell@2

--- a/dev/DeploymentAgent/packages.config
+++ b/dev/DeploymentAgent/packages.config
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.Windows.CppWinRT" version="2.0.220929.3" targetFramework="native" />
+  <package id="Microsoft.Windows.CppWinRT" version="2.0.221121.5" targetFramework="native" />
   <package id="Microsoft.Windows.ImplementationLibrary" version="1.0.220914.1" targetFramework="native" />
 </packages>

--- a/dev/Kozani/KozaniAppGraph/packages.config
+++ b/dev/Kozani/KozaniAppGraph/packages.config
@@ -3,6 +3,6 @@
   <package id="Microsoft.Build.Tasks.Git" version="1.1.1" targetFramework="native" developmentDependency="true" />
   <package id="Microsoft.SourceLink.Common" version="1.1.1" targetFramework="native" developmentDependency="true" />
   <package id="Microsoft.SourceLink.GitHub" version="1.1.1" targetFramework="native" developmentDependency="true" />
-  <package id="Microsoft.Windows.CppWinRT" version="2.0.220929.3" targetFramework="native" />
+  <package id="Microsoft.Windows.CppWinRT" version="2.0.221121.5" targetFramework="native" />
   <package id="Microsoft.Windows.ImplementationLibrary" version="1.0.220914.1" targetFramework="native" />
 </packages>

--- a/dev/Kozani/KozaniHostRuntime/packages.config
+++ b/dev/Kozani/KozaniHostRuntime/packages.config
@@ -3,6 +3,6 @@
   <package id="Microsoft.Build.Tasks.Git" version="1.1.1" targetFramework="native" developmentDependency="true" />
   <package id="Microsoft.SourceLink.Common" version="1.1.1" targetFramework="native" developmentDependency="true" />
   <package id="Microsoft.SourceLink.GitHub" version="1.1.1" targetFramework="native" developmentDependency="true" />
-  <package id="Microsoft.Windows.CppWinRT" version="2.0.220929.3" targetFramework="native" />
+  <package id="Microsoft.Windows.CppWinRT" version="2.0.221121.5" targetFramework="native" />
   <package id="Microsoft.Windows.ImplementationLibrary" version="1.0.220914.1" targetFramework="native" />
 </packages>

--- a/dev/Kozani/KozaniManager/packages.config
+++ b/dev/Kozani/KozaniManager/packages.config
@@ -3,6 +3,6 @@
   <package id="Microsoft.Build.Tasks.Git" version="1.1.1" targetFramework="native" developmentDependency="true" />
   <package id="Microsoft.SourceLink.Common" version="1.1.1" targetFramework="native" developmentDependency="true" />
   <package id="Microsoft.SourceLink.GitHub" version="1.1.1" targetFramework="native" developmentDependency="true" />
-  <package id="Microsoft.Windows.CppWinRT" version="2.0.220929.3" targetFramework="native" />
+  <package id="Microsoft.Windows.CppWinRT" version="2.0.221121.5" targetFramework="native" />
   <package id="Microsoft.Windows.ImplementationLibrary" version="1.0.220914.1" targetFramework="native" />
 </packages>

--- a/dev/Kozani/KozaniManagerRuntime/KozaniManagerRuntime.vcxproj.filters
+++ b/dev/Kozani/KozaniManagerRuntime/KozaniManagerRuntime.vcxproj.filters
@@ -68,7 +68,4 @@
       <Filter>Resource Files</Filter>
     </ResourceCompile>
   </ItemGroup>
-  <ItemGroup>
-    <Natvis Include="$(MSBuildThisFileDirectory)..\..\natvis\wil.natvis" />
-  </ItemGroup>
 </Project>

--- a/dev/Kozani/KozaniManagerRuntime/packages.config
+++ b/dev/Kozani/KozaniManagerRuntime/packages.config
@@ -3,6 +3,6 @@
   <package id="Microsoft.Build.Tasks.Git" version="1.1.1" targetFramework="native" developmentDependency="true" />
   <package id="Microsoft.SourceLink.Common" version="1.1.1" targetFramework="native" developmentDependency="true" />
   <package id="Microsoft.SourceLink.GitHub" version="1.1.1" targetFramework="native" developmentDependency="true" />
-  <package id="Microsoft.Windows.CppWinRT" version="2.0.220929.3" targetFramework="native" />
+  <package id="Microsoft.Windows.CppWinRT" version="2.0.221121.5" targetFramework="native" />
   <package id="Microsoft.Windows.ImplementationLibrary" version="1.0.220914.1" targetFramework="native" />
 </packages>

--- a/dev/Kozani/KozaniPackage/packages.config
+++ b/dev/Kozani/KozaniPackage/packages.config
@@ -3,6 +3,6 @@
   <package id="Microsoft.Build.Tasks.Git" version="1.1.1" targetFramework="native" developmentDependency="true" />
   <package id="Microsoft.SourceLink.Common" version="1.1.1" targetFramework="native" developmentDependency="true" />
   <package id="Microsoft.SourceLink.GitHub" version="1.1.1" targetFramework="native" developmentDependency="true" />
-  <package id="Microsoft.Windows.CppWinRT" version="2.0.220929.3" targetFramework="native" />
+  <package id="Microsoft.Windows.CppWinRT" version="2.0.221121.5" targetFramework="native" />
   <package id="Microsoft.Windows.ImplementationLibrary" version="1.0.220914.1" targetFramework="native" />
 </packages>

--- a/dev/Kozani/KozaniRemoteManager/packages.config
+++ b/dev/Kozani/KozaniRemoteManager/packages.config
@@ -3,6 +3,6 @@
   <package id="Microsoft.Build.Tasks.Git" version="1.1.1" targetFramework="native" developmentDependency="true" />
   <package id="Microsoft.SourceLink.Common" version="1.1.1" targetFramework="native" developmentDependency="true" />
   <package id="Microsoft.SourceLink.GitHub" version="1.1.1" targetFramework="native" developmentDependency="true" />
-  <package id="Microsoft.Windows.CppWinRT" version="2.0.220929.3" targetFramework="native" />
+  <package id="Microsoft.Windows.CppWinRT" version="2.0.221121.5" targetFramework="native" />
   <package id="Microsoft.Windows.ImplementationLibrary" version="1.0.220914.1" targetFramework="native" />
 </packages>

--- a/dev/Kozani/KozaniSendToLocal/packages.config
+++ b/dev/Kozani/KozaniSendToLocal/packages.config
@@ -3,6 +3,6 @@
   <package id="Microsoft.Build.Tasks.Git" version="1.1.1" targetFramework="native" developmentDependency="true" />
   <package id="Microsoft.SourceLink.Common" version="1.1.1" targetFramework="native" developmentDependency="true" />
   <package id="Microsoft.SourceLink.GitHub" version="1.1.1" targetFramework="native" developmentDependency="true" />
-  <package id="Microsoft.Windows.CppWinRT" version="2.0.220929.3" targetFramework="native" />
+  <package id="Microsoft.Windows.CppWinRT" version="2.0.221121.5" targetFramework="native" />
   <package id="Microsoft.Windows.ImplementationLibrary" version="1.0.220914.1" targetFramework="native" />
 </packages>

--- a/dev/Kozani/KozaniSendToRemote/packages.config
+++ b/dev/Kozani/KozaniSendToRemote/packages.config
@@ -3,6 +3,6 @@
   <package id="Microsoft.Build.Tasks.Git" version="1.1.1" targetFramework="native" developmentDependency="true" />
   <package id="Microsoft.SourceLink.Common" version="1.1.1" targetFramework="native" developmentDependency="true" />
   <package id="Microsoft.SourceLink.GitHub" version="1.1.1" targetFramework="native" developmentDependency="true" />
-  <package id="Microsoft.Windows.CppWinRT" version="2.0.220929.3" targetFramework="native" />
+  <package id="Microsoft.Windows.CppWinRT" version="2.0.221121.5" targetFramework="native" />
   <package id="Microsoft.Windows.ImplementationLibrary" version="1.0.220914.1" targetFramework="native" />
 </packages>

--- a/dev/Kozani/KozaniSettings/packages.config
+++ b/dev/Kozani/KozaniSettings/packages.config
@@ -3,6 +3,6 @@
   <package id="Microsoft.Build.Tasks.Git" version="1.1.1" targetFramework="native" developmentDependency="true" />
   <package id="Microsoft.SourceLink.Common" version="1.1.1" targetFramework="native" developmentDependency="true" />
   <package id="Microsoft.SourceLink.GitHub" version="1.1.1" targetFramework="native" developmentDependency="true" />
-  <package id="Microsoft.Windows.CppWinRT" version="2.0.220929.3" targetFramework="native" />
+  <package id="Microsoft.Windows.CppWinRT" version="2.0.221121.5" targetFramework="native" />
   <package id="Microsoft.Windows.ImplementationLibrary" version="1.0.220914.1" targetFramework="native" />
 </packages>

--- a/dev/Kozani/MakeMSIX/packages.config
+++ b/dev/Kozani/MakeMSIX/packages.config
@@ -3,6 +3,6 @@
   <package id="Microsoft.Build.Tasks.Git" version="1.1.1" targetFramework="native" developmentDependency="true" />
   <package id="Microsoft.SourceLink.Common" version="1.1.1" targetFramework="native" developmentDependency="true" />
   <package id="Microsoft.SourceLink.GitHub" version="1.1.1" targetFramework="native" developmentDependency="true" />
-  <package id="Microsoft.Windows.CppWinRT" version="2.0.220929.3" targetFramework="native" />
+  <package id="Microsoft.Windows.CppWinRT" version="2.0.221121.5" targetFramework="native" />
   <package id="Microsoft.Windows.ImplementationLibrary" version="1.0.220914.1" targetFramework="native" />
 </packages>

--- a/dev/MRTCore/mrt/Core/unittests/packages.config
+++ b/dev/MRTCore/mrt/Core/unittests/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.Taef" version="10.58.210222006-develop" targetFramework="native" />
+  <package id="Microsoft.Taef" version="10.75.221207001" targetFramework="native" />
 </packages>

--- a/dev/MRTCore/mrt/Microsoft.Windows.ApplicationModel.Resources/UnpackagedTests/MrtCoreUnpackagedTests.csproj
+++ b/dev/MRTCore/mrt/Microsoft.Windows.ApplicationModel.Resources/UnpackagedTests/MrtCoreUnpackagedTests.csproj
@@ -39,16 +39,16 @@
     <Reference Include="System.Data" />
     <Reference Include="System.Xml" />
     <Reference Include="TE.Managed, Version=10.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>$(NugetPackageDirectory)\Microsoft.Taef.$(MicrosoftTaefVersion)\lib\net45\TE.Managed.dll</HintPath>
+      <HintPath>$(NugetPackageDirectory)\Microsoft.Taef.$(MicrosoftTaefVersion)\lib\net452\TE.Managed.dll</HintPath>
     </Reference>
     <Reference Include="TE.Model.Managed, Version=10.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>$(NugetPackageDirectory)\Microsoft.Taef.$(MicrosoftTaefVersion)\lib\net45\TE.Model.Managed.dll</HintPath>
+      <HintPath>$(NugetPackageDirectory)\Microsoft.Taef.$(MicrosoftTaefVersion)\lib\net452\TE.Model.Managed.dll</HintPath>
     </Reference>
     <Reference Include="Wex.Common.Managed, Version=10.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>$(NugetPackageDirectory)\Microsoft.Taef.$(MicrosoftTaefVersion)\lib\net45\Wex.Common.Managed.dll</HintPath>
+      <HintPath>$(NugetPackageDirectory)\Microsoft.Taef.$(MicrosoftTaefVersion)\lib\net452\Wex.Common.Managed.dll</HintPath>
     </Reference>
     <Reference Include="Wex.Logger.Interop, Version=10.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>$(NugetPackageDirectory)\Microsoft.Taef.$(MicrosoftTaefVersion)\lib\net45\Wex.Logger.Interop.dll</HintPath>
+      <HintPath>$(NugetPackageDirectory)\Microsoft.Taef.$(MicrosoftTaefVersion)\lib\net452\Wex.Logger.Interop.dll</HintPath>
     </Reference>
     <Reference Include="Windows.Foundation.FoundationContract">
       <HintPath>C:\Program Files (x86)\Windows Kits\10\References\10.0.19041.0\Windows.Foundation.FoundationContract\4.0.0.0\Windows.Foundation.FoundationContract.winmd</HintPath>

--- a/dev/MRTCore/mrt/Microsoft.Windows.ApplicationModel.Resources/UnpackagedTests/packages.config
+++ b/dev/MRTCore/mrt/Microsoft.Windows.ApplicationModel.Resources/UnpackagedTests/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.Taef" version="10.58.210222006-develop" targetFramework="net45" />
+  <package id="Microsoft.Taef" version="10.75.221207001" targetFramework="net45" />
 </packages>

--- a/dev/MRTCore/mrt/Microsoft.Windows.ApplicationModel.Resources/src/packages.config
+++ b/dev/MRTCore/mrt/Microsoft.Windows.ApplicationModel.Resources/src/packages.config
@@ -3,5 +3,5 @@
   <package id="Microsoft.Build.Tasks.Git" version="1.1.1" targetFramework="native" developmentDependency="true" />
   <package id="Microsoft.SourceLink.Common" version="1.1.1" targetFramework="native" developmentDependency="true" />
   <package id="Microsoft.SourceLink.GitHub" version="1.1.1" targetFramework="native" developmentDependency="true" />
-  <package id="Microsoft.Windows.CppWinRT" version="2.0.220929.3" targetFramework="native" />
+  <package id="Microsoft.Windows.CppWinRT" version="2.0.221121.5" targetFramework="native" />
 </packages>

--- a/dev/MRTCore/mrt/mrm/UnitTests/packages.config
+++ b/dev/MRTCore/mrt/mrm/UnitTests/packages.config
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Microsoft.Windows.ImplementationLibrary" version="1.0.220914.1" targetFramework="native" />
-  <package id="Microsoft.Taef" version="10.58.210222006-develop" targetFramework="native" />
+  <package id="Microsoft.Taef" version="10.75.221207001" targetFramework="native" />
 </packages>

--- a/dev/PushNotifications/PushNotificationsLongRunningTask/packages.config
+++ b/dev/PushNotifications/PushNotificationsLongRunningTask/packages.config
@@ -3,6 +3,6 @@
   <package id="Microsoft.Build.Tasks.Git" version="1.1.1" targetFramework="native" developmentDependency="true" />
   <package id="Microsoft.SourceLink.Common" version="1.1.1" targetFramework="native" developmentDependency="true" />
   <package id="Microsoft.SourceLink.GitHub" version="1.1.1" targetFramework="native" developmentDependency="true" />
-  <package id="Microsoft.Windows.CppWinRT" version="2.0.220929.3" targetFramework="native" />
+  <package id="Microsoft.Windows.CppWinRT" version="2.0.221121.5" targetFramework="native" />
   <package id="Microsoft.Windows.ImplementationLibrary" version="1.0.220914.1" targetFramework="native" />
 </packages>

--- a/dev/RestartAgent/packages.config
+++ b/dev/RestartAgent/packages.config
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.Windows.CppWinRT" version="2.0.220929.3" targetFramework="native" />
+  <package id="Microsoft.Windows.CppWinRT" version="2.0.221121.5" targetFramework="native" />
   <package id="Microsoft.Windows.ImplementationLibrary" version="1.0.220914.1" targetFramework="native" />
 </packages>

--- a/dev/WindowsAppRuntime_DLL/packages.config
+++ b/dev/WindowsAppRuntime_DLL/packages.config
@@ -3,6 +3,6 @@
   <package id="Microsoft.Build.Tasks.Git" version="1.1.1" targetFramework="native" developmentDependency="true" />
   <package id="Microsoft.SourceLink.Common" version="1.1.1" targetFramework="native" developmentDependency="true" />
   <package id="Microsoft.SourceLink.GitHub" version="1.1.1" targetFramework="native" developmentDependency="true" />
-  <package id="Microsoft.Windows.CppWinRT" version="2.0.220929.3" targetFramework="native" />
+  <package id="Microsoft.Windows.CppWinRT" version="2.0.221121.5" targetFramework="native" />
   <package id="Microsoft.Windows.ImplementationLibrary" version="1.0.220914.1" targetFramework="native" />
 </packages>

--- a/eng/Version.Dependencies.xml
+++ b/eng/Version.Dependencies.xml
@@ -4,7 +4,7 @@
            e.g. if B depends on A v1 and A v2 is published, Maestro updates B's Version.Details.xml to A v2
         2. Dependencies in Version.Dependencies.xml are only changed by explicit (manual) developer action
            e.g. if B depends on A v1 and A v2 is published, B is unchanged
-        3. Dependencies' versions in Version.Details.xml and Version.Dependencies.xml are TheMasterSourceOfTruth(TM). 
+        3. Dependencies' versions in Version.Details.xml and Version.Dependencies.xml are TheMasterSourceOfTruth(TM).
             These are literal values. No macro expansion or magic substitution will occur
         4. <ProductDependencies><Dependency> are listed in sorted order (alphabetically, case-insensitive)
         5. <ToolsetDependencies><Dependency> are listed in sorted order (alphabetically, case-insensitive)
@@ -22,15 +22,15 @@
        17. Version.Dependencies.props is a generated file. DO NOT EDIT. Use DevCheck -SyncDependencies
        18. POLICY: Dependencies on Transport Packages are expressed as <ProductDependencies> in Version.Details.xml
        19. POLICY: Dependencies on non-Transport Packages are expressed as <ToolsetDependencies> in Version.Dependencies.xml
-       20. POLICY: Update Version.Dependencies.props via "DevCheck -CheckDependencies -SyncDependencies". 
+       20. POLICY: Update Version.Dependencies.props via "DevCheck -CheckDependencies -SyncDependencies".
             NOTE: This is required when adding or removing a dependency
     -->
 <Dependencies>
   <Dependency Name="Microsoft.Build.Tasks.Git"                Version="1.1.1"/>
   <Dependency Name="Microsoft.SourceLink.Common"              Version="1.1.1"/>
   <Dependency Name="Microsoft.SourceLink.GitHub"              Version="1.1.1"/>
-  <Dependency Name="Microsoft.Taef"                           Version="10.58.210222006-develop"/>
+  <Dependency Name="Microsoft.Taef"                           Version="10.75.221207001"/>
   <Dependency Name="Microsoft.Telemetry.Inbox.Native"         Version="10.0.19041.1-191206-1406.vb-release.x86fre" />
-  <Dependency Name="Microsoft.Windows.CppWinRT"               Version="2.0.220929.3"/>
+  <Dependency Name="Microsoft.Windows.CppWinRT"               Version="2.0.221121.5"/>
   <Dependency Name="Microsoft.Windows.ImplementationLibrary"  Version="1.0.220914.1"/>
 </Dependencies>

--- a/installer/dev/packages.config
+++ b/installer/dev/packages.config
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.Windows.CppWinRT" version="2.0.220929.3" targetFramework="native" />
+  <package id="Microsoft.Windows.CppWinRT" version="2.0.221121.5" targetFramework="native" />
   <package id="Microsoft.Windows.ImplementationLibrary" version="1.0.220914.1" targetFramework="native" />
 </packages>

--- a/installer/test/InstallerFunctionalTests/packages.config
+++ b/installer/test/InstallerFunctionalTests/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.Taef" version="10.58.210222006-develop" targetFramework="native" />
-  <package id="Microsoft.Windows.CppWinRT" version="2.0.220929.3" targetFramework="native" />
+  <package id="Microsoft.Taef" version="10.75.221207001" targetFramework="native" />
+  <package id="Microsoft.Windows.CppWinRT" version="2.0.221121.5" targetFramework="native" />
   <package id="Microsoft.Windows.ImplementationLibrary" version="1.0.220914.1" targetFramework="native" />
 </packages>

--- a/test/AccessControlTests/packages.config
+++ b/test/AccessControlTests/packages.config
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.Taef" version="10.58.210222006-develop" targetFramework="native" />
-  <package id="Microsoft.Windows.CppWinRT" version="2.0.220929.3" targetFramework="native" />
+  <package id="Microsoft.Taef" version="10.75.221207001" targetFramework="native" />
+  <package id="Microsoft.Windows.CppWinRT" version="2.0.221121.5" targetFramework="native" />
 </packages>

--- a/test/AppLifecycle/packages.config
+++ b/test/AppLifecycle/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.Taef" version="10.58.210222006-develop" targetFramework="native" />
-  <package id="Microsoft.Windows.CppWinRT" version="2.0.220929.3" targetFramework="native" />
+  <package id="Microsoft.Taef" version="10.75.221207001" targetFramework="native" />
+  <package id="Microsoft.Windows.CppWinRT" version="2.0.221121.5" targetFramework="native" />
   <package id="Microsoft.Windows.ImplementationLibrary" version="1.0.220914.1" targetFramework="native" />
 </packages>

--- a/test/AppNotificationBuilderTests/packages.config
+++ b/test/AppNotificationBuilderTests/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.Taef" version="10.58.210222006-develop" targetFramework="native" />
-  <package id="Microsoft.Windows.CppWinRT" version="2.0.220929.3" targetFramework="native" />
+  <package id="Microsoft.Taef" version="10.75.221207001" targetFramework="native" />
+  <package id="Microsoft.Windows.CppWinRT" version="2.0.221121.5" targetFramework="native" />
   <package id="Microsoft.Windows.ImplementationLibrary" version="1.0.220914.1" targetFramework="native" />
 </packages>

--- a/test/AppNotificationTests/packages.config
+++ b/test/AppNotificationTests/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.Taef" version="10.58.210222006-develop" targetFramework="native" />
-  <package id="Microsoft.Windows.CppWinRT" version="2.0.220929.3" targetFramework="native" />
+  <package id="Microsoft.Taef" version="10.75.221207001" targetFramework="native" />
+  <package id="Microsoft.Windows.CppWinRT" version="2.0.221121.5" targetFramework="native" />
   <package id="Microsoft.Windows.ImplementationLibrary" version="1.0.220914.1" targetFramework="native" />
 </packages>

--- a/test/Common/packages.config
+++ b/test/Common/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.Taef" version="10.58.210222006-develop" targetFramework="native" />
-  <package id="Microsoft.Windows.CppWinRT" version="2.0.220929.3" targetFramework="native" />
+  <package id="Microsoft.Taef" version="10.75.221207001" targetFramework="native" />
+  <package id="Microsoft.Windows.CppWinRT" version="2.0.221121.5" targetFramework="native" />
   <package id="Microsoft.Windows.ImplementationLibrary" version="1.0.220914.1" targetFramework="native" />
 </packages>

--- a/test/Deployment/API/packages.config
+++ b/test/Deployment/API/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.Taef" version="10.58.210222006-develop" targetFramework="native" />
-  <package id="Microsoft.Windows.CppWinRT" version="2.0.220929.3" targetFramework="native" />
+  <package id="Microsoft.Taef" version="10.75.221207001" targetFramework="native" />
+  <package id="Microsoft.Windows.CppWinRT" version="2.0.221121.5" targetFramework="native" />
   <package id="Microsoft.Windows.ImplementationLibrary" version="1.0.220914.1" targetFramework="native" />
 </packages>

--- a/test/Deployment/Test_DeploymentManagerAutoInitialize/CPP/Test_DeploymentManagerAutoInitialize_CPP_Default/packages.config
+++ b/test/Deployment/Test_DeploymentManagerAutoInitialize/CPP/Test_DeploymentManagerAutoInitialize_CPP_Default/packages.config
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.Windows.CppWinRT" version="2.0.220929.3" targetFramework="native" />
+  <package id="Microsoft.Windows.CppWinRT" version="2.0.221121.5" targetFramework="native" />
   <package id="Microsoft.Windows.ImplementationLibrary" version="1.0.220914.1" targetFramework="native" />
 </packages>

--- a/test/Deployment/Test_DeploymentManagerAutoInitialize/CPP/Test_DeploymentManagerAutoInitialize_CPP_Options_Default/packages.config
+++ b/test/Deployment/Test_DeploymentManagerAutoInitialize/CPP/Test_DeploymentManagerAutoInitialize_CPP_Options_Default/packages.config
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.Windows.CppWinRT" version="2.0.220929.3" targetFramework="native" />
+  <package id="Microsoft.Windows.CppWinRT" version="2.0.221121.5" targetFramework="native" />
   <package id="Microsoft.Windows.ImplementationLibrary" version="1.0.220914.1" targetFramework="native" />
 </packages>

--- a/test/Deployment/Test_DeploymentManagerAutoInitialize/CPP/Test_DeploymentManagerAutoInitialize_CPP_Options_Defined/packages.config
+++ b/test/Deployment/Test_DeploymentManagerAutoInitialize/CPP/Test_DeploymentManagerAutoInitialize_CPP_Options_Defined/packages.config
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.Windows.CppWinRT" version="2.0.220929.3" targetFramework="native" />
+  <package id="Microsoft.Windows.CppWinRT" version="2.0.221121.5" targetFramework="native" />
   <package id="Microsoft.Windows.ImplementationLibrary" version="1.0.220914.1" targetFramework="native" />
 </packages>

--- a/test/Deployment/Test_DeploymentManagerAutoInitialize/CPP/Test_DeploymentManagerAutoInitialize_CPP_Options_None/packages.config
+++ b/test/Deployment/Test_DeploymentManagerAutoInitialize/CPP/Test_DeploymentManagerAutoInitialize_CPP_Options_None/packages.config
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.Windows.CppWinRT" version="2.0.220929.3" targetFramework="native" />
+  <package id="Microsoft.Windows.CppWinRT" version="2.0.221121.5" targetFramework="native" />
   <package id="Microsoft.Windows.ImplementationLibrary" version="1.0.220914.1" targetFramework="native" />
 </packages>

--- a/test/DynamicDependency/Test_Win32/packages.config
+++ b/test/DynamicDependency/Test_Win32/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.Taef" version="10.58.210222006-develop" targetFramework="native" />
+  <package id="Microsoft.Taef" version="10.75.221207001" targetFramework="native" />
 </packages>

--- a/test/DynamicDependency/Test_WinRT/packages.config
+++ b/test/DynamicDependency/Test_WinRT/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.Taef" version="10.58.210222006-develop" targetFramework="native" />
+  <package id="Microsoft.Taef" version="10.75.221207001" targetFramework="native" />
 </packages>

--- a/test/DynamicDependency/data/Framework.Widgets/packages.config
+++ b/test/DynamicDependency/data/Framework.Widgets/packages.config
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.Windows.CppWinRT" version="2.0.220929.3" targetFramework="native" />
+  <package id="Microsoft.Windows.CppWinRT" version="2.0.221121.5" targetFramework="native" />
   <package id="Microsoft.Windows.ImplementationLibrary" version="1.0.220914.1" targetFramework="native" />
 </packages>

--- a/test/EnvironmentManagerTests/packages.config
+++ b/test/EnvironmentManagerTests/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.Taef" version="10.58.210222006-develop" targetFramework="native" />
-  <package id="Microsoft.Windows.CppWinRT" version="2.0.220929.3" targetFramework="native" />
+  <package id="Microsoft.Taef" version="10.75.221207001" targetFramework="native" />
+  <package id="Microsoft.Windows.CppWinRT" version="2.0.221121.5" targetFramework="native" />
   <package id="Microsoft.Windows.ImplementationLibrary" version="1.0.220914.1" targetFramework="native" />
 </packages>

--- a/test/Kozani/KozaniAppGraphTests/packages.config
+++ b/test/Kozani/KozaniAppGraphTests/packages.config
@@ -3,7 +3,7 @@
   <package id="Microsoft.Build.Tasks.Git" version="1.1.1" targetFramework="native" developmentDependency="true" />
   <package id="Microsoft.SourceLink.Common" version="1.1.1" targetFramework="native" developmentDependency="true" />
   <package id="Microsoft.SourceLink.GitHub" version="1.1.1" targetFramework="native" developmentDependency="true" />
-  <package id="Microsoft.Taef" version="10.58.210222006-develop" targetFramework="native" />
-  <package id="Microsoft.Windows.CppWinRT" version="2.0.220929.3" targetFramework="native" />
+  <package id="Microsoft.Taef" version="10.75.221207001" targetFramework="native" />
+  <package id="Microsoft.Windows.CppWinRT" version="2.0.221121.5" targetFramework="native" />
   <package id="Microsoft.Windows.ImplementationLibrary" version="1.0.220914.1" targetFramework="native" />
 </packages>

--- a/test/Kozani/KozaniHostRuntimeTests/packages.config
+++ b/test/Kozani/KozaniHostRuntimeTests/packages.config
@@ -3,7 +3,7 @@
   <package id="Microsoft.Build.Tasks.Git" version="1.1.1" targetFramework="native" developmentDependency="true" />
   <package id="Microsoft.SourceLink.Common" version="1.1.1" targetFramework="native" developmentDependency="true" />
   <package id="Microsoft.SourceLink.GitHub" version="1.1.1" targetFramework="native" developmentDependency="true" />
-  <package id="Microsoft.Taef" version="10.58.210222006-develop" targetFramework="native" />
-  <package id="Microsoft.Windows.CppWinRT" version="2.0.220929.3" targetFramework="native" />
+  <package id="Microsoft.Taef" version="10.75.221207001" targetFramework="native" />
+  <package id="Microsoft.Windows.CppWinRT" version="2.0.221121.5" targetFramework="native" />
   <package id="Microsoft.Windows.ImplementationLibrary" version="1.0.220914.1" targetFramework="native" />
 </packages>

--- a/test/Kozani/KozaniManagerRuntimeTests/packages.config
+++ b/test/Kozani/KozaniManagerRuntimeTests/packages.config
@@ -3,7 +3,7 @@
   <package id="Microsoft.Build.Tasks.Git" version="1.1.1" targetFramework="native" developmentDependency="true" />
   <package id="Microsoft.SourceLink.Common" version="1.1.1" targetFramework="native" developmentDependency="true" />
   <package id="Microsoft.SourceLink.GitHub" version="1.1.1" targetFramework="native" developmentDependency="true" />
-  <package id="Microsoft.Taef" version="10.58.210222006-develop" targetFramework="native" />
-  <package id="Microsoft.Windows.CppWinRT" version="2.0.220929.3" targetFramework="native" />
+  <package id="Microsoft.Taef" version="10.75.221207001" targetFramework="native" />
+  <package id="Microsoft.Windows.CppWinRT" version="2.0.221121.5" targetFramework="native" />
   <package id="Microsoft.Windows.ImplementationLibrary" version="1.0.220914.1" targetFramework="native" />
 </packages>

--- a/test/Kozani/KozaniManagerTests/packages.config
+++ b/test/Kozani/KozaniManagerTests/packages.config
@@ -3,7 +3,7 @@
   <package id="Microsoft.Build.Tasks.Git" version="1.1.1" targetFramework="native" developmentDependency="true" />
   <package id="Microsoft.SourceLink.Common" version="1.1.1" targetFramework="native" developmentDependency="true" />
   <package id="Microsoft.SourceLink.GitHub" version="1.1.1" targetFramework="native" developmentDependency="true" />
-  <package id="Microsoft.Taef" version="10.58.210222006-develop" targetFramework="native" />
-  <package id="Microsoft.Windows.CppWinRT" version="2.0.220929.3" targetFramework="native" />
+  <package id="Microsoft.Taef" version="10.75.221207001" targetFramework="native" />
+  <package id="Microsoft.Windows.CppWinRT" version="2.0.221121.5" targetFramework="native" />
   <package id="Microsoft.Windows.ImplementationLibrary" version="1.0.220914.1" targetFramework="native" />
 </packages>

--- a/test/Kozani/KozaniPackageTests/packages.config
+++ b/test/Kozani/KozaniPackageTests/packages.config
@@ -3,7 +3,7 @@
   <package id="Microsoft.Build.Tasks.Git" version="1.1.1" targetFramework="native" developmentDependency="true" />
   <package id="Microsoft.SourceLink.Common" version="1.1.1" targetFramework="native" developmentDependency="true" />
   <package id="Microsoft.SourceLink.GitHub" version="1.1.1" targetFramework="native" developmentDependency="true" />
-  <package id="Microsoft.Taef" version="10.58.210222006-develop" targetFramework="native" />
-  <package id="Microsoft.Windows.CppWinRT" version="2.0.220929.3" targetFramework="native" />
+  <package id="Microsoft.Taef" version="10.75.221207001" targetFramework="native" />
+  <package id="Microsoft.Windows.CppWinRT" version="2.0.221121.5" targetFramework="native" />
   <package id="Microsoft.Windows.ImplementationLibrary" version="1.0.220914.1" targetFramework="native" />
 </packages>

--- a/test/Kozani/KozaniRemoteManagerTests/packages.config
+++ b/test/Kozani/KozaniRemoteManagerTests/packages.config
@@ -3,7 +3,7 @@
   <package id="Microsoft.Build.Tasks.Git" version="1.1.1" targetFramework="native" developmentDependency="true" />
   <package id="Microsoft.SourceLink.Common" version="1.1.1" targetFramework="native" developmentDependency="true" />
   <package id="Microsoft.SourceLink.GitHub" version="1.1.1" targetFramework="native" developmentDependency="true" />
-  <package id="Microsoft.Taef" version="10.58.210222006-develop" targetFramework="native" />
-  <package id="Microsoft.Windows.CppWinRT" version="2.0.220929.3" targetFramework="native" />
+  <package id="Microsoft.Taef" version="10.75.221207001" targetFramework="native" />
+  <package id="Microsoft.Windows.CppWinRT" version="2.0.221121.5" targetFramework="native" />
   <package id="Microsoft.Windows.ImplementationLibrary" version="1.0.220914.1" targetFramework="native" />
 </packages>

--- a/test/Kozani/KozaniSendToLocalTests/packages.config
+++ b/test/Kozani/KozaniSendToLocalTests/packages.config
@@ -3,7 +3,7 @@
   <package id="Microsoft.Build.Tasks.Git" version="1.1.1" targetFramework="native" developmentDependency="true" />
   <package id="Microsoft.SourceLink.Common" version="1.1.1" targetFramework="native" developmentDependency="true" />
   <package id="Microsoft.SourceLink.GitHub" version="1.1.1" targetFramework="native" developmentDependency="true" />
-  <package id="Microsoft.Taef" version="10.58.210222006-develop" targetFramework="native" />
-  <package id="Microsoft.Windows.CppWinRT" version="2.0.220929.3" targetFramework="native" />
+  <package id="Microsoft.Taef" version="10.75.221207001" targetFramework="native" />
+  <package id="Microsoft.Windows.CppWinRT" version="2.0.221121.5" targetFramework="native" />
   <package id="Microsoft.Windows.ImplementationLibrary" version="1.0.220914.1" targetFramework="native" />
 </packages>

--- a/test/Kozani/KozaniSendToRemoteTests/packages.config
+++ b/test/Kozani/KozaniSendToRemoteTests/packages.config
@@ -3,7 +3,7 @@
   <package id="Microsoft.Build.Tasks.Git" version="1.1.1" targetFramework="native" developmentDependency="true" />
   <package id="Microsoft.SourceLink.Common" version="1.1.1" targetFramework="native" developmentDependency="true" />
   <package id="Microsoft.SourceLink.GitHub" version="1.1.1" targetFramework="native" developmentDependency="true" />
-  <package id="Microsoft.Taef" version="10.58.210222006-develop" targetFramework="native" />
-  <package id="Microsoft.Windows.CppWinRT" version="2.0.220929.3" targetFramework="native" />
+  <package id="Microsoft.Taef" version="10.75.221207001" targetFramework="native" />
+  <package id="Microsoft.Windows.CppWinRT" version="2.0.221121.5" targetFramework="native" />
   <package id="Microsoft.Windows.ImplementationLibrary" version="1.0.220914.1" targetFramework="native" />
 </packages>

--- a/test/Kozani/KozaniSettingsTests/packages.config
+++ b/test/Kozani/KozaniSettingsTests/packages.config
@@ -3,7 +3,7 @@
   <package id="Microsoft.Build.Tasks.Git" version="1.1.1" targetFramework="native" developmentDependency="true" />
   <package id="Microsoft.SourceLink.Common" version="1.1.1" targetFramework="native" developmentDependency="true" />
   <package id="Microsoft.SourceLink.GitHub" version="1.1.1" targetFramework="native" developmentDependency="true" />
-  <package id="Microsoft.Taef" version="10.58.210222006-develop" targetFramework="native" />
-  <package id="Microsoft.Windows.CppWinRT" version="2.0.220929.3" targetFramework="native" />
+  <package id="Microsoft.Taef" version="10.75.221207001" targetFramework="native" />
+  <package id="Microsoft.Windows.CppWinRT" version="2.0.221121.5" targetFramework="native" />
   <package id="Microsoft.Windows.ImplementationLibrary" version="1.0.220914.1" targetFramework="native" />
 </packages>

--- a/test/Kozani/MakeMSIXTests/packages.config
+++ b/test/Kozani/MakeMSIXTests/packages.config
@@ -3,7 +3,7 @@
   <package id="Microsoft.Build.Tasks.Git" version="1.1.1" targetFramework="native" developmentDependency="true" />
   <package id="Microsoft.SourceLink.Common" version="1.1.1" targetFramework="native" developmentDependency="true" />
   <package id="Microsoft.SourceLink.GitHub" version="1.1.1" targetFramework="native" developmentDependency="true" />
-  <package id="Microsoft.Taef" version="10.58.210222006-develop" targetFramework="native" />
-  <package id="Microsoft.Windows.CppWinRT" version="2.0.220929.3" targetFramework="native" />
+  <package id="Microsoft.Taef" version="10.75.221207001" targetFramework="native" />
+  <package id="Microsoft.Windows.CppWinRT" version="2.0.221121.5" targetFramework="native" />
   <package id="Microsoft.Windows.ImplementationLibrary" version="1.0.220914.1" targetFramework="native" />
 </packages>

--- a/test/LRPTests/packages.config
+++ b/test/LRPTests/packages.config
@@ -1,6 +1,6 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.Taef" version="10.58.210222006-develop" targetFramework="native" />
-  <package id="Microsoft.Windows.CppWinRT" version="2.0.220929.3" targetFramework="native" />
+  <package id="Microsoft.Taef" version="10.75.221207001" targetFramework="native" />
+  <package id="Microsoft.Windows.CppWinRT" version="2.0.221121.5" targetFramework="native" />
   <package id="Microsoft.Windows.ImplementationLibrary" version="1.0.220914.1" targetFramework="native" />
 </packages>

--- a/test/PowerNotifications/packages.config
+++ b/test/PowerNotifications/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.Taef" version="10.58.210222006-develop" targetFramework="native" />
-  <package id="Microsoft.Windows.CppWinRT" version="2.0.220929.3" targetFramework="native" />
+  <package id="Microsoft.Taef" version="10.75.221207001" targetFramework="native" />
+  <package id="Microsoft.Windows.CppWinRT" version="2.0.221121.5" targetFramework="native" />
   <package id="Microsoft.Windows.ImplementationLibrary" version="1.0.220914.1" targetFramework="native" />
 </packages>

--- a/test/PushNotificationTests/packages.config
+++ b/test/PushNotificationTests/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.Taef" version="10.58.210222006-develop" targetFramework="native" />
-  <package id="Microsoft.Windows.CppWinRT" version="2.0.220929.3" targetFramework="native" />
+  <package id="Microsoft.Taef" version="10.75.221207001" targetFramework="native" />
+  <package id="Microsoft.Windows.CppWinRT" version="2.0.221121.5" targetFramework="native" />
   <package id="Microsoft.Windows.ImplementationLibrary" version="1.0.220914.1" targetFramework="native" />
 </packages>

--- a/test/TestApps/AccessControlTestApp/packages.config
+++ b/test/TestApps/AccessControlTestApp/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.Taef" version="10.58.210222006-develop" targetFramework="native" />
-  <package id="Microsoft.Windows.CppWinRT" version="2.0.220929.3" targetFramework="native" />
+  <package id="Microsoft.Taef" version="10.75.221207001" targetFramework="native" />
+  <package id="Microsoft.Windows.CppWinRT" version="2.0.221121.5" targetFramework="native" />
   <package id="Microsoft.Windows.ImplementationLibrary" version="1.0.220914.1" targetFramework="native" />
 </packages>

--- a/test/TestApps/AppLifecycleTestApp/packages.config
+++ b/test/TestApps/AppLifecycleTestApp/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.Taef" version="10.58.210222006-develop" targetFramework="native" />
-  <package id="Microsoft.Windows.CppWinRT" version="2.0.220929.3" targetFramework="native" />
+  <package id="Microsoft.Taef" version="10.75.221207001" targetFramework="native" />
+  <package id="Microsoft.Windows.CppWinRT" version="2.0.221121.5" targetFramework="native" />
   <package id="Microsoft.Windows.ImplementationLibrary" version="1.0.220914.1" targetFramework="native" />
 </packages>

--- a/test/TestApps/ManualTestApp/packages.config
+++ b/test/TestApps/ManualTestApp/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.Taef" version="10.58.210222006-develop" targetFramework="native" />
-  <package id="Microsoft.Windows.CppWinRT" version="2.0.220929.3" targetFramework="native" />
+  <package id="Microsoft.Taef" version="10.75.221207001" targetFramework="native" />
+  <package id="Microsoft.Windows.CppWinRT" version="2.0.221121.5" targetFramework="native" />
   <package id="Microsoft.Windows.ImplementationLibrary" version="1.0.220914.1" targetFramework="native" />
 </packages>

--- a/test/TestApps/PushNotificationsDemoApp/packages.config
+++ b/test/TestApps/PushNotificationsDemoApp/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.Taef" version="10.58.210222006-develop" targetFramework="native" />
-  <package id="Microsoft.Windows.CppWinRT" version="2.0.220929.3" targetFramework="native" />
+  <package id="Microsoft.Taef" version="10.75.221207001" targetFramework="native" />
+  <package id="Microsoft.Windows.CppWinRT" version="2.0.221121.5" targetFramework="native" />
   <package id="Microsoft.Windows.ImplementationLibrary" version="1.0.220914.1" targetFramework="native" />
 </packages>

--- a/test/TestApps/PushNotificationsTestApp/packages.config
+++ b/test/TestApps/PushNotificationsTestApp/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.Taef" version="10.58.210222006-develop" targetFramework="native" />
-  <package id="Microsoft.Windows.CppWinRT" version="2.0.220929.3" targetFramework="native" />
+  <package id="Microsoft.Taef" version="10.75.221207001" targetFramework="native" />
+  <package id="Microsoft.Windows.CppWinRT" version="2.0.221121.5" targetFramework="native" />
   <package id="Microsoft.Windows.ImplementationLibrary" version="1.0.220914.1" targetFramework="native" />
 </packages>

--- a/test/TestApps/ToastNotificationsDemoApp/packages.config
+++ b/test/TestApps/ToastNotificationsDemoApp/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.Taef" version="10.58.210222006-develop" targetFramework="native" />
-  <package id="Microsoft.Windows.CppWinRT" version="2.0.220929.3" targetFramework="native" />
+  <package id="Microsoft.Taef" version="10.75.221207001" targetFramework="native" />
+  <package id="Microsoft.Windows.CppWinRT" version="2.0.221121.5" targetFramework="native" />
   <package id="Microsoft.Windows.ImplementationLibrary" version="1.0.220914.1" targetFramework="native" />
 </packages>

--- a/test/TestApps/ToastNotificationsTestApp/packages.config
+++ b/test/TestApps/ToastNotificationsTestApp/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.Taef" version="10.58.210222006-develop" targetFramework="native" />
-  <package id="Microsoft.Windows.CppWinRT" version="2.0.220929.3" targetFramework="native" />
+  <package id="Microsoft.Taef" version="10.75.221207001" targetFramework="native" />
+  <package id="Microsoft.Windows.CppWinRT" version="2.0.221121.5" targetFramework="native" />
   <package id="Microsoft.Windows.ImplementationLibrary" version="1.0.220914.1" targetFramework="native" />
 </packages>

--- a/test/VersionInfo/packages.config
+++ b/test/VersionInfo/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.Taef" version="10.58.210222006-develop" targetFramework="native" />
-  <package id="Microsoft.Windows.CppWinRT" version="2.0.220929.3" targetFramework="native" />
+  <package id="Microsoft.Taef" version="10.75.221207001" targetFramework="native" />
+  <package id="Microsoft.Windows.CppWinRT" version="2.0.221121.5" targetFramework="native" />
   <package id="Microsoft.Windows.ImplementationLibrary" version="1.0.220914.1" targetFramework="native" />
 </packages>

--- a/tools/ProjectTemplates/dev.cpp.dll.winrt-client-server/PurojekutoTenpuret.vcxproj.filters
+++ b/tools/ProjectTemplates/dev.cpp.dll.winrt-client-server/PurojekutoTenpuret.vcxproj.filters
@@ -68,7 +68,4 @@
       <Filter>Resource Files</Filter>
     </ResourceCompile>
   </ItemGroup>
-  <ItemGroup>
-    <Natvis Include="$(MSBuildThisFileDirectory)..\..\natvis\wil.natvis" />
-  </ItemGroup>
 </Project>

--- a/tools/ProjectTemplates/dev.cpp.dll.winrt-client-server/packages.config
+++ b/tools/ProjectTemplates/dev.cpp.dll.winrt-client-server/packages.config
@@ -3,6 +3,6 @@
   <package id="Microsoft.Build.Tasks.Git" version="1.1.1" targetFramework="native" developmentDependency="true" />
   <package id="Microsoft.SourceLink.Common" version="1.1.1" targetFramework="native" developmentDependency="true" />
   <package id="Microsoft.SourceLink.GitHub" version="1.1.1" targetFramework="native" developmentDependency="true" />
-  <package id="Microsoft.Windows.CppWinRT" version="2.0.220929.3" targetFramework="native" />
+  <package id="Microsoft.Windows.CppWinRT" version="2.0.221121.5" targetFramework="native" />
   <package id="Microsoft.Windows.ImplementationLibrary" version="1.0.220914.1" targetFramework="native" />
 </packages>

--- a/tools/ProjectTemplates/dev.cpp.dll.winrt-client/PurojekutoTenpuret.vcxproj.filters
+++ b/tools/ProjectTemplates/dev.cpp.dll.winrt-client/PurojekutoTenpuret.vcxproj.filters
@@ -62,7 +62,4 @@
       <Filter>Resource Files</Filter>
     </ResourceCompile>
   </ItemGroup>
-  <ItemGroup>
-    <Natvis Include="$(MSBuildThisFileDirectory)..\..\natvis\wil.natvis" />
-  </ItemGroup>
 </Project>

--- a/tools/ProjectTemplates/dev.cpp.dll.winrt-client/packages.config
+++ b/tools/ProjectTemplates/dev.cpp.dll.winrt-client/packages.config
@@ -3,6 +3,6 @@
   <package id="Microsoft.Build.Tasks.Git" version="1.1.1" targetFramework="native" developmentDependency="true" />
   <package id="Microsoft.SourceLink.Common" version="1.1.1" targetFramework="native" developmentDependency="true" />
   <package id="Microsoft.SourceLink.GitHub" version="1.1.1" targetFramework="native" developmentDependency="true" />
-  <package id="Microsoft.Windows.CppWinRT" version="2.0.220929.3" targetFramework="native" />
+  <package id="Microsoft.Windows.CppWinRT" version="2.0.221121.5" targetFramework="native" />
   <package id="Microsoft.Windows.ImplementationLibrary" version="1.0.220914.1" targetFramework="native" />
 </packages>

--- a/tools/ProjectTemplates/dev.cpp.exe+dll.com-oopserver/PurojekutoTenpuret/packages.config
+++ b/tools/ProjectTemplates/dev.cpp.exe+dll.com-oopserver/PurojekutoTenpuret/packages.config
@@ -3,6 +3,6 @@
   <package id="Microsoft.Build.Tasks.Git" version="1.1.1" targetFramework="native" developmentDependency="true" />
   <package id="Microsoft.SourceLink.Common" version="1.1.1" targetFramework="native" developmentDependency="true" />
   <package id="Microsoft.SourceLink.GitHub" version="1.1.1" targetFramework="native" developmentDependency="true" />
-  <package id="Microsoft.Windows.CppWinRT" version="2.0.220929.3" targetFramework="native" />
+  <package id="Microsoft.Windows.CppWinRT" version="2.0.221121.5" targetFramework="native" />
   <package id="Microsoft.Windows.ImplementationLibrary" version="1.0.220914.1" targetFramework="native" />
 </packages>

--- a/tools/ProjectTemplates/dev.cpp.exe.com-oopserver-main/packages.config
+++ b/tools/ProjectTemplates/dev.cpp.exe.com-oopserver-main/packages.config
@@ -3,6 +3,6 @@
   <package id="Microsoft.Build.Tasks.Git" version="1.1.1" targetFramework="native" developmentDependency="true" />
   <package id="Microsoft.SourceLink.Common" version="1.1.1" targetFramework="native" developmentDependency="true" />
   <package id="Microsoft.SourceLink.GitHub" version="1.1.1" targetFramework="native" developmentDependency="true" />
-  <package id="Microsoft.Windows.CppWinRT" version="2.0.220929.3" targetFramework="native" />
+  <package id="Microsoft.Windows.CppWinRT" version="2.0.221121.5" targetFramework="native" />
   <package id="Microsoft.Windows.ImplementationLibrary" version="1.0.220914.1" targetFramework="native" />
 </packages>

--- a/tools/ProjectTemplates/dev.cpp.exe.console-winrt-client/PurojekutoTenpuret.vcxproj.filters
+++ b/tools/ProjectTemplates/dev.cpp.exe.console-winrt-client/PurojekutoTenpuret.vcxproj.filters
@@ -59,7 +59,4 @@
       <Filter>Resource Files</Filter>
     </ResourceCompile>
   </ItemGroup>
-  <ItemGroup>
-    <Natvis Include="$(MSBuildThisFileDirectory)..\..\natvis\wil.natvis" />
-  </ItemGroup>
 </Project>

--- a/tools/ProjectTemplates/dev.cpp.exe.console-winrt-client/packages.config
+++ b/tools/ProjectTemplates/dev.cpp.exe.console-winrt-client/packages.config
@@ -3,6 +3,6 @@
   <package id="Microsoft.Build.Tasks.Git" version="1.1.1" targetFramework="native" developmentDependency="true" />
   <package id="Microsoft.SourceLink.Common" version="1.1.1" targetFramework="native" developmentDependency="true" />
   <package id="Microsoft.SourceLink.GitHub" version="1.1.1" targetFramework="native" developmentDependency="true" />
-  <package id="Microsoft.Windows.CppWinRT" version="2.0.220929.3" targetFramework="native" />
+  <package id="Microsoft.Windows.CppWinRT" version="2.0.221121.5" targetFramework="native" />
   <package id="Microsoft.Windows.ImplementationLibrary" version="1.0.220914.1" targetFramework="native" />
 </packages>

--- a/tools/ProjectTemplates/dev.cpp.exe.winmain-winrt-client/PurojekutoTenpuret.vcxproj.filters
+++ b/tools/ProjectTemplates/dev.cpp.exe.winmain-winrt-client/PurojekutoTenpuret.vcxproj.filters
@@ -59,7 +59,4 @@
       <Filter>Resource Files</Filter>
     </ResourceCompile>
   </ItemGroup>
-  <ItemGroup>
-    <Natvis Include="$(MSBuildThisFileDirectory)..\..\natvis\wil.natvis" />
-  </ItemGroup>
 </Project>

--- a/tools/ProjectTemplates/dev.cpp.exe.winmain-winrt-client/packages.config
+++ b/tools/ProjectTemplates/dev.cpp.exe.winmain-winrt-client/packages.config
@@ -3,6 +3,6 @@
   <package id="Microsoft.Build.Tasks.Git" version="1.1.1" targetFramework="native" developmentDependency="true" />
   <package id="Microsoft.SourceLink.Common" version="1.1.1" targetFramework="native" developmentDependency="true" />
   <package id="Microsoft.SourceLink.GitHub" version="1.1.1" targetFramework="native" developmentDependency="true" />
-  <package id="Microsoft.Windows.CppWinRT" version="2.0.220929.3" targetFramework="native" />
+  <package id="Microsoft.Windows.CppWinRT" version="2.0.221121.5" targetFramework="native" />
   <package id="Microsoft.Windows.ImplementationLibrary" version="1.0.220914.1" targetFramework="native" />
 </packages>

--- a/tools/ProjectTemplates/test.cpp.dll.taef/packages.config
+++ b/tools/ProjectTemplates/test.cpp.dll.taef/packages.config
@@ -3,7 +3,7 @@
   <package id="Microsoft.Build.Tasks.Git" version="1.1.1" targetFramework="native" developmentDependency="true" />
   <package id="Microsoft.SourceLink.Common" version="1.1.1" targetFramework="native" developmentDependency="true" />
   <package id="Microsoft.SourceLink.GitHub" version="1.1.1" targetFramework="native" developmentDependency="true" />
-  <package id="Microsoft.Taef" version="10.58.210222006-develop" targetFramework="native" />
-  <package id="Microsoft.Windows.CppWinRT" version="2.0.220929.3" targetFramework="native" />
+  <package id="Microsoft.Taef" version="10.75.221207001" targetFramework="native" />
+  <package id="Microsoft.Windows.CppWinRT" version="2.0.221121.5" targetFramework="native" />
   <package id="Microsoft.Windows.ImplementationLibrary" version="1.0.220914.1" targetFramework="native" />
 </packages>


### PR DESCRIPTION
Updated versions of TAEF and C++/WinRT to latest

Fixed DevCheck -SyncDependencies (wasn't updating files)

Updated DevCheck to treat -SyncDependencies equivalent to -CheckDependencies++ (before was treating -SyncDependencies equivalent to -All -SyncDependencies)

Updated dependencies via DevCheck -SyncDependencies

Removed references to non-existent .natvis files