### PR TITLE
[1.4] Correct Binary Deployment for .NET8 Breaking Change Support

### DIFF
--- a/build/CopyFilesToStagingDir.ps1
+++ b/build/CopyFilesToStagingDir.ps1
@@ -137,7 +137,9 @@ PublishFile $FullBuildOutput\WindowsAppRuntime_DLL\Microsoft.WindowsAppRuntime.l
 #
 # MSIX Framework package - DLLs/EXEs
 PublishFile $FullBuildOutput\WindowsAppRuntime_DLL\Microsoft.WindowsAppRuntime.dll $NugetDir\runtimes\win10-$Platform\native
+PublishFile $FullBuildOutput\WindowsAppRuntime_DLL\Microsoft.WindowsAppRuntime.dll $NugetDir\runtimes\win-$Platform\native
 PublishFile $FullBuildOutput\WindowsAppRuntime_DLL\Microsoft.WindowsAppRuntime.pdb $NugetDir\runtimes\win10-$Platform\native
+PublishFile $FullBuildOutput\WindowsAppRuntime_DLL\Microsoft.WindowsAppRuntime.pdb $NugetDir\runtimes\win-$Platform\native
 PublishFile $FullBuildOutput\RestartAgent\RestartAgent.exe $NugetDir\runtimes\win10-$Platform\native
 PublishFile $FullBuildOutput\RestartAgent\RestartAgent.pdb $NugetDir\runtimes\win10-$Platform\native
 PublishFile $FullBuildOutput\DeploymentAgent\DeploymentAgent.exe $NugetDir\runtimes\win10-$Platform\native

--- a/build/CopyFilesToStagingDir.ps1
+++ b/build/CopyFilesToStagingDir.ps1
@@ -137,9 +137,7 @@ PublishFile $FullBuildOutput\WindowsAppRuntime_DLL\Microsoft.WindowsAppRuntime.l
 #
 # MSIX Framework package - DLLs/EXEs
 PublishFile $FullBuildOutput\WindowsAppRuntime_DLL\Microsoft.WindowsAppRuntime.dll $NugetDir\runtimes\win10-$Platform\native
-PublishFile $FullBuildOutput\WindowsAppRuntime_DLL\Microsoft.WindowsAppRuntime.dll $NugetDir\runtimes\win-$Platform\native
 PublishFile $FullBuildOutput\WindowsAppRuntime_DLL\Microsoft.WindowsAppRuntime.pdb $NugetDir\runtimes\win10-$Platform\native
-PublishFile $FullBuildOutput\WindowsAppRuntime_DLL\Microsoft.WindowsAppRuntime.pdb $NugetDir\runtimes\win-$Platform\native
 PublishFile $FullBuildOutput\RestartAgent\RestartAgent.exe $NugetDir\runtimes\win10-$Platform\native
 PublishFile $FullBuildOutput\RestartAgent\RestartAgent.pdb $NugetDir\runtimes\win10-$Platform\native
 PublishFile $FullBuildOutput\DeploymentAgent\DeploymentAgent.exe $NugetDir\runtimes\win10-$Platform\native
@@ -169,6 +167,7 @@ PublishFile $FullBuildOutput\DynamicDependencyLifetimeManager.ProxyStub\DynamicD
 #
 # Native (not managed, AppLocal / no MSIX)
 PublishFile $FullBuildOutput\WindowsAppRuntime_BootstrapDLL\Microsoft.WindowsAppRuntime.Bootstrap.dll $NugetDir\runtimes\win10-$Platform\native
+PublishFile $FullBuildOutput\WindowsAppRuntime_BootstrapDLL\Microsoft.WindowsAppRuntime.Bootstrap.dll $NugetDir\runtimes\win-$Platform\native
 PublishFile $FullBuildOutput\WindowsAppRuntime_BootstrapDLL\Microsoft.WindowsAppRuntime.Bootstrap.pdb $NugetDir\runtimes\win10-$Platform\native
 #
 # Tools

