### PR TITLE
Enhance WindowsAppSDK with .NET 8 Support & Further Improvements

### DIFF
--- a/dev/VSIX/Extension/Cs/Dev17/WindowsAppSDK.Cs.Extension.Dev17.csproj
+++ b/dev/VSIX/Extension/Cs/Dev17/WindowsAppSDK.Cs.Extension.Dev17.csproj
@@ -1,4 +1,4 @@
-﻿<Project ToolsVersion="Current">
+﻿git <Project ToolsVersion="Current">
   <Import Project="Sdk.props" Sdk="Microsoft.NET.Sdk" />
   <PropertyGroup>
     <SchemaVersion>2.0</SchemaVersion>
@@ -28,7 +28,7 @@
     <IsProductComponent Condition="'$(Deployment)' == 'Component'">true</IsProductComponent>
     <!-- This MUST match VSPackage.PackageGuidString -->
     <PackageGuidString>{B0F1BA01-DE66-4EF9-9C8B-DBB99FB4DA4B}</PackageGuidString>
-    <!-- Dev17 templates should target .NET 6 -->
+    <!-- Dev17 templates should target .NET 8 -->
     <DotNetVersion>net8.0</DotNetVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' " />

--- a/dev/VSIX/Extension/Cs/Dev17/WindowsAppSDK.Cs.Extension.Dev17.csproj
+++ b/dev/VSIX/Extension/Cs/Dev17/WindowsAppSDK.Cs.Extension.Dev17.csproj
@@ -29,7 +29,7 @@
     <!-- This MUST match VSPackage.PackageGuidString -->
     <PackageGuidString>{B0F1BA01-DE66-4EF9-9C8B-DBB99FB4DA4B}</PackageGuidString>
     <!-- Dev17 templates should target .NET 6 -->
-    <DotNetVersion>net6.0</DotNetVersion>
+    <DotNetVersion>net8.0</DotNetVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' " />
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' " />

--- a/dev/VSIX/Extension/Cs/Dev17/WindowsAppSDK.Cs.Extension.Dev17.csproj
+++ b/dev/VSIX/Extension/Cs/Dev17/WindowsAppSDK.Cs.Extension.Dev17.csproj
@@ -1,4 +1,4 @@
-﻿git <Project ToolsVersion="Current">
+﻿<Project ToolsVersion="Current">
   <Import Project="Sdk.props" Sdk="Microsoft.NET.Sdk" />
   <PropertyGroup>
     <SchemaVersion>2.0</SchemaVersion>

--- a/dev/VSIX/ProjectTemplates/Desktop/CSharp/SingleProjectPackagedApp/ProjectTemplate.csproj
+++ b/dev/VSIX/ProjectTemplates/Desktop/CSharp/SingleProjectPackagedApp/ProjectTemplate.csproj
@@ -8,7 +8,7 @@
     <Platforms>x86;x64;ARM64</Platforms>    
     <RuntimeIdentifiers Condition="$([MSBuild]::GetTargetFrameworkVersion('$(TargetFramework)')) >= 8">win-x86;win-x64;win-arm64</RuntimeIdentifiers> 
     <RuntimeIdentifiers Condition="$([MSBuild]::GetTargetFrameworkVersion('$(TargetFramework)')) < 8">win10-x86;win10-x64;win10-arm64</RuntimeIdentifiers>
-    <PublishProfile>win10-$(Platform).pubxml</PublishProfile>
+    <PublishProfile>win-$(Platform).pubxml</PublishProfile>
     <UseWinUI>true</UseWinUI>
     <EnableMsixTooling>true</EnableMsixTooling>
   </PropertyGroup>

--- a/dev/VSIX/ProjectTemplates/Desktop/CSharp/UnitTestApp/ProjectTemplate.csproj
+++ b/dev/VSIX/ProjectTemplates/Desktop/CSharp/UnitTestApp/ProjectTemplate.csproj
@@ -6,8 +6,9 @@
     <RootNamespace>$safeprojectname$</RootNamespace>
     <ApplicationManifest>app.manifest</ApplicationManifest>
     <Platforms>x86;x64;ARM64</Platforms>
-    <RuntimeIdentifiers>win10-x86;win10-x64;win10-arm64</RuntimeIdentifiers>
-    <PublishProfile>win10-$(Platform).pubxml</PublishProfile>
+    <RuntimeIdentifiers Condition="$([MSBuild]::GetTargetFrameworkVersion('$(TargetFramework)')) >= 8">win-x86;win-x64;win-arm64</RuntimeIdentifiers> 
+    <RuntimeIdentifiers Condition="$([MSBuild]::GetTargetFrameworkVersion('$(TargetFramework)')) < 8">win10-x86;win10-x64;win10-arm64</RuntimeIdentifiers>
+    <PublishProfile>win-$(Platform).pubxml</PublishProfile>
     <UseWinUI>true</UseWinUI>
     <EnableMsixTooling>true</EnableMsixTooling>
   </PropertyGroup>

--- a/dev/VSIX/ProjectTemplates/Desktop/CSharp/UnitTestApp/Properties/PublishProfiles/win-arm64.pubxml
+++ b/dev/VSIX/ProjectTemplates/Desktop/CSharp/UnitTestApp/Properties/PublishProfiles/win-arm64.pubxml
@@ -5,8 +5,9 @@ https://go.microsoft.com/fwlink/?LinkID=208121.
 <Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <PublishProtocol>FileSystem</PublishProtocol>
