### PR TITLE
Bug 43948918 - fix error in the StageAndPackge stage in Foundation repo's weekly pipeline

### DIFF
--- a/build/ProjectReunion-BuildFoundation-Weekly.yml
+++ b/build/ProjectReunion-BuildFoundation-Weekly.yml
@@ -31,6 +31,9 @@ parameters:
   - name: "enableLicenseInstall"
     type: boolean
     default: true
+  - name: "pipelineType"
+    type: string
+    default: 'azurePipeline'
 
 resources:
   repositories:

--- a/build/ProjectReunion-BuildFoundation-Weekly.yml
+++ b/build/ProjectReunion-BuildFoundation-Weekly.yml
@@ -5,6 +5,8 @@ variables:
 - template: WindowsAppSDK-CommonVariables.yml
 - name: buildPool
   value: 'ProjectReunionESPool-2022'
+- name: pipelineType
+  value: 'azurePipeline'
 
 parameters:
   - name: "ReleaseSigning"
@@ -31,9 +33,6 @@ parameters:
   - name: "enableLicenseInstall"
     type: boolean
     default: true
-  - name: "pipelineType"
-    type: string
-    default: 'azurePipeline'
 
 resources:
   repositories:


### PR DESCRIPTION
**Problem**
When the packageVersion string is being referenced in StageAndPackge, it contains an unresolved PipelineType variable, like this: "1.4.0-20230325.0.develop.$(PipelineType)", resulting in the error.

**Proposed Fix**
Explicitly populate the PipelineType property in the pipeline definition yml file ProjectReunion-BuildFoundation-Weekly.yml.

**How built**
Earlier draft built fine. Will go through normal PR validation.

**How tested**
In the following sample run of the weekly pipeline, the error in question no longer repros. The packageVersion string is fully resolved to a valid package version string in StageAndPackge.
https://microsoft.visualstudio.com/ProjectReunion/_build/results?buildId=67377364&view=results

-----
A microsoft employee must use /azp run to validate using the pipelines below.

WARNING:
Comments made by azure-pipelines bot maybe inaccurate. 
Please see pipeline link to verify that the build is being ran.

For status checks on the develop branch, please use TransportPackage-Foundation-PR
(https://microsoft.visualstudio.com/ProjectReunion/_build?definitionId=81063&_a=summary)
and run the build against your PR branch with the default parameters.

For status checks on the main branch, please use microsoft.ProjectReunion
(https://dev.azure.com/ms/ProjectReunion/_build?definitionId=391&_a=summary)
and run the build against your PR branch with the default parameters.