### PR TITLE
Fix WinAppSDK Version Schema on WinAppSDKIntegrationBuildAndTest

### DIFF
--- a/build/AzurePipelinesTemplates/WindowsAppSDK-BuildTransportPackage-Stage.yml
+++ b/build/AzurePipelinesTemplates/WindowsAppSDK-BuildTransportPackage-Stage.yml
@@ -174,7 +174,7 @@ stages:
       name: 'ProjectReunionESPool-2022'
     variables:
       WindowsAppSDKTransportPackageVersion: $[ dependencies.NugetPackage.outputs['SetVersion.packageVersion'] ]
-      VersionWithDevTag: $[format('{0}.{1}.{2}-{3}.{4}.{5}', variables['major'], variables['minor'], variables['patch'], 'dev', variables['versionDate'], variables['versionCounter'])]
+      VersionWithDevTag: $[format('{0}.{1}.{2}-{3}', variables['major'], variables['minor'], variables['versionDate'], 'dev')]
       ob_outputDirectory: '$(REPOROOT)\out'
       ob_artifactBaseName: "WindowsAppSDKNugetPackage"
     steps:


### PR DESCRIPTION
A change in Buildall.ps1 in the Aggregator now properly passes the VersionTag which is now causing issues with any version tag that has a '.' char 