-    <Platform>x64</Platform>
-    <RuntimeIdentifier>win10-x64</RuntimeIdentifier>
+    <Platform>ARM64</Platform>
+    <RuntimeIdentifier Condition="$([MSBuild]::GetTargetFrameworkVersion('$(TargetFramework)')) >= 8">win-arm64</RuntimeIdentifier> 
+    <RuntimeIdentifier Condition="$([MSBuild]::GetTargetFrameworkVersion('$(TargetFramework)')) < 8">win10-arm64</RuntimeIdentifier>
     <PublishDir>bin\$(Configuration)\$(TargetFramework)\$(RuntimeIdentifier)\publish\</PublishDir>
     <SelfContained>true</SelfContained>
     <PublishSingleFile>False</PublishSingleFile>

--- a/dev/VSIX/ProjectTemplates/Desktop/CSharp/UnitTestApp/Properties/PublishProfiles/win-x64.pubxml
+++ b/dev/VSIX/ProjectTemplates/Desktop/CSharp/UnitTestApp/Properties/PublishProfiles/win-x64.pubxml
@@ -5,8 +5,9 @@ https://go.microsoft.com/fwlink/?LinkID=208121.
 <Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <PublishProtocol>FileSystem</PublishProtocol>
-    <Platform>ARM64</Platform>
-    <RuntimeIdentifier>win10-arm64</RuntimeIdentifier>
+    <Platform>x64</Platform>
+    <RuntimeIdentifier Condition="$([MSBuild]::GetTargetFrameworkVersion('$(TargetFramework)')) >= 8">win-x64</RuntimeIdentifier> 
+    <RuntimeIdentifier Condition="$([MSBuild]::GetTargetFrameworkVersion('$(TargetFramework)')) < 8">win10-x64</RuntimeIdentifier>
     <PublishDir>bin\$(Configuration)\$(TargetFramework)\$(RuntimeIdentifier)\publish\</PublishDir>
     <SelfContained>true</SelfContained>
     <PublishSingleFile>False</PublishSingleFile>

--- a/dev/VSIX/ProjectTemplates/Desktop/CSharp/UnitTestApp/Properties/PublishProfiles/win-x86.pubxml
+++ b/dev/VSIX/ProjectTemplates/Desktop/CSharp/UnitTestApp/Properties/PublishProfiles/win-x86.pubxml
@@ -6,7 +6,8 @@ https://go.microsoft.com/fwlink/?LinkID=208121.
   <PropertyGroup>
     <PublishProtocol>FileSystem</PublishProtocol>
     <Platform>x86</Platform>
-    <RuntimeIdentifier>win10-x86</RuntimeIdentifier>
+    <RuntimeIdentifier Condition="$([MSBuild]::GetTargetFrameworkVersion('$(TargetFramework)')) >= 8">win-x86</RuntimeIdentifier> 
+    <RuntimeIdentifier Condition="$([MSBuild]::GetTargetFrameworkVersion('$(TargetFramework)')) < 8">win10-x86</RuntimeIdentifier>
     <PublishDir>bin\$(Configuration)\$(TargetFramework)\$(RuntimeIdentifier)\publish\</PublishDir>
     <SelfContained>true</SelfContained>
     <PublishSingleFile>False</PublishSingleFile>

--- a/dev/VSIX/ProjectTemplates/Desktop/CSharp/UnitTestApp/WinUI.Desktop.Cs.UnitTestApp.vstemplate
+++ b/dev/VSIX/ProjectTemplates/Desktop/CSharp/UnitTestApp/WinUI.Desktop.Cs.UnitTestApp.vstemplate
@@ -32,9 +32,9 @@
     </CustomParameters>
     <Project File="ProjectTemplate.csproj" ReplaceParameters="true">
       <ProjectItem ReplaceParameters="true" TargetFileName="launchSettings.json">Properties\launchSettings.json</ProjectItem>
-      <ProjectItem ReplaceParameters="true" TargetFileName="win10-arm64.pubxml">Properties\PublishProfiles\win10-arm64.pubxml</ProjectItem>
-      <ProjectItem ReplaceParameters="true" TargetFileName="win10-x64.pubxml">Properties\PublishProfiles\win10-x64.pubxml</ProjectItem>
-      <ProjectItem ReplaceParameters="true" TargetFileName="win10-x86.pubxml">Properties\PublishProfiles\win10-x86.pubxml</ProjectItem>
+      <ProjectItem ReplaceParameters="true" TargetFileName="win-arm64.pubxml">Properties\PublishProfiles\win-arm64.pubxml</ProjectItem>
+      <ProjectItem ReplaceParameters="true" TargetFileName="win-x64.pubxml">Properties\PublishProfiles\win-x64.pubxml</ProjectItem>
+      <ProjectItem ReplaceParameters="true" TargetFileName="win-x86.pubxml">Properties\PublishProfiles\win-x86.pubxml</ProjectItem>
       <ProjectItem ReplaceParameters="true" TargetFileName="app.manifest">app.manifest</ProjectItem>
       <ProjectItem ReplaceParameters="true" TargetFileName="UnitTestApp.xaml">UnitTestApp.xaml</ProjectItem>
       <ProjectItem ReplaceParameters="true" TargetFileName="UnitTestApp.xaml.cs">UnitTestApp.xaml.cs</ProjectItem>


### PR DESCRIPTION
This pull request builds upon our ongoing efforts to enhance the WindowsAppSDK by introducing support for .NET 8 and making several key improvements:

**Unit Tests Updated for Portable RIDs:** Modified unit tests to use portable Runtime Identifiers (RIDs), enabling cross-platform compatibility.

**Corrected Publish Profile Path**: Fixed an outdated publish profile path to align with the current project structure.

**Default DotNetVersion Set to 8.0 in Project Templates**: Updated project templates to default to .NET 8.0,