### PR TITLE
Revert Building Mock WindowsAppSDK and SubModules

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "WindowsAppSDKAggregator"]
-	path = WindowsAppSDKAggregator
-	url = ../WindowsAppSDKAggregator

--- a/BuildAll.ps1
+++ b/BuildAll.ps1
@@ -410,11 +410,11 @@ Try {
             exit 1
         }
     }
-    if (($AzureBuildStep -eq "all") -Or ($AzureBuildStep -eq "BuildMock"))
-    {
-        $transportPackagepath = (Join-Path $OutputDirectory "Microsoft.WindowsAppSDK.Foundation.TransportPackage.$PackageVersion.nupkg")
-        . eng\common\Scripts\buildMockWinAppSdkPackage.ps1 -TransportPackageName "Foundation" -TransportPackagePath $transportPackagepath -RepoRoot $env:Build_SourcesDirectory -Output $OutputDirectory -Platform $Platform -Configuration $Configuration -TransportPackageVersion $PackageVersion -CleanOutput
-    }
+    # if (($AzureBuildStep -eq "all") -Or ($AzureBuildStep -eq "BuildMock"))
+    # {
+    #     $transportPackagepath = (Join-Path $OutputDirectory "Microsoft.WindowsAppSDK.Foundation.TransportPackage.$PackageVersion.nupkg")
+    #     . eng\common\Scripts\buildMockWinAppSdkPackage.ps1 -TransportPackageName "Foundation" -TransportPackagePath $transportPackagepath -RepoRoot $env:Build_SourcesDirectory -Output $OutputDirectory -Platform $Platform -Configuration $Configuration -TransportPackageVersion $PackageVersion -CleanOutput
+    # }
 
     $files = Get-ChildItem $OutputDirectory -File -Filter "*.nupkg"
     foreach ($file in $files)

--- a/build/AzurePipelinesTemplates/WindowsAppSDK-PackTransportPackage-Stage.yml
+++ b/build/AzurePipelinesTemplates/WindowsAppSDK-PackTransportPackage-Stage.yml
@@ -182,12 +182,13 @@ stages:
         filePath: 'BuildAll.ps1'
         arguments: -Platform "x64" -Configuration "release" -AzureBuildStep "PackNuget" -OutputDirectory "$(build.artifactStagingDirectory)\FullNuget" -PackageVersion "$(packageVersion)"
 
-    - ${{ if eq(parameters.BuildMockWindowsAppSDK, 'true') }}:
-      - task: PowerShell@2
-        name: BuildMock
-        inputs:
-          filePath: 'BuildAll.ps1'
-          arguments: -Platform "x64" -Configuration "release" -AzureBuildStep "BuildMock" -OutputDirectory "$(build.artifactStagingDirectory)\FullNuget" -PackageVersion "$(packageVersion)"
+    # Disable building MockWindowsAppSDK until we can consider the public vs private scenario
+    # - ${{ if eq(parameters.BuildMockWindowsAppSDK, 'true') }}:
+    #   - task: PowerShell@2
+    #     name: BuildMock
+    #     inputs:
+    #       filePath: 'BuildAll.ps1'
+    #       arguments: -Platform "x64" -Configuration "release" -AzureBuildStep "BuildMock" -OutputDirectory "$(build.artifactStagingDirectory)\FullNuget" -PackageVersion "$(packageVersion)"
 
     - ${{ if eq(parameters.SignOutput, 'true') }}:
       - task: EsrpCodeSigning@2


### PR DESCRIPTION
The relative path in the submodules to the Aggregator is causing issues. 

Because Foundation is public, I've failed to consider the implications of having a submodule to a private repository. 