--- a/dev/VSIX/ProjectTemplates/Desktop/CSharp/ClassLibrary/ProjectTemplate.csproj
+++ b/dev/VSIX/ProjectTemplates/Desktop/CSharp/ClassLibrary/ProjectTemplate.csproj
@@ -3,8 +3,8 @@
     <TargetFramework>$DotNetVersion$-windows10.0.19041.0</TargetFramework>
     <TargetPlatformMinVersion>10.0.17763.0</TargetPlatformMinVersion>
     <RootNamespace>$safeprojectname$</RootNamespace>
-    <RuntimeIdentifiers Condition=" $(TargetFramework.Contains('net8.0')) ">win-x86;win-x64;win-arm64</RuntimeIdentifiers>
-    <RuntimeIdentifiers Condition="!$(TargetFramework.Contains('net8.0'))">win10-x86;win10-x64;win10-arm64</RuntimeIdentifiers>
+    <RuntimeIdentifiers Condition="$([MSBuild]::GetTargetFrameworkVersion('$(TargetFramework)')) >= 8">win-x86;win-x64;win-arm64</RuntimeIdentifiers> 
+    <RuntimeIdentifiers Condition="$([MSBuild]::GetTargetFrameworkVersion('$(TargetFramework)')) < 8">win10-x86;win10-x64;win10-arm64</RuntimeIdentifiers>
     <UseWinUI>true</UseWinUI>
   </PropertyGroup>
 

--- a/dev/VSIX/ProjectTemplates/Desktop/CSharp/ClassLibrary/ProjectTemplate.csproj
+++ b/dev/VSIX/ProjectTemplates/Desktop/CSharp/ClassLibrary/ProjectTemplate.csproj
@@ -3,7 +3,8 @@
     <TargetFramework>$DotNetVersion$-windows10.0.19041.0</TargetFramework>
     <TargetPlatformMinVersion>10.0.17763.0</TargetPlatformMinVersion>
     <RootNamespace>$safeprojectname$</RootNamespace>
-    <RuntimeIdentifiers>win10-x86;win10-x64;win10-arm64</RuntimeIdentifiers>
+    <RuntimeIdentifiers Condition=" $(TargetFramework.Contains('net8.0')) ">win-x86;win-x64;win-arm64</RuntimeIdentifiers>
+    <RuntimeIdentifiers Condition="!$(TargetFramework.Contains('net8.0'))">win10-x86;win10-x64;win10-arm64</RuntimeIdentifiers>
     <UseWinUI>true</UseWinUI>
   </PropertyGroup>
 

--- a/dev/VSIX/ProjectTemplates/Desktop/CSharp/PackagedApp/BlankApp/ProjectTemplate.csproj
+++ b/dev/VSIX/ProjectTemplates/Desktop/CSharp/PackagedApp/BlankApp/ProjectTemplate.csproj
@@ -6,7 +6,8 @@
     <RootNamespace>$safeprojectname$</RootNamespace>
     <ApplicationManifest>app.manifest</ApplicationManifest>
     <Platforms>x86;x64;ARM64</Platforms>
-    <RuntimeIdentifiers>win10-x86;win10-x64;win10-arm64</RuntimeIdentifiers>
+    <RuntimeIdentifiers Condition=" $(TargetFramework.Contains('net8.0')) ">win-x86;win-x64;win-arm64</RuntimeIdentifiers>
+    <RuntimeIdentifiers Condition="!$(TargetFramework.Contains('net8.0'))">win10-x86;win10-x64;win10-arm64</RuntimeIdentifiers>
     <UseWinUI>true</UseWinUI>
   </PropertyGroup>
 

--- a/dev/VSIX/ProjectTemplates/Desktop/CSharp/PackagedApp/BlankApp/ProjectTemplate.csproj
+++ b/dev/VSIX/ProjectTemplates/Desktop/CSharp/PackagedApp/BlankApp/ProjectTemplate.csproj
@@ -6,8 +6,8 @@
     <RootNamespace>$safeprojectname$</RootNamespace>
     <ApplicationManifest>app.manifest</ApplicationManifest>
     <Platforms>x86;x64;ARM64</Platforms>
