### PR TITLE
Disable BuildMRT in public CI builds

### DIFF
--- a/build/ProjectReunion-CI.yml
+++ b/build/ProjectReunion-CI.yml
@@ -117,111 +117,114 @@ jobs:
       PathtoPublish: '$(build.SourcesDirectory)\BuildOutput'
       artifactName: 'BuildOutput'
 
-- job: BuildMRT
-  pool:
-    vmImage: 'windows-2022'
-  strategy:
-    maxParallel: 10
-    matrix:
-      Release_x86:
-        buildPlatform: 'x86'
-        buildConfiguration: 'Release'
-      Release_x64:
-        buildPlatform: 'x64'
-        buildConfiguration: 'Release'
-      Release_Arm64:
-        buildPlatform: 'ARM64'
-        buildConfiguration: 'Release'
-  steps:
-  - task: NuGetToolInstaller@1
+# Public validation for BuildMRT will be disabled until Microsoft.Taef becomes public.
+# Any development on MRT should occur on the Develop branch
 
-  - template: AzurePipelinesTemplates\WindowsAppSDK-BuildAndTestMRT-Steps.yml
+# - job: BuildMRT
+#   pool:
+#     vmImage: 'windows-2022'
+#   strategy:
+#     maxParallel: 10
+#     matrix:
+#       Release_x86:
+#         buildPlatform: 'x86'
+#         buildConfiguration: 'Release'
+#       Release_x64:
+#         buildPlatform: 'x64'
+#         buildConfiguration: 'Release'
+#       Release_Arm64:
+#         buildPlatform: 'ARM64'
+#         buildConfiguration: 'Release'
+#   steps:
+#   - task: NuGetToolInstaller@1
 
-  - task: PublishBuildArtifacts@1
-    displayName: 'Publish BuildOutput'
-    inputs:
-      artifactName: BuildOutput
-      PathtoPublish: '$(buildOutputDir)'
+#   - template: AzurePipelinesTemplates\WindowsAppSDK-BuildAndTestMRT-Steps.yml
 
-# We no longer run MRT tests in Helix here, due to dwindling Helix support. But one MRT test suite 
-# is still being run in WindowsAppSDK-BuildAndTestMRT-Steps.yml.
+#   - task: PublishBuildArtifacts@1
+#     displayName: 'Publish BuildOutput'
+#     inputs:
+#       artifactName: BuildOutput
+#       PathtoPublish: '$(buildOutputDir)'
 
-- job: StageAndPack
-  pool:
-    vmImage: 'windows-2022'
-  timeoutInMinutes: 120
-  dependsOn:
-    - Build
-    - BuildMRT
-  steps:
-  - task: DownloadBuildArtifacts@0
-    inputs:
-      artifactName: BuildOutput
-      downloadPath: '$(Build.SourcesDirectory)'
+# # We no longer run MRT tests in Helix here, due to dwindling Helix support. But one MRT test suite
+# # is still being run in WindowsAppSDK-BuildAndTestMRT-Steps.yml.
 
-  - task: PowerShell@2
-    name: StageFiles
-    inputs:
-      filePath: 'BuildAll.ps1'
-      arguments: -Platform "x86,x64,arm64" -Configuration "release" -AzureBuildStep "StageFiles"
+# - job: StageAndPack
+#   pool:
+#     vmImage: 'windows-2022'
+#   timeoutInMinutes: 120
+#   dependsOn:
+#     - Build
+#     - BuildMRT
+#   steps:
+#   - task: DownloadBuildArtifacts@0
+#     inputs:
+#       artifactName: BuildOutput
+#       downloadPath: '$(Build.SourcesDirectory)'
 
