### PR TITLE
Add auto initializer sources without a target, and define a user-available property to add WindowsAppSDK-VersionInfo.cs exactly once

### DIFF
--- a/build/AzurePipelinesTemplates/WindowsAppSDK-RunTestsInPipeline-Job.yml
+++ b/build/AzurePipelinesTemplates/WindowsAppSDK-RunTestsInPipeline-Job.yml
@@ -53,11 +53,6 @@ jobs:
           buildPlatform: x64
           buildConfiguration: release
           testLocale: ja-JP
-        21H1_x64fre:
-          imageName: Windows.10.Enterprise.21h1
-          buildPlatform: x64
-          buildConfiguration: release
-          testLocale: en-US
         21H2_MS_x64fre:
           imageName: Windows.11.Enterprise.MultiSession.21h2
           buildPlatform: x64

--- a/build/NuSpecs/Microsoft.WindowsAppSDK.Bootstrap.CS.targets
+++ b/build/NuSpecs/Microsoft.WindowsAppSDK.Bootstrap.CS.targets
@@ -8,13 +8,14 @@
         <DefineConstants Condition="'$(WindowsAppSDKBootstrapAutoInitializeOptions_OnError_FailFast)'=='true'">$(DefineConstants);MICROSOFT_WINDOWSAPPSDK_BOOTSTRAP_AUTO_INITIALIZE_OPTIONS_ONERROR_FAILFAST</DefineConstants>
         <DefineConstants Condition="'$(WindowsAppSDKBootstrapAutoInitializeOptions_OnNoMatch_ShowUI)'=='true'">$(DefineConstants);MICROSOFT_WINDOWSAPPSDK_BOOTSTRAP_AUTO_INITIALIZE_OPTIONS_ONNOMATCH_SHOWUI</DefineConstants>
         <DefineConstants Condition="'$(WindowsAppSDKBootstrapAutoInitializeOptions_OnPackageIdentity_NoOp)'=='true'">$(DefineConstants);MICROSOFT_WINDOWSAPPSDK_BOOTSTRAP_AUTO_INITIALIZE_OPTIONS_ONPACKAGEIDENTITY_NOOP</DefineConstants>
+        <WindowsAppSdkIncludeVersionInfo>true</WindowsAppSdkIncludeVersionInfo>
     </PropertyGroup>
 
-    <Target Name="GenerateBootstrapCS" BeforeTargets="BeforeCompile">
-        <ItemGroup>
-            <Compile Include="$(MSBuildThisFileDirectory)..\include\MddBootstrapAutoInitializer.cs" />
-            <Compile Include="$(MSBuildThisFileDirectory)..\include\WindowsAppSDK-VersionInfo.cs" />
-        </ItemGroup>
-    </Target>
+    <ItemGroup>
+        <Compile Include="$(MSBuildThisFileDirectory)..\include\MddBootstrapAutoInitializer.cs" />
+    </ItemGroup>
+
+    <!--Obsolete target retained to prevent build breaks-->
+    <Target Name="GenerateBootstrapCS" BeforeTargets="BeforeCompile" />
 
 </Project>

--- a/build/NuSpecs/Microsoft.WindowsAppSDK.DeploymentManager.CS.targets
+++ b/build/NuSpecs/Microsoft.WindowsAppSDK.DeploymentManager.CS.targets
@@ -4,13 +4,14 @@
         <DefineConstants Condition="'$(WindowsAppSDKDeploymentManagerAutoInitializeOptions_Default)'=='true'">$(DefineConstants);MICROSOFT_WINDOWSAPPSDK_DEPLOYMENTMANAGER_AUTO_INITIALIZE_OPTIONS_DEFAULT</DefineConstants>
         <DefineConstants Condition="'$(WindowsAppSDKDeploymentManagerAutoInitializeOptions_None)'=='true'">$(DefineConstants);MICROSOFT_WINDOWSAPPSDK_DEPLOYMENTMANAGER_AUTO_INITIALIZE_OPTIONS_NONE</DefineConstants>
         <DefineConstants Condition="'$(WindowsAppSDKDeploymentManagerAutoInitializeOptions_OnErrorShowUI)'=='true'">$(DefineConstants);MICROSOFT_WINDOWSAPPSDK_DEPLOYMENTMANAGER_AUTO_INITIALIZE_OPTIONS_ONERRORSHOWUI</DefineConstants>
+        <WindowsAppSdkIncludeVersionInfo>true</WindowsAppSdkIncludeVersionInfo>
     </PropertyGroup>
 
-    <Target Name="GenerateDeploymentManagerCS" BeforeTargets="BeforeCompile">
-        <ItemGroup>
-            <Compile Include="$(MSBuildThisFileDirectory)..\include\DeploymentManagerAutoInitializer.cs" />
-            <Compile Include="$(MSBuildThisFileDirectory)..\include\WindowsAppSDK-VersionInfo.cs" />
-        </ItemGroup>
-    </Target>
+    <ItemGroup>
+        <Compile Include="$(MSBuildThisFileDirectory)..\include\DeploymentManagerAutoInitializer.cs" />
+    </ItemGroup>
+
+    <!--Obsolete target retained to prevent build breaks-->
+    <Target Name="GenerateDeploymentManagerCS" BeforeTargets="BeforeCompile" />
 
 </Project>

--- a/build/NuSpecs/Microsoft.WindowsAppSDK.Foundation.targets
+++ b/build/NuSpecs/Microsoft.WindowsAppSDK.Foundation.targets
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <!-- Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT License. See LICENSE in the project root for license information. -->
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 
@@ -12,5 +12,9 @@
 
   <Import Project="$(MSBuildThisFileDirectory)Microsoft.WindowsAppSDK.DeploymentManagerCommon.targets" />
   <Import Project="$(MSBuildThisFileDirectory)Microsoft.WindowsAppSDK.DeploymentManager.CS.targets" Condition="'$(WindowsAppSdkDeploymentManagerInitialize)' == 'true'"/>
+
+  <ItemGroup>
+    <Compile Condition="'$(WindowsAppSdkIncludeVersionInfo)'=='true'" Include="$(MSBuildThisFileDirectory)..\include\WindowsAppSDK-VersionInfo.cs" />
+  </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Cherry-pick for 1.4.2 servicing. This fix enables removal of [this workaround](https://github.com/microsoft/WinUI-Gallery/blob/258d8c8b033b456689675b5f76cf66f62d5c300a/WinUIGallery/WinUIGallery.csproj#L251C39-L251C39).