### PR TITLE
Add /await:strict to C++ build props

### DIFF
--- a/WindowsAppSDK.Build.Cpp.props
+++ b/WindowsAppSDK.Build.Cpp.props
@@ -29,9 +29,8 @@
       <!-- /Qspectre Specifies compiler generation of instructions to mitigate certain Spectre variant 1 security vulnerabilities. BinSkim asks for this. -->
       <!-- /ZH:SHA_256 Hash algorithm for file checksums in debug info -->
       <!-- /await Enable coroutine support. -->
-      <!-- TODO:42560699 Replace /await with... /await:strict Enable coroutine support. Disable /await language extensions not adopted into C++20 -->
       <!-- /d1trimfile:$(RepoRoot) If the prefix for a source file path name string matches "trim-string" the prefix is replaced with the mapping-identifier (if present). Requires /Brepro. -->
-      <AdditionalOptions>%(AdditionalOptions) /Qspectre /ZH:SHA_256 /await /d1trimfile:$(RepoRoot)</AdditionalOptions>
+      <AdditionalOptions>%(AdditionalOptions) /Qspectre /ZH:SHA_256 /await:strict /d1trimfile:$(RepoRoot)</AdditionalOptions>
     </ClCompile>
     <Link>
       <!-- /DEBUG:FULL Create PDF containing full debug information -->

--- a/WindowsAppSDK.Build.Cpp.props
+++ b/WindowsAppSDK.Build.Cpp.props
@@ -28,7 +28,7 @@
 
       <!-- /Qspectre Specifies compiler generation of instructions to mitigate certain Spectre variant 1 security vulnerabilities. BinSkim asks for this. -->
       <!-- /ZH:SHA_256 Hash algorithm for file checksums in debug info -->
-      <!-- /await Enable coroutine support. -->
+      <!-- /await:strict Enable coroutine support. Disable language extensions present in /await that weren't adopted into C++20 -->
       <!-- /d1trimfile:$(RepoRoot) If the prefix for a source file path name string matches "trim-string" the prefix is replaced with the mapping-identifier (if present). Requires /Brepro. -->
       <AdditionalOptions>%(AdditionalOptions) /Qspectre /ZH:SHA_256 /await:strict /d1trimfile:$(RepoRoot)</AdditionalOptions>
     </ClCompile>

--- a/dev/AppNotifications/AppNotificationManager.cpp
+++ b/dev/AppNotifications/AppNotificationManager.cpp
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft Corporation and Contributors.
+// Copyright (c) Microsoft Corporation and Contributors.
 // Licensed under the MIT License.
 
 #include "pch.h"
@@ -514,7 +514,7 @@ namespace winrt::Microsoft::Windows::AppNotifications::implementation
     {
         if (!IsSupported())
         {
-            return;
+            co_return;
         }
 
         auto logTelemetry{ AppNotificationTelemetry::RemoveByIdAsync::Start(g_telemetryHelper, m_appId, notificationId) };
@@ -536,7 +536,7 @@ namespace winrt::Microsoft::Windows::AppNotifications::implementation
     {
         if (!IsSupported())
         {
-            return;
+            co_return;
         }
 
         auto logTelemetry{ AppNotificationTelemetry::RemoveByTagAsync::Start(g_telemetryHelper, m_appId, tag) };
@@ -558,7 +558,7 @@ namespace winrt::Microsoft::Windows::AppNotifications::implementation
     {
         if (!IsSupported())
         {
-            return;
+            co_return;
         }
 
         auto logTelemetry{ AppNotificationTelemetry::RemoveByTagAndGroupAsync::Start(g_telemetryHelper, m_appId, tag, group) };
@@ -581,7 +581,7 @@ namespace winrt::Microsoft::Windows::AppNotifications::implementation
     {
         if (!IsSupported())
         {
-            return;
+            co_return;
         }
 
         auto logTelemetry{ AppNotificationTelemetry::RemoveByGroupAsync::Start(g_telemetryHelper, m_appId, group) };
@@ -603,7 +603,7 @@ namespace winrt::Microsoft::Windows::AppNotifications::implementation
     {
         if (!IsSupported())
         {
-            return;
+            co_return;
         }
 
         auto strong = get_strong();


### PR DESCRIPTION
Fixing return strategy (needs to be co_return) preventing use of /await:strict when compiling the SDK