-  - task: PowerShell@2
-    name: SetVersion
-    displayName: Update metapackage version
-    inputs:
-      targetType: 'inline'
-      script: |
-        $packageVersion = '$(version)'
-        $pipelineType = '$(PipelineType)'
-        $sourceBranchName = '$(Build.SourceBranchName)'
-        if ($sourceBranchName -eq 'main' -or $sourceBranchName -eq 'develop')
-        {
-          $packageVersion = $packageVersion + '.' + $sourceBranchName + '.' + $pipelineType
-        }
-        Write-Host "##vso[task.setvariable variable=packageVersion;]$packageVersion"
-        Write-Host $packageVersion
-        [xml]$publicNuspec = Get-Content -Path $(Build.SourcesDirectory)\build\NuSpecs\Microsoft.WindowsAppSDK.Foundation.nuspec
-        $publicNuspec.package.metadata.version = $packageVersion
-        Set-Content -Value $publicNuspec.OuterXml $(Build.SourcesDirectory)\build\NuSpecs\Microsoft.WindowsAppSDK.Foundation.nuspec
-  - task: PowerShell@2
-    name: PackNuget
-    inputs:
-      filePath: 'BuildAll.ps1'
-      arguments: -Platform "x64" -Configuration "release" -AzureBuildStep "PackNuget" -OutputDirectory "$(build.artifactStagingDirectory)\FullNuget" -PackageVersion "$(packageVersion)"
+#   - task: PowerShell@2
+#     name: StageFiles
+#     inputs:
+#       filePath: 'BuildAll.ps1'
+#       arguments: -Platform "x86,x64,arm64" -Configuration "release" -AzureBuildStep "StageFiles"
 
-  - task: BinSkim@3
-    inputs:
-      InputType: 'Basic'
-      Function: 'analyze'
-      AnalyzeTarget: '$(build.SourcesDirectory)\BuildOutput\FullNuget\*.dll;$(build.SourcesDirectory)\BuildOutput\FullNuget\*.exe'
-      AnalyzeVerbose: true
+#   - task: PowerShell@2
+#     name: SetVersion
+#     displayName: Update metapackage version
+#     inputs:
+#       targetType: 'inline'
+#       script: |
+#         $packageVersion = '$(version)'
+#         $pipelineType = '$(PipelineType)'
+#         $sourceBranchName = '$(Build.SourceBranchName)'
+#         if ($sourceBranchName -eq 'main' -or $sourceBranchName -eq 'develop')
+#         {
+#           $packageVersion = $packageVersion + '.' + $sourceBranchName + '.' + $pipelineType
+#         }
+#         Write-Host "##vso[task.setvariable variable=packageVersion;]$packageVersion"
+#         Write-Host $packageVersion
+#         [xml]$publicNuspec = Get-Content -Path $(Build.SourcesDirectory)\build\NuSpecs\Microsoft.WindowsAppSDK.Foundation.nuspec
+#         $publicNuspec.package.metadata.version = $packageVersion
+#         Set-Content -Value $publicNuspec.OuterXml $(Build.SourcesDirectory)\build\NuSpecs\Microsoft.WindowsAppSDK.Foundation.nuspec
+#   - task: PowerShell@2
+#     name: PackNuget
+#     inputs:
+#       filePath: 'BuildAll.ps1'
+#       arguments: -Platform "x64" -Configuration "release" -AzureBuildStep "PackNuget" -OutputDirectory "$(build.artifactStagingDirectory)\FullNuget" -PackageVersion "$(packageVersion)"
 
-  - task: PostAnalysis@1
-    inputs:
-      AllTools: false
-      APIScan: false
-      BinSkim: true
-      BinSkimBreakOn: 'Error'
-      CodesignValidation: false
-      CredScan: false
-      FortifySCA: false
-      FxCop: false
-      ModernCop: false
-      PoliCheck: false
-      RoslynAnalyzers: false
-      SDLNativeRules: false
-      Semmle: false
-      TSLint: false
-      ToolLogsNotFoundAction: 'Standard'
+#   - task: BinSkim@3
+#     inputs:
+#       InputType: 'Basic'
+#       Function: 'analyze'
+#       AnalyzeTarget: '$(build.SourcesDirectory)\BuildOutput\FullNuget\*.dll;$(build.SourcesDirectory)\BuildOutput\FullNuget\*.exe'
+#       AnalyzeVerbose: true
 
