### PR TITLE
48525090 - Skipping a test case to temporarily avoid hitting this bug

### DIFF
--- a/dev/Common/IsWindowsVersion.h
+++ b/dev/Common/IsWindowsVersion.h
@@ -52,6 +52,11 @@ inline bool IsWindows11_22H2OrGreater()
     // GetPackageGraphRevisionId() added to kernelbase.dll in NTDDI_WIN10_NI (aka Windows 11 22H2)
     return IsExportPresent(L"kernelbase.dll", "GetPackageGraphRevisionId");
 }
+inline bool IsWindows11_23H1OrGreater()
+{
+    // TryCreatePackageDependency2() added to  in NTDDI_WIN10_GE (aka Windows 11 23H1)
+    return IsExportPresent(L"api-ms-win-appmodel-runtime-l1-1-7.dll", "TryCreatePackageDependency2");
+}
 }
 
 #endif // __ISWINDOWSVERSION_H

--- a/test/DynamicDependency/Test_Win32/DynamicDependency_Test_Win32.vcxproj
+++ b/test/DynamicDependency/Test_Win32/DynamicDependency_Test_Win32.vcxproj
@@ -105,7 +105,7 @@
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
     <ClCompile>
       <PrecompiledHeader>Use</PrecompiledHeader>
-      <AdditionalIncludeDirectories>$(VCInstallDir)UnitTest\include;%(AdditionalIncludeDirectories);$(OutDir)\..\WindowsAppRuntime_DLL;$(OutDir)\..\WindowsAppRuntime_BootstrapDLL;$(OutDir)\..\Framework.Math.Add;$(OutDir)\..\Framework.Math.Multiply;$(RepoRoot)\dev\common</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(VCInstallDir)UnitTest\include;%(AdditionalIncludeDirectories);$(OutDir)\..\WindowsAppRuntime_DLL;$(OutDir)\..\WindowsAppRuntime_BootstrapDLL;$(OutDir)\..\Framework.Math.Add;$(OutDir)\..\Framework.Math.Multiply;$(RepoRoot)\dev\common;$(RepoRoot)\test\inc</AdditionalIncludeDirectories>
       <PreprocessorDefinitions>WIN32;NDEBUG;%(PreprocessorDefinitions);PRTEST_MODE_UWP=0</PreprocessorDefinitions>
       <UseFullPaths>true</UseFullPaths>
       <PrecompiledHeaderFile>pch.h</PrecompiledHeaderFile>
@@ -120,7 +120,7 @@
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <ClCompile>
       <PrecompiledHeader>Use</PrecompiledHeader>
-      <AdditionalIncludeDirectories>$(VCInstallDir)UnitTest\include;%(AdditionalIncludeDirectories);$(OutDir)\..\WindowsAppRuntime_DLL;$(OutDir)\..\WindowsAppRuntime_BootstrapDLL;$(OutDir)\..\Framework.Math.Add;$(OutDir)\..\Framework.Math.Multiply;$(RepoRoot)\dev\common</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(VCInstallDir)UnitTest\include;%(AdditionalIncludeDirectories);$(OutDir)\..\WindowsAppRuntime_DLL;$(OutDir)\..\WindowsAppRuntime_BootstrapDLL;$(OutDir)\..\Framework.Math.Add;$(OutDir)\..\Framework.Math.Multiply;$(RepoRoot)\dev\common;$(RepoRoot)\test\inc</AdditionalIncludeDirectories>
       <PreprocessorDefinitions>WIN32;_DEBUG;%(PreprocessorDefinitions);PRTEST_MODE_UWP=0</PreprocessorDefinitions>
       <UseFullPaths>true</UseFullPaths>
       <PrecompiledHeaderFile>pch.h</PrecompiledHeaderFile>
@@ -135,7 +135,7 @@
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <ClCompile>
       <PrecompiledHeader>Use</PrecompiledHeader>
