### PR TITLE
API spec document for msix packaging in winappsdk

### DIFF
--- a/specs/WinRT/MakeMSIX-spec.md
+++ b/specs/WinRT/MakeMSIX-spec.md
@@ -1,398 +1,87 @@
 # MakeMSIX API in Windows App SDK
 - [1. Background](#1-background)
-- [2. Existing interfaces and options](#2-existing-interfaces-and-options)
-  - [2.1. Makeappx](#21-makeappx)
-    - [2.1.1. pack](#211-pack)
-    - [2.1.2. bundle](#212-bundle)
-    - [2.1.3. unpack](#213-unpack)
-    - [2.1.4. unbundle](#214-unbundle)
-  - [2.2. Makemsix](#21-makemsix)
-    - [2.2.1. pack](#221-pack)
-    - [2.2.2. bundle](#222-bundle)
-    - [2.2.3. unpack](#223-unpack)
-    - [2.2.4. unbundle](#224-unbundle)
-  - [2.3. MSIXMgr](#23-msixmgr)
-    - [2.3.1. unpack](#231-unpack)
-- [3. Summary of existing options in relation to proposed api](#3-summary-of-existing-options-in-relation-to-proposed-api)
-- [4. Examples](#4-examples)
-    - [4.1. Packing a package](#41-packing-a-package)
-    - [4.2. Unbundling and unpacking a package to change information](#42-unbundling-and-unpacking-a-package-to-change-information)
-    - [4.3. Helper methods for examples](#43-helper-methods-for-examples) 
-- [5. API Details](#5-api-details)
+- [2. Summary of existing options in relation to proposed API](#2-summary-of-existing-options-in-relation-to-proposed-API)
+- [3. Examples](#4-examples)
+    - [3.1. Packing a package](#41-packing-a-package)
+    - [3.2. Unbundling and unpacking a package to change information](#32-unbundling-and-unpacking-a-package-to-change-information)
+    - [3.3. Helper methods for examples](#33-helper-methods-for-examples) 
+- [4. API Details](#4-API-details)
+- [5. Appendix](#5-Appendix)
+- [6. Existing interfaces and options](#6-existing-interfaces-and-options)
+  - [6.1. Makeappx](#61-makeappx)
+    - [6.1.1. pack](#611-pack)
+    - [6.1.2. bundle](#612-bundle)
+    - [6.1.3. unpack](#613-unpack)
+    - [6.1.4. unbundle](#614-unbundle)
+  - [6.2. Makemsix](#62-makemsix)
+    - [6.2.1. pack](#621-pack)
+    - [6.2.2. bundle](#622-bundle)
+    - [6.2.3. unpack](#623-unpack)
+    - [6.2.4. unbundle](#624-unbundle)
+  - [6.3. MSIXMgr](#63-msixmgr)
+    - [6.3.1. unpack](#631-unpack)
 
 # 1. Background
 
-The MakeMSIX api allows developers to create app packages for distribution. The api
-provides a WinRT interface that joins the functionality from multiple existing command line tools in
-one developer friendly location to allow creation of msix\appx packages and msixbundle\appxbundle packages,
-unpacking of those packages, and creation of package images for Azure App Attach.
-In addition to functionality from those existing tools, this api adds support for creation of Kozani
-packages.
+The MakeMSIX API allows developers to create app packages for distribution. The API provides a WinRT
+interface that joins the functionality from multiple existing command line tools in one developer
+friendly location to allow creation of msix\appx packages and msixbundle\appxbundle packages,
+unpacking of those packages, and creation of package images for Azure App Attach. In addition to
+functionality from those existing tools, this API adds support for creation of Kozani packages.
 
-# 2. Existing interfaces and options
+# 2. Summary of existing options in relation to proposed API
 
-The existing tools are:
--   [The makeappx command line tool](https://learn.microsoft.com/en-us/windows/win32/appxpkg/make-appx-package--makeappx-exe-)
-    Shipped as part of the Windows Development Kit.
-    Exposes pack, unpack, bundle, and unbundle commands, as well as encryption support
-    via a custom key-file list file, and creation of packages via a custom mapping file
-    to allow creation of packages with different payloads from the same folder.
-
--   [The makemsix command line tool and dll](https://github.com/Microsoft/msix-packaging)
-    Available through the github project.
-    Exposes pack, unpack, unbundle, and bundle* commands (*Bundle command only supports creation of
-    flat bundles. Flat bundles are bundles where package locations are stored as external path references
-    rather than being stored inside the msixbundle file itself. Flat bundles referred to as
-    sparse bundles in the makeappx documentation).
-    
--   [The msixmgr command line tool](https://github.com/Microsoft/msix-packaging and 
-    https://learn.microsoft.com/en-us/azure/virtual-desktop/app-attach-msixmgr)
-    Available through github and as a direct download from the learn.microsoft.com site.
-    Exposes "unpack" command to convert msix packages to vhd, vhdx, cim image files.
-
-None of the existing tools provide a good programmatic interface for all aspects of packaging.
-
-The makeappx.exe built into windows provides the only complete implementation of packaging
-and bundling but requires CreateProcess and does not return any specific errors from process exit.
-It also does not support any of the azure app attach scenarios.
-
-The makemsix tool is designed as a cross-platform implementation of packaging, but does not support
-a complete set of bundling features. The functionality is exposed as a command line as well as flat dll exports.
-
-The msixmgr tool is mostly for specific azure app attach packaging scenarios that are not covered by
-the other tools. To use it programmatically would require either using CreateProcess or building
-the msix-packaging github project and linking the static lib it produces into a project.
-
-## 2.1. Makeappx
-
-### 2.1.1. Pack
-Usage:
-------
-    MakeAppx pack [options] /d <content directory> /p <output package name>
-    MakeAppx pack [options] /f <mapping file> /p <output package name>
-    MakeAppx pack [options] /m <app package manifest> /f <mapping file> /p <output package name>
-    MakeAppx pack [options] /r /m <app package manifest> /f <mapping file> /p <output package name>
-    MakeAppx pack [options] /d <content directory> /ep <encrypted output package name> /kf <key file>
-    MakeAppx pack [options] /d <content directory> /ep <encrypted output package name> /kt
-
-Options:
---------
-    /h, /hashAlgorithm: Specifies a hash algorithm to use for creating the
-        block map. Valid algorithm IDs are SHA256, SHA384, and SHA512. The
-        default is SHA256.
-    /nv, /noValidation: Skips validation that ensures the package will be
-        installable on Windows. The validation include: existence of files
-        referenced in manifest, ContentGroupMap correctness, and additional
-        manifest validation on Protocols and FileTypeAssociation. By default,
-        all semantic validation is performed.
-    /nfv, /noFileValidation: Skips validation that ensures that the files used
-        to create the package (from a folder through /d or layout file through
-        /l) exist and are accessible. By default, all files must exist and not
-        be read locked. If a file is inaccessible, it will not be added to the
-        package.
-    /nc, /noCompress: Prevents MakeAppx from compressing files in the package.
-        By default, files in the package are compressed based on detected file
-        type.
-    /m: Specifies the path to an input app manifest which will be used as the
-        basis for generating the output app package or resource package's
-        manifest. When you use this option, you must also use /f and include a
-        [ResourceMetadata] section in the mapping file to specify the resource
-        dimensions to be included in the generated manifest.
-    /r: Builds a resource package. You must use the /m option with this.
-    /kf: Use this option to encrypt or decrypt the package or bundle using a
-        key file. This option cannot be combined with /kt.
-    /kt: Use this option to encrypt or decrypt the package or bundle using the
-        global test key. This option cannot be combined with /kf.
-    /cgm: The input content group map (CGM) file path used to create a
-        stream-able package. Providing a content group map through this option
-        will disable the check that all files in the content group map exist in
-        the package.
-    /pri, /makepriExeFullPath: You can use /pri to override the default
-        MakePri.exe path with the custom fullpath from which makeappx.exe will
-        launch the tool from when needed.
-    /mp: Specifies the path to a main package in the same package family as the
-        resource package being built.  You should provide this when encrypting
-        a resource package or when the resource package contains a content
-        group map.
-    /pb, /publisherBridging: Use this option to add publisher bridging entries
-        to the package or bundle.  Publisher bridging is useful when the new
-        issued cert subject name changed but the old publisher name is still
-        desired to maintain package identity continuity.
-    /np, /noParallel: Use this option to disable parallel execution of this
-        command.
-    /ml, /memoryLimit: Specify maximum memory in bytes that MakeAppx should
-        consume while executing in parallel. By default, this value is set to
-        half of total physical memory.
-    /o, /overwrite: Forces the output to overwrite any existing files with the
-        same name. By default, the user is asked whether to overwrite existing
-        files with the same name. You can't use this option with /no.
-    /no, /noOverwrite: Prevents the output from overwriting any existing files
-        with the same name. By default, the user is asked whether to overwrite
-        existing files with the same name. You can't use this option with /o.
-    /v, /verbose: Enables verbose output of messages to the console.
-    /?, /help: Displays this help text.
-
-### 2.1.2. Bundle
-
-Usage:
-------
-    MakeAppx bundle [options] /d <content directory> /p <output bundle name>
-    MakeAppx bundle [options] /f <mapping file> /p <output bundle name>
-    MakeAppx bundle [options] /d <content directory> /ep <encrypted output bundle name> /kf MyKeyFile.txt
-    MakeAppx bundle [options] /f <mapping file> /ep <encrypted output bundle name> /kt
-
-Options:
---------
-    /bv: Specifies the version number of the bundle being created. The version
-        must be in dotted-quad notation of four integers
-        <Major>.<Minor>.<Build>.<Revision> ranging from 0 to 65535 each. If the
-        /bv option is not specified or is set to 0.0.0.0, the bundle is created
-        using the current date-time formatted as the version:
-        <Year>.<Month-Day>.<Hour-Minute>.<Second-Millisecond>.
-    /mo: Generates a bundle manifest only, instead of a full bundle. Input
-        files must all be package manifests in XML format if this option is
-        specified.
-    /fb: Generates a fully sparse bundle where all packages are references to
-        packages that exist outside of the bundle file
-    /pri, /makepriExeFullPath: You can use /pri to override the default
-        MakePri.exe path with the custom fullpath from which makeappx.exe will
-        launch the tool from when needed.
-    /kf: Use this option to encrypt or decrypt the package or bundle using a
-        key file. This option cannot be combined with /kt.
-    /kt: Use this option to encrypt or decrypt the package or bundle using the
-        global test key. This option cannot be combined with /kf.
-    /o, /overwrite: Forces the output to overwrite any existing files with the
-        same name. By default, the user is asked whether to overwrite existing
-        files with the same name. You can't use this option with /no.
-    /no, /noOverwrite: Prevents the output from overwriting any existing files
-        with the same name. By default, the user is asked whether to overwrite
-        existing files with the same name. You can't use this option with /o.
-    /v, /verbose: Enables verbose output of messages to the console.
-    /?, /help: Displays this help text.
-
-### 2.1.3. Unpack
-Usage:
-------
-    MakeAppx unpack [options] /p <input package name> /d <output directory>
-    MakeAppx unpack [options] /ep <encrypted input package name> /d <output directory> /kf <key file>
-    MakeAppx unpack [options] /ep <encrypted input package name> /d <output directory> /kt
-
-Options:
---------
-    /pfn: Unpacks all files to a subdirectory under the specified output path,
-        named after the package full name.
-    /nv, /noValidation: Skips validation that ensures the package will be
-        installable on Windows. The validation include: existence of files
-        referenced in manifest, ContentGroupMap correctness, and additional
-        manifest validation on Protocols and FileTypeAssociation. By default,
-        all semantic validation is performed.
-    /kf: Use this option to encrypt or decrypt the package or bundle using a
-        key file. This option cannot be combined with /kt.
-    /kt: Use this option to encrypt or decrypt the package or bundle using the
-        global test key. This option cannot be combined with /kf.
-    /nd: Skips decryption when unpacking an encrypted package or bundle.
-    /o, /overwrite: Forces the output to overwrite any existing files with the
-        same name. By default, the user is asked whether to overwrite existing
-        files with the same name. You can't use this option with /no.
-    /no, /noOverwrite: Prevents the output from overwriting any existing files
-        with the same name. By default, the user is asked whether to overwrite
-        existing files with the same name. You can't use this option with /o.
-    /v, /verbose: Enables verbose output of messages to the console.
-    /?, /help: Displays this help text.
-
-### 2.1.4. Unbundle
-
-Usage:
-------
-    MakeAppx unbundle [options] /p <input bundle name> /d <output directory>
-    MakeAppx unbundle [options] /ep <encrypted input bundle name> /d <output directory> /kf <key file>
-    MakeAppx unbundle [options] /ep <encrypted input bundle name> /d <output directory> /kt
-
-Options:
---------
-    /pfn: Unpacks all files to a subdirectory under the specified output path,
-        named after the package full name.
-    /kf: Use this option to encrypt or decrypt the package or bundle using a
-        key file. This option cannot be combined with /kt.
-    /kt: Use this option to encrypt or decrypt the package or bundle using the
-        global test key. This option cannot be combined with /kf.
-    /nd: Skips decryption when unpacking an encrypted package or bundle.
-    /o, /overwrite: Forces the output to overwrite any existing files with the
-        same name. By default, the user is asked whether to overwrite existing
-        files with the same name. You can't use this option with /no.
-    /no, /noOverwrite: Prevents the output from overwriting any existing files
-        with the same name. By default, the user is asked whether to overwrite
-        existing files with the same name. You can't use this option with /o.
-    /v, /verbose: Enables verbose output of messages to the console.
-    /?, /help: Displays this help text.
-
-## 2.2. MakeMsix
-
-MakeMSIX is generally a subset of MakeAppx's functionality. It lacks support for
-encryption, content groups, mapping files, and bundle support is limited to
-only allowing creation of flat bundles (bundles where the appxbundle file itself
-only references but does not contain the main and resource appxpackages)
-
-It does add the ability to optionally unpack all packages inside the bundle
-in one command using the -pfn-flat option, as in:
-makemsix.exe unbundle -p <bundle> -d <directory> -pfn-flat
-
-There is, however, no good option for reversing this command when recreating the
-packages and bundle. Callers need to call makemsix pack on each individual
-package folder and then follow it with a makemsix bundle call to generate a
-flat bundle.
-
-### 2.2.1. Pack
-Usage:
----------------
-    makemsix.exe pack -d <directory> -p <package> [options]
-
-Options:
----------------
-    -d <directory> {Required}
-        Input directory path.
-    -p <package> {Required}
-        Output package file path.
-    -? [Flag]
-        Displays this help text.
-
-### 2.2.2. Bundle
-Usage:
----------------
-    makemsix.exe bundle -p <outputBundle> [options]
-
-Options:
----------------
-    -d <inputDirectory>
-        Input directory path.
-    -p <outputBundle> {Required}
-        Output bundle file path.
-    -f <mappingFile>
-        Mapping file path.
-    -bv <version>
-        Specifies the version number of the bundle being created. The version must be in dotted - quad notation of four integers <Major>.<Minor>.<Build>.<Revision> ranging from 0 to 65535 each. If the -bv option is not specified or is set to 0.0.0.0, the bundle is created using the current date - time formatted as the version: <Year>.<Month - Day>.<Hour - Minute>.<Second - Millisecond>.
-    -mo [Flag]
-        Generates a bundle manifest only, instead of a full bundle. Input files must all be package manifests in XML format if this option is specified.
-    -fb [Flag]
-        Generates a fully sparse bundle where all packages are references to packages that exist outside of the bundle file.
-    -o [Flag]
-        Forces the output to overwrite any existing files with the same name.By default, the user is asked whether to overwrite existing files with the same name.You can't use this option with -no.
-    -no [Flag]
-        Prevents the output from overwriting any existing files with the same name. By default, the user is asked whether to overwrite existing files with the same name.You can't use this option with -o.
-    -v [Flag]
-        Enables verbose output of messages to the console.
-    -? [Flag]
-        Displays this help text.
-
-### 2.2.3. Unpack
-Usage:
----------------
-    makemsix.exe unpack -p <package> -d <directory> [options]
-
-Options:
----------------
-    -p <package> {Required}
-        Input package file path.
-    -d <directory> {Required}
-        Output directory path.
-    -pfn [Flag]
-        Unpacks all files to a subdirectory under the output path, named after the package full name.
-    -ac [Flag]
-        Allows any certificate. By default the signature origin must be known.
-    -ss [Flag]
-        Skips enforcement of signed packages. By default packages must be signed.
-    -pfn-flat [Flag]
-        Same behavior as -pfn for packages.
-    -? [Flag]
-        Displays this help text.
-
-### 2.2.4. Unbundle
-
-Usage:
----------------
-    makemsix.exe unbundle -p <bundle> -d <directory> [options]
-
-Options:
----------------
-    -p <bundle> {Required}
-        Input bundle file path.
-    -d <directory> {Required}
-        Output directory path.
-    -pfn [Flag]
-        Unpacks all files to a subdirectory under the output path, named after the package full name.
-    -ac [Flag]
-        Allows any certificate. By default the signature origin must be known.
-    -ss [Flag]
-        Skips enforcement of signed packages. By default packages must be signed.
-    -sl [Flag]
-        Skips matching packages with the language of the system. By default unpacked resources packages will match the system languages.
-    -sp [Flag]
-        Skips matching packages with of the same system. By default unpacked application packages will only match the platform.
-    -extract-all [Flag]
-        Extracts all packages from the bundle.
-    -pfn-flat [Flag]
-        Unpacks bundle's files to a subdirectory under the specified output path, named after the package full name. Unpacks packages to subdirectories also under the specified output path, named after the package full name. By default unpacked packages will be nested inside the bundle folder.
-    -? [Flag]
-        Displays this help text.
-
-## 2.3. MSIXMgr
-
-### 2.3.1. Unpack
-msixmgr.exe -Unpack -packagePath <path to package> -destination <output folder> [-applyacls] [-create] [-vhdSize <size in MB>] [-filetype <CIM | VHD | VHDX>] [-rootDirectory <rootDirectory>]
-
--Unpack: Unpack a package (.appx, .msix, .appxbundle, .msixbundle) and extract its contents to a folder.
-                -applyACLs: optional parameter that applies ACLs to the resulting package folder(s) and their parent folder
-                -create: optional parameter that creates a new image with the specified -filetype and unpacks the packages to that image
-                -destination: the directory to place the resulting package folder(s) in
-                -fileType: the type of file to unpack packages to. Valid file types include {VHD, VHDX, CIM}. This is a required parameter when unpacking to CIM files
-                -packagePath: the path to the package to unpack OR the path to a directory containing multiple packages to unpack
-                -rootDirectory: root directory on an image to unpack packages to. Required parameter for unpacking to new and existing CIM files
-                -validateSignature: optional parameter that validates a package's signature file before unpacking the package. This will require that the package's certificate is installed on the machine.
-                -vhdSize: the desired size of the VHD or VHDX file in MB. Must be between 5 and 2040000 MB. Use only for VHD or VHDX files
-
-# 3. Summary of existing options in relation to proposed api
-
-Existing options all treat pack and bundle as separate commands. Though they are similar, each command does have 
-some options that are irrelevant to the other command. Options that are relevant to bundling but not packaging are
-the Bundle Version, which nearly all callers will specify (the alternative is the tool setting the version based on a timestamp),
-and allowing creation of sparse bundles. Options that are relevant for packaging but not bundling are hash algorithm, and creation
+Existing options all treat pack and bundle as separate commands. Though they are similar, each
+command does have some options that are irrelevant to the other command. Options that are relevant
+to bundling but not packaging are the Bundle Version, which nearly all callers will specify (the
+alternative is the tool setting the version based on a timestamp), and allowing creation of flat
+bundles. Options that are relevant for packaging but not bundling are hash algorithm, and creation
 of streamable packages and resource packages.
 
-In the long term it's likely that these differences in the information and flags required to support creating a bundle
-and creating a package will only continue to grow.
+In the long term it's likely that these differences in the information and flags required to support
+creating a bundle and creating a package will only continue to grow.
 
-It is less likely that differences will arise between unbundle and unpack. However, as seen with the existing makemsix tool,
-as long as pack and bundle are separate operations it may not be especially useful for unbundle and unpack to be joined. Unpacking of
-all bundled packages makes sense for a command line tool where an IT admin may be typing in individual commands each time and so
-there's a good reason to avoid having to run multiple commands. In cases where the api is actually being used programattically, 
-to do something like extract all packages and update every manifest with a different version number, there is no avoiding use of filesystem
-apis to find each unpacked package. In such a case merging the unbundle and unpack command into one api just adds hidden complexity into the api
-in the form of either requiring more configuration options or hiding decisions about default choices like folder naming decisions in the api documentation.
+It is less likely that differences will arise between unbundle and unpack. However, as seen with the
+existing makemsix tool, as long as pack and bundle are separate operations it may not be especially
+useful for unbundle and unpack to be joined. Unpacking of all bundled packages makes sense for a
+command line tool where an IT admin may be typing in individual commands each time and so there's a
+good reason to avoid having to run multiple commands. In cases where the API is actually being used
+programattically, to do something like extract all packages and update every manifest with a
+different version number, there is no avoiding use of filesystem APIs to find each unpacked package.
+In such a case merging the unbundle and unpack command into one API just adds hidden complexity into
+the API in the form of either requiring more configuration options or hiding decisions about default
+choices like folder naming decisions in the API documentation.
 
 For these reasons pack, bundle, unpack, unbundle have been left as separate commands. 
 
 MSIXMgr defines an unpack command which has fairly different usage from the makeappx unpack command.
-The msixmgr unpack command merges creation of an image file and adding packages to that image file into one command.
-The msixmgr command line supports adding all packages in a folder to an image at once. The CIM file format it supports always expands to fit those apps,
-but msixmgr does not currently support expandable vhdx files. This means that the caller needs to know up front the size of all unpacked packages when
-creating vhds, which will be difficult to know without either unpacking them first or reading each package's block map to get file sizes.
-This api proposes getting rid of that requirement and having the api implementation itself determine the size of all packages being added in 
-order to create an image of the correct size. This behavior is more consistent with other types of package creation and eliminates the api differences
-between CIM files and VHD\VHDX files. 
+The msixmgr unpack command merges creation of an image file and adding packages to that image file
+into one command. The msixmgr command line supports adding all packages in a folder to an image at
+once. The CIM file format it supports always expands to fit those apps, but msixmgr does not
+currently support expandable vhdx files. This means that the caller needs to know up front the size
+of all unpacked packages when creating vhds, which will be difficult to know without either
+unpacking them first or reading each package's block map to get file sizes. This API proposes
+getting rid of that requirement and having the API implementation itself determine the size of all
+packages being added in order to create an image of the correct size. This behavior is more
+consistent with other types of package creation and eliminates the API differences between CIM files
+and VHD\VHDX files.
 
-Since the api surface supports creation of the CIM, VHD, VHDX file as well as creation of msix and msixbundle files, callers may
-find it strange to need to first pack their directory to an msix, and then create the vhdx from the msix, rather than just
-creating the vhdx directly. However, signing is not integrated into any of these tools, and is a separate step that
-is done after packaging is complete. The Appx SIP knows how to sign packages, but not vhdx and other mounted directories. The result
-is that creating a vhdx with an appx signature file (appxsignature.p7x) requires first creating the package, then signing it, then
-creating the vhdx. Allowing creation of a CIM, VHD, or VHDX file directly from a directory seems likely to cause confusion for 
-developers who may not realize that they won't be able to sign the package in the image. This api also proposes always applying acls
-for the package to the folder, and never validating the signature. If signature validation of a package  (checking that the root cert of a package 
-is trusted on the current machine) is an important api for callers it can be done as a separate operation from creation of an image file.
+As the API supports creation of .cim, .vhd, and .vhdx file as well as .msix and .msixbundle files,
+callers may find it strange to need to first pack their directory to an msix, and then create the
+vhdx from the msix, rather than just creating the vhdx directly. However, signing is not integrated
+into any of these tools, and is a separate step that is done after packaging is complete. The Appx
+SIP knows how to sign packages, but not vhdx and other mounted directories. The result is that
+creating a vhdx with an appx signature file (appxsignature.p7x) requires first creating the package,
+then signing it, then creating the vhdx. Allowing creation of a cim, vhd, or vhdx file directly from
+a directory seems likely to cause confusion for developers who may not realize that they won't be
+able to sign the package in the image. This API always applies ACLs for the package
+to the folder, and never validates the signature. If signature validation of a package (checking
+that the root cert of a package is trusted on the current machine) is an important API for callers
+it can be done as a separate operation from creation of an image file.
 
-# 4. Examples
+# 3. Examples
 
-## 4.1. Packing a package
+## 3.1. Packing a package
 
 ```cpp
     void CreatePackagesFromFolderExample()
@@ -429,42 +118,40 @@ is trusted on the current machine) is an important api for callers it can be don
             {
                 continue;
             }
-            PackOptions packOptions = PackOptions();
-            packOptions.OverwriteFiles(true);
+            CreatePackageOptions createPackageOptions = CreatePackageOptions();
+            createPackageOptions.OverwriteOutputFileIfExists(true);
             std::wstring packageFolderName = directoryEntry.path().filename().wstring();
             std::wstring packageOutputFilePath{ packageOutputRootDirectoryPath + packageFolderName + L".appx" };
-            packOptions.PackageFilePath(packageOutputFilePath);
 
-            MakeMSIXManager::Pack(directoryEntry.path().c_str(), packOptions).get();
+            MakeMSIXManager::CreatePackage(directoryEntry.path().c_str(), packageOutputFilePath.c_str(), createPackageOptions).get();
         }
         // Bundle all the packages together.
-        auto bundleOptions = BundleOptions();
-        bundleOptions.OverwriteFiles(true);
-        bundleOptions.BundleFilePath(bundleOutputFilePath);
-        bundleOptions.BundleVersion(winrt::Windows::ApplicationModel::PackageVersion(1, 1, 0, 0));
-        MakeMSIXManager::Bundle(packageOutputRootDirectoryPath, bundleOptions).get();
+        CreateBundleOptions createbundleOptions = CreateBundleOptions();
+        createbundleOptions.OverwriteOutputFileIfExists(true);
+        createbundleOptions.FlatBundle(true);
+        createbundleOptions.Version(winrt::Windows::ApplicationModel::PackageVersion(1, 1, 0, 0));
+        MakeMSIXManager::CreateBundle(packageOutputRootDirectoryPath, bundleOutputFilePath.c_str(), createbundleOptions).get();
 
         // Sign the bundle
         Example_SignPackage(developerCertPfxFile, bundleOutputFilePath);
 
         // Step 2. Create the kozani package from the bundle created in Step 1.
-        CreateKozaniPackageOptions kozaniPackOptions = CreateKozaniPackageOptions();
-        kozaniPackOptions.OverwriteFiles(true);
-        kozaniPackOptions.PackageFilePath(kozaniPackageOutputFilePath);
-        MakeMSIXManager::CreateKozaniPackage(bundleOutputFilePath, kozaniPackOptions).get();
+        CreateKozaniPackageOptions createKozaniPackageOptions = CreateKozaniPackageOptions();
+        createKozaniPackageOptions.OverwriteOutputFileIfExists(true);
+        createKozaniPackageOptions.RemoveExtensions(true);
+        MakeMSIXManager::CreateKozaniPackage(bundleOutputFilePath, kozaniPackageOutputFilePath.c_str(), createKozaniPackageOptions).get();
 
         // Step 3. Create app attach vhd from the bundle created in Step 1.
         CreateMountableImageOptions mountableImageOptions = CreateMountableImageOptions();
-        mountableImageOptions.ImageFilePath(appAttachImageFilePath);
-        mountableImageOptions.OverwriteFiles(true);
+        mountableImageOptions.OverwriteOutputFileIfExists(true);
         winrt::Windows::Foundation::Collections::IVector<winrt::hstring> packagesToAddToImage{ winrt::single_threaded_vector<winrt::hstring>() };
         packagesToAddToImage.Append(bundleOutputFilePath);
 
-        MakeMSIXManager::CreateMountableImage(packagesToAddToImage, mountableImageOptions).get();
+        MakeMSIXManager::CreateMountableImage(packagesToAddToImage, appAttachImageFilePath.c_str(), mountableImageOptions).get();
     }
 ```
 
-## 4.2. Unbundling and unpacking a package to change information
+## 3.2. Unbundling and unpacking a package to change information
 
 ```cpp
     void ChangeVersionOfAllPackagesInBundle()
@@ -485,17 +172,16 @@ is trusted on the current machine) is an important api for callers it can be don
 
             // Unbundle the bundle to its own folder. After the operation the folder will contain the
             // bundled packages as appx\msix packages, as well as the bundle metadata.
-            auto unbundleOptions = UnbundleOptions();
-            unbundleOptions.OverwriteFiles(true);
-            unbundleOptions.UnbundledPackageRootDirectory(outputDirForBundle.c_str());
-            MakeMSIXManager::Unbundle(bundleFilePath.c_str(), unbundleOptions).get();
+            auto extractBundleOptions = ExtractBundleOptions();
+            extractBundleOptions.OverwriteOutputFilesIfExists(true);
+            MakeMSIXManager::ExtractBundle(bundleFilePath.c_str(), outputDirForBundle.c_str(), extractBundleOptions).get();
 
             // Iterate through the bundled packages and unpack each one.
             for (const auto& file : std::filesystem::directory_iterator(outputDirForBundle))
             {
                 // Skip the metadata files.
                 std::wstring fileExtension{ file.path().extension() };
-                std::transform(fileExtension.begin(), fileExtension.end(), fileExtension.begin(), tolower);
+                std::transform(fileExtension.begin(), fileExtension.end(), fileExtension.begin(), towlower);
                 if ((fileExtension.compare(L".appx") != 0) &&
                     (fileExtension.compare(L".msix") != 0))
                 {
@@ -506,10 +192,9 @@ is trusted on the current machine) is an important api for callers it can be don
                 std::filesystem::path outputDirForPackage{ outputDirRootForPackages };
                 outputDirForPackage /= file.path().stem();
 
-                auto unpackOptions = UnpackOptions();
-                unpackOptions.OverwriteFiles(true);
-                unpackOptions.UnpackedPackageRootDirectory(outputDirForPackage.c_str());
-                MakeMSIXManager::Unpack(file.path().c_str(), unpackOptions).get();
+                auto extractPackageOptions = ExtractPackageOptions();
+                extractPackageOptions.OverwriteOutputFilesIfExists(true);
+                MakeMSIXManager::ExtractPackage(file.path().c_str(), outputDirForPackage.c_str(), extractPackageOptions).get();
             }
                             
             std::filesystem::path outputDirRootForPackedPackages{ outputDirRoot };
@@ -520,27 +205,22 @@ is trusted on the current machine) is an important api for callers it can be don
             // Iterate through packages and repack each one.
             for (const auto& packageDir : std::filesystem::directory_iterator(outputDirRootForPackages))
             {
-                // Open the manifest and change the version before re-packing
-                std::filesystem::path appxManifestPath{ packageDir };
-                appxManifestPath /= L"AppxManifest.xml";
-                Example_ChangeManifestVersion(appxManifestPath, newVersion);                    
-
                 std::filesystem::path outputPackagePath{ outputDirRootForPackedPackages };
                 std::wstring outputPackageFileName = packageDir.path().filename().wstring() + L".appx";
                 outputPackagePath /= outputPackageFileName;
 
-                auto packOptions = PackOptions();
-                packOptions.OverwriteFiles(true);
-                packOptions.PackageFilePath(outputPackagePath.c_str());
-                MakeMSIXManager::Pack(packageDir.path().c_str(), packOptions).get();
+                // Change the version when re-packing
+                auto createPackageOptions = CreatePackageOptions();
+                createPackageOptions.OverwriteOutputFileIfExists(true);
+                createPackageOptions.Version(newVersion);
+                MakeMSIXManager::CreatePackage(packageDir.path().c_str(), outputPackagePath.c_str(), createPackageOptions).get();
             }
 
             // Re-bundle with the new version
-            auto bundleOptions = BundleOptions();
-            bundleOptions.OverwriteFiles(true);
-            bundleOptions.BundleFilePath(outputPathForBundle.c_str());
-            bundleOptions.BundleVersion(newVersion);
-            MakeMSIXManager::Bundle(outputDirRootForPackedPackages.c_str(), bundleOptions).get();
+            auto createBundleOptions = CreateBundleOptions();
+            createBundleOptions.OverwriteOutputFileIfExists(true);
+            createBundleOptions.Version(newVersion);
+            MakeMSIXManager::CreateBundle(outputDirRootForPackedPackages.c_str(), outputPathForBundle.c_str(), createBundleOptions).get();
         }
         catch (winrt::hresult_error const& ex)
         {
@@ -550,30 +230,13 @@ is trusted on the current machine) is an important api for callers it can be don
     }
 ```
 
-## 4.3. Helper methods for examples
+## 3.3. Helper methods for examples
 
-Windows has existing non-WinRT apis for signing packages available in the CryptoAPI
+Windows has existing non-WinRT APIs for signing packages available in the CryptoAPI
 https://learn.microsoft.com/en-us/windows/win32/seccrypto/using-cryptography
 For completeness purposes some helper methods to instead find and call signtool.exe
 from the Windows SDK are included here.
 ```cpp
-    void Example_ChangeManifestVersion(std::wstring appxManifestPath, winrt::Windows::ApplicationModel::PackageVersion newVersion)
-    {
-        winrt::Windows::Storage::StorageFile manifestFile = winrt::Windows::Storage::StorageFile::GetFileFromPathAsync(appxManifestPath).get();
-        winrt::Windows::Data::Xml::Dom::XmlDocument docElement = winrt::Windows::Data::Xml::Dom::XmlDocument::LoadFromFileAsync(manifestFile).get();
-
-        std::wstring packageIdentityVersionQuery{ L"/*[local-name()='Package']/*[local-name()='Identity']/@Version" };
-        winrt::Windows::Data::Xml::Dom::IXmlNode identityVersionAttributeNode = docElement.SelectSingleNode(packageIdentityVersionQuery.c_str());
-
-        std::wstring newVersionString = std::to_wstring(newVersion.Major) + L"."
-            + std::to_wstring(newVersion.Minor) + L"."
-            + std::to_wstring(newVersion.Build) + L"."
-            + std::to_wstring(newVersion.Revision);
-        identityVersionAttributeNode.InnerText(newVersionString);
-
-        docElement.SaveToFileAsync(manifestFile).get();
-    }
-
     /// <summary>
     /// Create a process and synchronously wait for it to exit.
     /// </summary>
@@ -721,7 +384,7 @@ from the Windows SDK are included here.
     }
 ```
 
-# 5. API Details
+# 4. API Details
 
 ```c#
 // Copyright (c) Microsoft Corporation and Contributors.
@@ -734,226 +397,556 @@ namespace Microsoft.Kozani.MakeMSIX
 
     /// Options for creating a package
     [contract(MakeMSIXContract, 1)]
-    runtimeclass PackOptions
+    runtimeclass CreatePackageOptions
     {
-        /// <summary>
-        /// Created by callers to pass options into CreatePackage
-        /// </summary>
-        PackOptions();
+        /// Created by callers to pass options into CreatePackage()
+        CreatePackageOptions();
 
-        /// <summary>
-        /// Output path for the full packaged file.
-        /// </summary>
-        String PackageFilePath{ get; set; };
+        /// Optional replacement package name.
+        /// If field is empty, values from AppxManifest.xml are unchanged.
+        String Name;
 
-        /// <summary>
-        /// Overwrite PackageFilePath if it already exists.
+        /// Optional replacement package publisher.
+        /// If field is empty, values from AppxManifest.xml are unchanged.
+        String Publisher;
+
+        /// Optional replacement package version
+        /// If version is 0, version is created based on the current time.
+        Windows.ApplicationModel.PackageVersion Version;
+        
+        /// Overwrite output file if it already exists.
         /// Defaults to true.
-        /// </summary>
-        Boolean OverwriteFiles{ get; set; };
-        /// <summary>
+        Boolean OverwriteOutputFileIfExists;
+
         /// Validates elements of the package during creation.
         /// Defaults to false.
-        /// </summary>
-        Boolean ValidateFiles{ get; set; };
+        Boolean ValidateFiles;
     };
 
     /// Options for creating a Kozani package
     [contract(MakeMSIXContract, 1)]
     runtimeclass CreateKozaniPackageOptions
     {
-        /// <summary>
-        /// 
-        /// </summary>
+        /// Created by callers to pass options into CreateKozaniPackage()
         CreateKozaniPackageOptions();
 
-        /// <summary>
-        /// Output path for the kozani packaged file.
-        /// Format must match input file. If packageFilePathToConvert is an appx or msix, then PackageFilePath must be an appx or msix.
-        /// If packageFilePathToConvert is an appxbundle or msixbundle, then PackageFilePath must be an appxbundle or msixbundle.
-        /// </summary>
-        String PackageFilePath{ get; set; };
+        /// Remove extensions from the manifest.
+        /// Defaults to false.
+        Boolean RemoveExtensions;
 
-        /// <summary>
-        /// Optional replacement package publisher.
-        /// If not set, publisher from appxmanifest.xml is unchaged.
-        /// </summary>
-        String PackagePublisher{ get; set; };
-
-        /// <summary>
         /// Optional replacement package name.
-        /// If not set, name from appxmanifest.xml is unchaged.
-        /// </summary>
-        String PackageName{ get; set; };
+        /// If field is empty, values from AppxManifest.xml are unchanged.
+        String Name;
 
-        /// <summary>
-        /// Overwrite PackageFilePath if it already exists.
+        /// Optional replacement package publisher.
+        /// If field is empty, values from AppxManifest.xml are unchanged.
+        String Publisher;
+
+        /// Optional replacement package version
+        /// If version is 0, version is created based on the current time.
+        Windows.ApplicationModel.PackageVersion Version;
+
+        /// Overwrite output file if it already exists.
         /// Defaults to true.
-        /// </summary>
-        Boolean OverwriteFiles{ get; set; };
+        Boolean OverwriteOutputFileIfExists;
 
-        /// <summary>
         /// Validates elements of the package during creation.
         /// Defaults to false.
-        /// </summary>
-        Boolean ValidateFiles{ get; set; };
+        Boolean ValidateFiles;
     };
 
     /// Options for creating a bundle
     [contract(MakeMSIXContract, 1)]
-    runtimeclass BundleOptions
+    runtimeclass CreateBundleOptions
     {
-        /// <summary>
-        /// Created by callers to pass options into Bundle
-        /// </summary>
-        BundleOptions();
+        /// Created by callers to pass options into CreateBundle()
+        CreateBundleOptions();
 
-        /// <summary>
-        /// Output path for the full bundled file.
-        /// </summary>
-        String BundleFilePath{ get; set; };
-
-        /// <summary>
-        /// Overwrite BundleFilePath if they already exist.
-        /// Defaults to true.
-        /// </summary>
-        Boolean OverwriteFiles{ get; set; };
-
-        /// <summary>
         /// Create as a flat bundle. Package locations will be stored as external path references
         /// rather than being stored inside the msixbundle file itself. 
         /// Defaults to false.
-        /// </summary>
-        Boolean FlatBundle{ get; set; };
+        Boolean FlatBundle;
 
-        /// <summary>
         /// Optional. Sets the version in the AppxBundleManifest.xml
         /// If not set the version is created based on the current time.
-        /// </summary>
-        Windows.ApplicationModel.PackageVersion BundleVersion{ get; set; };
+        Windows.ApplicationModel.PackageVersion Version;
+
+        /// Overwrite output file if it already exists.
+        /// Defaults to true.
+        Boolean OverwriteOutputFileIfExists;
     };
 
-    /// <summary>
     /// Options for unpacking a package
-    /// </summary>
     [contract(MakeMSIXContract, 1)]
-    runtimeclass UnpackOptions
+    runtimeclass ExtractPackageOptions
     {
-        /// <summary>
-        /// Created by callers to pass options into UnpackPackage
-        /// </summary>
-        UnpackOptions();
+        /// Created by callers to pass options into ExtractPackage()
+        ExtractPackageOptions();
 
-        /// <summary>
-        /// The output folder to unpack the package into.
-        /// </summary>
-        String UnpackedPackageRootDirectory{ get; set; };
-        /// <summary>
-        /// If true, the operation will overwrite existing files in the UnpackedPackageRootDirectory
+        /// If true, the operation will overwrite existing files in the output path
         /// when unpacking.
         /// If false, the operation will fail if a file already exists.
-        /// </summary>
-        Boolean OverwriteFiles{ get; set; };
+        Boolean OverwriteOutputFilesIfExists;
     };
 
-    /// <summary>
     /// Options for unpacking a package
-    /// </summary>
     [contract(MakeMSIXContract, 1)]
-    runtimeclass UnbundleOptions
+    runtimeclass ExtractBundleOptions
     {
-        /// <summary>
-        /// Created by callers to pass options into UnpackPackage
-        /// </summary>
-        UnbundleOptions();
-
-        /// <summary>
-        /// The output folder to unpack the bundle package into.
-        /// </summary>
-        String UnbundledPackageRootDirectory{ get; set; };
-        /// <summary>
-        /// If true, the operation will overwrite existing files in the UnbundledPackageRootDirectory
+        /// Created by callers to pass options into ExtractBundle()
+        ExtractBundleOptions();
+        
+        /// If true, the operation will overwrite existing files in the output path
         /// when unpacking.
         /// If false, the operation will fail if a file already exists.
-        /// </summary>
-        Boolean OverwriteFiles{ get; set; };
+        Boolean OverwriteOutputFilesIfExists;
     };
 
-    /// <summary>
     /// 
-    /// </summary>
     [contract(MakeMSIXContract, 1)]
     runtimeclass CreateMountableImageOptions
     {
-        /// <summary>
-        /// Created by callers to pass options into CreateMountableImage
-        /// </summary>
+        /// Created by callers to pass options into CreateMountableImage()
         CreateMountableImageOptions();
-
-        /// <summary>
-        /// Output path for the image file.
-        /// Valid file extensions are vhd, vhdx, and CIM.
-        /// </summary>
-        String ImageFilePath{ get; set; };
-
-        /// <summary>
+        
         /// Root directory path for packages inside the image.
         /// Defaults to "WindowsApps"
-        /// </summary>
-        String PackageRootDirectoryInImage{ get; set; };
+        String PackageRootDirectoryInImage;
 
-        /// <summary>
-        /// If true, the operation will overwrite an existing file in the ImageFilePath
-        /// when unpacking.
-        /// If false, the operation will fail if the file already exists.
-        /// </summary>
-        Boolean OverwriteFiles{ get; set; };
+        /// Overwrite output file if it already exists.
+        /// Defaults to true.
+        Boolean OverwriteOutputFileIfExists;
     };
 
-    /// <summary>
+    runtimeclass PackageIdentity
+    {
+        /// Name of the package
+        /// Defaults to empty.
+        String Name;
+        
+        /// Publisher of the package
+        /// Defaults to empty.
+        String Publisher;
+        
+        /// FamilyName of the package
+        /// Defaults to empty.
+        String FamilyName;
+        
+        /// Version of the package
+        /// Defaults to 0.0.0.0.
+        Windows.ApplicationModel.PackageVersion Version { get; set; };
+        
+        /// Architecture of the package
+        /// Defaults to Unknown.
+        Windows.System.ProcessorArchitecture Architecture;
+        
+        /// ResourceId of the package
+        /// Defaults to empty.
+        String ResourceId;
+ 
+        /// FullName of the package.
+        /// Defaults to empty.
+        String FullName;
+    }
+    
     /// Static methods for creating and unpacking packages.
-    /// </summary>
     [contract(MakeMSIXContract, 1)]
     runtimeclass MakeMSIXManager
     {
-        /// <summary>
-        /// Creates packages from the directoryPathToPack as specified by the packOptions.
-        /// </summary>
-        static Windows.Foundation.IAsyncAction Pack(String directoryPathToPack, PackOptions packOptions);
-        /// <summary>
-        /// Creates bundles from the directoryPathToBundle as specified by the bundleOptions.
-        /// </summary>
-        static Windows.Foundation.IAsyncAction Bundle(String directoryPathToBundle, BundleOptions bundleOptions);
-        /// <summary>
-        /// Unpacks a package at packageFilePathToUnpack as specified by the unpackOptions.
-        /// </summary>
-        static Windows.Foundation.IAsyncAction Unpack(String packageFilePathToUnpack, UnpackOptions unpackOptions);
-        /// <summary>
-        /// Unbundles a package at bundleFilePathToUnbundle as specified by the unbundleOptions.
-        /// </summary>
-        static Windows.Foundation.IAsyncAction Unbundle(
-            String bundleFilePathToUnbundle,
-            UnbundleOptions unbundleOptions);
+        /// Creates packages from the inputPath as specified by the packOptions.
+        /// Output path for the full packaged file.
+        static Windows.Foundation.IAsyncAction CreatePackage(
+            String inputPath,
+            String outputFileName,
+            CreatePackageOptions packOptions);
 
-        /// <summary>
+        /// Creates bundles from the inputPath as specified by the bundleOptions.
+        /// Output path for the full bundled file.
+        static Windows.Foundation.IAsyncAction CreateBundle(
+            String inputPath,
+            String outputFileName,
+            CreateBundleOptions bundleOptions);
+
+        /// Unpacks a package at inputFileName as specified by the extractPackageOptions.
+        /// The output folder to unpack the package into.
+        static Windows.Foundation.IAsyncAction ExtractPackage(
+            String inputFileName, 
+            String outputPath, 
+            ExtractPackageOptions extractPackageOptions);
+
+        /// Unbundles a package at inputFileName as specified by the extractBundleOptions.
+        /// The output folder to unpack the bundle package into.
+        static Windows.Foundation.IAsyncAction ExtractBundle(
+            String inputFileName,
+            String outputPath,
+            ExtractBundleOptions extractBundleOptions);
+
         /// Creates a Kozani package from an existing package.
-        /// packageFilePathToConvert can be an appx, appxbundle, msix, or msixbundle
-        /// </summary>
-        static Windows.Foundation.IAsyncAction CreateKozaniPackage(
-            String packageFilePathToConvert,
-            CreateKozaniPackageOptions createKozaniPackageOptions);
+        /// inputFileName can be an appx, appxbundle, msix, or msixbundle
+        /// Output path for the kozani packaged file.
+        /// Format must match input file. If inputFileName is an msix, then outputFileName must be an msix.
+        /// If inputFileName is an msixbundle, then outputFileName must be an msixbundle.
+        static Windows.Foundation.IAsyncAction CreateKozani(
+            String inputFileName,
+            String outputFileName,
+            CreateKozaniOptions createKozaniOptions);
 
-        /// <summary>
-        /// Creates a mountable image that contains the packages at packageFilePathsToAdd.
+        /// Creates a mountable image that contains the packages at inputFileNames.
+        /// Valid file extensions for outputFileName are vhd, vhdx, and CIM.
         /// Can be used for Azure App Attach.
-        /// </summary>
         static Windows.Foundation.IAsyncAction CreateMountableImage(
-            Windows.Foundation.Collections.IVector<String> packageFilePathsToAdd,
+            Windows.Foundation.Collections.IVector<String> inputFileNames,
+            String outputFileName,
             CreateMountableImageOptions createMountableImageOptions);
+
+        /// Gets the identity information about a package 
+        static Windows.Foundation.IAsyncOperation<PackageIdentity> GetPackageIdentity(String packageFileName);
     };
 }
 
 
 ```
 
-# Appendix
+# 5. Appendix
+
+# 6. Existing interfaces and options
+
+The existing tools are:
+-   [Makeappx.exe](https://learn.microsoft.com/en-us/windows/win32/appxpkg/make-appx-package--makeappx-exe-)
+    Shipped in Windows' Platform SDK.
+    Exposes pack, unpack, bundle, and unbundle commands, as well as encryption support
+    via a custom key-file list file, and creation of packages via a custom mapping file
+    to allow creation of packages with different payloads from the same folder.
+
+-   [Makemsix.exe](https://github.com/Microsoft/msix-packaging) Available via the msix-packaging
+    project. Exposes pack, unpack, unbundle, and bundle* commands (*Bundle command only supports
+    creation of
+    [flat bundles](https://learn.microsoft.com/en-us/windows/msix/package/flat-bundles). Flat
+    bundles are bundles where package locations are stored as external path references rather than
+    being stored inside the msixbundle file itself. Flat bundles are referred to as sparse bundles
+    in the makeappx documentation).
+    
+-   [Msixmgr.exe](https://github.com/Microsoft/msix-packaging) Available via the msix-packaging
+    project and
+    [direct download from learn.microsoft.com](https://learn.microsoft.com/en-us/azure/virtual-desktop/app-attach-msixmgr).
+    Exposes "unpack" command to convert msix packages to vhd, vhdx, cim image files.
+
+None of the existing tools provide a programmatic interface for all aspects of packaging.
+
+Makeappx.exe provides the only complete implementation of packaging and bundling but requires
+process creation and does not return any specific errors from process exit. It also does not support
+any of the Azure app attach scenarios.
+
+Makemsix.exe is a cross-platform implementation of packaging, but does not support a complete set of
+bundling features. The functionality is exposed as a command line as well as flat dll exports.
+
+Msixmgr.exe is mostly for specific Azure app attach packaging scenarios not covered by the other
+tools. To use it programmatically would require either process creation or building the
+msix-packaging github project and linking the static lib it produces into a project.
+
+## 6.1. Makeappx
+
+### 6.1.1. Pack
+Usage:
+------
+    MakeAppx pack [options] /d <content directory> /p <output package name>
+    MakeAppx pack [options] /f <mapping file> /p <output package name>
+    MakeAppx pack [options] /m <app package manifest> /f <mapping file> /p <output package name>
+    MakeAppx pack [options] /r /m <app package manifest> /f <mapping file> /p <output package name>
+    MakeAppx pack [options] /d <content directory> /ep <encrypted output package name> /kf <key file>
+    MakeAppx pack [options] /d <content directory> /ep <encrypted output package name> /kt
+
+Options:
+--------
+    /h, /hashAlgorithm: Specifies a hash algorithm to use for creating the
+        block map. Valid algorithm IDs are SHA256, SHA384, and SHA512. The
+        default is SHA256.
+    /nv, /noValidation: Skips validation that ensures the package will be
+        installable on Windows. The validation include: existence of files
+        referenced in manifest, ContentGroupMap correctness, and additional
+        manifest validation on Protocols and FileTypeAssociation. By default,
+        all semantic validation is performed.
+    /nfv, /noFileValidation: Skips validation that ensures that the files used
+        to create the package (from a folder through /d or layout file through
+        /l) exist and are accessible. By default, all files must exist and not
+        be read locked. If a file is inaccessible, it will not be added to the
+        package.
+    /nc, /noCompress: Prevents MakeAppx from compressing files in the package.
+        By default, files in the package are compressed based on detected file
+        type.
+    /m: Specifies the path to an input app manifest which will be used as the
+        basis for generating the output app package or resource package's
+        manifest. When you use this option, you must also use /f and include a
+        [ResourceMetadata] section in the mapping file to specify the resource
+        dimensions to be included in the generated manifest.
+    /r: Builds a resource package. You must use the /m option with this.
+    /kf: Use this option to encrypt or decrypt the package or bundle using a
+        key file. This option cannot be combined with /kt.
+    /kt: Use this option to encrypt or decrypt the package or bundle using the
+        global test key. This option cannot be combined with /kf.
+    /cgm: The input content group map (CGM) file path used to create a
+        stream-able package. Providing a content group map through this option
+        will disable the check that all files in the content group map exist in
+        the package.
+    /pri, /makepriExeFullPath: You can use /pri to override the default
+        MakePri.exe path with the custom fullpath from which makeappx.exe will
+        launch the tool from when needed.
+    /mp: Specifies the path to a main package in the same package family as the
+        resource package being built.  You should provide this when encrypting
+        a resource package or when the resource package contains a content
+        group map.
+    /pb, /publisherBridging: Use this option to add publisher bridging entries
+        to the package or bundle.  Publisher bridging is useful when the new
+        issued cert subject name changed but the old publisher name is still
+        desired to maintain package identity continuity.
+    /np, /noParallel: Use this option to disable parallel execution of this
+        command.
+    /ml, /memoryLimit: Specify maximum memory in bytes that MakeAppx should
+        consume while executing in parallel. By default, this value is set to
+        half of total physical memory.
+    /o, /overwrite: Forces the output to overwrite any existing files with the
+        same name. By default, the user is asked whether to overwrite existing
+        files with the same name. You can't use this option with /no.
+    /no, /noOverwrite: Prevents the output from overwriting any existing files
+        with the same name. By default, the user is asked whether to overwrite
+        existing files with the same name. You can't use this option with /o.
+    /v, /verbose: Enables verbose output of messages to the console.
+    /?, /help: Displays this help text.
+
+### 6.1.2. Bundle
+
+Usage:
+------
+    MakeAppx bundle [options] /d <content directory> /p <output bundle name>
+    MakeAppx bundle [options] /f <mapping file> /p <output bundle name>
+    MakeAppx bundle [options] /d <content directory> /ep <encrypted output bundle name> /kf MyKeyFile.txt
+    MakeAppx bundle [options] /f <mapping file> /ep <encrypted output bundle name> /kt
+
+Options:
+--------
+    /bv: Specifies the version number of the bundle being created. The version
+        must be in dotted-quad notation of four integers
+        <Major>.<Minor>.<Build>.<Revision> ranging from 0 to 65535 each. If the
+        /bv option is not specified or is set to 0.0.0.0, the bundle is created
+        using the current date-time formatted as the version:
+        <Year>.<Month-Day>.<Hour-Minute>.<Second-Millisecond>.
+    /mo: Generates a bundle manifest only, instead of a full bundle. Input
+        files must all be package manifests in XML format if this option is
+        specified.
+    /fb: Generates a fully [sparse bundle](https://learn.microsoft.com/en-us/windows/msix/package/flat-bundles) 
+        where all packages are references to packages that exist outside of 
+        the bundle file
+    /pri, /makepriExeFullPath: You can use /pri to override the default
+        MakePri.exe path with the custom fullpath from which makeappx.exe will
+        launch the tool from when needed.
+    /kf: Use this option to encrypt or decrypt the package or bundle using a
+        key file. This option cannot be combined with /kt.
+    /kt: Use this option to encrypt or decrypt the package or bundle using the
+        global test key. This option cannot be combined with /kf.
+    /o, /overwrite: Forces the output to overwrite any existing files with the
+        same name. By default, the user is asked whether to overwrite existing
+        files with the same name. You can't use this option with /no.
+    /no, /noOverwrite: Prevents the output from overwriting any existing files
+        with the same name. By default, the user is asked whether to overwrite
+        existing files with the same name. You can't use this option with /o.
+    /v, /verbose: Enables verbose output of messages to the console.
+    /?, /help: Displays this help text.
+
+### 6.1.3. Unpack
+Usage:
+------
+    MakeAppx unpack [options] /p <input package name> /d <output directory>
+    MakeAppx unpack [options] /ep <encrypted input package name> /d <output directory> /kf <key file>
+    MakeAppx unpack [options] /ep <encrypted input package name> /d <output directory> /kt
+
+Options:
+--------
+    /pfn: Unpacks all files to a subdirectory under the specified output path,
+        named after the package full name.
+    /nv, /noValidation: Skips validation that ensures the package will be
+        installable on Windows. The validation include: existence of files
+        referenced in manifest, ContentGroupMap correctness, and additional
+        manifest validation on Protocols and FileTypeAssociation. By default,
+        all semantic validation is performed.
+    /kf: Use this option to encrypt or decrypt the package or bundle using a
+        key file. This option cannot be combined with /kt.
+    /kt: Use this option to encrypt or decrypt the package or bundle using the
+        global test key. This option cannot be combined with /kf.
+    /nd: Skips decryption when unpacking an encrypted package or bundle.
+    /o, /overwrite: Forces the output to overwrite any existing files with the
+        same name. By default, the user is asked whether to overwrite existing
+        files with the same name. You can't use this option with /no.
+    /no, /noOverwrite: Prevents the output from overwriting any existing files
+        with the same name. By default, the user is asked whether to overwrite
+        existing files with the same name. You can't use this option with /o.
+    /v, /verbose: Enables verbose output of messages to the console.
+    /?, /help: Displays this help text.
+
+### 6.1.4. Unbundle
+
+Usage:
+------
+    MakeAppx unbundle [options] /p <input bundle name> /d <output directory>
+    MakeAppx unbundle [options] /ep <encrypted input bundle name> /d <output directory> /kf <key file>
+    MakeAppx unbundle [options] /ep <encrypted input bundle name> /d <output directory> /kt
+
+Options:
+--------
+    /pfn: Unpacks all files to a subdirectory under the specified output path,
+        named after the package full name.
+    /kf: Use this option to encrypt or decrypt the package or bundle using a
+        key file. This option cannot be combined with /kt.
+    /kt: Use this option to encrypt or decrypt the package or bundle using the
+        global test key. This option cannot be combined with /kf.
+    /nd: Skips decryption when unpacking an encrypted package or bundle.
+    /o, /overwrite: Forces the output to overwrite any existing files with the
+        same name. By default, the user is asked whether to overwrite existing
+        files with the same name. You can't use this option with /no.
+    /no, /noOverwrite: Prevents the output from overwriting any existing files
+        with the same name. By default, the user is asked whether to overwrite
+        existing files with the same name. You can't use this option with /o.
+    /v, /verbose: Enables verbose output of messages to the console.
+    /?, /help: Displays this help text.
+
+## 6.2. MakeMsix
+
+MakeMSIX is generally a subset of MakeAppx's functionality. It lacks support for
+encryption, content groups, mapping files, and bundle support is limited to
+only allowing creation of flat bundles (bundles where the appxbundle file itself
+only references but does not contain the main and resource appxpackages)
+
+It does add the ability to optionally unpack all packages inside the bundle
+in one command using the -pfn-flat option, as in:
+makemsix.exe unbundle -p <bundle> -d <directory> -pfn-flat
+
+There is, however, no good option for reversing this command when recreating the
+packages and bundle. Callers need to call makemsix pack on each individual
+package folder and then follow it with a makemsix bundle call to generate a
+flat bundle.
+
+### 6.2.1. Pack
+Usage:
+---------------
+    makemsix.exe pack -d <directory> -p <package> [options]
+
+Options:
+---------------
+    -d <directory> {Required}
+        Input directory path.
+    -p <package> {Required}
+        Output package file path.
+    -? [Flag]
+        Displays this help text.
+
+### 6.2.2. Bundle
+Usage:
+---------------
+    makemsix.exe bundle -p <outputBundle> [options]
+
+Options:
+---------------
+    -d <inputDirectory>
+        Input directory path.
+    -p <outputBundle> {Required}
+        Output bundle file path.
+    -f <mappingFile>
+        Mapping file path.
+    -bv <version>
+        Specifies the version number of the bundle being created. The version must be in dotted - quad 
+        notation of four integers <Major>.<Minor>.<Build>.<Revision> ranging from 0 to 65535 each. If 
+        the -bv option is not specified or is set to 0.0.0.0, the bundle is created using the current 
+        date - time formatted as the version: <Year>.<Month - Day>.<Hour - Minute>.<Second - Millisecond>.
+    -mo [Flag]
+        Generates a bundle manifest only, instead of a full bundle. Input files must all be package 
+        manifests in XML format if this option is specified.
+    -fb [Flag]
+        Generates a fully sparse bundle where all packages are references to packages that exist 
+        outside of the bundle file.
+    -o [Flag]
+        Forces the output to overwrite any existing files with the same name.By default, the user is 
+        asked whether to overwrite existing files with the same name.You can't use this option with -no.
+    -no [Flag]
+        Prevents the output from overwriting any existing files with the same name. By default, the 
+        user is asked whether to overwrite existing files with the same name.You can't use this option 
+        with -o.
+    -v [Flag]
+        Enables verbose output of messages to the console.
+    -? [Flag]
+        Displays this help text.
+
+### 6.2.3. Unpack
+Usage:
+---------------
+    makemsix.exe unpack -p <package> -d <directory> [options]
+
+Options:
+---------------
+    -p <package> {Required}
+        Input package file path.
+    -d <directory> {Required}
+        Output directory path.
+    -pfn [Flag]
+        Unpacks all files to a subdirectory under the output path, named after the package full name.
+    -ac [Flag]
+        Allows any certificate. By default the signature origin must be known.
+    -ss [Flag]
+        Skips enforcement of signed packages. By default packages must be signed.
+    -pfn-flat [Flag]
+        Same behavior as -pfn for packages.
+    -? [Flag]
+        Displays this help text.
+
+### 6.2.4. Unbundle
+
+Usage:
+---------------
+    makemsix.exe unbundle -p <bundle> -d <directory> [options]
+
+Options:
+---------------
+    -p <bundle> {Required}
+        Input bundle file path.
+    -d <directory> {Required}
+        Output directory path.
+    -pfn [Flag]
+        Unpacks all files to a subdirectory under the output path, named after the package full name.
+    -ac [Flag]
+        Allows any certificate. By default the signature origin must be known.
+    -ss [Flag]
+        Skips enforcement of signed packages. By default packages must be signed.
+    -sl [Flag]
+        Skips matching packages with the language of the system. By default unpacked resources 
+        packages will match the system languages.
+    -sp [Flag]
+        Skips matching packages with of the same system. By default unpacked application packages 
+        will only match the platform.
+    -extract-all [Flag]
+        Extracts all packages from the bundle.
+    -pfn-flat [Flag]
+        Unpacks bundle's files to a subdirectory under the specified output path, named after the 
+        package full name. Unpacks packages to subdirectories also under the specified output path, 
+        named after the package full name. By default unpacked packages will be nested inside the bundle folder.
+    -? [Flag]
+        Displays this help text.
+
+## 6.3. MSIXMgr
+
+### 6.3.1. Unpack
+msixmgr.exe -Unpack -packagePath <path to package> -destination <output folder> [-applyacls] [-create] [-vhdSize <size in MB>] [-filetype <CIM | VHD | VHDX>] [-rootDirectory <rootDirectory>]
+
+-Unpack: Unpack a package (.appx, .msix, .appxbundle, .msixbundle) and extract its contents to a folder.
+                -applyACLs: optional parameter that applies ACLs to the resulting package folder(s) and 
+                their parent folder
+                -create: optional parameter that creates a new image with the specified -filetype and 
+                unpacks the packages to that image
+                -destination: the directory to place the resulting package folder(s) in
+                -fileType: the type of file to unpack packages to. Valid file types include {VHD, VHDX, CIM}. 
+                This is a required parameter when unpacking to CIM files
+                -packagePath: the path to the package to unpack OR the path to a directory containing 
+                multiple packages to unpack
+                -rootDirectory: root directory on an image to unpack packages to. Required parameter 
+                for unpacking to new and existing CIM files
+                -validateSignature: optional parameter that validates a package's signature file before 
+                unpacking the package. This will require that the package's certificate is installed on the machine.
+                -vhdSize: the desired size of the VHD or VHDX file in MB. Must be between 5 and 2040000 MB. 
+                Use only for VHD or VHDX files

--- a/specs/WinRT/MakeMSIX-spec.md
+++ b/specs/WinRT/MakeMSIX-spec.md
@@ -1,0 +1,640 @@
+# Make MSIX API in Windows App SDK
+
+# Background
+
+The Make MSIX api allows developers to create app packages for distribution. The api
+provides similar functionality as multiple existing command line tools.
+
+For more details see:
+
+-   [The makeappx command line tool](https://learn.microsoft.com/en-us/windows/win32/appxpkg/make-appx-package--makeappx-exe-)
+    Shipped as part of the Windows Development Kit.
+    Exposes pack, unpack, bundle, and unbundle commands, as well as encryption support
+    via a custom key-file list file, and mapping .
+
+-   [The makemsix command line tool and dll](https://github.com/Microsoft/msix-packaging)
+    Available through the github project.
+    Exposes pack, unpack, unbundle, and bundle* commands (*Bundle command is not implemented).
+    
+-   [The msixmgr command line tool](https://github.com/Microsoft/msix-packaging and 
+    https://learn.microsoft.com/en-us/azure/virtual-desktop/app-attach-msixmgr)
+    Available through github and as a direct download from the learn.microsoft.com site.
+    Exposes "unpack" command to convert msix packages to vhd, vhdx, cim image files.
+
+## The problems today
+
+None of the existing tools provide a good programmatic interface for all aspects of packaging.
+
+The makeappx.exe built into windows provides the only complete implementation of packaging
+and bundling but requires CreateProcess and does not return any specific errors from process exit.
+It also does not support any of the azure app attach scenarios.
+
+The makemsix tool is designed as a cross-platform implementation of packaging, but does not support
+the bundle command. The functionality is exposed as a command line as well as flat dll exports.
+
+The msixmgr tool is mostly for specific azure app attach packaging scenarios that are not covered by
+the other tools. To use it programmatically would require either using CreateProcess or building
+the msix-packaging github project and linking the static lib it produces into a project.
+
+# Existing interfaces and options
+
+## Makeappx
+
+### Pack
+Usage:
+------
+    MakeAppx pack [options] /d <content directory> /p <output package name>
+    MakeAppx pack [options] /f <mapping file> /p <output package name>
+    MakeAppx pack [options] /m <app package manifest> /f <mapping file> /p <output package name>
+    MakeAppx pack [options] /r /m <app package manifest> /f <mapping file> /p <output package name>
+    MakeAppx pack [options] /d <content directory> /ep <encrypted output package name> /kf <key file>
+    MakeAppx pack [options] /d <content directory> /ep <encrypted output package name> /kt
+
+Options:
+--------
+    /h, /hashAlgorithm: Specifies a hash algorithm to use for creating the
+        block map. Valid algorithm IDs are SHA256, SHA384, and SHA512. The
+        default is SHA256.
+    /nv, /noValidation: Skips validation that ensures the package will be
+        installable on Windows. The validation include: existence of files
+        referenced in manifest, ContentGroupMap correctness, and additional
+        manifest validation on Protocols and FileTypeAssociation. By default,
+        all semantic validation is performed.
+    /nfv, /noFileValidation: Skips validation that ensures that the files used
+        to create the package (from a folder through /d or layout file through
+        /l) exist and are accessible. By default, all files must exist and not
+        be read locked. If a file is inaccessible, it will not be added to the
+        package.
+    /nc, /noCompress: Prevents MakeAppx from compressing files in the package.
+        By default, files in the package are compressed based on detected file
+        type.
+    /m: Specifies the path to an input app manifest which will be used as the
+        basis for generating the output app package or resource package's
+        manifest. When you use this option, you must also use /f and include a
+        [ResourceMetadata] section in the mapping file to specify the resource
+        dimensions to be included in the generated manifest.
+    /r: Builds a resource package. You must use the /m option with this.
+    /kf: Use this option to encrypt or decrypt the package or bundle using a
+        key file. This option cannot be combined with /kt.
+    /kt: Use this option to encrypt or decrypt the package or bundle using the
+        global test key. This option cannot be combined with /kf.
+    /cgm: The input content group map (CGM) file path used to create a
+        stream-able package. Providing a content group map through this option
+        will disable the check that all files in the content group map exist in
+        the package.
+    /pri, /makepriExeFullPath: You can use /pri to override the default
+        MakePri.exe path with the custom fullpath from which makeappx.exe will
+        launch the tool from when needed.
+    /mp: Specifies the path to a main package in the same package family as the
+        resource package being built.  You should provide this when encrypting
+        a resource package or when the resource package contains a content
+        group map.
+    /pb, /publisherBridging: Use this option to add publisher bridging entries
+        to the package or bundle.  Publisher bridging is useful when the new
+        issued cert subject name changed but the old publisher name is still
+        desired to maintain package identity continuity.
+    /np, /noParallel: Use this option to disable parallel execution of this
+        command.
+    /ml, /memoryLimit: Specify maximum memory in bytes that MakeAppx should
+        consume while executing in parallel. By default, this value is set to
+        half of total physical memory.
+    /o, /overwrite: Forces the output to overwrite any existing files with the
+        same name. By default, the user is asked whether to overwrite existing
+        files with the same name. You can't use this option with /no.
+    /no, /noOverwrite: Prevents the output from overwriting any existing files
+        with the same name. By default, the user is asked whether to overwrite
+        existing files with the same name. You can't use this option with /o.
+    /v, /verbose: Enables verbose output of messages to the console.
+    /?, /help: Displays this help text.
+
+### Bundle
+
+Usage:
+------
+    MakeAppx bundle [options] /d <content directory> /p <output bundle name>
+    MakeAppx bundle [options] /f <mapping file> /p <output bundle name>
+    MakeAppx bundle [options] /d <content directory> /ep <encrypted output bundle name> /kf MyKeyFile.txt
+    MakeAppx bundle [options] /f <mapping file> /ep <encrypted output bundle name> /kt
+
+Options:
+--------
+    /bv: Specifies the version number of the bundle being created. The version
+        must be in dotted-quad notation of four integers
+        <Major>.<Minor>.<Build>.<Revision> ranging from 0 to 65535 each. If the
+        /bv option is not specified or is set to 0.0.0.0, the bundle is created
+        using the current date-time formatted as the version:
+        <Year>.<Month-Day>.<Hour-Minute>.<Second-Millisecond>.
+    /mo: Generates a bundle manifest only, instead of a full bundle. Input
+        files must all be package manifests in XML format if this option is
+        specified.
+    /fb: Generates a fully sparse bundle where all packages are references to
+        packages that exist outside of the bundle file
+    /pri, /makepriExeFullPath: You can use /pri to override the default
+        MakePri.exe path with the custom fullpath from which makeappx.exe will
+        launch the tool from when needed.
+    /kf: Use this option to encrypt or decrypt the package or bundle using a
+        key file. This option cannot be combined with /kt.
+    /kt: Use this option to encrypt or decrypt the package or bundle using the
+        global test key. This option cannot be combined with /kf.
+    /o, /overwrite: Forces the output to overwrite any existing files with the
+        same name. By default, the user is asked whether to overwrite existing
+        files with the same name. You can't use this option with /no.
+    /no, /noOverwrite: Prevents the output from overwriting any existing files
+        with the same name. By default, the user is asked whether to overwrite
+        existing files with the same name. You can't use this option with /o.
+    /v, /verbose: Enables verbose output of messages to the console.
+    /?, /help: Displays this help text.
+
+### Unpack
+Usage:
+------
+    MakeAppx unpack [options] /p <input package name> /d <output directory>
+    MakeAppx unpack [options] /ep <encrypted input package name> /d <output directory> /kf <key file>
+    MakeAppx unpack [options] /ep <encrypted input package name> /d <output directory> /kt
+
+Options:
+--------
+    /pfn: Unpacks all files to a subdirectory under the specified output path,
+        named after the package full name.
+    /nv, /noValidation: Skips validation that ensures the package will be
+        installable on Windows. The validation include: existence of files
+        referenced in manifest, ContentGroupMap correctness, and additional
+        manifest validation on Protocols and FileTypeAssociation. By default,
+        all semantic validation is performed.
+    /kf: Use this option to encrypt or decrypt the package or bundle using a
+        key file. This option cannot be combined with /kt.
+    /kt: Use this option to encrypt or decrypt the package or bundle using the
+        global test key. This option cannot be combined with /kf.
+    /nd: Skips decryption when unpacking an encrypted package or bundle.
+    /o, /overwrite: Forces the output to overwrite any existing files with the
+        same name. By default, the user is asked whether to overwrite existing
+        files with the same name. You can't use this option with /no.
+    /no, /noOverwrite: Prevents the output from overwriting any existing files
+        with the same name. By default, the user is asked whether to overwrite
+        existing files with the same name. You can't use this option with /o.
+    /v, /verbose: Enables verbose output of messages to the console.
+    /?, /help: Displays this help text.
+
+### Unbundle
+
+Usage:
+------
+    MakeAppx unbundle [options] /p <input bundle name> /d <output directory>
+    MakeAppx unbundle [options] /ep <encrypted input bundle name> /d <output directory> /kf <key file>
+    MakeAppx unbundle [options] /ep <encrypted input bundle name> /d <output directory> /kt
+
+Options:
+--------
+    /pfn: Unpacks all files to a subdirectory under the specified output path,
+        named after the package full name.
+    /kf: Use this option to encrypt or decrypt the package or bundle using a
+        key file. This option cannot be combined with /kt.
+    /kt: Use this option to encrypt or decrypt the package or bundle using the
+        global test key. This option cannot be combined with /kf.
+    /nd: Skips decryption when unpacking an encrypted package or bundle.
+    /o, /overwrite: Forces the output to overwrite any existing files with the
+        same name. By default, the user is asked whether to overwrite existing
+        files with the same name. You can't use this option with /no.
+    /no, /noOverwrite: Prevents the output from overwriting any existing files
+        with the same name. By default, the user is asked whether to overwrite
+        existing files with the same name. You can't use this option with /o.
+    /v, /verbose: Enables verbose output of messages to the console.
+    /?, /help: Displays this help text.
+
+## MakeMsix
+
+MakeMSIX is generally a subset of MakeAppx's functionality. It lacks support for
+encryption, content groups, mapping files, and bundle support is limited to
+only allowing creation of flat-bundles (bundles where the appxbundle file itself
+only references but does not contain the main and resource appxpackages)
+
+It does add the ability to optionally unpack all packages inside the bundle
+in one command using the -pfn-flat option, as in:
+makemsix.exe unbundle -p <bundle> -d <directory> -pfn-flat
+
+There is, however, no good option for reversing this command when recreating the
+packages and bundle. Callers need to call makemsix pack on each individual
+package folder and then follow it with a makemsix bundle call to generate a
+flat bundle.
+
+### Pack
+Usage:
+---------------
+    makemsix.exe pack -d <directory> -p <package> [options]
+
+Options:
+---------------
+    -d <directory> {Required}
+        Input directory path.
+    -p <package> {Required}
+        Output package file path.
+    -? [Flag]
+        Displays this help text.
+
+### Bundle
+Usage:
+---------------
+    makemsix.exe bundle -p <outputBundle> [options]
+
+Options:
+---------------
+    -d <inputDirectory>
+        Input directory path.
+    -p <outputBundle> {Required}
+        Output bundle file path.
+    -f <mappingFile>
+        Mapping file path.
+    -bv <version>
+        Specifies the version number of the bundle being created. The version must be in dotted - quad notation of four integers <Major>.<Minor>.<Build>.<Revision> ranging from 0 to 65535 each. If the -bv option is not specified or is set to 0.0.0.0, the bundle is created using the current date - time formatted as the version: <Year>.<Month - Day>.<Hour - Minute>.<Second - Millisecond>.
+    -mo [Flag]
+        Generates a bundle manifest only, instead of a full bundle. Input files must all be package manifests in XML format if this option is specified.
+    -fb [Flag]
+        Generates a fully sparse bundle where all packages are references to packages that exist outside of the bundle file.
+    -o [Flag]
+        Forces the output to overwrite any existing files with the same name.By default, the user is asked whether to overwrite existing files with the same name.You can't use this option with -no.
+    -no [Flag]
+        Prevents the output from overwriting any existing files with the same name. By default, the user is asked whether to overwrite existing files with the same name.You can't use this option with -o.
+    -v [Flag]
+        Enables verbose output of messages to the console.
+    -? [Flag]
+        Displays this help text.
+
+### Unpack
+Usage:
+---------------
+    makemsix.exe unpack -p <package> -d <directory> [options]
+
+Options:
+---------------
+    -p <package> {Required}
+        Input package file path.
+    -d <directory> {Required}
+        Output directory path.
+    -pfn [Flag]
+        Unpacks all files to a subdirectory under the output path, named after the package full name.
+    -ac [Flag]
+        Allows any certificate. By default the signature origin must be known.
+    -ss [Flag]
+        Skips enforcement of signed packages. By default packages must be signed.
+    -pfn-flat [Flag]
+        Same behavior as -pfn for packages.
+    -? [Flag]
+        Displays this help text.
+
+### Unbundle
+
+Usage:
+---------------
+    makemsix.exe unbundle -p <bundle> -d <directory> [options]
+
+Options:
+---------------
+    -p <bundle> {Required}
+        Input bundle file path.
+    -d <directory> {Required}
+        Output directory path.
+    -pfn [Flag]
+        Unpacks all files to a subdirectory under the output path, named after the package full name.
+    -ac [Flag]
+        Allows any certificate. By default the signature origin must be known.
+    -ss [Flag]
+        Skips enforcement of signed packages. By default packages must be signed.
+    -sl [Flag]
+        Skips matching packages with the language of the system. By default unpacked resources packages will match the system languages.
+    -sp [Flag]
+        Skips matching packages with of the same system. By default unpacked application packages will only match the platform.
+    -extract-all [Flag]
+        Extracts all packages from the bundle.
+    -pfn-flat [Flag]
+        Unpacks bundle's files to a subdirectory under the specified output path, named after the package full name. Unpacks packages to subdirectories also under the specified output path, named after the package full name. By default unpacked packages will be nested inside the bundle folder.
+    -? [Flag]
+        Displays this help text.
+
+## MSIXMgr
+
+### Unpack
+msixmgr.exe -Unpack -packagePath <path to package> -destination <output folder> [-applyacls] [-create] [-vhdSize <size in MB>] [-filetype <CIM | VHD | VHDX>] [-rootDirectory <rootDirectory>]
+
+-Unpack: Unpack a package (.appx, .msix, .appxbundle, .msixbundle) and extract its contents to a folder.
+                -applyACLs: optional parameter that applies ACLs to the resulting package folder(s) and their parent folder
+                -create: optional parameter that creates a new image with the specified -filetype and unpacks the packages to that image
+                -destination: the directory to place the resulting package folder(s) in
+                -fileType: the type of file to unpack packages to. Valid file types include {VHD, VHDX, CIM}. This is a required parameter when unpacking to CIM files
+                -packagePath: the path to the package to unpack OR the path to a directory containing multiple packages to unpack
+                -rootDirectory: root directory on an image to unpack packages to. Required parameter for unpacking to new and existing CIM files
+                -validateSignature: optional parameter that validates a package's signature file before unpacking the package. This will require that the package's certificate is installed on the machine.
+                -vhdSize: the desired size of the VHD or VHDX file in MB. Must be between 5 and 2040000 MB. Use only for VHD or VHDX files
+
+# Summary of existing options
+
+Existing options all treat pack and bundle as separate commands. Though they are similar, each command does have 
+some options that are irrelevant to the other command. For bundling that means specifying the Bundle Version, which
+nearly all callers will specify (the alternative is the tool setting the version based on a timestamp), and allowing
+creation of sparse bundles. For packaging that means hash algorithm, and creation of streamable packages and resource
+packages.
+
+In the long term it's likely that these differences in the information and flags required to support creating a bundle
+and creating a package will only continue to grow.
+
+Unpack and Unbundle is a somewhat different story. MSIXMgr defines an unpack command which in some ways looks more like a
+"convert" than an "unpack" (i.e. "unpack" msix to folder, "pack" folder to vhdx). This means that the msixmgr unpack command
+needs to take many more options to define the "unpack" destination than the makeappx unpack command which always unpacks
+to a folder. With the set of options to describe the output it looks more like the "pack\bundle" commands of the other tools.
+In an api that supported creation of the CIM, VHD, VHDX file as well as creation of msix and msixbundle files, callers might
+find it strange to need to first pack their directory to an msix, and then create the vhdx from the msix, rather than just
+creating the vhdx directly. However, signing is not integrated into any of these tools, and is a separate step that
+is done after packaging is complete. This may prevent direct creation of VHDX files from the layout directory if
+signing tools don't support this scenario (TODO: sreading, looking into this)
+
+If defined as an atomic operation where a package is unpacked to a folder, it is less likely that differences
+will arise between unbundle and unpack. However, as seen with the existing makemsix tool, as long as pack and bundle
+are separate operations it may not be especially useful for unbundle and unpack to be joined. Unpacking of
+all bundled packages might save time if someone wanted to examine the manifest of a main package inside the bundle,
+as might be an expected use case for a command line tool.
+But in cases where the api is actually being used programattically, to do something like extract all packages and update
+every manifest, say with a different version number, there is no avoiding use of filesystem apis to find each
+unpacked package. In such a case merging the unbundle and unpack command into one api call saves very little complexity for
+the caller, especially if pack and bundle have not also been merged to allow callers to use one call to package all subfolders
+with appxmanifests and then bundle all of them together.
+
+For these reasons pack, bundle, unpack, unbundle have been left as separate commands. The MSIXMgr "unpack" command
+is implemented here as another form of pack.
+
+
+# Examples
+
+## Packing a package
+
+```cpp
+    TEST_METHOD(TestPack)
+    {
+        winrt::init_apartment();
+        auto packOptions = PackOptions();
+        packOptions.OverwriteFiles(true);
+        //PackOptions.KozaniPackageFilePath(L"E:\\vm\\apps\\kozaniPackage.msix");
+        packOptions.PackageFilePath(L"E:\\test\\packagedOutput.msix");
+        
+        PackagingResult result{ MakeMSIXManager::Pack(L"E:\\test\\unpackedPackageInput", packOptions).get()};
+        VERIFY_IS_TRUE(SUCCEEDED(result.Status() == PackagingResultStatus::Ok));
+        VERIFY_IS_TRUE(SUCCEEDED(result.ExtendedErrorCode()));
+
+        auto kozaniPackOptions = PackOptions();
+        kozaniPackOptions.OverwriteFiles(true);
+        kozaniPackOptions.CreateAsKozaniPackage(true);
+        kozaniPackOptions.PackageFilePath(L"E:\\test\\kozaniPackagedOutput.msix");
+
+        PackagingResult kozaniResult{ MakeMSIXManager::Pack(L"E:\\test\\unpackedPackageInput", kozaniPackOptions).get() };
+        VERIFY_IS_TRUE(SUCCEEDED(kozaniResult.Status() == PackagingResultStatus::Ok));
+        VERIFY_IS_TRUE(SUCCEEDED(kozaniResult.ExtendedErrorCode()));
+    }
+```
+
+## Bundling a package
+
+```cpp
+    TEST_METHOD(TestBundle)
+    {
+        winrt::init_apartment();
+        auto bundleOptions = BundleOptions();
+        bundleOptions.OverwriteFiles(true);
+        bundleOptions.BundleFilePath(L"E:\\test\\bundledOutput.msixbundle");
+
+        PackagingResult result{ MakeMSIXManager::Bundle(L"E:\\test\\unbundledPackageInput", bundleOptions).get() };
+        VERIFY_IS_TRUE(SUCCEEDED(result.Status() == PackagingResultStatus::Ok));
+        VERIFY_IS_TRUE(SUCCEEDED(result.ExtendedErrorCode()));
+    }
+```
+
+## Unpacking a package
+
+```cpp
+    TEST_METHOD(TestUnpack)
+    {
+        winrt::init_apartment();
+        auto unpackOptions = UnpackOptions();
+        unpackOptions.OverwriteFiles(true);
+        unpackOptions.UnpackedPackageRootDirectory(L"E:\\test\\unpackedPackageOutput");
+
+        PackagingResult result{ MakeMSIXManager::Unpack(L"E:\\test\\package.msix", unpackOptions).get() };
+        VERIFY_IS_TRUE(SUCCEEDED(result.Status() == PackagingResultStatus::Ok));
+        VERIFY_IS_TRUE(SUCCEEDED(result.ExtendedErrorCode()));
+    }
+```
+
+## Unbundling a package
+
+```cpp
+    TEST_METHOD(TestUnbundle)
+    {
+        winrt::init_apartment();
+        std::wstring outputDir{ L"E:\\test\\unpackedBundleOutput" };
+        auto unbundleOptions = UnbundleOptions();
+        unbundleOptions.OverwriteFiles(true);
+        unbundleOptions.UnbundledPackageRootDirectory(outputDir);
+
+        PackagingResult result{ MakeMSIXManager::Unbundle(L"E:\\test\\bundle.msixbundle", unbundleOptions).get() };
+        VERIFY_IS_TRUE(SUCCEEDED(result.Status() == PackagingResultStatus::Ok));
+        VERIFY_IS_TRUE(SUCCEEDED(result.ExtendedErrorCode()));
+
+        // Iterate through packages and unpack each one.
+        for (const auto& file : std::filesystem::directory_iterator(outputDir))
+        {
+            auto unpackOptions = UnpackOptions();
+            unpackOptions.OverwriteFiles(true);
+            std::filesystem::path outputDirForPackage{ outputDir };
+            outputDirForPackage /= file.path().filename();
+            unpackOptions.UnpackedPackageRootDirectory(outputDirForPackage.c_str());
+
+            PackagingResult unpackResult{ MakeMSIXManager::Unpack(file.path().c_str(), unpackOptions).get()};
+            VERIFY_IS_TRUE(SUCCEEDED(unpackResult.Status() == PackagingResultStatus::Ok));
+            VERIFY_IS_TRUE(SUCCEEDED(unpackResult.ExtendedErrorCode()));
+        }
+    }
+```
+
+# API Details
+
+```c#
+// Copyright (c) Microsoft Corporation and Contributors.
+// Licensed under the MIT License.
+
+namespace Microsoft.Kozani.MakeMSIX
+{
+    [contractversion(1)]
+    apicontract MakeMSIXContract{};
+
+    /// <summary>
+    /// Result of the packaging operation
+    /// </summary>
+    [contract(MakeMSIXContract, 1)]
+    enum PackagingResultStatus
+    {
+        Ok,
+        InvalidOptions,
+        FileAlreadyExistsError,
+        InternalError,
+    };
+
+    /// <summary>
+    /// Result of the packaging operation
+    /// </summary>
+    [contract(MakeMSIXContract, 1)]
+    runtimeclass PackagingResult
+    {
+        /// <summary>
+        /// Status of the overall operation.
+        /// </summary>
+        PackagingResultStatus Status { get; };
+        /// <summary>
+        /// Error code of the overall operation.
+        /// </summary>
+        HRESULT ExtendedErrorCode { get; };
+    };
+
+    /// Options for creating a package
+    [contract(MakeMSIXContract, 1)]
+    runtimeclass PackOptions
+    {
+        /// <summary>
+        /// Created by callers to pass options into CreatePackage
+        /// </summary>
+        PackOptions();
+
+        /// <summary>
+        /// Output path for the full packaged file.
+        /// </summary>
+        String PackageFilePath{ get; set; };
+
+        // API REVIEW NOTE: Two options here. Needing to create a traditional package
+        // and a Kozani package at the same time may be fairly common for certain users
+        // but most users will not ever need to create Kozani packages.
+        // Either require the caller to make two separate calls, or allow creation of both
+        // packages in one call. My preference is separate calls, which makes it clearer
+        // that Kozani packages are optional.
+
+        /// <summary>
+        /// If true, writes a Kozani package to PackageFilePath.
+        /// Defaults to false.
+        /// </summary>
+        Boolean CreateAsKozaniPackage{ get; set; };
+        /// <summary>
+        /// Output path for the Kozani package file.
+        /// At least one of PackageFilePath and KozaniPackageFilePath must be set.
+        /// </summary>
+        String KozaniPackageFilePath{ get; set; };
+
+
+        /// <summary>
+        /// Overwrite PackageFilePath and KozaniPackageFilePath if they already exist.
+        /// Defaults to true.
+        /// </summary>
+        Boolean OverwriteFiles{ get; set; };
+        /// <summary>
+        /// Validates elements of the package during creation.
+        /// Defaults to false.
+        /// </summary>
+        Boolean ValidateFiles{ get; set; };
+    };
+
+    /// Options for creating a bundle
+    [contract(MakeMSIXContract, 1)]
+    runtimeclass BundleOptions
+    {
+        /// <summary>
+        /// Created by callers to pass options into Bundle
+        /// </summary>
+        BundleOptions();
+
+        /// <summary>
+        /// Output path for the full bundled file.
+        /// </summary>
+        String BundleFilePath{ get; set; };
+
+        /// <summary>
+        /// Overwrite BundleFilePath if they already exist.
+        /// Defaults to true.
+        /// </summary>
+        Boolean OverwriteFiles{ get; set; };
+
+        /// <summary>
+        /// Sets the version in the AppxBundleManifest.xml during packaging if
+        /// the source layout is a bundle.
+        /// </summary>
+        Windows.ApplicationModel.PackageVersion BundleVersion{ get; set; };
+    };
+
+    /// <summary>
+    /// Options for unpacking a package
+    /// </summary>
+    [contract(MakeMSIXContract, 1)]
+    runtimeclass UnpackOptions
+    {
+        /// <summary>
+        /// Created by callers to pass options into UnpackPackage
+        /// </summary>
+        UnpackOptions();
+    
+        /// <summary>
+        /// The output folder to unpack the package into.
+        /// </summary>
+        String UnpackedPackageRootDirectory;
+        /// <summary>
+        /// If true, the operation will overwrite existing files in the UnpackedPackageRootDirectory
+        /// when unpacking.
+        /// If false, the operation will fail if a file already exists.
+        /// </summary>
+        Boolean OverwriteFiles;
+    };
+
+    /// <summary>
+    /// Options for unpacking a package
+    /// </summary>
+    [contract(MakeMSIXContract, 1)]
+    runtimeclass UnbundleOptions
+    {
+        /// <summary>
+        /// Created by callers to pass options into UnpackPackage
+        /// </summary>
+        UnbundleOptions();
+
+        /// <summary>
+        /// The output folder to unpack the bundle package into.
+        /// </summary>
+        String UnbundledPackageRootDirectory;
+        /// <summary>
+        /// If true, the operation will overwrite existing files in the UnbundledPackageRootDirectory
+        /// when unpacking.
+        /// If false, the operation will fail if a file already exists.
+        /// </summary>
+        Boolean OverwriteFiles;
+    };
+
+    /// <summary>
+    /// Static methods for creating and unpacking packages.
+    /// </summary>
+    [contract(MakeMSIXContract, 1)]
+    runtimeclass MakeMSIXManager
+    {
+        /// <summary>
+        /// Creates packages from the directoryPathToPack as specified by the packOptions.
+        /// </summary>
+        static Windows.Foundation.IAsyncOperation<PackagingResult> Pack(String directoryPathToPack, PackOptions packOptions);
+        /// <summary>
+        /// Creates bundles from the directoryPathToBundle as specified by the bundleOptions.
+        /// </summary>
+        static Windows.Foundation.IAsyncOperation<PackagingResult> Bundle(String directoryPathToBundle, BundleOptions bundleOptions);
+        /// <summary>
+        /// Unpacks a package at packageFilePathToUnpack as specified by the unpackOptions.
+        /// </summary>
+        static Windows.Foundation.IAsyncOperation<PackagingResult> Unpack(String packageFilePathToUnpack, UnpackOptions unpackOptions);
+        /// <summary>
+        /// Unbundles a package at bundleFilePathToUnbundle as specified by the unbundleOptions.
+        /// </summary>
+        static Windows.Foundation.IAsyncOperation<PackagingResult> Unbundle(String bundleFilePathToUnbundle, UnbundleOptions unbundleOptions);
+    };
+}
+
+
+```
+
+# Appendix


### PR DESCRIPTION
API spec document for msix packaging in winappsdk

A microsoft employee must use /azp run to validate using the pipelines below.

WARNING:
Comments made by azure-pipelines bot maybe inaccurate. 
Please see pipeline link to verify that the build is being ran.

For status checks on the develop branch, please use TransportPackage-Foundation-PR
(https://microsoft.visualstudio.com/ProjectReunion/_build?definitionId=81063&_a=summary)
and run the build against your PR branch with the default parameters.

For status checks on the main branch, please use microsoft.ProjectReunion
(https://dev.azure.com/ms/ProjectReunion/_build?definitionId=391&_a=summary)
and run the build against your PR branch with the default parameters.