-  - task: PublishBuildArtifacts@1
-    displayName: 'Publish artifact: NugetContent'
-    inputs:
-      PathtoPublish: '$(Build.SourcesDirectory)\BuildOutput\FullNuget'
-      artifactName: 'NugetContent'
+#   - task: PostAnalysis@1
+#     inputs:
+#       AllTools: false
+#       APIScan: false
+#       BinSkim: true
+#       BinSkimBreakOn: 'Error'
+#       CodesignValidation: false
+#       CredScan: false
+#       FortifySCA: false
+#       FxCop: false
+#       ModernCop: false
+#       PoliCheck: false
+#       RoslynAnalyzers: false
+#       SDLNativeRules: false
+#       Semmle: false
+#       TSLint: false
+#       ToolLogsNotFoundAction: 'Standard'
 
-  - task: PublishBuildArtifacts@1
-    displayName: 'Publish artifact: TransportPackage'
-    inputs:
-      PathtoPublish: '$(build.artifactStagingDirectory)\FullNuget'
-      artifactName: 'TransportPackage'
+#   - task: PublishBuildArtifacts@1
+#     displayName: 'Publish artifact: NugetContent'
+#     inputs:
+#       PathtoPublish: '$(Build.SourcesDirectory)\BuildOutput\FullNuget'
+#       artifactName: 'NugetContent'
+
+#   - task: PublishBuildArtifacts@1
+#     displayName: 'Publish artifact: TransportPackage'
+#     inputs:
+#       PathtoPublish: '$(build.artifactStagingDirectory)\FullNuget'
+#       artifactName: 'TransportPackage'

--- a/dev/MRTCore/mrt/Core/unittests/packages.config
+++ b/dev/MRTCore/mrt/Core/unittests/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.Taef" version="10.75.221207001" targetFramework="native" />
+  <package id="Microsoft.Taef" version="10.58.210222006-develop" targetFramework="native" />
 </packages>

--- a/dev/MRTCore/mrt/Microsoft.Windows.ApplicationModel.Resources/UnpackagedTests/packages.config
+++ b/dev/MRTCore/mrt/Microsoft.Windows.ApplicationModel.Resources/UnpackagedTests/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.Taef" version="10.75.221207001" targetFramework="net45" />
+  <package id="Microsoft.Taef" version="10.58.210222006-develop" targetFramework="net45" />
 </packages>

--- a/dev/MRTCore/mrt/mrm/UnitTests/packages.config
+++ b/dev/MRTCore/mrt/mrm/UnitTests/packages.config
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Microsoft.Windows.ImplementationLibrary" version="1.0.220914.1" targetFramework="native" />
-  <package id="Microsoft.Taef" version="10.75.221207001" targetFramework="native" />
+  <package id="Microsoft.Taef" version="10.58.210222006-develop" targetFramework="native" />
 </packages>

--- a/eng/Version.Dependencies.xml
+++ b/eng/Version.Dependencies.xml
@@ -29,7 +29,7 @@
   <Dependency Name="Microsoft.Build.Tasks.Git"                Version="1.1.1"/>
   <Dependency Name="Microsoft.SourceLink.Common"              Version="1.1.1"/>
   <Dependency Name="Microsoft.SourceLink.GitHub"              Version="1.1.1"/>
-  <Dependency Name="Microsoft.Taef"                           Version="10.75.221207001"/>
+  <Dependency Name="Microsoft.Taef"                           Version="10.58.210222006-develop"/>
   <Dependency Name="Microsoft.Telemetry.Inbox.Native"         Version="10.0.19041.1-191206-1406.vb-release.x86fre" />
   <Dependency Name="Microsoft.Windows.CppWinRT"               Version="2.0.221121.5"/>
   <Dependency Name="Microsoft.Windows.ImplementationLibrary"  Version="1.0.220914.1"/>

--- a/installer/test/InstallerFunctionalTests/packages.config
+++ b/installer/test/InstallerFunctionalTests/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.Taef" version="10.75.221207001" targetFramework="native" />
+  <package id="Microsoft.Taef" version="10.58.210222006-develop" targetFramework="native" />
   <package id="Microsoft.Windows.CppWinRT" version="2.0.221121.5" targetFramework="native" />
   <package id="Microsoft.Windows.ImplementationLibrary" version="1.0.220914.1" targetFramework="native" />
 </packages>