-    <RuntimeIdentifiers Condition=" $(TargetFramework.Contains('net8.0')) ">win-x86;win-x64;win-arm64</RuntimeIdentifiers>
-    <RuntimeIdentifiers Condition="!$(TargetFramework.Contains('net8.0'))">win10-x86;win10-x64;win10-arm64</RuntimeIdentifiers>
+    <RuntimeIdentifiers Condition="$([MSBuild]::GetTargetFrameworkVersion('$(TargetFramework)')) >= 8">win-x86;win-x64;win-arm64</RuntimeIdentifiers>
+    <RuntimeIdentifiers Condition="$([MSBuild]::GetTargetFrameworkVersion('$(TargetFramework)')) < 8">win10-x86;win10-x64;win10-arm64</RuntimeIdentifiers>
     <UseWinUI>true</UseWinUI>
   </PropertyGroup>
 

--- a/dev/VSIX/ProjectTemplates/Desktop/CSharp/PackagedApp/BlankApp/Properties/PublishProfiles/win-arm64.pubxml
+++ b/dev/VSIX/ProjectTemplates/Desktop/CSharp/PackagedApp/BlankApp/Properties/PublishProfiles/win-arm64.pubxml
@@ -5,8 +5,9 @@ https://go.microsoft.com/fwlink/?LinkID=208121.
 <Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <PublishProtocol>FileSystem</PublishProtocol>
-    <Platform>x64</Platform>
-    <RuntimeIdentifier>win10-x64</RuntimeIdentifier>
+    <Platform>ARM64</Platform>
+    <RuntimeIdentifier Condition=" $(TargetFramework.Contains('net8.0')) ">win-arm64</RuntimeIdentifier>
+    <RuntimeIdentifier Condition="!$(TargetFramework.Contains('net8.0'))">win10-arm64</RuntimeIdentifier>
     <PublishDir>bin\$(Configuration)\$(TargetFramework)\$(RuntimeIdentifier)\publish\</PublishDir>
     <SelfContained>true</SelfContained>
     <PublishSingleFile>False</PublishSingleFile>

--- a/dev/VSIX/ProjectTemplates/Desktop/CSharp/PackagedApp/BlankApp/Properties/PublishProfiles/win-arm64.pubxml
+++ b/dev/VSIX/ProjectTemplates/Desktop/CSharp/PackagedApp/BlankApp/Properties/PublishProfiles/win-arm64.pubxml
@@ -6,8 +6,8 @@ https://go.microsoft.com/fwlink/?LinkID=208121.
   <PropertyGroup>
     <PublishProtocol>FileSystem</PublishProtocol>
     <Platform>ARM64</Platform>
-    <RuntimeIdentifier Condition=" $(TargetFramework.Contains('net8.0')) ">win-arm64</RuntimeIdentifier>
-    <RuntimeIdentifier Condition="!$(TargetFramework.Contains('net8.0'))">win10-arm64</RuntimeIdentifier>
+    <RuntimeIdentifier Condition="$([MSBuild]::GetTargetFrameworkVersion('$(TargetFramework)')) >= 8">win-arm64</RuntimeIdentifier> 
+    <RuntimeIdentifier Condition="$([MSBuild]::GetTargetFrameworkVersion('$(TargetFramework)')) < 8">win10-arm64</RuntimeIdentifier>
     <PublishDir>bin\$(Configuration)\$(TargetFramework)\$(RuntimeIdentifier)\publish\</PublishDir>
     <SelfContained>true</SelfContained>
     <PublishSingleFile>False</PublishSingleFile>

--- a/dev/VSIX/ProjectTemplates/Desktop/CSharp/PackagedApp/BlankApp/Properties/PublishProfiles/win-x64.pubxml
+++ b/dev/VSIX/ProjectTemplates/Desktop/CSharp/PackagedApp/BlankApp/Properties/PublishProfiles/win-x64.pubxml
@@ -5,8 +5,9 @@ https://go.microsoft.com/fwlink/?LinkID=208121.
 <Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <PublishProtocol>FileSystem</PublishProtocol>