-      <AdditionalIncludeDirectories>$(VCInstallDir)UnitTest\include;%(AdditionalIncludeDirectories);$(OutDir)\..\WindowsAppRuntime_DLL;$(OutDir)\..\WindowsAppRuntime_BootstrapDLL;$(OutDir)\..\Framework.Math.Add;$(OutDir)\..\Framework.Math.Multiply;$(RepoRoot)\dev\common</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(VCInstallDir)UnitTest\include;%(AdditionalIncludeDirectories);$(OutDir)\..\WindowsAppRuntime_DLL;$(OutDir)\..\WindowsAppRuntime_BootstrapDLL;$(OutDir)\..\Framework.Math.Add;$(OutDir)\..\Framework.Math.Multiply;$(RepoRoot)\dev\common;$(RepoRoot)\test\inc</AdditionalIncludeDirectories>
       <PreprocessorDefinitions>_DEBUG;%(PreprocessorDefinitions);PRTEST_MODE_UWP=0</PreprocessorDefinitions>
       <UseFullPaths>true</UseFullPaths>
       <PrecompiledHeaderFile>pch.h</PrecompiledHeaderFile>
@@ -150,7 +150,7 @@
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|ARM64'">
     <ClCompile>
       <PrecompiledHeader>Use</PrecompiledHeader>
-      <AdditionalIncludeDirectories>$(VCInstallDir)UnitTest\include;%(AdditionalIncludeDirectories);$(OutDir)\..\WindowsAppRuntime_DLL;$(OutDir)\..\WindowsAppRuntime_BootstrapDLL;$(OutDir)\..\Framework.Math.Add;$(OutDir)\..\Framework.Math.Multiply;$(RepoRoot)\dev\common</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(VCInstallDir)UnitTest\include;%(AdditionalIncludeDirectories);$(OutDir)\..\WindowsAppRuntime_DLL;$(OutDir)\..\WindowsAppRuntime_BootstrapDLL;$(OutDir)\..\Framework.Math.Add;$(OutDir)\..\Framework.Math.Multiply;$(RepoRoot)\dev\common;$(RepoRoot)\test\inc</AdditionalIncludeDirectories>
       <PreprocessorDefinitions>_DEBUG;%(PreprocessorDefinitions);PRTEST_MODE_UWP=0</PreprocessorDefinitions>
       <UseFullPaths>true</UseFullPaths>
       <PrecompiledHeaderFile>pch.h</PrecompiledHeaderFile>
@@ -165,7 +165,7 @@
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <ClCompile>
       <PrecompiledHeader>Use</PrecompiledHeader>
-      <AdditionalIncludeDirectories>$(VCInstallDir)UnitTest\include;%(AdditionalIncludeDirectories);$(OutDir)\..\WindowsAppRuntime_DLL;$(OutDir)\..\WindowsAppRuntime_BootstrapDLL;$(OutDir)\..\Framework.Math.Add;$(OutDir)\..\Framework.Math.Multiply;$(RepoRoot)\dev\common</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(VCInstallDir)UnitTest\include;%(AdditionalIncludeDirectories);$(OutDir)\..\WindowsAppRuntime_DLL;$(OutDir)\..\WindowsAppRuntime_BootstrapDLL;$(OutDir)\..\Framework.Math.Add;$(OutDir)\..\Framework.Math.Multiply;$(RepoRoot)\dev\common;$(RepoRoot)\test\inc</AdditionalIncludeDirectories>
       <PreprocessorDefinitions>NDEBUG;%(PreprocessorDefinitions);PRTEST_MODE_UWP=0</PreprocessorDefinitions>
       <UseFullPaths>true</UseFullPaths>
       <PrecompiledHeaderFile>pch.h</PrecompiledHeaderFile>
@@ -180,7 +180,7 @@
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|ARM64'">
     <ClCompile>
       <PrecompiledHeader>Use</PrecompiledHeader>
-      <AdditionalIncludeDirectories>$(VCInstallDir)UnitTest\include;%(AdditionalIncludeDirectories);$(OutDir)\..\WindowsAppRuntime_DLL;$(OutDir)\..\WindowsAppRuntime_BootstrapDLL;$(OutDir)\..\Framework.Math.Add;$(OutDir)\..\Framework.Math.Multiply;$(RepoRoot)\dev\common</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(VCInstallDir)UnitTest\include;%(AdditionalIncludeDirectories);$(OutDir)\..\WindowsAppRuntime_DLL;$(OutDir)\..\WindowsAppRuntime_BootstrapDLL;$(OutDir)\..\Framework.Math.Add;$(OutDir)\..\Framework.Math.Multiply;$(RepoRoot)\dev\common;$(RepoRoot)\test\inc</AdditionalIncludeDirectories>
       <PreprocessorDefinitions>NDEBUG;%(PreprocessorDefinitions);PRTEST_MODE_UWP=0</PreprocessorDefinitions>
       <UseFullPaths>true</UseFullPaths>
       <PrecompiledHeaderFile>pch.h</PrecompiledHeaderFile>