--- a/test/AccessControlTests/packages.config
+++ b/test/AccessControlTests/packages.config
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.Taef" version="10.75.221207001" targetFramework="native" />
+  <package id="Microsoft.Taef" version="10.58.210222006-develop" targetFramework="native" />
   <package id="Microsoft.Windows.CppWinRT" version="2.0.221121.5" targetFramework="native" />
 </packages>

--- a/test/AppLifecycle/packages.config
+++ b/test/AppLifecycle/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.Taef" version="10.75.221207001" targetFramework="native" />
+  <package id="Microsoft.Taef" version="10.58.210222006-develop" targetFramework="native" />
   <package id="Microsoft.Windows.CppWinRT" version="2.0.221121.5" targetFramework="native" />
   <package id="Microsoft.Windows.ImplementationLibrary" version="1.0.220914.1" targetFramework="native" />
 </packages>

--- a/test/AppNotificationBuilderTests/packages.config
+++ b/test/AppNotificationBuilderTests/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.Taef" version="10.75.221207001" targetFramework="native" />
+  <package id="Microsoft.Taef" version="10.58.210222006-develop" targetFramework="native" />
   <package id="Microsoft.Windows.CppWinRT" version="2.0.221121.5" targetFramework="native" />
   <package id="Microsoft.Windows.ImplementationLibrary" version="1.0.220914.1" targetFramework="native" />
 </packages>

--- a/test/AppNotificationTests/packages.config
+++ b/test/AppNotificationTests/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.Taef" version="10.75.221207001" targetFramework="native" />
+  <package id="Microsoft.Taef" version="10.58.210222006-develop" targetFramework="native" />
   <package id="Microsoft.Windows.CppWinRT" version="2.0.221121.5" targetFramework="native" />
   <package id="Microsoft.Windows.ImplementationLibrary" version="1.0.220914.1" targetFramework="native" />
 </packages>

--- a/test/Common/packages.config
+++ b/test/Common/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.Taef" version="10.75.221207001" targetFramework="native" />
+  <package id="Microsoft.Taef" version="10.58.210222006-develop" targetFramework="native" />
   <package id="Microsoft.Windows.CppWinRT" version="2.0.221121.5" targetFramework="native" />
   <package id="Microsoft.Windows.ImplementationLibrary" version="1.0.220914.1" targetFramework="native" />
 </packages>

--- a/test/Deployment/API/packages.config
+++ b/test/Deployment/API/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.Taef" version="10.75.221207001" targetFramework="native" />
+  <package id="Microsoft.Taef" version="10.58.210222006-develop" targetFramework="native" />
   <package id="Microsoft.Windows.CppWinRT" version="2.0.221121.5" targetFramework="native" />
   <package id="Microsoft.Windows.ImplementationLibrary" version="1.0.220914.1" targetFramework="native" />
 </packages>

--- a/test/DynamicDependency/Test_Win32/packages.config
+++ b/test/DynamicDependency/Test_Win32/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.Taef" version="10.75.221207001" targetFramework="native" />
+  <package id="Microsoft.Taef" version="10.58.210222006-develop" targetFramework="native" />
 </packages>

--- a/test/DynamicDependency/Test_WinRT/packages.config
+++ b/test/DynamicDependency/Test_WinRT/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.Taef" version="10.75.221207001" targetFramework="native" />
+  <package id="Microsoft.Taef" version="10.58.210222006-develop" targetFramework="native" />
 </packages>

--- a/test/EnvironmentManagerTests/packages.config
+++ b/test/EnvironmentManagerTests/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.Taef" version="10.75.221207001" targetFramework="native" />
+  <package id="Microsoft.Taef" version="10.58.210222006-develop" targetFramework="native" />
   <package id="Microsoft.Windows.CppWinRT" version="2.0.221121.5" targetFramework="native" />
   <package id="Microsoft.Windows.ImplementationLibrary" version="1.0.220914.1" targetFramework="native" />
 </packages>

