### PR TITLE
Make BuildAll.ps1 compatible with VS prerelease installs

### DIFF
--- a/BuildAll.ps1
+++ b/BuildAll.ps1
@@ -68,7 +68,7 @@ if(-not (test-path ".nuget\nuget.exe"))
 $configurationForMrtAndAnyCPU = "Release"
 $MRTSourcesDirectory = "dev\MRTCore"
 
-$VCToolsInstallDir = . "${env:ProgramFiles(x86)}\Microsoft Visual Studio\Installer\vswhere.exe" -Latest -requires Microsoft.Component.MSBuild -property InstallationPath
+$VCToolsInstallDir = . "${env:ProgramFiles(x86)}\Microsoft Visual Studio\Installer\vswhere.exe" -Latest -prerelease -requires Microsoft.Component.MSBuild -property InstallationPath
 write-host "VCToolsInstallDir: $VCToolsInstallDir"
 
 $msBuildPath = "$VCToolsInstallDir\MSBuild\Current\Bin\msbuild.exe"


### PR DESCRIPTION
Small tweak to the `BuildAll.ps1`'s `vswhere` command so it can find and use Visual Studio Preview installations. This allows `BuildAll.cmd/ps1` to actually be usable by people like me who only have a prerelease version of Visual Studio installed.