### PR TITLE
Improve MRTCore build reliability

### DIFF
--- a/build/AzurePipelinesTemplates/WindowsAppSDK-BuildMRT-Steps.yml
+++ b/build/AzurePipelinesTemplates/WindowsAppSDK-BuildMRT-Steps.yml
@@ -47,6 +47,7 @@ steps:
 - ${{ if not( parameters.RunPrefast ) }}:
   - task: PowerShell@2
     name: BuildBinaries
+    retryCountOnTaskFailure: 10
     inputs:
       filePath: 'BuildAll.ps1'
       arguments: -Platform "$(buildPlatform)" -Configuration "$(buildConfiguration)" -AzureBuildStep "BuildMRT"


### PR DESCRIPTION
Improve MRTCore build reliability by adding retry on build task. 

This stage has been failing with 
  C:\__w\_temp\codeql3000\d\cpp\working/tmp/2b2bea2d-680e-4ece-8bea-034b1315f03a.c(1): error C2118: negative subscript [C:\__w\1\s\dev\MRTCore\mrt\Microsoft.Windows.ApplicationModel.Resources\src\Microsoft.Windows.ApplicationModel.Resources.vcxproj]
from time to time