--- a/test/Kozani/KozaniAppGraphTests/packages.config
+++ b/test/Kozani/KozaniAppGraphTests/packages.config
@@ -3,7 +3,7 @@
   <package id="Microsoft.Build.Tasks.Git" version="1.1.1" targetFramework="native" developmentDependency="true" />
   <package id="Microsoft.SourceLink.Common" version="1.1.1" targetFramework="native" developmentDependency="true" />
   <package id="Microsoft.SourceLink.GitHub" version="1.1.1" targetFramework="native" developmentDependency="true" />
-  <package id="Microsoft.Taef" version="10.75.221207001" targetFramework="native" />
+  <package id="Microsoft.Taef" version="10.58.210222006-develop" targetFramework="native" />
   <package id="Microsoft.Windows.CppWinRT" version="2.0.221121.5" targetFramework="native" />
   <package id="Microsoft.Windows.ImplementationLibrary" version="1.0.220914.1" targetFramework="native" />
 </packages>

--- a/test/Kozani/KozaniHostRuntimeTests/packages.config
+++ b/test/Kozani/KozaniHostRuntimeTests/packages.config
@@ -3,7 +3,7 @@
   <package id="Microsoft.Build.Tasks.Git" version="1.1.1" targetFramework="native" developmentDependency="true" />
   <package id="Microsoft.SourceLink.Common" version="1.1.1" targetFramework="native" developmentDependency="true" />
   <package id="Microsoft.SourceLink.GitHub" version="1.1.1" targetFramework="native" developmentDependency="true" />
-  <package id="Microsoft.Taef" version="10.75.221207001" targetFramework="native" />
+  <package id="Microsoft.Taef" version="10.58.210222006-develop" targetFramework="native" />
   <package id="Microsoft.Windows.CppWinRT" version="2.0.221121.5" targetFramework="native" />
   <package id="Microsoft.Windows.ImplementationLibrary" version="1.0.220914.1" targetFramework="native" />
 </packages>

--- a/test/Kozani/KozaniManagerRuntimeTests/packages.config
+++ b/test/Kozani/KozaniManagerRuntimeTests/packages.config
@@ -3,7 +3,7 @@
   <package id="Microsoft.Build.Tasks.Git" version="1.1.1" targetFramework="native" developmentDependency="true" />
   <package id="Microsoft.SourceLink.Common" version="1.1.1" targetFramework="native" developmentDependency="true" />
   <package id="Microsoft.SourceLink.GitHub" version="1.1.1" targetFramework="native" developmentDependency="true" />
-  <package id="Microsoft.Taef" version="10.75.221207001" targetFramework="native" />
+  <package id="Microsoft.Taef" version="10.58.210222006-develop" targetFramework="native" />
   <package id="Microsoft.Windows.CppWinRT" version="2.0.221121.5" targetFramework="native" />
   <package id="Microsoft.Windows.ImplementationLibrary" version="1.0.220914.1" targetFramework="native" />
 </packages>

--- a/test/Kozani/KozaniManagerTests/packages.config
+++ b/test/Kozani/KozaniManagerTests/packages.config
@@ -3,7 +3,7 @@
   <package id="Microsoft.Build.Tasks.Git" version="1.1.1" targetFramework="native" developmentDependency="true" />
   <package id="Microsoft.SourceLink.Common" version="1.1.1" targetFramework="native" developmentDependency="true" />
   <package id="Microsoft.SourceLink.GitHub" version="1.1.1" targetFramework="native" developmentDependency="true" />
-  <package id="Microsoft.Taef" version="10.75.221207001" targetFramework="native" />
+  <package id="Microsoft.Taef" version="10.58.210222006-develop" targetFramework="native" />
   <package id="Microsoft.Windows.CppWinRT" version="2.0.221121.5" targetFramework="native" />
   <package id="Microsoft.Windows.ImplementationLibrary" version="1.0.220914.1" targetFramework="native" />
 </packages>

--- a/test/Kozani/KozaniPackageTests/packages.config
+++ b/test/Kozani/KozaniPackageTests/packages.config
@@ -3,7 +3,7 @@
   <package id="Microsoft.Build.Tasks.Git" version="1.1.1" targetFramework="native" developmentDependency="true" />
   <package id="Microsoft.SourceLink.Common" version="1.1.1" targetFramework="native" developmentDependency="true" />
   <package id="Microsoft.SourceLink.GitHub" version="1.1.1" targetFramework="native" developmentDependency="true" />