-    <Platform>x86</Platform>
-    <RuntimeIdentifier>win10-x86</RuntimeIdentifier>
+    <Platform>x64</Platform>
+    <RuntimeIdentifier Condition=" $(TargetFramework.Contains('net8.0')) ">win-x64</RuntimeIdentifier>
+    <RuntimeIdentifier Condition="!$(TargetFramework.Contains('net8.0'))">win10-x64</RuntimeIdentifier>
     <PublishDir>bin\$(Configuration)\$(TargetFramework)\$(RuntimeIdentifier)\publish\</PublishDir>
     <SelfContained>true</SelfContained>
     <PublishSingleFile>False</PublishSingleFile>

--- a/dev/VSIX/ProjectTemplates/Desktop/CSharp/PackagedApp/BlankApp/Properties/PublishProfiles/win-x64.pubxml
+++ b/dev/VSIX/ProjectTemplates/Desktop/CSharp/PackagedApp/BlankApp/Properties/PublishProfiles/win-x64.pubxml
@@ -6,8 +6,8 @@ https://go.microsoft.com/fwlink/?LinkID=208121.
   <PropertyGroup>
     <PublishProtocol>FileSystem</PublishProtocol>
     <Platform>x64</Platform>
-    <RuntimeIdentifier Condition=" $(TargetFramework.Contains('net8.0')) ">win-x64</RuntimeIdentifier>
-    <RuntimeIdentifier Condition="!$(TargetFramework.Contains('net8.0'))">win10-x64</RuntimeIdentifier>
+    <RuntimeIdentifier Condition="$([MSBuild]::GetTargetFrameworkVersion('$(TargetFramework)')) >= 8">win-x64</RuntimeIdentifier> 
+    <RuntimeIdentifier Condition="$([MSBuild]::GetTargetFrameworkVersion('$(TargetFramework)')) < 8">win10-x64</RuntimeIdentifier>
     <PublishDir>bin\$(Configuration)\$(TargetFramework)\$(RuntimeIdentifier)\publish\</PublishDir>
     <SelfContained>true</SelfContained>
     <PublishSingleFile>False</PublishSingleFile>

--- a/dev/VSIX/ProjectTemplates/Desktop/CSharp/PackagedApp/BlankApp/Properties/PublishProfiles/win-x86.pubxml
+++ b/dev/VSIX/ProjectTemplates/Desktop/CSharp/PackagedApp/BlankApp/Properties/PublishProfiles/win-x86.pubxml
@@ -5,8 +5,9 @@ https://go.microsoft.com/fwlink/?LinkID=208121.
 <Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <PublishProtocol>FileSystem</PublishProtocol>
-    <Platform>ARM64</Platform>
-    <RuntimeIdentifier>win10-arm64</RuntimeIdentifier>
+    <Platform>x86</Platform>
+    <RuntimeIdentifier Condition=" $(TargetFramework.Contains('net8.0')) ">win-x86</RuntimeIdentifier>
+    <RuntimeIdentifier Condition="!$(TargetFramework.Contains('net8.0'))">win10-x86</RuntimeIdentifier>
     <PublishDir>bin\$(Configuration)\$(TargetFramework)\$(RuntimeIdentifier)\publish\</PublishDir>
     <SelfContained>true</SelfContained>
     <PublishSingleFile>False</PublishSingleFile>

--- a/dev/VSIX/ProjectTemplates/Desktop/CSharp/PackagedApp/BlankApp/Properties/PublishProfiles/win-x86.pubxml
+++ b/dev/VSIX/ProjectTemplates/Desktop/CSharp/PackagedApp/BlankApp/Properties/PublishProfiles/win-x86.pubxml
@@ -6,8 +6,8 @@ https://go.microsoft.com/fwlink/?LinkID=208121.
   <PropertyGroup>
     <PublishProtocol>FileSystem</PublishProtocol>
     <Platform>x86</Platform>