--- a/test/DynamicDependency/Test_Win32/Test_Win32.cpp
+++ b/test/DynamicDependency/Test_Win32/Test_Win32.cpp
@@ -19,6 +19,12 @@ wil::unique_hmodule Test::DynamicDependency::Test_Win32::m_bootstrapDll;
 
 bool Test::DynamicDependency::Test_Win32::Setup()
 {
+    if (/*TODO ::WindowsVersion::IsWindows11_23H1OrGreater() &&*/ !::Test::TAEF::IsEnabled(L"DynamicDependency.23H1"))
+    {
+        WEX::Logging::Log::Result(WEX::Logging::TestResults::Skipped, L"Skipping tests to avoid https://task.ms/48525090");
+        return true;
+    }
+
     // Remove our packages in case they were previously installed and incompletely removed
     TP::RemovePackage_DynamicDependencyLifetimeManager();
     TP::RemovePackage_DynamicDependencyDataStore();

--- a/test/DynamicDependency/Test_Win32/Test_Win32.h
+++ b/test/DynamicDependency/Test_Win32/Test_Win32.h
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft Corporation and Contributors.
+// Copyright (c) Microsoft Corporation and Contributors.
 // Licensed under the MIT License.
 
 #pragma once
@@ -246,6 +246,11 @@ namespace Test::DynamicDependency
 
         TEST_CLASS_SETUP(Setup_Elevated)
         {
+            if (/*TODO ::WindowsVersion::IsWindows11_23H1OrGreater() &&*/ !::Test::TAEF::IsEnabled(L"DynamicDependency.23H1"))
+            {
+                WEX::Logging::Log::Result(WEX::Logging::TestResults::Skipped, L"Skipping tests to avoid https://task.ms/48525090");
+                return true;
+            }
             return Setup();
         }
         TEST_CLASS_CLEANUP(Cleanup_Elevated)
@@ -277,8 +282,7 @@ namespace Test::DynamicDependency
         }
         TEST_METHOD(FullLifecycle_FilePathLifetime_Frameworks_WindowsAppRuntime_MathAdd_Elevated)
         {
-            WEX::Logging::Log::Result(WEX::Logging::TestResults::Skipped, L"Temporarily skipping this to avoid hitting b#48525090.");
-            // FullLifecycle_FilePathLifetime_Frameworks_WindowsAppRuntime_MathAdd();
+            FullLifecycle_FilePathLifetime_Frameworks_WindowsAppRuntime_MathAdd();
         }
         TEST_METHOD(FullLifecycle_RegistryLifetime_Frameworks_WindowsAppRuntime_MathAdd_Elevated)
         {

--- a/test/DynamicDependency/Test_Win32/Test_Win32.h
+++ b/test/DynamicDependency/Test_Win32/Test_Win32.h
@@ -277,7 +277,8 @@ namespace Test::DynamicDependency
         }
         TEST_METHOD(FullLifecycle_FilePathLifetime_Frameworks_WindowsAppRuntime_MathAdd_Elevated)
         {
-            FullLifecycle_FilePathLifetime_Frameworks_WindowsAppRuntime_MathAdd();
+            WEX::Logging::Log::Result(WEX::Logging::TestResults::Skipped, L"Temporarily skipping this to avoid hitting b#48525090.");
+            // FullLifecycle_FilePathLifetime_Frameworks_WindowsAppRuntime_MathAdd();
         }
         TEST_METHOD(FullLifecycle_RegistryLifetime_Frameworks_WindowsAppRuntime_MathAdd_Elevated)
         {

--- a/test/DynamicDependency/Test_Win32/Test_Win32.h
+++ b/test/DynamicDependency/Test_Win32/Test_Win32.h
@@ -246,11 +246,6 @@ namespace Test::DynamicDependency
 
         TEST_CLASS_SETUP(Setup_Elevated)
         {
-            if (/*TODO ::WindowsVersion::IsWindows11_23H1OrGreater() &&*/ !::Test::TAEF::IsEnabled(L"DynamicDependency.23H1"))
-            {
-                WEX::Logging::Log::Result(WEX::Logging::TestResults::Skipped, L"Skipping tests to avoid https://task.ms/48525090");
-                return true;
-            }
             return Setup();
         }
         TEST_CLASS_CLEANUP(Cleanup_Elevated)

--- a/test/DynamicDependency/Test_Win32/pch.h
+++ b/test/DynamicDependency/Test_Win32/pch.h
@@ -40,10 +40,12 @@
 
 #include <appmodel.identity.h>
 #include <appmodel.packagegraph.h>
+#include <IsWindowsVersion.h>
 #include <security.integritylevel.h>
 
 #include "TestFilesystem.h"
 #include "TestPackages.h"
+#include <WindowsAppRuntime.Test.TAEF.h>
 
 #include <winrt/Microsoft.Test.DynamicDependency.Widgets.h>
 

--- a/test/DynamicDependency/Test_WinRT/DynamicDependency_Test_WinRT.vcxproj
+++ b/test/DynamicDependency/Test_WinRT/DynamicDependency_Test_WinRT.vcxproj
@@ -110,7 +110,7 @@
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
     <ClCompile>
       <PrecompiledHeader>Use</PrecompiledHeader>
-      <AdditionalIncludeDirectories>$(VCInstallDir)UnitTest\include;%(AdditionalIncludeDirectories);$(OutDir)\..\WindowsAppRuntime_DLL;$(OutDir)\..\WindowsAppRuntime_BootstrapDLL;$(OutDir)\..\Framework.Math.Add;$(OutDir)\..\Framework.Math.Multiply;$(RepoRoot)\dev\common</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(VCInstallDir)UnitTest\include;%(AdditionalIncludeDirectories);$(OutDir)\..\WindowsAppRuntime_DLL;$(OutDir)\..\WindowsAppRuntime_BootstrapDLL;$(OutDir)\..\Framework.Math.Add;$(OutDir)\..\Framework.Math.Multiply;$(RepoRoot)\dev\common;$(RepoRoot)\test\inc</AdditionalIncludeDirectories>
       <PreprocessorDefinitions>WIN32;NDEBUG;%(PreprocessorDefinitions);PRTEST_MODE_UWP=0</PreprocessorDefinitions>
       <UseFullPaths>true</UseFullPaths>
       <PrecompiledHeaderFile>pch.h</PrecompiledHeaderFile>
@@ -125,7 +125,7 @@
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <ClCompile>
       <PrecompiledHeader>Use</PrecompiledHeader>
-      <AdditionalIncludeDirectories>$(VCInstallDir)UnitTest\include;%(AdditionalIncludeDirectories);$(OutDir)\..\WindowsAppRuntime_DLL;$(OutDir)\..\WindowsAppRuntime_BootstrapDLL;$(OutDir)\..\Framework.Math.Add;$(OutDir)\..\Framework.Math.Multiply;$(RepoRoot)\dev\common</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(VCInstallDir)UnitTest\include;%(AdditionalIncludeDirectories);$(OutDir)\..\WindowsAppRuntime_DLL;$(OutDir)\..\WindowsAppRuntime_BootstrapDLL;$(OutDir)\..\Framework.Math.Add;$(OutDir)\..\Framework.Math.Multiply;$(RepoRoot)\dev\common;$(RepoRoot)\test\inc</AdditionalIncludeDirectories>
       <PreprocessorDefinitions>WIN32;_DEBUG;%(PreprocessorDefinitions);PRTEST_MODE_UWP=0</PreprocessorDefinitions>
       <UseFullPaths>true</UseFullPaths>
       <PrecompiledHeaderFile>pch.h</PrecompiledHeaderFile>
@@ -140,7 +140,7 @@
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <ClCompile>
       <PrecompiledHeader>Use</PrecompiledHeader>
-      <AdditionalIncludeDirectories>$(VCInstallDir)UnitTest\include;%(AdditionalIncludeDirectories);$(OutDir)\..\WindowsAppRuntime_DLL;$(OutDir)\..\WindowsAppRuntime_BootstrapDLL;$(OutDir)\..\Framework.Math.Add;$(OutDir)\..\Framework.Math.Multiply;$(RepoRoot)\dev\common</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(VCInstallDir)UnitTest\include;%(AdditionalIncludeDirectories);$(OutDir)\..\WindowsAppRuntime_DLL;$(OutDir)\..\WindowsAppRuntime_BootstrapDLL;$(OutDir)\..\Framework.Math.Add;$(OutDir)\..\Framework.Math.Multiply;$(RepoRoot)\dev\common;$(RepoRoot)\test\inc</AdditionalIncludeDirectories>
       <PreprocessorDefinitions>_DEBUG;%(PreprocessorDefinitions);PRTEST_MODE_UWP=0</PreprocessorDefinitions>
       <UseFullPaths>true</UseFullPaths>
       <PrecompiledHeaderFile>pch.h</PrecompiledHeaderFile>
@@ -155,7 +155,7 @@
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|ARM64'">
     <ClCompile>
       <PrecompiledHeader>Use</PrecompiledHeader>
-      <AdditionalIncludeDirectories>$(VCInstallDir)UnitTest\include;%(AdditionalIncludeDirectories);$(OutDir)\..\WindowsAppRuntime_DLL;$(OutDir)\..\WindowsAppRuntime_BootstrapDLL;$(OutDir)\..\Framework.Math.Add;$(OutDir)\..\Framework.Math.Multiply;$(RepoRoot)\dev\common</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(VCInstallDir)UnitTest\include;%(AdditionalIncludeDirectories);$(OutDir)\..\WindowsAppRuntime_DLL;$(OutDir)\..\WindowsAppRuntime_BootstrapDLL;$(OutDir)\..\Framework.Math.Add;$(OutDir)\..\Framework.Math.Multiply;$(RepoRoot)\dev\common;$(RepoRoot)\test\inc</AdditionalIncludeDirectories>
       <PreprocessorDefinitions>_DEBUG;%(PreprocessorDefinitions);PRTEST_MODE_UWP=0</PreprocessorDefinitions>
       <UseFullPaths>true</UseFullPaths>
       <PrecompiledHeaderFile>pch.h</PrecompiledHeaderFile>
@@ -170,7 +170,7 @@
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <ClCompile>
       <PrecompiledHeader>Use</PrecompiledHeader>
-      <AdditionalIncludeDirectories>$(VCInstallDir)UnitTest\include;%(AdditionalIncludeDirectories);$(OutDir)\..\WindowsAppRuntime_DLL;$(OutDir)\..\WindowsAppRuntime_BootstrapDLL;$(OutDir)\..\Framework.Math.Add;$(OutDir)\..\Framework.Math.Multiply;$(RepoRoot)\dev\common</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(VCInstallDir)UnitTest\include;%(AdditionalIncludeDirectories);$(OutDir)\..\WindowsAppRuntime_DLL;$(OutDir)\..\WindowsAppRuntime_BootstrapDLL;$(OutDir)\..\Framework.Math.Add;$(OutDir)\..\Framework.Math.Multiply;$(RepoRoot)\dev\common;$(RepoRoot)\test\inc</AdditionalIncludeDirectories>
       <PreprocessorDefinitions>NDEBUG;%(PreprocessorDefinitions);PRTEST_MODE_UWP=0</PreprocessorDefinitions>
       <UseFullPaths>true</UseFullPaths>
       <PrecompiledHeaderFile>pch.h</PrecompiledHeaderFile>
@@ -185,7 +185,7 @@
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|ARM64'">
     <ClCompile>
       <PrecompiledHeader>Use</PrecompiledHeader>
-      <AdditionalIncludeDirectories>$(VCInstallDir)UnitTest\include;%(AdditionalIncludeDirectories);$(OutDir)\..\WindowsAppRuntime_DLL;$(OutDir)\..\WindowsAppRuntime_BootstrapDLL;$(OutDir)\..\Framework.Math.Add;$(OutDir)\..\Framework.Math.Multiply;$(RepoRoot)\dev\common</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(VCInstallDir)UnitTest\include;%(AdditionalIncludeDirectories);$(OutDir)\..\WindowsAppRuntime_DLL;$(OutDir)\..\WindowsAppRuntime_BootstrapDLL;$(OutDir)\..\Framework.Math.Add;$(OutDir)\..\Framework.Math.Multiply;$(RepoRoot)\dev\common;$(RepoRoot)\test\inc</AdditionalIncludeDirectories>
       <PreprocessorDefinitions>NDEBUG;%(PreprocessorDefinitions);PRTEST_MODE_UWP=0</PreprocessorDefinitions>
       <UseFullPaths>true</UseFullPaths>
       <PrecompiledHeaderFile>pch.h</PrecompiledHeaderFile>

--- a/test/DynamicDependency/Test_WinRT/Test_WinRT.cpp
+++ b/test/DynamicDependency/Test_WinRT/Test_WinRT.cpp
@@ -21,6 +21,12 @@ wil::unique_hmodule Test::DynamicDependency::Test_WinRT::m_bootstrapDll;
 
 bool Test::DynamicDependency::Test_WinRT::Setup()
 {
+    if (/*TODO ::WindowsVersion::IsWindows11_23H1OrGreater() &&*/ !::Test::TAEF::IsEnabled(L"DynamicDependency.23H1"))
+    {
+        WEX::Logging::Log::Result(WEX::Logging::TestResults::Skipped, L"Skipping tests to avoid https://task.ms/48525090");
+        return true;
+    }
+
     // Remove our packages in case they were previously installed and incompletely removed
     TP::RemovePackage_DynamicDependencyLifetimeManager();
     TP::RemovePackage_DynamicDependencyDataStore();

--- a/test/DynamicDependency/Test_WinRT/Test_WinRT.h
+++ b/test/DynamicDependency/Test_WinRT/Test_WinRT.h
@@ -235,11 +235,6 @@ namespace Test::DynamicDependency
 
         TEST_CLASS_SETUP(Setup_Elevated)
         {
-            if (/*TODO ::WindowsVersion::IsWindows11_23H1OrGreater() &&*/ !::Test::TAEF::IsEnabled(L"DynamicDependency.23H1"))
-            {
-                WEX::Logging::Log::Result(WEX::Logging::TestResults::Skipped, L"Skipping tests to avoid https://task.ms/48525090");
-                return true;
-            }
             return Setup();
         }
         TEST_CLASS_CLEANUP(Cleanup_Elevated)

--- a/test/DynamicDependency/Test_WinRT/Test_WinRT.h
+++ b/test/DynamicDependency/Test_WinRT/Test_WinRT.h
@@ -266,7 +266,8 @@ namespace Test::DynamicDependency
         }
         TEST_METHOD(FullLifecycle_FilePathLifetime_Frameworks_WindowsAppRuntime_MathAdd_Elevated)
         {
-            FullLifecycle_FilePathLifetime_Frameworks_WindowsAppRuntime_MathAdd();
+            WEX::Logging::Log::Result(WEX::Logging::TestResults::Skipped, L"Temporarily skipping this to avoid hitting b#48525090.");
+            // FullLifecycle_FilePathLifetime_Frameworks_WindowsAppRuntime_MathAdd();
         }
         TEST_METHOD(FullLifecycle_RegistryLifetime_Frameworks_WindowsAppRuntime_MathAdd_Elevated)
         {

--- a/test/DynamicDependency/Test_WinRT/Test_WinRT.h
+++ b/test/DynamicDependency/Test_WinRT/Test_WinRT.h
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft Corporation and Contributors.
+// Copyright (c) Microsoft Corporation and Contributors.
 // Licensed under the MIT License.
 
 #pragma once
@@ -235,6 +235,11 @@ namespace Test::DynamicDependency
 
         TEST_CLASS_SETUP(Setup_Elevated)
         {
+            if (/*TODO ::WindowsVersion::IsWindows11_23H1OrGreater() &&*/ !::Test::TAEF::IsEnabled(L"DynamicDependency.23H1"))
+            {
+                WEX::Logging::Log::Result(WEX::Logging::TestResults::Skipped, L"Skipping tests to avoid https://task.ms/48525090");
+                return true;
+            }
             return Setup();
         }
         TEST_CLASS_CLEANUP(Cleanup_Elevated)
@@ -266,8 +271,7 @@ namespace Test::DynamicDependency
         }
         TEST_METHOD(FullLifecycle_FilePathLifetime_Frameworks_WindowsAppRuntime_MathAdd_Elevated)
         {
-            WEX::Logging::Log::Result(WEX::Logging::TestResults::Skipped, L"Temporarily skipping this to avoid hitting b#48525090.");
-            // FullLifecycle_FilePathLifetime_Frameworks_WindowsAppRuntime_MathAdd();
+            FullLifecycle_FilePathLifetime_Frameworks_WindowsAppRuntime_MathAdd();
         }
         TEST_METHOD(FullLifecycle_RegistryLifetime_Frameworks_WindowsAppRuntime_MathAdd_Elevated)
         {

--- a/test/DynamicDependency/Test_WinRT/pch.h
+++ b/test/DynamicDependency/Test_WinRT/pch.h
@@ -38,8 +38,10 @@
 #include <WexTestClass.h>
 
 #include <appmodel.identity.h>
+#include <IsWindowsVersion.h>
 
 #include "TestFilesystem.h"
 #include "TestPackages.h"
+#include <WindowsAppRuntime.Test.TAEF.h>
 
 #endif //PCH_H

--- a/test/inc/WindowsAppRuntime.Test.TAEF.h
+++ b/test/inc/WindowsAppRuntime.Test.TAEF.h
@@ -12,6 +12,82 @@ namespace Test::TAEF
         WEX::TestExecution::RuntimeParameters::TryGetValue(L"TestDeploymentDir", testDeploymentDir);
         return static_cast<PCWSTR>(testDeploymentDir);
     }
+
+    inline bool TryGetOption(
+        _In_ PCWSTR name,
+        WEX::Common::String& value)
+    {
+        HRESULT hr = WEX::TestExecution::RuntimeParameters::TryGetValue(name, value);
+        if (!SUCCEEDED(hr))
+        {
+            VERIFY_ARE_EQUAL(hr, HRESULT_FROM_WIN32(ERROR_NOT_FOUND));
+        }
+        return SUCCEEDED(hr);
+    }
+
+    inline bool TryGetOption(
+        _In_ PCWSTR name,
+        UINT32& value)
+    {
+        WEX::Common::String valueString;
+        if (!TryGetOption(name, valueString))
+        {
+            return false;
+        }
+        WCHAR * s = nullptr;
+        int base = ((wcslen(valueString) >= 2) && (valueString[0] == L'0') && (valueString[1] == L'x')) ? 16 : 10;
+        unsigned long n = wcstoul(valueString, &s, base);
+        if (*valueString != L'\0')
+        {
+            WEX::Common::String invalidParameter;
+            invalidParameter.Format(L"Invalid parameter: /p:%s=<n>", name);
+            return false;
+        }
+        value = n;
+        return true;
+    }
+
+    inline bool IsEnabled(
+        _In_ PCWSTR name,
+        const WEX::Common::String& value,
+        bool defaultValue = false)
+    {
+        if (value.GetLength() == 0)
+        {
+            return defaultValue;
+        }
+        WCHAR * s = nullptr;
+        long n = wcstol(value, &s, 10);
+        if ((*s != L'\0') || ((n != 0) && (n != 1)))
+        {
+            WEX::Common::String invalidParameter;
+            invalidParameter.Format(L"Invalid parameter: /p:%s=<0|1>", name);
+            VERIFY_IS_TRUE(*s == L'\0', invalidParameter);
+            VERIFY_IS_TRUE((n == 0) || (n == 1), invalidParameter);
+        }
+        return n != 0;
+    }
+
+    inline bool IsEnabled(
+        _In_ PCWSTR name,
+        bool defaultValue = false)
+    {
+        WEX::Common::String value;
+        const bool ok = TryGetOption(name, value);
+        if (!ok)
+        {
+            WEX::Common::String environmentVariableName;
+            environmentVariableName.Format(L"STATEREPOSITORY_TEST_%s", name);
+            WCHAR environmentVariable[10]{};
+            const auto length{ GetEnvironmentVariableW(environmentVariableName, environmentVariable, ARRAYSIZE(environmentVariable)) };
+            if ((length == 0) || (length > ARRAYSIZE(environmentVariable)))
+            {
+               return defaultValue;
+            }
+            value = environmentVariable;
+        }
+        return IsEnabled(name, value, defaultValue);
+    }
 }
 
 #endif // __WINDOWSAPPRUNTIME_TEST_TAEF_H


### PR DESCRIPTION
Temporarily skip test case FullLifecycle_FilePathLifetime_Frameworks_WindowsAppRuntime_MathAdd_Elevated() to unblock pipeline runs.
---------

A microsoft employee must use /azp run to validate using the pipelines below.

WARNING:
Comments made by azure-pipelines bot maybe inaccurate.
Please see pipeline link to verify that the build is being ran.

For status checks on the main branch, please use TransportPackage-Foundation-PR
(https://microsoft.visualstudio.com/ProjectReunion/_build?definitionId=81063&_a=summary)
and run the build against your PR branch with the default parameters.
