### PR TITLE
Nightly Build Break Fixes 

### DIFF
--- a/build/AzurePipelinesTemplates/WindowsAppSDK-Publish-Stage.yml
+++ b/build/AzurePipelinesTemplates/WindowsAppSDK-Publish-Stage.yml
@@ -14,9 +14,6 @@ stages:
   jobs:
   # Publish
   - job: Publish
-    dependsOn:
-    - NugetPackage
-    # - WinAppSDKIntegrationBuildAndTest
     condition: and(or(succeeded(), eq(${{ parameters.IgnoreFailures }}, 'true')), eq('${{ parameters.PublishToMaestro }}', 'true'))
     pool:
       type: windows

--- a/build/AzurePipelinesTemplates/WindowsAppSDK-Publish-Stage.yml
+++ b/build/AzurePipelinesTemplates/WindowsAppSDK-Publish-Stage.yml
@@ -6,7 +6,7 @@ parameters:
   type: boolean
   default: True
 stages:
-- stage: Test
+- stage: Publish
   dependsOn:
   - Test
   - Pack


### PR DESCRIPTION
[4034](https://github.com/microsoft/WindowsAppSDK/pull/4034) broke the yml.

1) Two Stages had the same name
2) A job in a stage needs to have zero dependencies