### PR TITLE
Update WindowsAppSDK-RunTestsInPipeline-Job.yml

### DIFF
--- a/build/AzurePipelinesTemplates/WindowsAppSDK-RunTestsInPipeline-Job.yml
+++ b/build/AzurePipelinesTemplates/WindowsAppSDK-RunTestsInPipeline-Job.yml
@@ -53,11 +53,6 @@ jobs:
           buildPlatform: x64
           buildConfiguration: release
           testLocale: ja-JP
-        21H1_x64fre:
-          imageName: Windows.10.Enterprise.21h1
-          buildPlatform: x64
-          buildConfiguration: release
-          testLocale: en-US
         21H2_MS_x64fre:
           imageName: Windows.11.Enterprise.MultiSession.21h2
           buildPlatform: x64


### PR DESCRIPTION
Stop running tests on 21h1 OS image because this version has reached end of support, and the image is no longer in the test VM pool.
-----------------------------------
A microsoft employee must use /azp run to validate using the pipelines below.

WARNING:
Comments made by azure-pipelines bot maybe inaccurate. 
Please see pipeline link to verify that the build is being ran.

For status checks on the develop branch, please use TransportPackage-Foundation-PR
(https://microsoft.visualstudio.com/ProjectReunion/_build?definitionId=81063&_a=summary)
and run the build against your PR branch with the default parameters.

For status checks on the main branch, please use microsoft.ProjectReunion
(https://dev.azure.com/ms/ProjectReunion/_build?definitionId=391&_a=summary)
and run the build against your PR branch with the default parameters.