### PR TITLE
Start running tests on Win11 23h2 Profession arm64 OS image

### DIFF
--- a/build/AzurePipelinesTemplates/WindowsAppSDK-RunTestsInPipeline-Job.yml
+++ b/build/AzurePipelinesTemplates/WindowsAppSDK-RunTestsInPipeline-Job.yml
@@ -85,6 +85,12 @@ jobs:
           buildPlatform: arm64
           buildConfiguration: release
           testLocale: en-US
+        Win11_Pro_23h2_arm64fre:
+          imageName: Windows.11.Professional.23h2.Arm64
+          buildPlatform: arm64
+          buildConfiguration: release
+          testLocale: en-US
+
   pool:
     type: windows
     isCustom: true


### PR DESCRIPTION
Start running tests on Win11 23h2 Professional arm64 OS image

--------

A microsoft employee must use /azp run to validate using the pipelines below.

WARNING:
Comments made by azure-pipelines bot maybe inaccurate.
Please see pipeline link to verify that the build is being ran.

For status checks on the main branch, please use TransportPackage-Foundation-PR
(https://microsoft.visualstudio.com/ProjectReunion/_build?definitionId=81063&_a=summary)
and run the build against your PR branch with the default parameters.
