### PR TITLE
Fixing build break by manually porting changes in Main to 1.4-stable

### DIFF
--- a/build/AzurePipelinesTemplates/WindowsAppSDK-RunTestsInPipeline-Job.yml
+++ b/build/AzurePipelinesTemplates/WindowsAppSDK-RunTestsInPipeline-Job.yml
@@ -63,11 +63,6 @@ jobs:
           buildPlatform: x86
           buildConfiguration: release
           testLocale: en-US
-        co_refresh_x64fre:
-          imageName: co_refresh
-          buildPlatform: x64
-          buildConfiguration: release
-          testLocale: en-US
         rs_prerelease_x64fre:
           imageName: rs_prerelease
           buildPlatform: x64
@@ -87,11 +82,6 @@ jobs:
           testLocale: en-US
         Win11_Enterprise_arm64fre:
           imageName: Windows.11.Enterprise.arm64
-          buildPlatform: arm64
-          buildConfiguration: release
-          testLocale: en-US
-        Server22_DC_arm64fre:
-          imageName: Windows.11.Server2022.DataCenter.arm64
           buildPlatform: arm64
           buildConfiguration: release
           testLocale: en-US


### PR DESCRIPTION
Stop running tests on retired OS images.

------

A microsoft employee must use /azp run to validate using the pipelines below.

WARNING:
Comments made by azure-pipelines bot maybe inaccurate.
Please see pipeline link to verify that the build is being ran.

For status checks on the main branch, please use TransportPackage-Foundation-PR
(https://microsoft.visualstudio.com/ProjectReunion/_build?definitionId=81063&_a=summary)
and run the build against your PR branch with the default parameters.