-    <RuntimeIdentifier Condition=" $(TargetFramework.Contains('net8.0')) ">win-x86</RuntimeIdentifier>
-    <RuntimeIdentifier Condition="!$(TargetFramework.Contains('net8.0'))">win10-x86</RuntimeIdentifier>
+    <RuntimeIdentifier Condition="$([MSBuild]::GetTargetFrameworkVersion('$(TargetFramework)')) >= 8">win-x86</RuntimeIdentifier> 
+    <RuntimeIdentifier Condition="$([MSBuild]::GetTargetFrameworkVersion('$(TargetFramework)')) < 8">win10-x86</RuntimeIdentifier>
     <PublishDir>bin\$(Configuration)\$(TargetFramework)\$(RuntimeIdentifier)\publish\</PublishDir>
     <SelfContained>true</SelfContained>
     <PublishSingleFile>False</PublishSingleFile>

--- a/dev/VSIX/ProjectTemplates/Desktop/CSharp/PackagedApp/BlankApp/WinUI.Desktop.Cs.BlankApp.vstemplate
+++ b/dev/VSIX/ProjectTemplates/Desktop/CSharp/PackagedApp/BlankApp/WinUI.Desktop.Cs.BlankApp.vstemplate
@@ -26,9 +26,9 @@
   </TemplateData>
   <TemplateContent PreferedSolutionConfiguration="Debug|x86">
     <Project File="ProjectTemplate.csproj" ReplaceParameters="true">
-      <ProjectItem ReplaceParameters="true" TargetFileName="win10-arm64.pubxml">Properties\PublishProfiles\win10-arm64.pubxml</ProjectItem>
-      <ProjectItem ReplaceParameters="true" TargetFileName="win10-x64.pubxml">Properties\PublishProfiles\win10-x64.pubxml</ProjectItem>
-      <ProjectItem ReplaceParameters="true" TargetFileName="win10-x86.pubxml">Properties\PublishProfiles\win10-x86.pubxml</ProjectItem>
+      <ProjectItem ReplaceParameters="true" TargetFileName="win-arm64.pubxml">Properties\PublishProfiles\win-arm64.pubxml</ProjectItem>
+      <ProjectItem ReplaceParameters="true" TargetFileName="win-x64.pubxml">Properties\PublishProfiles\win-x64.pubxml</ProjectItem>
+      <ProjectItem ReplaceParameters="true" TargetFileName="win-x86.pubxml">Properties\PublishProfiles\win-x86.pubxml</ProjectItem>
       <ProjectItem ReplaceParameters="true" TargetFileName="app.manifest">app.manifest</ProjectItem>
       <ProjectItem ReplaceParameters="true" TargetFileName="App.xaml">App.xaml</ProjectItem>
       <ProjectItem ReplaceParameters="true" TargetFileName="App.xaml.cs">App.xaml.cs</ProjectItem>

--- a/dev/VSIX/ProjectTemplates/Desktop/CSharp/SingleProjectPackagedApp/ProjectTemplate.csproj
+++ b/dev/VSIX/ProjectTemplates/Desktop/CSharp/SingleProjectPackagedApp/ProjectTemplate.csproj
@@ -5,8 +5,9 @@
     <TargetPlatformMinVersion>10.0.17763.0</TargetPlatformMinVersion>
     <RootNamespace>$safeprojectname$</RootNamespace>
     <ApplicationManifest>app.manifest</ApplicationManifest>
-    <Platforms>x86;x64;ARM64</Platforms>
-    <RuntimeIdentifiers>win10-x86;win10-x64;win10-arm64</RuntimeIdentifiers>
+    <Platforms>x86;x64;ARM64</Platforms>    
+    <RuntimeIdentifiers Condition=" $(TargetFramework.Contains('net8.0')) ">win-x86;win-x64;win-arm64</RuntimeIdentifiers>
+    <RuntimeIdentifiers Condition="!$(TargetFramework.Contains('net8.0'))">win10-x86;win10-x64;win10-arm64</RuntimeIdentifiers>
     <PublishProfile>win10-$(Platform).pubxml</PublishProfile>
     <UseWinUI>true</UseWinUI>
     <EnableMsixTooling>true</EnableMsixTooling>

