### PR TITLE
[release/1.4-stable] Use latest C++/WinRT in C++ project templates

### DIFF
--- a/dev/VSIX/Directory.Build.props
+++ b/dev/VSIX/Directory.Build.props
@@ -6,7 +6,7 @@
         <RestoreSources Condition="'$(RestoreSources)'==''">
             https://pkgs.dev.azure.com/microsoft/ProjectReunion/_packaging/Project.Reunion.nuget.internal/nuget/v3/index.json
         </RestoreSources>
-        <CppWinRTVersion Condition="'$(CppWinRTVersion)' == ''">2.0.220929.3</CppWinRTVersion>
+        <CppWinRTVersion Condition="'$(CppWinRTVersion)' == ''">2.0.230706.1</CppWinRTVersion>
         <WindowsSDKBuildToolsVersion Condition="'$(WindowsSDKBuildToolsVersion)' == ''">10.0.22621.755</WindowsSDKBuildToolsVersion>
         <WILVersion Condition="'$(WILVersion)' == ''">1.0.220914.1</WILVersion>
         <!-- Provides a default package version in order to simplify dev inner loop testing -->


### PR DESCRIPTION
(cherry picked from commit 9005d3311dd6c8e80ee7479f117a593e173625d9)

Original PR description (#3729):

> Updating VS project templates to use the latest C++/WinRT Nuget package. The version we were previously using in some cases did not emit the fully-qualified name for types in the function signatures of projected types (e.g. the projection for Microsoft.UI.Xaml.Markup.ComponentConnector; the projected Connect() method had the signature void Connect(int32_t connectionId, Windows::Foundation::IInspectable const& target) rather than void Connect(int32_t connectionId, winrt::Windows::Foundation::IInspectable const& target). Because the Microsoft.UI.Xaml namespace now has an API that consumes a type from the Microsoft.Windows.ApplicationModel.Resources namespace, the non-fully qualified name resulted in a namespace conflict during compilation. The updated version of C++/WinRT introduced by this change addresses that oversight.