### PR TITLE
PackageManagement Microsoft...StubPackageOptions + Projection + /we47…

### DIFF
--- a/WindowsAppRuntime.sln
+++ b/WindowsAppRuntime.sln
@@ -707,6 +707,11 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Workloads", "Workloads", "{
 EndProject
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "Workloads", "dev\Workloads\Workloads.vcxitems", "{B5798CEB-4E60-4D2D-B456-7C406B5F5B67}"
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.Windows.Management.Deployment", "dev\Projections\CS\Microsoft.Windows.Management.Deployment\Microsoft.Windows.Management.Deployment.csproj", "{57E6CCBE-EDEB-4300-8334-98A591D11B3F}"
+	ProjectSection(ProjectDependencies) = postProject
+		{B73AD907-6164-4294-88FB-F3C9C10DA1F1} = {B73AD907-6164-4294-88FB-F3C9C10DA1F1}
+	EndProjectSection
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -2397,6 +2402,22 @@ Global
 		{D0A1DFB8-8CEE-4CFC-B57B-B7C574B411C2}.Release|x64.Build.0 = Release|x64
 		{D0A1DFB8-8CEE-4CFC-B57B-B7C574B411C2}.Release|x86.ActiveCfg = Release|Win32
 		{D0A1DFB8-8CEE-4CFC-B57B-B7C574B411C2}.Release|x86.Build.0 = Release|Win32
+		{57E6CCBE-EDEB-4300-8334-98A591D11B3F}.Debug|Any CPU.ActiveCfg = Debug|x64
+		{57E6CCBE-EDEB-4300-8334-98A591D11B3F}.Debug|Any CPU.Build.0 = Debug|x64
+		{57E6CCBE-EDEB-4300-8334-98A591D11B3F}.Debug|ARM64.ActiveCfg = Debug|arm64
+		{57E6CCBE-EDEB-4300-8334-98A591D11B3F}.Debug|ARM64.Build.0 = Debug|arm64
+		{57E6CCBE-EDEB-4300-8334-98A591D11B3F}.Debug|x64.ActiveCfg = Debug|x64
+		{57E6CCBE-EDEB-4300-8334-98A591D11B3F}.Debug|x64.Build.0 = Debug|x64
+		{57E6CCBE-EDEB-4300-8334-98A591D11B3F}.Debug|x86.ActiveCfg = Debug|x86
+		{57E6CCBE-EDEB-4300-8334-98A591D11B3F}.Debug|x86.Build.0 = Debug|x86
+		{57E6CCBE-EDEB-4300-8334-98A591D11B3F}.Release|Any CPU.ActiveCfg = Release|x64
+		{57E6CCBE-EDEB-4300-8334-98A591D11B3F}.Release|Any CPU.Build.0 = Release|x64
+		{57E6CCBE-EDEB-4300-8334-98A591D11B3F}.Release|ARM64.ActiveCfg = Release|arm64
+		{57E6CCBE-EDEB-4300-8334-98A591D11B3F}.Release|ARM64.Build.0 = Release|arm64
+		{57E6CCBE-EDEB-4300-8334-98A591D11B3F}.Release|x64.ActiveCfg = Release|x64
+		{57E6CCBE-EDEB-4300-8334-98A591D11B3F}.Release|x64.Build.0 = Release|x64
+		{57E6CCBE-EDEB-4300-8334-98A591D11B3F}.Release|x86.ActiveCfg = Release|x86
+		{57E6CCBE-EDEB-4300-8334-98A591D11B3F}.Release|x86.Build.0 = Release|x86
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -2607,6 +2628,7 @@ Global
 		{D0A1DFB8-8CEE-4CFC-B57B-B7C574B411C2} = {B6B68924-6A0B-457E-AD53-018696EC8889}
 		{48948EF9-8B91-4F7A-98AD-0F8FA3EFAA38} = {448ED2E5-0B37-4D97-9E6B-8C10A507976A}
 		{B5798CEB-4E60-4D2D-B456-7C406B5F5B67} = {48948EF9-8B91-4F7A-98AD-0F8FA3EFAA38}
+		{57E6CCBE-EDEB-4300-8334-98A591D11B3F} = {716C26A0-E6B0-4981-8412-D14A4D410531}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {4B3D7591-CFEC-4762-9A07-ABE99938FB77}

--- a/WindowsAppSDK.Build.Cpp.props
+++ b/WindowsAppSDK.Build.Cpp.props
@@ -30,7 +30,8 @@
       <!-- /ZH:SHA_256 Hash algorithm for file checksums in debug info -->
       <!-- /await:strict Enable coroutine support. Disable language extensions present in /await that weren't adopted into C++20 -->
       <!-- /d1trimfile:$(RepoRoot) If the prefix for a source file path name string matches "trim-string" the prefix is replaced with the mapping-identifier (if present). Requires /Brepro. -->
-      <AdditionalOptions>%(AdditionalOptions) /Qspectre /ZH:SHA_256 /await:strict /d1trimfile:$(RepoRoot)</AdditionalOptions>
+      <!-- /we4715 If warning 4715 as an error (C4715 = 'function': not all control paths return a value) -->
+      <AdditionalOptions>%(AdditionalOptions) /Qspectre /ZH:SHA_256 /await:strict /d1trimfile:$(RepoRoot) /we4715</AdditionalOptions>
     </ClCompile>
     <Link>
       <!-- /DEBUG:FULL Create PDF containing full debug information -->

--- a/dev/PackageManager/API/M.W.M.D.AddPackageOptions.cpp
+++ b/dev/PackageManager/API/M.W.M.D.AddPackageOptions.cpp
@@ -58,11 +58,11 @@ namespace winrt::Microsoft::Windows::Management::Deployment::implementation
     {
         m_externalLocationUri = value;
     }
-    winrt::Windows::Management::Deployment::StubPackageOption AddPackageOptions::StubPackageOption()
+    winrt::Microsoft::Windows::Management::Deployment::StubPackageOption AddPackageOptions::StubPackageOption()
     {
         return m_stubPackageOption;
     }
-    void AddPackageOptions::StubPackageOption(winrt::Windows::Management::Deployment::StubPackageOption const& value)
+    void AddPackageOptions::StubPackageOption(winrt::Microsoft::Windows::Management::Deployment::StubPackageOption const& value)
     {
         m_stubPackageOption = value;
     }

--- a/dev/PackageManager/API/M.W.M.D.AddPackageOptions.h
+++ b/dev/PackageManager/API/M.W.M.D.AddPackageOptions.h
@@ -19,8 +19,8 @@ namespace winrt::Microsoft::Windows::Management::Deployment::implementation
         winrt::Windows::Foundation::Collections::IVector<winrt::Windows::Foundation::Uri> RelatedPackageUris();
         winrt::Windows::Foundation::Uri ExternalLocationUri();
         void ExternalLocationUri(winrt::Windows::Foundation::Uri const& value);
-        winrt::Windows::Management::Deployment::StubPackageOption StubPackageOption();
-        void StubPackageOption(winrt::Windows::Management::Deployment::StubPackageOption const& value);
+        winrt::Microsoft::Windows::Management::Deployment::StubPackageOption StubPackageOption();
+        void StubPackageOption(winrt::Microsoft::Windows::Management::Deployment::StubPackageOption const& value);
         bool AllowUnsigned();
         void AllowUnsigned(bool value);
         bool DeveloperMode();
@@ -54,7 +54,7 @@ namespace winrt::Microsoft::Windows::Management::Deployment::implementation
         winrt::Windows::Foundation::Collections::IVector<winrt::Windows::Foundation::Uri> m_optionalPackageUris;
         winrt::Windows::Foundation::Collections::IVector<winrt::Windows::Foundation::Uri> m_relatedPackageUris;
         winrt::Windows::Foundation::Uri m_externalLocationUri{ nullptr };
-        winrt::Windows::Management::Deployment::StubPackageOption m_stubPackageOption{};
+        winrt::Microsoft::Windows::Management::Deployment::StubPackageOption m_stubPackageOption{};
         bool m_allowUnsigned{};
         bool m_developerMode{};
         bool m_forceAppShutdown{};

--- a/dev/PackageManager/API/M.W.M.D.PackageDeploymentManager.cpp
+++ b/dev/PackageManager/API/M.W.M.D.PackageDeploymentManager.cpp
@@ -11,14 +11,14 @@
 
 #include "PackageManagerTelemetry.h"
 
-static_assert(static_cast<int>(winrt::Windows::Management::Deployment::StubPackageOption::Default) == static_cast<int>(winrt::Windows::Management::Deployment::StubPackageOption::Default),
-              "winrt::Windows::Management::Deployment::StubPackageOption::Default != winrt::Windows::Management::Deployment::StubPackageOption::Default");
-static_assert(static_cast<int>(winrt::Windows::Management::Deployment::StubPackageOption::InstallFull) == static_cast<int>(winrt::Windows::Management::Deployment::StubPackageOption::InstallFull),
-              "winrt::Windows::Management::Deployment::StubPackageOption::InstallFull != winrt::Windows::Management::Deployment::StubPackageOption::InstallFull");
-static_assert(static_cast<int>(winrt::Windows::Management::Deployment::StubPackageOption::InstallStub) == static_cast<int>(winrt::Windows::Management::Deployment::StubPackageOption::InstallStub),
-              "winrt::Windows::Management::Deployment::StubPackageOption::InstallStub != winrt::Windows::Management::Deployment::StubPackageOption::InstallStub");
-static_assert(static_cast<int>(winrt::Windows::Management::Deployment::StubPackageOption::UsePreference) == static_cast<int>(winrt::Windows::Management::Deployment::StubPackageOption::UsePreference),
-              "winrt::Windows::Management::Deployment::StubPackageOption::UsePreference != winrt::Windows::Management::Deployment::StubPackageOption::UsePreference");
+static_assert(static_cast<int>(winrt::Microsoft::Windows::Management::Deployment::StubPackageOption::Default) == static_cast<int>(winrt::Windows::Management::Deployment::StubPackageOption::Default),
+              "winrt::Microsoft::Windows::Management::Deployment::StubPackageOption::Default != winrt::Windows::Management::Deployment::StubPackageOption::Default");
+static_assert(static_cast<int>(winrt::Microsoft::Windows::Management::Deployment::StubPackageOption::InstallFull) == static_cast<int>(winrt::Windows::Management::Deployment::StubPackageOption::InstallFull),
+              "winrt::Microsoft::Windows::Management::Deployment::StubPackageOption::InstallFull != winrt::Windows::Management::Deployment::StubPackageOption::InstallFull");
+static_assert(static_cast<int>(winrt::Microsoft::Windows::Management::Deployment::StubPackageOption::InstallStub) == static_cast<int>(winrt::Windows::Management::Deployment::StubPackageOption::InstallStub),
+              "winrt::Microsoft::Windows::Management::Deployment::StubPackageOption::InstallStub != winrt::Windows::Management::Deployment::StubPackageOption::InstallStub");
+static_assert(static_cast<int>(winrt::Microsoft::Windows::Management::Deployment::StubPackageOption::UsePreference) == static_cast<int>(winrt::Windows::Management::Deployment::StubPackageOption::UsePreference),
+              "winrt::Microsoft::Windows::Management::Deployment::StubPackageOption::UsePreference != winrt::Windows::Management::Deployment::StubPackageOption::UsePreference");
 
 namespace winrt::Microsoft::Windows::Management::Deployment::implementation
 {

--- a/dev/PackageManager/API/M.W.M.D.StagePackageOptions.cpp
+++ b/dev/PackageManager/API/M.W.M.D.StagePackageOptions.cpp
@@ -58,11 +58,11 @@ namespace winrt::Microsoft::Windows::Management::Deployment::implementation
     {
         m_externalLocationUri = value;
     }
-    winrt::Windows::Management::Deployment::StubPackageOption StagePackageOptions::StubPackageOption()
+    winrt::Microsoft::Windows::Management::Deployment::StubPackageOption StagePackageOptions::StubPackageOption()
     {
         return m_stubPackageOption;
     }
-    void StagePackageOptions::StubPackageOption(winrt::Windows::Management::Deployment::StubPackageOption const& value)
+    void StagePackageOptions::StubPackageOption(winrt::Microsoft::Windows::Management::Deployment::StubPackageOption const& value)
     {
         m_stubPackageOption = value;
     }

--- a/dev/PackageManager/API/M.W.M.D.StagePackageOptions.h
+++ b/dev/PackageManager/API/M.W.M.D.StagePackageOptions.h
@@ -19,8 +19,8 @@ namespace winrt::Microsoft::Windows::Management::Deployment::implementation
         winrt::Windows::Foundation::Collections::IVector<winrt::Windows::Foundation::Uri> RelatedPackageUris();
         winrt::Windows::Foundation::Uri ExternalLocationUri();
         void ExternalLocationUri(winrt::Windows::Foundation::Uri const& value);
-        winrt::Windows::Management::Deployment::StubPackageOption StubPackageOption();
-        void StubPackageOption(winrt::Windows::Management::Deployment::StubPackageOption const& value);
+        winrt::Microsoft::Windows::Management::Deployment::StubPackageOption StubPackageOption();
+        void StubPackageOption(winrt::Microsoft::Windows::Management::Deployment::StubPackageOption const& value);
         bool DeveloperMode();
         void DeveloperMode(bool value);
         bool ForceUpdateFromAnyVersion();
@@ -43,7 +43,7 @@ namespace winrt::Microsoft::Windows::Management::Deployment::implementation
         winrt::Windows::Foundation::Collections::IVector<winrt::Windows::Foundation::Uri> m_optionalPackageUris;
         winrt::Windows::Foundation::Collections::IVector<winrt::Windows::Foundation::Uri> m_relatedPackageUris;
         winrt::Windows::Foundation::Uri m_externalLocationUri{ nullptr };
-        winrt::Windows::Management::Deployment::StubPackageOption m_stubPackageOption{};
+        winrt::Microsoft::Windows::Management::Deployment::StubPackageOption m_stubPackageOption{};
         bool m_developerMode{};
         bool m_forceUpdateFromAnyVersion{};
         bool m_installAllResources{};

--- a/dev/PackageManager/API/PackageDeploymentResolver.cpp
+++ b/dev/PackageManager/API/PackageDeploymentResolver.cpp
@@ -113,18 +113,18 @@ static PCWSTR GetSystemSupportedArchitecturesAsString()
     return GetSystemSupportedArchitecturesAsString(nativeMachine);
 }
 
-static bool IsArchitectureSupporedByHostMachine(
+static bool IsArchitectureSupportedByHostMachine(
     const winrt::Microsoft::Windows::ApplicationModel::DynamicDependency::PackageDependencyProcessorArchitectures architecture)
 {
     const auto supportedArchitectures{ GetSystemSupportedArchitectures() };
     return WI_IsAnyFlagSet(supportedArchitectures, architecture);
 }
 
-static bool IsArchitectureSupporedByHostMachine(
+static bool IsArchitectureSupportedByHostMachine(
     const winrt::Windows::System::ProcessorArchitecture architecture)
 {
     const auto architectureAsPackageDependencyProcessorArchitectures{ ToPackageDependencyProcessorArchitectures(architecture) };
-    return IsArchitectureSupporedByHostMachine(architectureAsPackageDependencyProcessorArchitectures);
+    return IsArchitectureSupportedByHostMachine(architectureAsPackageDependencyProcessorArchitectures);
 }
 }
 

--- a/dev/PackageManager/API/PackageManager.idl
+++ b/dev/PackageManager/API/PackageManager.idl
@@ -60,6 +60,17 @@ namespace Microsoft.Windows.Management.Deployment
         void Repair();
     };
 
+    /// Defines the stub behavior for an app package that is being added or staged.
+    /// @see https://learn.microsoft.com/uwp/api/windows.management.deployment.stubpackageoption
+    [contract(PackageDeploymentContract, 1)]
+    enum StubPackageOption
+    {
+        Default,
+        InstallFull,
+        InstallStub,
+        UsePreference,
+    };
+
     /// The progress status of the deployment request.
     /// @see https://learn.microsoft.com/uwp/api/windows.management.deployment.deploymentprogress.state
     [contract(PackageDeploymentContract, 1)]
@@ -150,7 +161,7 @@ namespace Microsoft.Windows.Management.Deployment
         IVector<Windows.Foundation.Uri> OptionalPackageUris { get; };
         IVector<Windows.Foundation.Uri> RelatedPackageUris { get; };
         Windows.Foundation.Uri ExternalLocationUri;
-        Windows.Management.Deployment.StubPackageOption StubPackageOption;
+        StubPackageOption StubPackageOption;
         Boolean AllowUnsigned;
         Boolean DeveloperMode;
         Boolean ForceAppShutdown;
@@ -181,7 +192,7 @@ namespace Microsoft.Windows.Management.Deployment
         IVector<Windows.Foundation.Uri> OptionalPackageUris { get; };
         IVector<Windows.Foundation.Uri> RelatedPackageUris { get; };
         Windows.Foundation.Uri ExternalLocationUri;
-        Windows.Management.Deployment.StubPackageOption StubPackageOption;
+        StubPackageOption StubPackageOption;
         Boolean DeveloperMode;
         Boolean ForceUpdateFromAnyVersion;
         Boolean InstallAllResources;

--- a/dev/Projections/CS/Microsoft.Windows.Management.Deployment/Microsoft.Windows.Management.Deployment.csproj
+++ b/dev/Projections/CS/Microsoft.Windows.Management.Deployment/Microsoft.Windows.Management.Deployment.csproj
@@ -1,0 +1,60 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net6.0-windows10.0.17763.0</TargetFramework>
+    <TargetPlatformMinVersion>10.0.17763.0</TargetPlatformMinVersion>
+    <Platforms>x64;x86;arm64</Platforms>
+    <PlatformTarget>AnyCPU</PlatformTarget>
+    <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
+  </PropertyGroup>
+
+  <PropertyGroup>
+    <EnableTrimAnalyzer>true</EnableTrimAnalyzer>
+    <IsTrimmable>true</IsTrimmable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.SourceLink.Common">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="Microsoft.SourceLink.GitHub">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="Microsoft.Windows.CsWinRT" />
+  </ItemGroup>
+
+  <PropertyGroup>
+    <CSWinRTIncludes>Microsoft.Windows.Management.Deployment</CSWinRTIncludes>
+    <CSWinRTIncludes>Microsoft.Windows.ApplicationModel.DynamicDependency</CSWinRTIncludes>
+    <CSWinRTWindowsMetadata>10.0.17763.0</CSWinRTWindowsMetadata>
+    <WindowsSdkPackageVersion>10.0.17763.$(CsWinRTDependencyWindowsSdkVersionSuffixPackageVersion)</WindowsSdkPackageVersion>
+    <ProduceReferenceAssembly>false</ProduceReferenceAssembly>
+  </PropertyGroup>
+
+  <!-- Configure the release build binary to be as required by internal API scanning tools. -->
+  <PropertyGroup Condition="'$(Configuration)'=='Release'">
+    <DebugType>pdbonly</DebugType>
+    <DebugSymbols>true</DebugSymbols>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <CsWinRTInputs Include="$(OutDir)/**/*.winmd" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Compile Include="$(RepoRoot)\eng\common\VersionInfo\AssemblyInfo.cs" Link="AssemblyInfo.cs" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Reference Include="Microsoft.Windows.ApplicationModel.DynamicDependency">
+      <HintPath>$(OutDir)..\WindowsAppRuntime_DLL\StrippedWinMD\Microsoft.Windows.ApplicationModel.DynamicDependency.winmd</HintPath>
+      <IsWinMDFile>true</IsWinMDFile>
+    </Reference>
+    <Reference Include="Microsoft.Windows.Management.Deployment">
+      <HintPath>$(OutDir)..\WindowsAppRuntime_DLL\StrippedWinMD\Microsoft.Windows.Management.Deployment.winmd</HintPath>
+      <IsWinMDFile>true</IsWinMDFile>
+    </Reference>
+  </ItemGroup>
+
+</Project>

--- a/specs/packagemanager/PackageManagement.md
+++ b/specs/packagemanager/PackageManagement.md
@@ -656,8 +656,19 @@ namespace Microsoft.Windows.Management.Deployment
         void Repair();
     };
 
