### PR TITLE
[Cherrypick] Updated WindowsAppSDK-RunTestsInPipeline-Job.yml

### DIFF
--- a/build/AzurePipelinesTemplates/WindowsAppSDK-RunTestsInPipeline-Job.yml
+++ b/build/AzurePipelinesTemplates/WindowsAppSDK-RunTestsInPipeline-Job.yml
@@ -63,11 +63,6 @@ jobs:
           buildPlatform: x86
           buildConfiguration: release
           testLocale: en-US
-        co_refresh_x64fre:
-          imageName: co_refresh
-          buildPlatform: x64
-          buildConfiguration: release
-          testLocale: en-US
         rs_prerelease_x64fre:
           imageName: rs_prerelease
           buildPlatform: x64
@@ -87,11 +82,6 @@ jobs:
           testLocale: en-US
         Win11_Enterprise_arm64fre:
           imageName: Windows.11.Enterprise.arm64
-          buildPlatform: arm64
-          buildConfiguration: release
-          testLocale: en-US
-        Server22_DC_arm64fre:
-          imageName: Windows.11.Server2022.DataCenter.arm64
           buildPlatform: arm64
           buildConfiguration: release
           testLocale: en-US


### PR DESCRIPTION
Cherrypick of https://github.com/microsoft/WindowsAppSDK/pull/3996

Pipeline runs seem to be failing consistently due to failure to acquire a co_refresh VM for testing.
OSGWiki says cobalt Home/Pro SKUs hit End of Support on Oct 10, 2023. That appears to explain it.
Skipping testing on co_refresh to unblock pipeline runs. Cobalt is 21h2. We are still testing the Windows.11.Enterprise.MultiSession.21h2 OS image which has another year before end of support, so we don't lose much test coverage with this change.