### PR TITLE
Fix crashes in the installer

### DIFF
--- a/installer/dev/InstallActivityContext.h
+++ b/installer/dev/InstallActivityContext.h
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft Corporation and Contributors.
+// Copyright (c) Microsoft Corporation and Contributors.
 // Licensed under the MIT License.
 
 #pragma once
@@ -137,7 +137,7 @@ namespace WindowsAppRuntimeInstaller::InstallActivity
             return m_hEventLog;
         }
 
-        const BOOL& DeregisterInstallerEventSourceW()
+        const BOOL DeregisterInstallerEventSourceW()
         {
             return DeregisterEventSource(m_hEventLog);
         }

--- a/installer/dev/install.cpp
+++ b/installer/dev/install.cpp
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft Corporation and Contributors.
+// Copyright (c) Microsoft Corporation and Contributors.
 // Licensed under the MIT License.
 
 #include "pch.h"
@@ -35,6 +35,8 @@ namespace WindowsAppRuntimeInstaller
 
             RETURN_HR(static_cast<HRESULT>(deploymentResult.ExtendedErrorCode() ? deploymentResult.ExtendedErrorCode() : deploymentOperation.ErrorCode()));
         }
+
+        return S_OK;
     }
 
     HRESULT RegisterPackage(


### PR DESCRIPTION
Fix crashes in the installer, which appears to account for 95%+ of crashes in WindowsAppRuntimeInstall.exe.

Errors fixed:
* InstallActivityContext.cpp was passing an hstring to StringCchPrintf for the activity Id. **Fix**: call ".data()" on the hstring to properly pass the WCHAR*.
* InstallActivityContext.cpp was passing std::wstring to StringCchPrintf for the resource (package) id and error text. **Fix**: call ".c_str()" on the std::wstring to properly pass the WCHAR*.
* InstallActivityContext.cpp for ProvisionPackage failures wasn't passing the resource/package id for one of the "%s" arguments. **Fix**: Pass m_currentResourceId.c_str() for that argument.
* InstallActivityContext.cpp for StagePackage failures was passing a GUID for one of the "%s" arguments. **Fix**: convert the GUID to a string, like is done for active Ids elsewhere.
* GetAndLogDeploymentOperationResult() didn't always return a value. **Fix**: put back the "return S_OK" which was removed in a previous change.
* DeregisterInstallerEventSourceW() was returning a "const BOOL&", which was a reference to a stack variable. **Fix**: Fixed that   compiler warning by making it not a reference.

This change is intended to address issues reported in #3760.