### PR TITLE
Change Get-Service calls to ignore errors

### DIFF
--- a/DevCheck.ps1
+++ b/DevCheck.ps1
@@ -755,7 +755,7 @@ function Test-TAEFService
     }
 
     # Double-check the TAEF service is known as a service as far as Windows is concerned
-    $service = Get-Service |Where-Object {$_.Name -eq "TE.Service"}
+    $service = Get-Service -ErrorAction SilentlyContinue | Where-Object {$_.Name -eq "TE.Service"}
     if ([string]::IsNullOrEmpty($service))
     {
         Write-Host "TAEF service...Not Installed"
@@ -812,7 +812,7 @@ function Install-TAEFService
 
     $args = '/install:TE.Service'
     $output = Run-Process $path $args
-    $service = Get-Service |Where-Object {$_.Name -eq "TE.Service"}
+    $service = Get-Service -ErrorAction SilentlyContinue | Where-Object {$_.Name -eq "TE.Service"}
     if ([string]::IsNullOrEmpty($service))
     {
         Write-Host "Install TAEF service...Failed"
@@ -845,7 +845,7 @@ function Uninstall-TAEFService
     $filename = Get-TAEFServiceImagePath
     $args = '/remove:TE.Service'
     $output = Run-Process $filename $args
-    $service = Get-Service |Where-Object {$_.Name -eq "TE.Service"}
+    $service = Get-Service -ErrorAction SilentlyContinue | Where-Object {$_.Name -eq "TE.Service"}
     if (-not([string]::IsNullOrEmpty($service)))
     {
         Write-Host "Uninstall TAEF service...Failed"
@@ -870,7 +870,7 @@ function Start-TAEFService
     }
 
     $ok = Start-Service 'TE.Service'
-    $service = Get-Service |Where-Object {$_.Name -eq "TE.Service"}
+    $service = Get-Service -ErrorAction SilentlyContinue | Where-Object {$_.Name -eq "TE.Service"}
     if ($service.Status -ne "Running")
     {
         Write-Host "Start TAEF service...Failed"
@@ -893,7 +893,7 @@ function Stop-TAEFService
         return $false
     }
 
-    $service = Get-Service |Where-Object {$_.Name -eq "TE.Service"}
+    $service = Get-Service -ErrorAction SilentlyContinue | Where-Object {$_.Name -eq "TE.Service"}
     if ($service -eq $null)
     {
         return 'NotFound'
@@ -902,7 +902,7 @@ function Stop-TAEFService
     {
         $ok = Stop-Service 'TE.Service'
     }
-    $service = Get-Service |Where-Object {$_.Name -eq "TE.Service"}
+    $service = Get-Service -ErrorAction SilentlyContinue | Where-Object {$_.Name -eq "TE.Service"}
     if ($service -eq $null)
     {
         return 'NotFound'


### PR DESCRIPTION
Change Get-Service to ignore errors, for when there's a service that's malformed or would otherwise tank the Get-Service command

A microsoft employee must use /azp run to validate using the pipelines below.

WARNING:
Comments made by azure-pipelines bot maybe inaccurate. 
Please see pipeline link to verify that the build is being ran.

For status checks on the develop branch, please use TransportPackage-Foundation-PR
(https://microsoft.visualstudio.com/ProjectReunion/_build?definitionId=81063&_a=summary)
and run the build against your PR branch with the default parameters.

For status checks on the main branch, please use microsoft.ProjectReunion
(https://dev.azure.com/ms/ProjectReunion/_build?definitionId=391&_a=summary)
and run the build against your PR branch with the default parameters.