### PR TITLE
Visual Studio Template Unit Test App: Fix name and id strings for experimental builds.

### DIFF
--- a/dev/VSIX/Extension/Cpp/Common/VSPackage.resx
+++ b/dev/VSIX/Extension/Cpp/Common/VSPackage.resx
@@ -198,10 +198,13 @@
   <data name="1035" xml:space="preserve">
     <value>A project for creating a C++/WinRT Windows Runtime Component (.winmd) for both Desktop and Universal Windows Platform (UWP) apps, based on the Windows UI Library (WinUI 3).</value>
   </data>
-  <data name="1036" xml:space="preserve">
+  <data name="1037" xml:space="preserve">
     <value>Unit Test App (WinUI 3)</value>
   </data>
-  <data name="1037" xml:space="preserve">
+  <data name="1038" xml:space="preserve">
+    <value>[Experimental] Unit Test App (WinUI 3)</value>
+  </data>
+  <data name="1039" xml:space="preserve">
     <value>A project for creating a C++/WinRT unit test app for WinUI 3 using MSTest.</value>
   </data>
 </root>

--- a/dev/VSIX/Extension/Cs/Common/VSPackage.resx
+++ b/dev/VSIX/Extension/Cs/Common/VSPackage.resx
@@ -198,10 +198,13 @@
   <data name="1035" xml:space="preserve">
     <value>A project template for creating a Desktop app based on the Windows UI Library (WinUI 3) along with a MSIX package for side-loading or distribution via the Microsoft Store.</value>
   </data>
-  <data name="1036" xml:space="preserve">
+  <data name="1037" xml:space="preserve">
     <value>Unit Test App (WinUI 3 in Desktop)</value>
   </data>
-  <data name="1037" xml:space="preserve">
+  <data name="1038" xml:space="preserve">
+    <value>[Experimental] Unit Test App (WinUI 3 in Desktop)</value>
+  </data>
+  <data name="1039" xml:space="preserve">
     <value>A project to create a unit test app for WinUI 3 apps using MSTest.</value>
   </data>
 </root>

--- a/dev/VSIX/ProjectTemplates/Desktop/CSharp/UnitTestApp/WinUI.Desktop.Cs.UnitTestApp.vstemplate
+++ b/dev/VSIX/ProjectTemplates/Desktop/CSharp/UnitTestApp/WinUI.Desktop.Cs.UnitTestApp.vstemplate
@@ -1,8 +1,8 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <VSTemplate Version="3.0.0" xmlns="http://schemas.microsoft.com/developer/vstemplate/2005" Type="Project">
   <TemplateData>
-    <Name ID="1036" Package="FIXME-PACKAGEGUID" />
-    <Description ID="1037" Package="FIXME-PACKAGEGUID" />
+    <Name ID="1037" Package="FIXME-PACKAGEGUID" />
+    <Description ID="1039" Package="FIXME-PACKAGEGUID" />
     <Icon>WinUI.Desktop.Cs.UnitTestApp.ico</Icon>
     <TemplateID>Microsoft.WinUI.Desktop.Cs.UnitTestApp</TemplateID>
     <TemplateGroupID>WinRT-Managed</TemplateGroupID>

--- a/dev/VSIX/ProjectTemplates/Desktop/CppWinRT/UnitTestApp/WinUI.Desktop.CppWinRT.UnitTestApp.vstemplate
+++ b/dev/VSIX/ProjectTemplates/Desktop/CppWinRT/UnitTestApp/WinUI.Desktop.CppWinRT.UnitTestApp.vstemplate
@@ -1,8 +1,8 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <VSTemplate Version="3.0.0" xmlns="http://schemas.microsoft.com/developer/vstemplate/2005" Type="Project">
   <TemplateData>
-    <Name ID="1036" Package="FIXME-PACKAGEGUID" />
-    <Description ID="1037" Package="FIXME-PACKAGEGUID" />
+    <Name ID="1037" Package="FIXME-PACKAGEGUID" />
+    <Description ID="1039" Package="FIXME-PACKAGEGUID" />
     <Icon>WinUI.Desktop.CppWinRT.UnitTestApp.ico</Icon>
     <TemplateID>Microsoft.WinUI.Desktop.CppWinRT.UnitTestApp</TemplateID>
     <ProjectType>VC</ProjectType>


### PR DESCRIPTION
The vsix can be built for both 'stable' and 'experimental' releases. The name of the template as displayed in the Visual Studio UI is different across these two flavors. For the experimental build we add 1 to the localized resource id to get the id for the experimental version. 

This is done in `Extension\Directory.Build.targets` by `_ExperimentalVsTemplateXslt`. To make the two new unit test projects work correctly here, I had to update the resource ids and include a string for use by the experimental vsix.