### PR TITLE
[CherryPick] Fix PushNotificationChannel::ExpirationTime (#3388)

### DIFF
--- a/dev/PushNotifications/PushNotificationManager.cpp
+++ b/dev/PushNotifications/PushNotificationManager.cpp
@@ -119,7 +119,14 @@ namespace winrt::Microsoft::Windows::PushNotifications::implementation
 
         THROW_IF_FAILED(operationalCode);
 
-        winrt::copy_from_abi(channelInfo.channelExpiryTime, &channelExpiryTime);
+        // Need to manually convert from the ABI::DateTime type to the winrt::DateTime type since they have different contracts.
+        FILETIME filetime;
+        LARGE_INTEGER largeTime;
+        largeTime.QuadPart = channelExpiryTime.UniversalTime;
+        filetime.dwLowDateTime = largeTime.LowPart;
+        filetime.dwHighDateTime = largeTime.HighPart;
+
+        channelInfo.channelExpiryTime = winrt::clock::from_FILETIME(filetime);
         channelInfo.appId = winrt::hstring{ appId.get() };
         channelInfo.channelId = winrt::hstring{ channelId.get() };
         channelInfo.channelUri = winrt::hstring{ channelUri.get() };

--- a/test/PushNotificationTests/BaseTestSuite.h
+++ b/test/PushNotificationTests/BaseTestSuite.h
@@ -21,6 +21,7 @@ class BaseTestSuite
 
         // Base unit tests
         void ChannelRequestUsingNullRemoteId();
+        void ChannelRequestCheckExpirationTime();
         void ChannelRequestUsingRemoteId();
         void MultipleChannelClose(); // Currently failing
         void VerifyRegisterAndUnregister();

--- a/test/PushNotificationTests/PackagedTests.cpp
+++ b/test/PushNotificationTests/PackagedTests.cpp
@@ -13,6 +13,11 @@ void PackagedTests::ChannelRequestUsingRemoteId()
     BaseTestSuite::ChannelRequestUsingRemoteId();
 }
 
+void PackagedTests::ChannelRequestCheckExpirationTime()
+{
+    BaseTestSuite::ChannelRequestCheckExpirationTime();
+}
+
 // Currently failing - https://github.com/microsoft/WindowsAppSDK/issues/2392
 void PackagedTests::MultipleChannelClose()
 {

--- a/test/PushNotificationTests/PackagedTests.h
+++ b/test/PushNotificationTests/PackagedTests.h
@@ -46,6 +46,7 @@ class PackagedTests : BaseTestSuite
 
     TEST_METHOD(ChannelRequestUsingNullRemoteId);
     TEST_METHOD(ChannelRequestUsingRemoteId);
+    TEST_METHOD(ChannelRequestCheckExpirationTime);
     BEGIN_TEST_METHOD(MultipleChannelClose) // Currently failing 
         TEST_METHOD_PROPERTY(L"Ignore", L"true")
     END_TEST_METHOD()

--- a/test/PushNotificationTests/UnpackagedTests.cpp
+++ b/test/PushNotificationTests/UnpackagedTests.cpp
@@ -13,6 +13,11 @@ void UnpackagedTests::ChannelRequestUsingRemoteId()
     BaseTestSuite::ChannelRequestUsingRemoteId();
 }
 
+void UnpackagedTests::ChannelRequestCheckExpirationTime()
+{
+    BaseTestSuite::ChannelRequestCheckExpirationTime();
+}
+
 // Currently failing - https://github.com/microsoft/WindowsAppSDK/issues/2392
 void UnpackagedTests::MultipleChannelClose()
 {

--- a/test/PushNotificationTests/UnpackagedTests.h
+++ b/test/PushNotificationTests/UnpackagedTests.h
@@ -44,6 +44,7 @@ class UnpackagedTests : BaseTestSuite
 
     TEST_METHOD(ChannelRequestUsingNullRemoteId);
     TEST_METHOD(ChannelRequestUsingRemoteId);
+    TEST_METHOD(ChannelRequestCheckExpirationTime);
     BEGIN_TEST_METHOD(MultipleChannelClose) // Currently failing 
         TEST_METHOD_PROPERTY(L"Ignore", L"true")
     END_TEST_METHOD()


### PR DESCRIPTION
* Fix PushNotificationChannel::ExpirationTime incorrectly returning DateTime (#3335)
Cherrypick of https://github.com/microsoft/WindowsAppSDK/pull/3388
https://github.com/microsoft/WindowsAppSDK/pull/3335

A microsoft employee must use /azp run to validate using the pipelines below.

WARNING:
Comments made by azure-pipelines bot maybe inaccurate. 
Please see pipeline link to verify that the build is being ran.

For status checks on the develop branch, please use TransportPackage-Foundation-PR
(https://microsoft.visualstudio.com/ProjectReunion/_build?definitionId=81063&_a=summary)
and run the build against your PR branch with the default parameters.

For status checks on the main branch, please use microsoft.ProjectReunion
(https://dev.azure.com/ms/ProjectReunion/_build?definitionId=391&_a=summary)
and run the build against your PR branch with the default parameters.