### PR TITLE
Udpate CsWinRT and WinAppSDK Depedency versions

### DIFF
--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -41,15 +41,15 @@
       <Uri>https://dev.azure.com/microsoft/ProjectReunion/_git/WindowsAppSDKAggregator</Uri>
       <Sha>4af33042dd35c5b7c41ce901320657a64be2e7ab</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Windows.CsWinRT" Version="2.0.0">
+    <Dependency Name="Microsoft.Windows.CsWinRT" Version="2.0.2">
       <Uri>https://github.com/microsoft/CsWinRT</Uri>
       <Sha>fa7f5565cb53353dc15c28a09ebd500577dc0b72</Sha>
     </Dependency>
-    <Dependency Name="CsWinRT.Dependency.DotNetCoreSdk" Version="6.0.301">
+    <Dependency Name="CsWinRT.Dependency.DotNetCoreSdk" Version="6.0.412">
       <Uri>https://github.com/microsoft/CsWinRT</Uri>
       <Sha>fa7f5565cb53353dc15c28a09ebd500577dc0b72</Sha>
     </Dependency>
-    <Dependency Name="CsWinRT.Dependency.DotNetCoreRuntime" Version="6.0.6">
+    <Dependency Name="CsWinRT.Dependency.DotNetCoreRuntime" Version="6.0.20">
       <Uri>https://github.com/microsoft/CsWinRT</Uri>
       <Sha>fa7f5565cb53353dc15c28a09ebd500577dc0b72</Sha>
     </Dependency>


### PR DESCRIPTION
Basically, to match versions in use by Win UI:

CSWinRT – 2.0.2 (currently 2.0.0)
.NET SDK – 6.0.412 (currently 6.0.301)
.NET Runtime – 6.0.20 (currently 6.0.6)
-----
A microsoft employee must use /azp run to validate using the pipelines below.

WARNING:
Comments made by azure-pipelines bot maybe inaccurate. 
Please see pipeline link to verify that the build is being ran.

For status checks on the develop branch, please use TransportPackage-Foundation-PR
(https://microsoft.visualstudio.com/ProjectReunion/_build?definitionId=81063&_a=summary)
and run the build against your PR branch with the default parameters.

For status checks on the main branch, please use microsoft.ProjectReunion
(https://dev.azure.com/ms/ProjectReunion/_build?definitionId=391&_a=summary)
and run the build against your PR branch with the default parameters.