### PR TITLE
Add version info to WindowsAppRuntimeInstall.exe for release/1.4-stable

### DIFF
--- a/installer/dev/WindowsAppRuntimeInstall.rc
+++ b/installer/dev/WindowsAppRuntimeInstall.rc
@@ -117,3 +117,8 @@ END
 /////////////////////////////////////////////////////////////////////////////
 #endif    // not APSTUDIO_INVOKED
 
+#include <WindowsAppSDK-VersionInfo.h>
+
+#define VERSIONINFO_FILENAME "WindowsAppRuntimeInstall.exe"
+#define VERSIONINFO_FILETYPE VFT_APP
+#include "eng\common\VersionInfo\AssemblyInfo.ver"

--- a/installer/dev/WindowsAppRuntimeInstall.vcxproj
+++ b/installer/dev/WindowsAppRuntimeInstall.vcxproj
@@ -159,6 +159,7 @@
   <ItemGroup>
     <ResourceCompile Include="WindowsAppRuntimeInstall.rc">
       <PreprocessorDefinitions Condition="Exists('windowsappruntime_definitions_override.h')">USE_DEFINITIONS_OVERRIDE_HEADER;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <AdditionalIncludeDirectories>$(RepoRoot);%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ResourceCompile>
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />

--- a/installer/dev/WindowsAppSDK-VersionInfo.h
+++ b/installer/dev/WindowsAppSDK-VersionInfo.h
@@ -1,0 +1,7 @@
+// Copyright (c) Microsoft Corporation and Contributors.
+// Licensed under the MIT License.
+//
+// This file is a PLACEHOLDER which will be replaced in the CreateInstaller
+// build pipeline with a file which defines WINDOWSAPPSDK_RELEASE_MAJOR
+// and WINDOWSAPPSDK_RELEASE_MINOR. For the dev inner loop, these will remain
+// undefined and just version the installer as 0.0.


### PR DESCRIPTION
Cherry-pick from #3884.

WindowsAppRuntimeInstall.exe doesn't have a version resource. That means all crash telemetry comes in for version 0.0.0.0, which prevents seeing if fixes in the latest version have improved reliability.

This fix adds a version resource using the existing AssemblyInfo.ver. This won't provide enough information to see if/which servicing release the installer is from, but it at least will show which major.minor version it is from.