### PR TITLE
Increase Job Timeout to 120 for Build 

### DIFF
--- a/build/AzurePipelinesTemplates/WindowsAppSDK-BuildTransportPackage-Stage.yml
+++ b/build/AzurePipelinesTemplates/WindowsAppSDK-BuildTransportPackage-Stage.yml
@@ -39,6 +39,7 @@ stages:
         type: windows
         isCustom: true
         name: 'ProjectReunionESPool-2022'
+    timeoutInMinutes: 120
     strategy:
       maxParallel: 10
       matrix:


### PR DESCRIPTION
Increase Job Timeout to 120 for Build

It is timing out because PublishPipelineArtifacts is taking a long time on non-OneBranch Pipeline builds.

Cherrypick of https://github.com/microsoft/WindowsAppSDK/pull/4001