-  <package id="Microsoft.Taef" version="10.75.221207001" targetFramework="native" />
+  <package id="Microsoft.Taef" version="10.58.210222006-develop" targetFramework="native" />
   <package id="Microsoft.Windows.CppWinRT" version="2.0.221121.5" targetFramework="native" />
   <package id="Microsoft.Windows.ImplementationLibrary" version="1.0.220914.1" targetFramework="native" />
 </packages>

--- a/test/Kozani/KozaniRemoteManagerTests/packages.config
+++ b/test/Kozani/KozaniRemoteManagerTests/packages.config
@@ -3,7 +3,7 @@
   <package id="Microsoft.Build.Tasks.Git" version="1.1.1" targetFramework="native" developmentDependency="true" />
   <package id="Microsoft.SourceLink.Common" version="1.1.1" targetFramework="native" developmentDependency="true" />
   <package id="Microsoft.SourceLink.GitHub" version="1.1.1" targetFramework="native" developmentDependency="true" />
-  <package id="Microsoft.Taef" version="10.75.221207001" targetFramework="native" />
+  <package id="Microsoft.Taef" version="10.58.210222006-develop" targetFramework="native" />
   <package id="Microsoft.Windows.CppWinRT" version="2.0.221121.5" targetFramework="native" />
   <package id="Microsoft.Windows.ImplementationLibrary" version="1.0.220914.1" targetFramework="native" />
 </packages>

--- a/test/Kozani/KozaniSendToLocalTests/packages.config
+++ b/test/Kozani/KozaniSendToLocalTests/packages.config
@@ -3,7 +3,7 @@
   <package id="Microsoft.Build.Tasks.Git" version="1.1.1" targetFramework="native" developmentDependency="true" />
   <package id="Microsoft.SourceLink.Common" version="1.1.1" targetFramework="native" developmentDependency="true" />
   <package id="Microsoft.SourceLink.GitHub" version="1.1.1" targetFramework="native" developmentDependency="true" />
-  <package id="Microsoft.Taef" version="10.75.221207001" targetFramework="native" />
+  <package id="Microsoft.Taef" version="10.58.210222006-develop" targetFramework="native" />
   <package id="Microsoft.Windows.CppWinRT" version="2.0.221121.5" targetFramework="native" />
   <package id="Microsoft.Windows.ImplementationLibrary" version="1.0.220914.1" targetFramework="native" />
 </packages>

--- a/test/Kozani/KozaniSendToRemoteTests/packages.config
+++ b/test/Kozani/KozaniSendToRemoteTests/packages.config
@@ -3,7 +3,7 @@
   <package id="Microsoft.Build.Tasks.Git" version="1.1.1" targetFramework="native" developmentDependency="true" />
   <package id="Microsoft.SourceLink.Common" version="1.1.1" targetFramework="native" developmentDependency="true" />
   <package id="Microsoft.SourceLink.GitHub" version="1.1.1" targetFramework="native" developmentDependency="true" />
-  <package id="Microsoft.Taef" version="10.75.221207001" targetFramework="native" />
+  <package id="Microsoft.Taef" version="10.58.210222006-develop" targetFramework="native" />
   <package id="Microsoft.Windows.CppWinRT" version="2.0.221121.5" targetFramework="native" />
   <package id="Microsoft.Windows.ImplementationLibrary" version="1.0.220914.1" targetFramework="native" />
 </packages>

--- a/test/Kozani/KozaniSettingsTests/packages.config
+++ b/test/Kozani/KozaniSettingsTests/packages.config
@@ -3,7 +3,7 @@
   <package id="Microsoft.Build.Tasks.Git" version="1.1.1" targetFramework="native" developmentDependency="true" />
   <package id="Microsoft.SourceLink.Common" version="1.1.1" targetFramework="native" developmentDependency="true" />
   <package id="Microsoft.SourceLink.GitHub" version="1.1.1" targetFramework="native" developmentDependency="true" />
