### PR TITLE
ADO b#44156775 - Updated versions of some tasks

### DIFF
--- a/build/ProjectReunion-CI.yml
+++ b/build/ProjectReunion-CI.yml
@@ -23,12 +23,12 @@ jobs:
       failOnStderr: true
 
   # Scans the root source folder for security vulnerability
-  - task: CredScan@2
+  - task: CredScan@3
     inputs:
-      toolMajorVersion: 'V2'
+      toolMajorVersion: 'Latest'
 
   # This PostAnalysis will fail the pipeline if CredScan identifies an issue
-  - task: PostAnalysis@1
+  - task: PostAnalysis@2
     inputs:
       AllTools: false
       APIScan: false


### PR DESCRIPTION
Updated the CredScan and PostAnalysis tasks to target their newer versions, according to warnings in Guardian logs.

How Built:
- will go through usual PR validation

How tested:
- will observe in official pipeline runs whether the Guardian warnings are gone.
--------

A microsoft employee must use /azp run to validate using the pipelines below.

WARNING:
Comments made by azure-pipelines bot maybe inaccurate. 
Please see pipeline link to verify that the build is being ran.

For status checks on the develop branch, please use TransportPackage-Foundation-PR
(https://microsoft.visualstudio.com/ProjectReunion/_build?definitionId=81063&_a=summary)
and run the build against your PR branch with the default parameters.

For status checks on the main branch, please use microsoft.ProjectReunion
(https://dev.azure.com/ms/ProjectReunion/_build?definitionId=391&_a=summary)
and run the build against your PR branch with the default parameters.