--- a/dev/VSIX/ProjectTemplates/Desktop/CSharp/SingleProjectPackagedApp/ProjectTemplate.csproj
+++ b/dev/VSIX/ProjectTemplates/Desktop/CSharp/SingleProjectPackagedApp/ProjectTemplate.csproj
@@ -6,8 +6,8 @@
     <RootNamespace>$safeprojectname$</RootNamespace>
     <ApplicationManifest>app.manifest</ApplicationManifest>
     <Platforms>x86;x64;ARM64</Platforms>    
-    <RuntimeIdentifiers Condition=" $(TargetFramework.Contains('net8.0')) ">win-x86;win-x64;win-arm64</RuntimeIdentifiers>
-    <RuntimeIdentifiers Condition="!$(TargetFramework.Contains('net8.0'))">win10-x86;win10-x64;win10-arm64</RuntimeIdentifiers>
+    <RuntimeIdentifiers Condition="$([MSBuild]::GetTargetFrameworkVersion('$(TargetFramework)')) >= 8">win-x86;win-x64;win-arm64</RuntimeIdentifiers> 
+    <RuntimeIdentifiers Condition="$([MSBuild]::GetTargetFrameworkVersion('$(TargetFramework)')) < 8">win10-x86;win10-x64;win10-arm64</RuntimeIdentifiers>
     <PublishProfile>win10-$(Platform).pubxml</PublishProfile>
     <UseWinUI>true</UseWinUI>
     <EnableMsixTooling>true</EnableMsixTooling>

--- a/dev/VSIX/ProjectTemplates/Desktop/CSharp/SingleProjectPackagedApp/Properties/PublishProfiles/win-arm64.pubxml
+++ b/dev/VSIX/ProjectTemplates/Desktop/CSharp/SingleProjectPackagedApp/Properties/PublishProfiles/win-arm64.pubxml
@@ -5,8 +5,9 @@ https://go.microsoft.com/fwlink/?LinkID=208121.
 <Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <PublishProtocol>FileSystem</PublishProtocol>
-    <Platform>x64</Platform>
-    <RuntimeIdentifier>win10-x64</RuntimeIdentifier>
+    <Platform>ARM64</Platform>
+    <RuntimeIdentifier Condition=" $(TargetFramework.Contains('net8.0')) ">win-arm64</RuntimeIdentifier>
+    <RuntimeIdentifier Condition="!$(TargetFramework.Contains('net8.0'))">win10-arm64</RuntimeIdentifier>
     <PublishDir>bin\$(Configuration)\$(TargetFramework)\$(RuntimeIdentifier)\publish\</PublishDir>
     <SelfContained>true</SelfContained>
     <PublishSingleFile>False</PublishSingleFile>

--- a/dev/VSIX/ProjectTemplates/Desktop/CSharp/SingleProjectPackagedApp/Properties/PublishProfiles/win-arm64.pubxml
+++ b/dev/VSIX/ProjectTemplates/Desktop/CSharp/SingleProjectPackagedApp/Properties/PublishProfiles/win-arm64.pubxml
@@ -6,8 +6,8 @@ https://go.microsoft.com/fwlink/?LinkID=208121.
   <PropertyGroup>
     <PublishProtocol>FileSystem</PublishProtocol>
     <Platform>ARM64</Platform>
-    <RuntimeIdentifier Condition=" $(TargetFramework.Contains('net8.0')) ">win-arm64</RuntimeIdentifier>
-    <RuntimeIdentifier Condition="!$(TargetFramework.Contains('net8.0'))">win10-arm64</RuntimeIdentifier>
+    <RuntimeIdentifier Condition="$([MSBuild]::GetTargetFrameworkVersion('$(TargetFramework)')) >= 8">win-arm64</RuntimeIdentifier> 
+    <RuntimeIdentifier Condition="$([MSBuild]::GetTargetFrameworkVersion('$(TargetFramework)')) < 8">win10-arm64</RuntimeIdentifier>
     <PublishDir>bin\$(Configuration)\$(TargetFramework)\$(RuntimeIdentifier)\publish\</PublishDir>
     <SelfContained>true</SelfContained>
     <PublishSingleFile>False</PublishSingleFile>