-  <package id="Microsoft.Taef" version="10.75.221207001" targetFramework="native" />
+  <package id="Microsoft.Taef" version="10.58.210222006-develop" targetFramework="native" />
   <package id="Microsoft.Windows.CppWinRT" version="2.0.221121.5" targetFramework="native" />
   <package id="Microsoft.Windows.ImplementationLibrary" version="1.0.220914.1" targetFramework="native" />
 </packages>

--- a/test/Kozani/MakeMSIXTests/packages.config
+++ b/test/Kozani/MakeMSIXTests/packages.config
@@ -3,7 +3,7 @@
   <package id="Microsoft.Build.Tasks.Git" version="1.1.1" targetFramework="native" developmentDependency="true" />
   <package id="Microsoft.SourceLink.Common" version="1.1.1" targetFramework="native" developmentDependency="true" />
   <package id="Microsoft.SourceLink.GitHub" version="1.1.1" targetFramework="native" developmentDependency="true" />
-  <package id="Microsoft.Taef" version="10.75.221207001" targetFramework="native" />
+  <package id="Microsoft.Taef" version="10.58.210222006-develop" targetFramework="native" />
   <package id="Microsoft.Windows.CppWinRT" version="2.0.221121.5" targetFramework="native" />
   <package id="Microsoft.Windows.ImplementationLibrary" version="1.0.220914.1" targetFramework="native" />
 </packages>

--- a/test/LRPTests/packages.config
+++ b/test/LRPTests/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.Taef" version="10.75.221207001" targetFramework="native" />
+  <package id="Microsoft.Taef" version="10.58.210222006-develop" targetFramework="native" />
   <package id="Microsoft.Windows.CppWinRT" version="2.0.221121.5" targetFramework="native" />
   <package id="Microsoft.Windows.ImplementationLibrary" version="1.0.220914.1" targetFramework="native" />
 </packages>

--- a/test/PowerNotifications/packages.config
+++ b/test/PowerNotifications/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.Taef" version="10.75.221207001" targetFramework="native" />
+  <package id="Microsoft.Taef" version="10.58.210222006-develop" targetFramework="native" />
   <package id="Microsoft.Windows.CppWinRT" version="2.0.221121.5" targetFramework="native" />
   <package id="Microsoft.Windows.ImplementationLibrary" version="1.0.220914.1" targetFramework="native" />
 </packages>

--- a/test/PushNotificationTests/packages.config
+++ b/test/PushNotificationTests/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.Taef" version="10.75.221207001" targetFramework="native" />
+  <package id="Microsoft.Taef" version="10.58.210222006-develop" targetFramework="native" />
   <package id="Microsoft.Windows.CppWinRT" version="2.0.221121.5" targetFramework="native" />
   <package id="Microsoft.Windows.ImplementationLibrary" version="1.0.220914.1" targetFramework="native" />
 </packages>

--- a/test/TestApps/AccessControlTestApp/packages.config
+++ b/test/TestApps/AccessControlTestApp/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.Taef" version="10.75.221207001" targetFramework="native" />
+  <package id="Microsoft.Taef" version="10.58.210222006-develop" targetFramework="native" />
   <package id="Microsoft.Windows.CppWinRT" version="2.0.221121.5" targetFramework="native" />
   <package id="Microsoft.Windows.ImplementationLibrary" version="1.0.220914.1" targetFramework="native" />
 </packages>

--- a/test/TestApps/AppLifecycleTestApp/packages.config
+++ b/test/TestApps/AppLifecycleTestApp/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.Taef" version="10.75.221207001" targetFramework="native" />
+  <package id="Microsoft.Taef" version="10.58.210222006-develop" targetFramework="native" />
   <package id="Microsoft.Windows.CppWinRT" version="2.0.221121.5" targetFramework="native" />
   <package id="Microsoft.Windows.ImplementationLibrary" version="1.0.220914.1" targetFramework="native" />
 </packages>