+    /// Defines the stub behavior for an app package that is being added or staged.
+    /// @see https://learn.microsoft.com/uwp/api/windows.management.deployment.stubpackageoption
+    [contract(PackageDeploymentContract, 1)]
+    enum StubPackageOption
+    {
+        Default,
+        InstallFull,
+        InstallStub,
+        UsePreference,
+    };
+
     /// The progress status of the deployment request.
-    /// @see https://learn.microsoft.com/uwp/api/windows.management.deployment.deploymentprogress.state?view=winrt-22621
+    /// @see https://learn.microsoft.com/uwp/api/windows.management.deployment.deploymentprogress.state
     [contract(PackageDeploymentContract, 1)]
     enum PackageDeploymentProgressStatus
     {
@@ -668,7 +679,7 @@ namespace Microsoft.Windows.Management.Deployment
     };
 
     /// Contains progress information for the deployment request.
-    /// @see https://learn.microsoft.com/uwp/api/windows.management.deployment.deploymentprogress?view=winrt-22621
+    /// @see https://learn.microsoft.com/uwp/api/windows.management.deployment.deploymentprogress
     [contract(PackageDeploymentContract, 1)]
     struct PackageDeploymentProgress
     {
@@ -746,7 +757,7 @@ namespace Microsoft.Windows.Management.Deployment
         IVector<Windows.Foundation.Uri> OptionalPackageUris { get; };
         IVector<Windows.Foundation.Uri> RelatedPackageUris { get; };
         Windows.Foundation.Uri ExternalLocationUri;
-        Windows.Management.Deployment.StubPackageOption StubPackageOption;
+        StubPackageOption StubPackageOption;
         Boolean AllowUnsigned;
         Boolean DeveloperMode;
         Boolean ForceAppShutdown;
@@ -777,7 +788,7 @@ namespace Microsoft.Windows.Management.Deployment
         IVector<Windows.Foundation.Uri> OptionalPackageUris { get; };
         IVector<Windows.Foundation.Uri> RelatedPackageUris { get; };
         Windows.Foundation.Uri ExternalLocationUri;
-        Windows.Management.Deployment.StubPackageOption StubPackageOption;
+        StubPackageOption StubPackageOption;
         Boolean DeveloperMode;
         Boolean ForceUpdateFromAnyVersion;
         Boolean InstallAllResources;
@@ -796,16 +807,17 @@ namespace Microsoft.Windows.Management.Deployment
         RegisterPackageOptions();
 
         PackageVolume AppDataVolume;
+        IVector<String> DependencyPackageFamilyNames { get; };
         IVector<Windows.Foundation.Uri> DependencyPackageUris { get; };
         IVector<String> OptionalPackageFamilyNames { get; };
         Windows.Foundation.Uri ExternalLocationUri;
+        Boolean AllowUnsigned;
         Boolean DeveloperMode;
         Boolean ForceAppShutdown;
         Boolean ForceTargetAppShutdown;
         Boolean ForceUpdateFromAnyVersion;
         Boolean InstallAllResources;
         Boolean StageInPlace;
-        Boolean AllowUnsigned;
         Boolean DeferRegistrationWhenPackagesAreInUse;
 
         Boolean IsExpectedDigestsSupported { get; };            // Requires Windows >= 10.0.22621.0 (aka Win11 22H2)

--- a/test/PackageManager/API/PackageManagerTests.Packages.h
+++ b/test/PackageManager/API/PackageManagerTests.Packages.h
@@ -133,7 +133,7 @@ namespace Test::PackageManager::Tests
         {
             TP::RemovePackage(TPF::Red::GetPackageFullName());
         }
-        else if (IsPackageStaged_Red)
+        else if (IsPackageStaged_Red())
         {
             // We can't directly remove a Stage package not registered for current user
             // w/o admin privilege but we can add it to make it registered and then remove it.


### PR DESCRIPTION
…15 (#4111)

* Added C# projection

* Changed Windows StubPackageOption for a Microsoft equivalent to aid downlevel support. Fixed some docs

* Add /we4715 to treat warning 4715 as an error (C4715 = 'function': not all control paths return a value)

* Fixed typo

A microsoft employee must use /azp run to validate using the pipelines below.

WARNING:
Comments made by azure-pipelines bot maybe inaccurate.
Please see pipeline link to verify that the build is being ran.

For status checks on the main branch, please use TransportPackage-Foundation-PR
(https://microsoft.visualstudio.com/ProjectReunion/_build?definitionId=81063&_a=summary)
and run the build against your PR branch with the default parameters.
