### PR TITLE
Resolve Nuget install error when creating new C++ project using WinAppSDK 1.3 VSIX

### DIFF
--- a/NuGet.config
+++ b/NuGet.config
@@ -12,4 +12,7 @@
   <disabledPackageSources>
     <clear />
   </disabledPackageSources>
+  <fallbackPackageFolders>
+    <clear />
+  </fallbackPackageFolders>
 </configuration>

--- a/eng/common/nuget.config
+++ b/eng/common/nuget.config
@@ -15,4 +15,7 @@
   <disabledPackageSources>
     <clear />
   </disabledPackageSources>
+  <fallbackPackageFolders>
+    <clear />
+  </fallbackPackageFolders>
 </configuration>


### PR DESCRIPTION
This PR addresses https://task.ms/44315588.

In order to support the Nuget template wizard (used for installing Nuget packages into newly created projects that utilize `packages.config`, i.e. our C++ project templates) it is necessary to include all Nuget packages that will be installed in the VSIX's payload. An error will occur during project creation if one of those packages is missing. 

In this case, it turns out that `Microsoft.Windows.SDK.BuildTools` is now included in Visual Studio's shared Nuget package cache (used by Nuget as the default fallback source) which prevents the build from locating the corresponding `.nupkg` for inclusion in the VSIX payload. The solution is to disable the fallback sources in `nuget.config` to ensure that the `.nupkg` will be downloaded and present in the package cache.