### PR TITLE
 Resolve VSIX Load Failure in Experimental Builds

### DIFF
--- a/dev/VSIX/Extension/Cpp/Dev17/WindowsAppSDK.Cpp.Extension.Dev17.csproj
+++ b/dev/VSIX/Extension/Cpp/Dev17/WindowsAppSDK.Cpp.Extension.Dev17.csproj
@@ -10,6 +10,7 @@
     <BaseAssemblyName>WindowsAppSDK.Cpp.Extension.Dev17</BaseAssemblyName>
     <JsonName Condition="'$(EnableExperimentalVSIXFeatures)'!='true'">Microsoft.WindowsAppSDK.Cpp.Dev17.json</JsonName>
     <JsonName Condition="'$(EnableExperimentalVSIXFeatures)'=='true'">Microsoft.WindowsAppSDK.Cpp.Dev17.Experimental.json</JsonName>
+    <AssemblyName>$(BaseAssemblyName)</AssemblyName>
     <TargetFramework>net472</TargetFramework>
     <!-- This project may not have any C# source files, so suppress that compiler warning. -->
     <NoWarn>2008</NoWarn>

--- a/dev/VSIX/Extension/Cpp/Dev17/WindowsAppSDK.Cpp.Extension.Dev17.csproj
+++ b/dev/VSIX/Extension/Cpp/Dev17/WindowsAppSDK.Cpp.Extension.Dev17.csproj
@@ -8,8 +8,6 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>WindowsAppSDK.Cpp.Extension</RootNamespace>
     <BaseAssemblyName>WindowsAppSDK.Cpp.Extension.Dev17</BaseAssemblyName>
-    <AssemblyName Condition="'$(EnableExperimentalVSIXFeatures)'!='true'">$(BaseAssemblyName)</AssemblyName>
-    <AssemblyName Condition="'$(EnableExperimentalVSIXFeatures)'=='true'">$(BaseAssemblyName).Experimental</AssemblyName>
     <JsonName Condition="'$(EnableExperimentalVSIXFeatures)'!='true'">Microsoft.WindowsAppSDK.Cpp.Dev17.json</JsonName>
     <JsonName Condition="'$(EnableExperimentalVSIXFeatures)'=='true'">Microsoft.WindowsAppSDK.Cpp.Dev17.Experimental.json</JsonName>
     <TargetFramework>net472</TargetFramework>

--- a/dev/VSIX/Extension/Cs/Dev17/WindowsAppSDK.Cs.Extension.Dev17.csproj
+++ b/dev/VSIX/Extension/Cs/Dev17/WindowsAppSDK.Cs.Extension.Dev17.csproj
@@ -8,8 +8,6 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>WindowsAppSDK.Cs.Extension</RootNamespace>
     <BaseAssemblyName>WindowsAppSDK.Cs.Extension.Dev17</BaseAssemblyName>
-    <AssemblyName Condition="'$(EnableExperimentalVSIXFeatures)'!='true'">$(BaseAssemblyName)</AssemblyName>
-    <AssemblyName Condition="'$(EnableExperimentalVSIXFeatures)'=='true'">$(BaseAssemblyName).Experimental</AssemblyName>
     <JsonName Condition="'$(EnableExperimentalVSIXFeatures)'!='true'">Microsoft.WindowsAppSDK.Cs.Dev17.json</JsonName>
     <JsonName Condition="'$(EnableExperimentalVSIXFeatures)'=='true'">Microsoft.WindowsAppSDK.Cs.Dev17.Experimental.json</JsonName>
     <TargetFramework>net472</TargetFramework>

--- a/dev/VSIX/Extension/Cs/Dev17/WindowsAppSDK.Cs.Extension.Dev17.csproj
+++ b/dev/VSIX/Extension/Cs/Dev17/WindowsAppSDK.Cs.Extension.Dev17.csproj
@@ -10,6 +10,7 @@
     <BaseAssemblyName>WindowsAppSDK.Cs.Extension.Dev17</BaseAssemblyName>
     <JsonName Condition="'$(EnableExperimentalVSIXFeatures)'!='true'">Microsoft.WindowsAppSDK.Cs.Dev17.json</JsonName>
     <JsonName Condition="'$(EnableExperimentalVSIXFeatures)'=='true'">Microsoft.WindowsAppSDK.Cs.Dev17.Experimental.json</JsonName>
+    <AssemblyName>$(BaseAssemblyName)</AssemblyName>
     <TargetFramework>net472</TargetFramework>
     <!-- This project may not have any C# source files, so suppress that compiler warning. -->
     <NoWarn>2008</NoWarn>


### PR DESCRIPTION
This PR removes the line
`<AssemblyName Condition="'$(EnableExperimentalVSIXFeatures)'=='true'">$(BaseAssemblyName).Experimental</AssemblyName>` from our Azure DevOps XAML build configuration. This change addresses a critical issue where experimental builds append .Experimental to DLL names, causing VSIX load failures in projects using the WindowsAppSDK.Cs.Extension.Dev17.dll. The removal ensures consistent DLL naming and reliable VSIX loading across all build types. Testing confirms no adverse effects on experimental or standard builds, enhancing overall development experience and pipeline stability.