### PR TITLE
[CherryPick] Fix PushNotificationChannel::ExpirationTime

### DIFF
--- a/dev/PushNotifications/PushNotificationManager.cpp
+++ b/dev/PushNotifications/PushNotificationManager.cpp
@@ -119,7 +119,14 @@ namespace winrt::Microsoft::Windows::PushNotifications::implementation
 
         THROW_IF_FAILED(operationalCode);
 
-        winrt::copy_from_abi(channelInfo.channelExpiryTime, &channelExpiryTime);
+        // Need to manually convert from the ABI::DateTime type to the winrt::DateTime type since they have different contracts.
+        FILETIME filetime;
+        LARGE_INTEGER largeTime;
+        largeTime.QuadPart = channelExpiryTime.UniversalTime;
+        filetime.dwLowDateTime = largeTime.LowPart;
+        filetime.dwHighDateTime = largeTime.HighPart;
+
+        channelInfo.channelExpiryTime = winrt::clock::from_FILETIME(filetime);
         channelInfo.appId = winrt::hstring{ appId.get() };
         channelInfo.channelId = winrt::hstring{ channelId.get() };
         channelInfo.channelUri = winrt::hstring{ channelUri.get() };

--- a/test/PushNotificationTests/BaseTestSuite.cpp
+++ b/test/PushNotificationTests/BaseTestSuite.cpp
@@ -18,6 +18,8 @@ using namespace winrt::Windows::Management::Deployment;
 using namespace winrt::Windows::Storage;
 using namespace winrt::Windows::System;
 using namespace winrt::Microsoft::Windows::PushNotifications;
+using namespace std::literals;
+using namespace std::chrono;
 
 void BaseTestSuite::ClassSetup()
 {
@@ -37,7 +39,7 @@ void BaseTestSuite::MethodSetup()
     if (!isSelfContained)
     {
         ::WindowsAppRuntime::VersionInfo::TestInitialize(::Test::Bootstrap::TP::WindowsAppRuntimeFramework::c_PackageFamilyName,
-                                                         ::Test::Bootstrap::TP::WindowsAppRuntimeMain::c_PackageFamilyName);
+            ::Test::Bootstrap::TP::WindowsAppRuntimeMain::c_PackageFamilyName);
         VERIFY_IS_FALSE(::WindowsAppRuntime::SelfContained::IsSelfContained());
     }
     else