--- a/dev/VSIX/ProjectTemplates/Desktop/CSharp/SingleProjectPackagedApp/Properties/PublishProfiles/win-x64.pubxml
+++ b/dev/VSIX/ProjectTemplates/Desktop/CSharp/SingleProjectPackagedApp/Properties/PublishProfiles/win-x64.pubxml
@@ -5,8 +5,9 @@ https://go.microsoft.com/fwlink/?LinkID=208121.
 <Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <PublishProtocol>FileSystem</PublishProtocol>
-    <Platform>x86</Platform>
-    <RuntimeIdentifier>win10-x86</RuntimeIdentifier>
+    <Platform>x64</Platform>
+    <RuntimeIdentifier Condition=" $(TargetFramework.Contains('net8.0')) ">win-x64</RuntimeIdentifier>
+    <RuntimeIdentifier Condition="!$(TargetFramework.Contains('net8.0'))">win10-x64</RuntimeIdentifier>
     <PublishDir>bin\$(Configuration)\$(TargetFramework)\$(RuntimeIdentifier)\publish\</PublishDir>
     <SelfContained>true</SelfContained>
     <PublishSingleFile>False</PublishSingleFile>

--- a/dev/VSIX/ProjectTemplates/Desktop/CSharp/SingleProjectPackagedApp/Properties/PublishProfiles/win-x64.pubxml
+++ b/dev/VSIX/ProjectTemplates/Desktop/CSharp/SingleProjectPackagedApp/Properties/PublishProfiles/win-x64.pubxml
@@ -6,8 +6,8 @@ https://go.microsoft.com/fwlink/?LinkID=208121.
   <PropertyGroup>
     <PublishProtocol>FileSystem</PublishProtocol>
     <Platform>x64</Platform>
-    <RuntimeIdentifier Condition=" $(TargetFramework.Contains('net8.0')) ">win-x64</RuntimeIdentifier>
-    <RuntimeIdentifier Condition="!$(TargetFramework.Contains('net8.0'))">win10-x64</RuntimeIdentifier>
+    <RuntimeIdentifier Condition="$([MSBuild]::GetTargetFrameworkVersion('$(TargetFramework)')) >= 8">win-x64</RuntimeIdentifier> 
+    <RuntimeIdentifier Condition="$([MSBuild]::GetTargetFrameworkVersion('$(TargetFramework)')) < 8">win10-x64</RuntimeIdentifier>
     <PublishDir>bin\$(Configuration)\$(TargetFramework)\$(RuntimeIdentifier)\publish\</PublishDir>
     <SelfContained>true</SelfContained>
     <PublishSingleFile>False</PublishSingleFile>

--- a/dev/VSIX/ProjectTemplates/Desktop/CSharp/SingleProjectPackagedApp/Properties/PublishProfiles/win-x86.pubxml
+++ b/dev/VSIX/ProjectTemplates/Desktop/CSharp/SingleProjectPackagedApp/Properties/PublishProfiles/win-x86.pubxml
@@ -5,8 +5,9 @@ https://go.microsoft.com/fwlink/?LinkID=208121.
 <Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <PublishProtocol>FileSystem</PublishProtocol>
-    <Platform>ARM64</Platform>
-    <RuntimeIdentifier>win10-arm64</RuntimeIdentifier>
+    <Platform>x86</Platform>    
+    <RuntimeIdentifier Condition=" $(TargetFramework.Contains('net8.0')) ">win-x86</RuntimeIdentifier>
+    <RuntimeIdentifier Condition="!$(TargetFramework.Contains('net8.0'))">win10-x86</RuntimeIdentifier>
     <PublishDir>bin\$(Configuration)\$(TargetFramework)\$(RuntimeIdentifier)\publish\</PublishDir>
     <SelfContained>true</SelfContained>
     <PublishSingleFile>False</PublishSingleFile>

