### PR TITLE
Only Publish NuGet Package to Feed in Release and Nightly Builds

### DIFF
--- a/build/AzurePipelinesTemplates/WindowsAppSDK-BuildTransportPackage-Stage.yml
+++ b/build/AzurePipelinesTemplates/WindowsAppSDK-BuildTransportPackage-Stage.yml
@@ -2,6 +2,9 @@ parameters:
 - name: "PublishToMaestro"
   type: boolean
   default: False
+- name: "PublishPackage"
+  type: boolean
+  default: False
 - name: "IgnoreFailures"
   type: boolean
   default: False
@@ -163,6 +166,7 @@ stages:
       parameters:
         SignOutput: ${{ parameters.SignOutput }}
         IsOneBranch: ${{ parameters.IsOneBranch }}
+        PublishPackage: ${{ parameters.PublishPackage }}
 
   # Build WinAppSDK and Run Integration Test from TestAll.ps1
   - job: WinAppSDKIntegrationBuildAndTest

--- a/build/AzurePipelinesTemplates/WindowsAppSDK-PackNuget-Steps.yml
+++ b/build/AzurePipelinesTemplates/WindowsAppSDK-PackNuget-Steps.yml
@@ -2,6 +2,9 @@ parameters:
 - name: "SignOutput"
   type: boolean
   default: False
+- name: "PublishPackage"
+  type: boolean
+  default: False
 - name: "IsOneBranch"
   type: boolean
   default: True
@@ -162,13 +165,14 @@ steps:
       PathtoPublish: '$(ob_outputDirectory)'
       artifactName: '$(ob_artifactBaseName)'
 
-# this mysterious guid fixes the "NuGetCommand@2 is ambiguous" error :-(
-- task: 333b11bd-d341-40d9-afcf-b32d5ce6f23b@2
-  displayName: 'NuGet push to ProjectReunion.nuget.internal'
-  inputs:
-    command: 'push'
-    packagesToPush: '$(ob_outputDirectory)\TransportPackage\*.nupkg'
-    verbosityPush: 'Detailed'
-    nuGetFeedType: 'internal'
-    #Note: The project qualifier is always required when using a feed name. Also, do not use organization scoped feeds.
-    publishVstsFeed: 'ProjectReunion/Project.Reunion.nuget.internal'
+- ${{ if eq(parameters.PublishPackage, 'true') }}:
+  # this mysterious guid fixes the "NuGetCommand@2 is ambiguous" error :-(
+  - task: 333b11bd-d341-40d9-afcf-b32d5ce6f23b@2
+    displayName: 'NuGet push to ProjectReunion.nuget.internal'
+    inputs:
+      command: 'push'
+      packagesToPush: '$(ob_outputDirectory)\TransportPackage\*.nupkg'
+      verbosityPush: 'Detailed'
+      nuGetFeedType: 'internal'
+      #Note: The project qualifier is always required when using a feed name. Also, do not use organization scoped feeds.
+      publishVstsFeed: 'ProjectReunion/Project.Reunion.nuget.internal'

--- a/build/AzurePipelinesTemplates/WindowsAppSDK-PackNuget-Steps.yml
+++ b/build/AzurePipelinesTemplates/WindowsAppSDK-PackNuget-Steps.yml
@@ -157,7 +157,7 @@ steps:
   displayName: MoveToOutputDirectory
   inputs:
     SourceFolder: '$(build.artifactStagingDirectory)\FullNuget'
-    TargetFolder: '$(ob_outputDirectory)\TransportPackage'
+    TargetFolder: '$(ob_outputDirectory)'
 
 - ${{ if not( parameters.IsOneBranch ) }}:
   - task: PublishBuildArtifacts@1
@@ -171,7 +171,7 @@ steps:
     displayName: 'NuGet push to ProjectReunion.nuget.internal'
     inputs:
       command: 'push'
-      packagesToPush: '$(ob_outputDirectory)\TransportPackage\*.nupkg'
+      packagesToPush: '$(ob_outputDirectory)\*.nupkg'
       verbosityPush: 'Detailed'
       nuGetFeedType: 'internal'
       #Note: The project qualifier is always required when using a feed name. Also, do not use organization scoped feeds.

--- a/build/ProjectReunion-BuildFoundation.yml
+++ b/build/ProjectReunion-BuildFoundation.yml
@@ -12,3 +12,4 @@ stages:
     PublishToMaestro: False
     SignOutput: False
     IsOneBranch: False
+    PublishPackage: False

--- a/build/WindowsAppSDK-Foundation-Nightly.yml
+++ b/build/WindowsAppSDK-Foundation-Nightly.yml
@@ -77,3 +77,4 @@ extends:
         PublishToMaestro: ${{ parameters.PublishToMaestro }}
         IgnoreFailures: ${{ parameters.IgnoreFailures }}
         SignOutput: ${{ parameters.SignOutput }}
+        PublishPackage: true

--- a/build/WindowsAppSDK-Foundation-PR.yml
+++ b/build/WindowsAppSDK-Foundation-PR.yml
@@ -51,5 +51,6 @@ extends:
     stages:
     - template: AzurePipelinesTemplates\WindowsAppSDK-BuildTransportPackage-Stage.yml@self
       parameters:
-        PublishToMaestro: False
-        SignOutput: False
+        PublishToMaestro: false
+        SignOutput: false
+        PublishPackage: false

--- a/build/WindowsAppSDK-Foundation-Release.yml
+++ b/build/WindowsAppSDK-Foundation-Release.yml
@@ -65,3 +65,4 @@ extends:
         PublishToMaestro: ${{ parameters.PublishToMaestro }}
         IgnoreFailures: ${{ parameters.IgnoreFailures }}
         SignOutput: ${{ parameters.SignOutput }}
+        PublishPackage: true

--- a/eng/common/AzurePipelinesTemplates/WindowsAppSDK-Build-Steps.yml
+++ b/eng/common/AzurePipelinesTemplates/WindowsAppSDK-Build-Steps.yml
@@ -46,7 +46,7 @@ parameters:
 
 steps:
   - ${{ if ne(parameters.TransportPackageArtifactName, '') }}:
-    - task: DownloadBuildArtifacts@0
+    - task: DownloadPipelineArtifact@2
       inputs:
         artifactName: ${{ parameters.TransportPackageArtifactName }}
         downloadPath: '$(Build.SourcesDirectory)\localpackages'


### PR DESCRIPTION
A microsoft employee must use /azp run to validate using the pipelines below.

WARNING:
Comments made by azure-pipelines bot maybe inaccurate. 
Please see pipeline link to verify that the build is being ran.

For status checks on the develop branch, please use TransportPackage-Foundation-PR
(https://microsoft.visualstudio.com/ProjectReunion/_build?definitionId=81063&_a=summary)
and run the build against your PR branch with the default parameters.

For status checks on the main branch, please use microsoft.ProjectReunion
(https://dev.azure.com/ms/ProjectReunion/_build?definitionId=391&_a=summary)
and run the build against your PR branch with the default parameters.