### PR TITLE
PublishSingleFile dll and resources.pri redirection support

### DIFF
--- a/dev/MRTCore/mrt/Core/src/MRM.cpp
+++ b/dev/MRTCore/mrt/Core/src/MRM.cpp
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft Corporation and Contributors.
+// Copyright (c) Microsoft Corporation and Contributors.
 // Licensed under the MIT License.
 
 #include <Windows.h>
@@ -989,6 +989,12 @@ STDAPI MrmGetFilePathFromName(_In_opt_ PCWSTR filename, _Outptr_ PWSTR* filePath
     PCWSTR filenameToUse = filename;
     if (filename == nullptr || *filename == L'\0')
     {
+        wil::unique_cotaskmem_string baseDir;
+        if(SUCCEEDED(wil::TryGetEnvironmentVariableW(L"MICROSOFT_WINDOWSAPPRUNTIME_BASE_DIRECTORY", baseDir)))
+        {
+            path.swap(baseDir);
+            RETURN_IF_FAILED(StringCchLengthW(path.get(), STRSAFE_MAX_CCH, &bufferCount));
+        }
         filenameToUse = c_defaultPriFilename;
     }
 
@@ -997,8 +1003,8 @@ STDAPI MrmGetFilePathFromName(_In_opt_ PCWSTR filename, _Outptr_ PWSTR* filePath
     //   - search under exe path
     //   - if not exist, search parent path
     // If filename is not provided:
-    //   - search under exe path with default name (resources.pri)
-    //   - if not exist, search under same path with [modulename].pri
+    //   - search under exe path (or baseDir) with default name (resources.pri)
+    //   - if not exist, search under exe path (or baseDir) with [modulename].pri
     for (int i = 0; i < 2; i++)
     {
         size_t lengthOfName;

--- a/dev/UndockedRegFreeWinRT/UndockedRegFreeWinRT-AutoInitializer.cs
+++ b/dev/UndockedRegFreeWinRT/UndockedRegFreeWinRT-AutoInitializer.cs
@@ -6,6 +6,7 @@
 // DO NOT MODIFY. Changes to this file may cause incorrect behavior and will be lost on updates.
 // </auto-generated>
 
+using System;
 using System.Reflection;
 using System.Runtime.InteropServices;
 

--- a/dev/UndockedRegFreeWinRT/UndockedRegFreeWinRT-AutoInitializer.cs
+++ b/dev/UndockedRegFreeWinRT/UndockedRegFreeWinRT-AutoInitializer.cs
@@ -22,6 +22,9 @@ namespace Microsoft.Windows.Foundation.UndockedRegFreeWinRTCS
         [global::System.Runtime.CompilerServices.ModuleInitializer]
         internal static void AccessWindowsAppSDK()
         {
+            // Set base directory env var for PublishSingleFile support (referenced by SxS redirection)
+            Environment.SetEnvironmentVariable("MICROSOFT_WINDOWSAPPRUNTIME_BASE_DIRECTORY", AppContext.BaseDirectory);
+
             // No error handling needed as the target function does nothing (just {return S_OK}).
             // It's the act of calling the function causing the DllImport to load the DLL that
             // matters. This provides the moral equivalent of a native DLL's Import Address

--- a/dev/UndockedRegFreeWinRT/catalog.cpp
+++ b/dev/UndockedRegFreeWinRT/catalog.cpp
@@ -212,7 +212,6 @@ HRESULT ParseFileTag(IXmlReader* xmlReader)
     PCWSTR value = nullptr;
     std::wstring fileName;
     auto locale = _create_locale(LC_ALL, "C");
-    // Using this pattern intead of calling multiple MoveToAttributeByName improves performance
     HRESULT hr = xmlReader->MoveToFirstAttribute();
     if (S_FALSE == hr)
     {
@@ -275,7 +274,6 @@ HRESULT ParseActivatableClassTag(IXmlReader* xmlReader, PCWSTR fileName)
     auto this_component = make_shared<component>();
     this_component->module_name = fileName;
     HRESULT hr = xmlReader->MoveToFirstAttribute();
-    // Using this pattern intead of calling multiple MoveToAttributeByName improves performance
     const WCHAR* activatableClass = nullptr;
     const WCHAR* threadingModel = nullptr;
     if (S_FALSE == hr)


### PR DESCRIPTION
PublishSingleFile creates a self-extracting exe that deposits embedded files into a temporary folder.  As noted in #2597, this causes dll SxS redirection issues, as well as resources.pri lookup issues.  The support here (which requires coordinated changes in aggregator) sets a base directory env var, which is used to configure the generated self-contained app.manifest entries to enable custom SxS redirection via the undocumented loadFrom attribute, e.g.:
`<asmv3:file name="microsoft.ui.xaml.dll" loadFrom="%MICROSOFT_WINDOWSAPPRUNTIME_BASE_DIRECTORY%microsoft.ui.xaml.dll">`
