### PR TITLE
Set Channel Variable back to Experimental

### DIFF
--- a/build/WindowsAppSDK-CommonVariables.yml
+++ b/build/WindowsAppSDK-CommonVariables.yml
@@ -15,7 +15,7 @@ variables:
 
   Codeql.Enabled: true #  CodeQL runs every 3 days on the default branch for all languages its applicable to in that pipeline.
 
-  channel: 'preview'
+  channel: 'experimental'
   rerunPassesRequiredToAvoidFailure: 5
   versionDate: $[format('{0:yyyyMMdd}', pipeline.startTime)]
   versionCounter: $[counter(variables['versionDate'], 0)]


### PR DESCRIPTION
A microsoft employee must use /azp run to validate using the pipelines below.

WARNING:
Comments made by azure-pipelines bot maybe inaccurate.
Please see pipeline link to verify that the build is being ran.

For status checks on the main branch, please use TransportPackage-Foundation-PR
(https://microsoft.visualstudio.com/ProjectReunion/_build?definitionId=81063&_a=summary)
and run the build against your PR branch with the default parameters.
