### PR TITLE
DevCheck fix: No taefservice detected = boom

### DIFF
--- a/DevCheck.ps1
+++ b/DevCheck.ps1
@@ -701,7 +701,7 @@ function Remove-DevTestCert
 
 function Get-TAEFServiceImagePath
 {
-    $regkey = Registry::HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Services\Te.Service
+    $regkey = 'Registry::HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Services\Te.Service'
     if (-not(Test-Path -Path $regkey))
     {
         return $null

--- a/DevCheck.ps1
+++ b/DevCheck.ps1
@@ -701,7 +701,13 @@ function Remove-DevTestCert
 
 function Get-TAEFServiceImagePath
 {
-    $path = Get-ItemProperty -Path Registry::HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Services\Te.Service | Select-Object 'ImagePath'
+    $regkey = Registry::HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Services\Te.Service
+    if (-not(Test-Path -Path $regkey))
+    {
+        return $null
+    }
+
+    $path = Get-ItemProperty -Path $regkey | Select-Object 'ImagePath'
     $path.ImagePath
 }
 


### PR DESCRIPTION
@kythant this fixes a pipeline break so the PR can't complete on its own. Need a superadmin (like yourself :-) to complete it without waiting for the PR build to complete.

Check-TAEFServiceImagePath would fail (Powershell error) if no TAEF service is registered. Repro'd locally and verified the fix fixes it.