### PR TITLE
Make MrtCore copy its build files (including binlog) to outputDirectory (2)

### DIFF
--- a/BuildAll.ps1
+++ b/BuildAll.ps1
@@ -247,7 +247,7 @@ Try {
 
                     if ($lastexitcode -ne 0)
                     {
-                        write-host "ERROR: msbuild restore '$MRTSourcesDirectory\mrt\MrtCore.sln' FAILED."
+                        write-host "ERROR: Building '$MRTSourcesDirectory\mrt\MrtCore.sln' FAILED."
                         exit 1
                     }
                 }

--- a/build/AzurePipelinesTemplates/WindowsAppSDK-BuildMRT-Steps.yml
+++ b/build/AzurePipelinesTemplates/WindowsAppSDK-BuildMRT-Steps.yml
@@ -103,6 +103,7 @@ steps:
 
 - task: CopyFiles@2
   displayName: MoveToOutputDirectory
+  condition: always()
   inputs:
     SourceFolder: '$(build.SourcesDirectory)\BuildOutput'
     TargetFolder: '$(ob_outputDirectory)'


### PR DESCRIPTION
Make MrtCore copy its build files (including binlog) to outputDirectory.