--- a/dev/VSIX/ProjectTemplates/Desktop/CSharp/SingleProjectPackagedApp/Properties/PublishProfiles/win-x86.pubxml
+++ b/dev/VSIX/ProjectTemplates/Desktop/CSharp/SingleProjectPackagedApp/Properties/PublishProfiles/win-x86.pubxml
@@ -6,8 +6,8 @@ https://go.microsoft.com/fwlink/?LinkID=208121.
   <PropertyGroup>
     <PublishProtocol>FileSystem</PublishProtocol>
     <Platform>x86</Platform>    
-    <RuntimeIdentifier Condition=" $(TargetFramework.Contains('net8.0')) ">win-x86</RuntimeIdentifier>
-    <RuntimeIdentifier Condition="!$(TargetFramework.Contains('net8.0'))">win10-x86</RuntimeIdentifier>
+    <RuntimeIdentifier Condition="$([MSBuild]::GetTargetFrameworkVersion('$(TargetFramework)')) >= 8">win-x86</RuntimeIdentifier> 
+    <RuntimeIdentifier Condition="$([MSBuild]::GetTargetFrameworkVersion('$(TargetFramework)')) < 8">win10-x86</RuntimeIdentifier>
     <PublishDir>bin\$(Configuration)\$(TargetFramework)\$(RuntimeIdentifier)\publish\</PublishDir>
     <SelfContained>true</SelfContained>
     <PublishSingleFile>False</PublishSingleFile>

--- a/dev/VSIX/ProjectTemplates/Desktop/CSharp/SingleProjectPackagedApp/WinUI.Desktop.Cs.SingleProjectPackagedApp.vstemplate
+++ b/dev/VSIX/ProjectTemplates/Desktop/CSharp/SingleProjectPackagedApp/WinUI.Desktop.Cs.SingleProjectPackagedApp.vstemplate
@@ -31,9 +31,9 @@
     </CustomParameters>
     <Project File="ProjectTemplate.csproj" ReplaceParameters="true">
       <ProjectItem ReplaceParameters="true" TargetFileName="launchSettings.json">Properties\launchSettings.json</ProjectItem>
-      <ProjectItem ReplaceParameters="true" TargetFileName="win10-arm64.pubxml">Properties\PublishProfiles\win10-arm64.pubxml</ProjectItem>
-      <ProjectItem ReplaceParameters="true" TargetFileName="win10-x64.pubxml">Properties\PublishProfiles\win10-x64.pubxml</ProjectItem>
-      <ProjectItem ReplaceParameters="true" TargetFileName="win10-x86.pubxml">Properties\PublishProfiles\win10-x86.pubxml</ProjectItem>
+      <ProjectItem ReplaceParameters="true" TargetFileName="win-arm64.pubxml">Properties\PublishProfiles\win-arm64.pubxml</ProjectItem>
+      <ProjectItem ReplaceParameters="true" TargetFileName="win-x64.pubxml">Properties\PublishProfiles\win-x64.pubxml</ProjectItem>
+      <ProjectItem ReplaceParameters="true" TargetFileName="win-x86.pubxml">Properties\PublishProfiles\win-x86.pubxml</ProjectItem>
       <ProjectItem ReplaceParameters="true" TargetFileName="app.manifest">app.manifest</ProjectItem>
       <ProjectItem ReplaceParameters="true" TargetFileName="App.xaml">App.xaml</ProjectItem>
       <ProjectItem ReplaceParameters="true" TargetFileName="App.xaml.cs">App.xaml.cs</ProjectItem>


### PR DESCRIPTION
.NET8 introduced a [conditional breaking change](https://github.com/dotnet/docs/issues/35398) that influences how the runtime host looks for RID-specific assets. In NET8, support for non-portable RIDs (runtime identifiers specific to versions and distributions, such as win10-x86) is discontinued. The folder structure of the Microsoft.WindowsAppSDK NuGet is structured with assets marked using these non-portable RIDs:

The changes made to the `CopyFilesToStagingDir.ps1` script along with the project template changes should help support the .NET8 scenario. The selection of the project template's RIDs is conditional and based on the TFM chosen by the user. If NET8 is chosen, the RIDs become portable, enabling the runtime host to locate the RID-specific assets that were previously unattainable.
