### PR TITLE
DevCheck ExitCode if issues detected. Fix dependencies

### DIFF
--- a/DevCheck.ps1
+++ b/DevCheck.ps1
@@ -1384,9 +1384,11 @@ if (($RemoveAll -ne $false) -Or ($RemoveTestPfx -ne $false))
 if ($global:issues -eq 0)
 {
     Write-Output "Coding time!"
+    Exit 0
 }
 else
 {
     $n = $global:issues
     Write-Output "$n issue(s) detected"
+    Exit 2
 }

--- a/test/Kozani/KozaniManagerRuntimeTests/packages.config
+++ b/test/Kozani/KozaniManagerRuntimeTests/packages.config
@@ -3,7 +3,7 @@
   <package id="Microsoft.Build.Tasks.Git" version="1.1.1" targetFramework="native" developmentDependency="true" />
   <package id="Microsoft.SourceLink.Common" version="1.1.1" targetFramework="native" developmentDependency="true" />
   <package id="Microsoft.SourceLink.GitHub" version="1.1.1" targetFramework="native" developmentDependency="true" />
-  <package id="Microsoft.Taef" version="10.58.210222006-develop" targetFramework="native" />
+  <package id="Microsoft.Taef" version="10.75.221207001" targetFramework="native" />
   <package id="Microsoft.Windows.CppWinRT" version="2.0.221121.5" targetFramework="native" />
   <package id="Microsoft.Windows.ImplementationLibrary" version="1.0.220914.1" targetFramework="native" />
 </packages>


### PR DESCRIPTION
DevCheck: set ExitCode to non-zero if 1+ issues detected
Fix KozaniManagerRuntimeTests' Dependencies