### PR TITLE
Add /-I to xcopy command to fix build errors.

### DIFF
--- a/build/NuSpecs/WindowsAppSDK-Nuget-Native.C.props
+++ b/build/NuSpecs/WindowsAppSDK-Nuget-Native.C.props
@@ -29,7 +29,7 @@
       </AdditionalDependencies>
     </Link>
     <PostBuildEvent>
-      <Command>xcopy.exe /y "$(MSBuildThisFileDirectory)..\..\runtimes\win10-$(_WindowsAppSDKFoundationPlatform)\native\Microsoft.WindowsAppRuntime.Bootstrap.dll" "$(OutDir)Microsoft.WindowsAppRuntime.Bootstrap.dll"</Command>
+      <Command>xcopy.exe /-I /y "$(MSBuildThisFileDirectory)..\..\runtimes\win10-$(_WindowsAppSDKFoundationPlatform)\native\Microsoft.WindowsAppRuntime.Bootstrap.dll" "$(OutDir)Microsoft.WindowsAppRuntime.Bootstrap.dll"</Command>
     </PostBuildEvent>
   </ItemDefinitionGroup>
 


### PR DESCRIPTION
Commit `e03da672` from Fix #3683 caused build errors in some cases like this:
```
PostBuildEvent:
  xcopy.exe /y "D:\app\Output\Packages\Microsoft.WindowsAppSDK.1.4.230705001-experimental.nightly\build\native\..\..\runtimes\win10-x64\native\Microsoft.WindowsAppRuntime.Bootstrap.dll" "D:\app\Output\Debug\x64\Internal\V7\Bin\appoutput\Microsoft.WindowsAppRuntime.Bootstrap.dll"
  :VCEnd
  Does D:\app\Output\Debug\x64\Internal\V7\Bin\appoutput\Microsoft.WindowsAppRuntime.Bootstrap.dll specify a file name
  or directory name on the target
  (F = file, D = directory)?
```
Adding `/-I` in the xcopy command should fix this by telling it to assume single file in this case.

Note: This `/-I` can cause "insufficient memory" errors if a filename isn't specified. Also note that the GitHub customer had some forward slashes in the output path, which are necessary in order to hit the "insufficient memory" errors. Since this xcopy does specify a filename, though, this problem should not be hit.