### PR TITLE
VSIX Cruft Cherry-Pick 

### DIFF
--- a/dev/VSIX/Extension/Cs/Dev17/WindowsAppSDK.Cs.Extension.Dev17.csproj
+++ b/dev/VSIX/Extension/Cs/Dev17/WindowsAppSDK.Cs.Extension.Dev17.csproj
@@ -39,8 +39,6 @@
     </None>
   </ItemGroup>
   <ItemGroup>
-    <ContentNugetPackages Include="$(PkgMicrosoft_Windows_SDK_BuildTools)\*.nupkg" />
-    <ContentNugetPackages Include="$(PkgMicrosoft_WindowsAppSDK)\*.nupkg" />
     <Content Include="@(ContentNugetPackages)">
       <IncludeInVSIX>true</IncludeInVSIX>
       <VSIXSubPath>Packages</VSIXSubPath>

--- a/dev/VSIX/WindowsAppSDK.Extension.sln
+++ b/dev/VSIX/WindowsAppSDK.Extension.sln
@@ -76,11 +76,7 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "WinUI.Desktop.Cs.SingleProj
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "WinUI.Desktop.CppWinRT.SingleProjectPackagedApp", "ProjectTemplates\Desktop\CppWinRT\SingleProjectPackagedApp\WinUI.Desktop.CppWinRT.SingleProjectPackagedApp.csproj", "{E54D1AD4-E935-479D-8A69-FC073E4DB33D}"
 EndProject
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "WindowsAppSDK.Cs.Extension.Dev16", "Extension\Cs\Dev16\WindowsAppSDK.Cs.Extension.Dev16.csproj", "{EBCE08A8-372E-47B8-88C4-24EEA650C44A}"
-EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "WindowsAppSDK.Cs.Extension.Dev17", "Extension\Cs\Dev17\WindowsAppSDK.Cs.Extension.Dev17.csproj", "{E700DF09-42A9-4AC7-9855-400029FBFDBE}"
-EndProject
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "WindowsAppSDK.Cpp.Extension.Dev16", "Extension\Cpp\Dev16\WindowsAppSDK.Cpp.Extension.Dev16.csproj", "{7C5EAFA9-BDB7-4A2E-A9CF-2AE62352B75A}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "WindowsAppSDK.Cpp.Extension.Dev17", "Extension\Cpp\Dev17\WindowsAppSDK.Cpp.Extension.Dev17.csproj", "{85E88201-049C-4E42-AE85-DFEEFA7C533C}"
 EndProject
@@ -236,14 +232,6 @@ Global
 		{E54D1AD4-E935-479D-8A69-FC073E4DB33D}.Release|Any CPU.Build.0 = Release|Any CPU
 		{E54D1AD4-E935-479D-8A69-FC073E4DB33D}.Release|x64.ActiveCfg = Release|Any CPU
 		{E54D1AD4-E935-479D-8A69-FC073E4DB33D}.Release|x64.Build.0 = Release|Any CPU
-		{EBCE08A8-372E-47B8-88C4-24EEA650C44A}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{EBCE08A8-372E-47B8-88C4-24EEA650C44A}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{EBCE08A8-372E-47B8-88C4-24EEA650C44A}.Debug|x64.ActiveCfg = Debug|Any CPU
-		{EBCE08A8-372E-47B8-88C4-24EEA650C44A}.Debug|x64.Build.0 = Debug|Any CPU
-		{EBCE08A8-372E-47B8-88C4-24EEA650C44A}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{EBCE08A8-372E-47B8-88C4-24EEA650C44A}.Release|Any CPU.Build.0 = Release|Any CPU
-		{EBCE08A8-372E-47B8-88C4-24EEA650C44A}.Release|x64.ActiveCfg = Release|Any CPU
-		{EBCE08A8-372E-47B8-88C4-24EEA650C44A}.Release|x64.Build.0 = Release|Any CPU
 		{E700DF09-42A9-4AC7-9855-400029FBFDBE}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{E700DF09-42A9-4AC7-9855-400029FBFDBE}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{E700DF09-42A9-4AC7-9855-400029FBFDBE}.Debug|x64.ActiveCfg = Debug|Any CPU
@@ -252,14 +240,6 @@ Global
 		{E700DF09-42A9-4AC7-9855-400029FBFDBE}.Release|Any CPU.Build.0 = Release|Any CPU
 		{E700DF09-42A9-4AC7-9855-400029FBFDBE}.Release|x64.ActiveCfg = Release|Any CPU
 		{E700DF09-42A9-4AC7-9855-400029FBFDBE}.Release|x64.Build.0 = Release|Any CPU
-		{7C5EAFA9-BDB7-4A2E-A9CF-2AE62352B75A}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{7C5EAFA9-BDB7-4A2E-A9CF-2AE62352B75A}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{7C5EAFA9-BDB7-4A2E-A9CF-2AE62352B75A}.Debug|x64.ActiveCfg = Debug|Any CPU
-		{7C5EAFA9-BDB7-4A2E-A9CF-2AE62352B75A}.Debug|x64.Build.0 = Debug|Any CPU
-		{7C5EAFA9-BDB7-4A2E-A9CF-2AE62352B75A}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{7C5EAFA9-BDB7-4A2E-A9CF-2AE62352B75A}.Release|Any CPU.Build.0 = Release|Any CPU
-		{7C5EAFA9-BDB7-4A2E-A9CF-2AE62352B75A}.Release|x64.ActiveCfg = Release|Any CPU
-		{7C5EAFA9-BDB7-4A2E-A9CF-2AE62352B75A}.Release|x64.Build.0 = Release|Any CPU
 		{85E88201-049C-4E42-AE85-DFEEFA7C533C}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{85E88201-049C-4E42-AE85-DFEEFA7C533C}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{85E88201-049C-4E42-AE85-DFEEFA7C533C}.Debug|x64.ActiveCfg = Debug|Any CPU


### PR DESCRIPTION
This cherry pick implements the removal of VSIX Cruft and drops support for older versions of Visual Studio. 

Original PR: https://github.com/microsoft/WindowsAppSDK/pull/3739. 