--- a/test/TestApps/ManualTestApp/packages.config
+++ b/test/TestApps/ManualTestApp/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.Taef" version="10.75.221207001" targetFramework="native" />
+  <package id="Microsoft.Taef" version="10.58.210222006-develop" targetFramework="native" />
   <package id="Microsoft.Windows.CppWinRT" version="2.0.221121.5" targetFramework="native" />
   <package id="Microsoft.Windows.ImplementationLibrary" version="1.0.220914.1" targetFramework="native" />
 </packages>

--- a/test/TestApps/PushNotificationsDemoApp/packages.config
+++ b/test/TestApps/PushNotificationsDemoApp/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.Taef" version="10.75.221207001" targetFramework="native" />
+  <package id="Microsoft.Taef" version="10.58.210222006-develop" targetFramework="native" />
   <package id="Microsoft.Windows.CppWinRT" version="2.0.221121.5" targetFramework="native" />
   <package id="Microsoft.Windows.ImplementationLibrary" version="1.0.220914.1" targetFramework="native" />
 </packages>

--- a/test/TestApps/PushNotificationsTestApp/packages.config
+++ b/test/TestApps/PushNotificationsTestApp/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.Taef" version="10.75.221207001" targetFramework="native" />
+  <package id="Microsoft.Taef" version="10.58.210222006-develop" targetFramework="native" />
   <package id="Microsoft.Windows.CppWinRT" version="2.0.221121.5" targetFramework="native" />
   <package id="Microsoft.Windows.ImplementationLibrary" version="1.0.220914.1" targetFramework="native" />
 </packages>

--- a/test/TestApps/ToastNotificationsDemoApp/packages.config
+++ b/test/TestApps/ToastNotificationsDemoApp/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.Taef" version="10.75.221207001" targetFramework="native" />
+  <package id="Microsoft.Taef" version="10.58.210222006-develop" targetFramework="native" />
   <package id="Microsoft.Windows.CppWinRT" version="2.0.221121.5" targetFramework="native" />
   <package id="Microsoft.Windows.ImplementationLibrary" version="1.0.220914.1" targetFramework="native" />
 </packages>

--- a/test/TestApps/ToastNotificationsTestApp/packages.config
+++ b/test/TestApps/ToastNotificationsTestApp/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.Taef" version="10.75.221207001" targetFramework="native" />
+  <package id="Microsoft.Taef" version="10.58.210222006-develop" targetFramework="native" />
   <package id="Microsoft.Windows.CppWinRT" version="2.0.221121.5" targetFramework="native" />
   <package id="Microsoft.Windows.ImplementationLibrary" version="1.0.220914.1" targetFramework="native" />
 </packages>

--- a/test/VersionInfo/packages.config
+++ b/test/VersionInfo/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.Taef" version="10.75.221207001" targetFramework="native" />
+  <package id="Microsoft.Taef" version="10.58.210222006-develop" targetFramework="native" />
   <package id="Microsoft.Windows.CppWinRT" version="2.0.221121.5" targetFramework="native" />
   <package id="Microsoft.Windows.ImplementationLibrary" version="1.0.220914.1" targetFramework="native" />
 </packages>

--- a/tools/ProjectTemplates/test.cpp.dll.taef/packages.config
+++ b/tools/ProjectTemplates/test.cpp.dll.taef/packages.config
@@ -3,7 +3,7 @@
   <package id="Microsoft.Build.Tasks.Git" version="1.1.1" targetFramework="native" developmentDependency="true" />
   <package id="Microsoft.SourceLink.Common" version="1.1.1" targetFramework="native" developmentDependency="true" />
   <package id="Microsoft.SourceLink.GitHub" version="1.1.1" targetFramework="native" developmentDependency="true" />
-  <package id="Microsoft.Taef" version="10.75.221207001" targetFramework="native" />
+  <package id="Microsoft.Taef" version="10.58.210222006-develop" targetFramework="native" />
   <package id="Microsoft.Windows.CppWinRT" version="2.0.221121.5" targetFramework="native" />
   <package id="Microsoft.Windows.ImplementationLibrary" version="1.0.220914.1" targetFramework="native" />
 </packages>


### PR DESCRIPTION
Disable BuildMRT in public CI builds

Microsoft.Taef's version update won't be publicly available for the time being