### PR TITLE
ADO bug 43814738 - Fixed call to deprecated NuGetAuthenticate

### DIFF
--- a/build/AzurePipelinesTemplates/WindowsAppSDK-SetupBuildEnvironment-Steps.yml
+++ b/build/AzurePipelinesTemplates/WindowsAppSDK-SetupBuildEnvironment-Steps.yml
@@ -16,7 +16,7 @@ steps:
   inputs:
     filename: 'set'
 
-- task: NuGetAuthenticate@0
+- task: NuGetAuthenticate@1
   inputs:
     nuGetServiceConnections: 'WindowsES'
 


### PR DESCRIPTION
One instance of the call to the NuGetAuthenticate task is still referencing an old version.
Updated to reference the same newer task version as elsewhere in the project.

How built:
- Topic branch built fine.
- Will go through usual PR validation

How tested:
In the test run below, the 2nd call to the NuGetAuthenticate task from the job "Build Release_x64" no longer triggers the "version is deprecated, needs to upgrade task" warning in the ADO bug.
- https://microsoft.visualstudio.com/ProjectReunion/_build/results?buildId=67739316&view=results
---
A microsoft employee must use /azp run to validate using the pipelines below.

WARNING:
Comments made by azure-pipelines bot maybe inaccurate. 
Please see pipeline link to verify that the build is being ran.

For status checks on the develop branch, please use TransportPackage-Foundation-PR
(https://microsoft.visualstudio.com/ProjectReunion/_build?definitionId=81063&_a=summary)
and run the build against your PR branch with the default parameters.

For status checks on the main branch, please use microsoft.ProjectReunion
(https://dev.azure.com/ms/ProjectReunion/_build?definitionId=391&_a=summary)
and run the build against your PR branch with the default parameters.