### PR TITLE
Update Installer exe to include Architecture

### DIFF
--- a/installer/dev/WindowsAppRuntimeInstall.vcxproj
+++ b/installer/dev/WindowsAppRuntimeInstall.vcxproj
@@ -41,6 +41,7 @@
       <Platform>ARM64</Platform>
     </ProjectConfiguration>
   </ItemGroup>
+  <PropertyGroup Label="Globals">
     <TargetName>WindowsAppRuntimeInstall-$(Platform)</TargetName>
   </PropertyGroup>
   <PropertyGroup Label="Configuration">

--- a/installer/dev/WindowsAppRuntimeInstall.vcxproj
+++ b/installer/dev/WindowsAppRuntimeInstall.vcxproj
@@ -13,6 +13,7 @@
     <RootNamespace>WindowsAppRuntimeInstall</RootNamespace>
     <WindowsTargetPlatformVersion Condition=" '$(WindowsTargetPlatformVersion)' == '' ">10.0.22000.0</WindowsTargetPlatformVersion>
     <WindowsTargetPlatformMinVersion>10.0.17763.0</WindowsTargetPlatformMinVersion>
+    <TargetName>WindowsAppRuntimeInstall-</TargetName>
   </PropertyGroup>
   <ItemGroup Label="ProjectConfigurations">
     <ProjectConfiguration Include="Debug|Win32">
@@ -40,6 +41,8 @@
       <Platform>ARM64</Platform>
     </ProjectConfiguration>
   </ItemGroup>
+    <TargetName>WindowsAppRuntimeInstall-$(Platform)</TargetName>
+  </PropertyGroup>
   <PropertyGroup Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <PlatformToolset>v143</PlatformToolset>

--- a/installer/dev/WindowsAppRuntimeInstall.vcxproj
+++ b/installer/dev/WindowsAppRuntimeInstall.vcxproj
@@ -41,8 +41,14 @@
       <Platform>ARM64</Platform>
     </ProjectConfiguration>
   </ItemGroup>
-  <PropertyGroup Label="Globals">
-    <TargetName>WindowsAppRuntimeInstall-$(Platform)</TargetName>
+  <PropertyGroup Label="Globals" Condition="'$(Platform)'=='Win32'">
+    <TargetName>WindowsAppRuntimeInstall-x86</TargetName>
+  </PropertyGroup>
+  <PropertyGroup Label="Globals" Condition="'$(Platform)'=='x64'">
+    <TargetName>WindowsAppRuntimeInstall-x64</TargetName>
+  </PropertyGroup>
+  <PropertyGroup Label="Globals" Condition="'$(Platform)'=='ARM64'">
+    <TargetName>WindowsAppRuntimeInstall-arm64</TargetName>
   </PropertyGroup>
   <PropertyGroup Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>

--- a/installer/test/InstallerFunctionalTests/constants.h
+++ b/installer/test/InstallerFunctionalTests/constants.h
@@ -21,7 +21,7 @@
 
 #define BUILDOUTPUT_DIR L"BuildOutput"
 #define INSTALLER_DIR L"WindowsAppRuntimeInstall"
-#define INSTALLER_FILENAME L"WindowsAppRuntimeInstall.exe"
+#define INSTALLER_FILENAME L"WindowsAppRuntimeInstall" ARCH L"exe"
 #define INSTALLER_EXE_PATH BUILDOUTPUT_DIR L"\\" CONFIGURATION L"\\" ARCH L"\\" INSTALLER_DIR L"\\" INSTALLER_FILENAME
 
 namespace WindowsAppRuntimeInstallerTests

--- a/installer/test/InstallerFunctionalTests/constants.h
+++ b/installer/test/InstallerFunctionalTests/constants.h
@@ -21,7 +21,7 @@
 
 #define BUILDOUTPUT_DIR L"BuildOutput"
 #define INSTALLER_DIR L"WindowsAppRuntimeInstall"
-#define INSTALLER_FILENAME L"WindowsAppRuntimeInstall" ARCH L"exe"
+#define INSTALLER_FILENAME L"WindowsAppRuntimeInstall-" ARCH L"exe"
 #define INSTALLER_EXE_PATH BUILDOUTPUT_DIR L"\\" CONFIGURATION L"\\" ARCH L"\\" INSTALLER_DIR L"\\" INSTALLER_FILENAME
 
 namespace WindowsAppRuntimeInstallerTests


### PR DESCRIPTION
To improve our naming convention, we are updateing Installer exe name to specify architecture to differentiate between each architecture. 