@@ -105,6 +107,27 @@ void BaseTestSuite::ChannelRequestUsingRemoteId()
     {
         auto channelOperation{ PushNotificationManager::Default().CreateChannelAsync(c_azureRemoteId) };
         VERIFY_SUCCEEDED(ChannelRequestHelper(channelOperation));
+    }
+    else
+    {
+        auto channelOperation{ PushNotificationManager::Default().CreateChannelAsync(c_azureRemoteId) };
+        VERIFY_ARE_EQUAL(ChannelRequestHelper(channelOperation), E_FAIL);
+    }
+}
+
+void BaseTestSuite::ChannelRequestCheckExpirationTime()
+{
+    if (PushNotificationManager::Default().IsSupported())
+    {
+        auto channelOperation{ PushNotificationManager::Default().CreateChannelAsync(c_azureRemoteId) };
+        VERIFY_SUCCEEDED(ChannelRequestHelper(channelOperation));
+
+        auto channel{ channelOperation.GetResults().Channel() };
+        auto expirationTime{ channel.ExpirationTime() };
+        auto expiryBound{ winrt::clock::now() + days(30) + minutes(1) };
+
+        // Need to add 30 days to match expiration time.
+        VERIFY_IS_LESS_THAN(expirationTime, expiryBound);
     }
     else
     {

--- a/test/PushNotificationTests/BaseTestSuite.cpp
+++ b/test/PushNotificationTests/BaseTestSuite.cpp
@@ -124,10 +124,12 @@ void BaseTestSuite::ChannelRequestCheckExpirationTime()
 
         auto channel{ channelOperation.GetResults().Channel() };
         auto expirationTime{ channel.ExpirationTime() };
-        auto expiryBound{ winrt::clock::now() + (hours(24) * 30) + minutes(1) };
+        auto expiryLowerBound{ winrt::clock::now() };
+        auto expiryUpperBound{ expiryLowerBound + (hours(24) * 30) + minutes(1) };
 
         // Need to add 30 days to match expiration time.
-        VERIFY_IS_LESS_THAN(expirationTime, expiryBound);
+        VERIFY_IS_GREATER_THAN(expirationTime, expiryLowerBound);
+        VERIFY_IS_LESS_THAN(expirationTime, expiryUpperBound);
     }
     else
     {

--- a/test/PushNotificationTests/BaseTestSuite.cpp
+++ b/test/PushNotificationTests/BaseTestSuite.cpp
@@ -124,7 +124,7 @@ void BaseTestSuite::ChannelRequestCheckExpirationTime()
 
         auto channel{ channelOperation.GetResults().Channel() };
         auto expirationTime{ channel.ExpirationTime() };
-        auto expiryBound{ winrt::clock::now() + days(30) + minutes(1) };
+        auto expiryBound{ winrt::clock::now() + (hours(24) * 30) + minutes(1) };
 
         // Need to add 30 days to match expiration time.
         VERIFY_IS_LESS_THAN(expirationTime, expiryBound);

--- a/test/PushNotificationTests/BaseTestSuite.h
+++ b/test/PushNotificationTests/BaseTestSuite.h
@@ -21,6 +21,7 @@ class BaseTestSuite
 
         // Base unit tests
         void ChannelRequestUsingNullRemoteId();
+        void ChannelRequestCheckExpirationTime();
         void ChannelRequestUsingRemoteId();
         void MultipleChannelClose(); // Currently failing
         void VerifyRegisterAndUnregister();

--- a/test/PushNotificationTests/PackagedTests.cpp
+++ b/test/PushNotificationTests/PackagedTests.cpp
@@ -13,6 +13,11 @@ void PackagedTests::ChannelRequestUsingRemoteId()
     BaseTestSuite::ChannelRequestUsingRemoteId();
 }
 
+void PackagedTests::ChannelRequestCheckExpirationTime()
+{
+    BaseTestSuite::ChannelRequestCheckExpirationTime();
+}
+
 // Currently failing - https://github.com/microsoft/WindowsAppSDK/issues/2392
 void PackagedTests::MultipleChannelClose()
 {

--- a/test/PushNotificationTests/PackagedTests.h
+++ b/test/PushNotificationTests/PackagedTests.h
@@ -46,6 +46,7 @@ class PackagedTests : BaseTestSuite
 
     TEST_METHOD(ChannelRequestUsingNullRemoteId);
     TEST_METHOD(ChannelRequestUsingRemoteId);
+    TEST_METHOD(ChannelRequestCheckExpirationTime);
     BEGIN_TEST_METHOD(MultipleChannelClose) // Currently failing 
         TEST_METHOD_PROPERTY(L"Ignore", L"true")
     END_TEST_METHOD()

--- a/test/PushNotificationTests/UnpackagedTests.cpp
+++ b/test/PushNotificationTests/UnpackagedTests.cpp
@@ -13,6 +13,11 @@ void UnpackagedTests::ChannelRequestUsingRemoteId()
     BaseTestSuite::ChannelRequestUsingRemoteId();
 }
 
+void UnpackagedTests::ChannelRequestCheckExpirationTime()
+{
+    BaseTestSuite::ChannelRequestCheckExpirationTime();
+}
+
 // Currently failing - https://github.com/microsoft/WindowsAppSDK/issues/2392
 void UnpackagedTests::MultipleChannelClose()
 {

--- a/test/PushNotificationTests/UnpackagedTests.h
+++ b/test/PushNotificationTests/UnpackagedTests.h
@@ -44,6 +44,7 @@ class UnpackagedTests : BaseTestSuite
 
     TEST_METHOD(ChannelRequestUsingNullRemoteId);
     TEST_METHOD(ChannelRequestUsingRemoteId);
+    TEST_METHOD(ChannelRequestCheckExpirationTime);
     BEGIN_TEST_METHOD(MultipleChannelClose) // Currently failing 
         TEST_METHOD_PROPERTY(L"Ignore", L"true")
     END_TEST_METHOD()


### PR DESCRIPTION
…eTime (#3335)

* Initial fix
The ExpirationTime being returned by PushNotificationChannel has been returning incorrectly. Instead of returning value 30 days from the request, it is returning some value in year 1602. This is because originally, the code was using winrt::copy_from_abi to copy the DateTime. The fix is to take the ExpirationTime from the ABI and convert it to a winrt::DateTime.

* Add unit test
Added a unit test verifying the returned channel is within the expected range.

* Change constraint

* Update upper bound

* Change upper bound to 1 min

A microsoft employee must use /azp run to validate using the pipelines below.

WARNING:
Comments made by azure-pipelines bot maybe inaccurate. 
Please see pipeline link to verify that the build is being ran.

For status checks on the develop branch, please use TransportPackage-Foundation-PR
(https://microsoft.visualstudio.com/ProjectReunion/_build?definitionId=81063&_a=summary)
and run the build against your PR branch with the default parameters.

For status checks on the main branch, please use microsoft.ProjectReunion
(https://dev.azure.com/ms/ProjectReunion/_build?definitionId=391&_a=summary)
and run the build against your PR branch with the default parameters.