### PR TITLE
CI trigger Foundation-ES-SyncMirrorRepos via Trigger Pipeline

### DIFF
--- a/build/WindowsAppSDK-SyncMirroredRepository.yml
+++ b/build/WindowsAppSDK-SyncMirroredRepository.yml
@@ -1,26 +1,22 @@
 name: $(BuildDefinitionName)_$(date:yyMM).$(date:dd)$(rev:rrr)
-parameters:
-- name: "SourceToTargetBranch"
-  type: object
-  default:
-    main: main
-    release/1.3-stable: release/1.3-stable
-    release/1.4-stable: release/1.4-stable
-    release/1.5-stable: release/1.5-stable
+
+resources:
+  pipelines:
+  - pipeline: SyncMirrorPipeline
+    project: ProjectReunion
+    source: Foundation-ES-SyncMirrorRepos
+    trigger:
+      branches:
+        include:
+        - $(Build.SourceBranch)
 
 jobs:
 - job: SyncMirror
-  strategy:
-    matrix:
-      ${{ each branches in parameters.SourceToTargetBranch }}:
-        ${{ branches.key }}:
-          SourceBranch: ${{ branches.key }}
-          TargetBranch: ${{ branches.value }}
   dependsOn: []
   pool: 'ProjectReunionESPool-2022'
   steps:
   - template: ..\eng\common\AzurePipelinesTemplates\WindowsAppSDK-SyncMirror-Steps.yml
     parameters:
       SourceRepository: "https://github.com/microsoft/WindowsAppSDK.git"
-      TargetBranch: $(TargetBranch)
-      SourceBranch: $(SourceBranch)
+      TargetBranch: $(Build.SourceBranch)
+      SourceBranch: $(Build.SourceBranch)

--- a/build/WindowsAppSDK-SyncMirroredRepository.yml
+++ b/build/WindowsAppSDK-SyncMirroredRepository.yml
@@ -1,12 +1,26 @@
 name: $(BuildDefinitionName)_$(date:yyMM).$(date:dd)$(rev:rrr)
+parameters:
+- name: "SourceToTargetBranch"
+  type: object
+  default:
+    main: main
+    release/1.3-stable: release/1.3-stable
+    release/1.4-stable: release/1.4-stable
+    release/1.5-stable: release/1.5-stable
 
 jobs:
 - job: SyncMirror
+  strategy:
+    matrix:
+      ${{ each branches in parameters.SourceToTargetBranch }}:
+        ${{ branches.key }}:
+          SourceBranch: ${{ branches.key }}
+          TargetBranch: ${{ branches.value }}
   dependsOn: []
   pool: 'ProjectReunionESPool-2022'
   steps:
   - template: ..\eng\common\AzurePipelinesTemplates\WindowsAppSDK-SyncMirror-Steps.yml
     parameters:
       SourceRepository: "https://github.com/microsoft/WindowsAppSDK.git"
-      TargetBranch: $(Build.SourceBranch)
-      SourceBranch: $(Build.SourceBranch)
+      TargetBranch: $(TargetBranch)
+      SourceBranch: $(SourceBranch)

--- a/build/WindowsAppSDK-SyncMirroredRepository.yml
+++ b/build/WindowsAppSDK-SyncMirroredRepository.yml
@@ -8,7 +8,7 @@ resources:
     trigger:
       branches:
         include:
-        - $(Build.SourceBranch)
+        - user/kythant/TriggerPipeline
 
 jobs:
 - job: SyncMirror
@@ -18,5 +18,5 @@ jobs:
   - template: ..\eng\common\AzurePipelinesTemplates\WindowsAppSDK-SyncMirror-Steps.yml
     parameters:
       SourceRepository: "https://github.com/microsoft/WindowsAppSDK.git"
-      TargetBranch: $(Build.SourceBranch)
-      SourceBranch: $(Build.SourceBranch)
+      TargetBranch: user/kythant/TriggerPipeline
+      SourceBranch: user/kythant/TriggerPipeline

--- a/build/WindowsAppSDK-SyncMirroredRepository.yml
+++ b/build/WindowsAppSDK-SyncMirroredRepository.yml
@@ -1,15 +1,5 @@
 name: $(BuildDefinitionName)_$(date:yyMM).$(date:dd)$(rev:rrr)
 
-resources:
-  pipelines:
-  - pipeline: SyncMirrorPipeline
-    project: ProjectReunion
-    source: Foundation-ES-SyncMirrorTrigger
-    trigger:
-      branches:
-        include:
-        - $(Build.SourceBranch)
-
 jobs:
 - job: SyncMirror
   dependsOn: []

--- a/build/WindowsAppSDK-SyncMirroredRepository.yml
+++ b/build/WindowsAppSDK-SyncMirroredRepository.yml
@@ -8,7 +8,7 @@ resources:
     trigger:
       branches:
         include:
-        - user/kythant/TriggerPipeline
+        - $(Build.SourceBranch)
 
 jobs:
 - job: SyncMirror
@@ -18,5 +18,5 @@ jobs:
   - template: ..\eng\common\AzurePipelinesTemplates\WindowsAppSDK-SyncMirror-Steps.yml
     parameters:
       SourceRepository: "https://github.com/microsoft/WindowsAppSDK.git"
-      TargetBranch: user/kythant/TriggerPipeline
-      SourceBranch: user/kythant/TriggerPipeline
+      TargetBranch: $(Build.SourceBranch)
+      SourceBranch: $(Build.SourceBranch)

--- a/build/WindowsAppSDK-SyncMirroredRepository.yml
+++ b/build/WindowsAppSDK-SyncMirroredRepository.yml
@@ -4,7 +4,7 @@ resources:
   pipelines:
   - pipeline: SyncMirrorPipeline
     project: ProjectReunion
-    source: Foundation-ES-SyncMirrorRepos
+    source: Foundation-ES-SyncMirrorTrigger
     trigger:
       branches:
         include:

--- a/build/WindowsAppSDK-SyncTrigger.yml
+++ b/build/WindowsAppSDK-SyncTrigger.yml
@@ -3,8 +3,8 @@ name: $(BuildDefinitionName)_$(date:yyMM).$(date:dd)$(rev:rrr)
 resources:
   pipelines:
   - pipeline: SyncMirrorPipeline
-    project: $(System.TeamProject)
-    source: $(pipelineName)
+    project: ProjectReunion
+    source: Foundation-ES-SyncMirrorRepos
     trigger:
       branches:
         include:

--- a/build/WindowsAppSDK-SyncTrigger.yml
+++ b/build/WindowsAppSDK-SyncTrigger.yml
@@ -3,7 +3,7 @@ name: $(BuildDefinitionName)_$(date:yyMM).$(date:dd)$(rev:rrr)
 resources:
   pipelines:
   - pipeline: SyncMirrorPipeline
-    project: $(projectName)
+    project: $(System.TeamProject)
     source: $(pipelineName)
     trigger:
       branches:

--- a/build/WindowsAppSDK-SyncTrigger.yml
+++ b/build/WindowsAppSDK-SyncTrigger.yml
@@ -1,0 +1,23 @@
+name: $(BuildDefinitionName)_$(date:yyMM).$(date:dd)$(rev:rrr)
+
+resources:
+  pipelines:
+  - pipeline: SyncMirrorPipeline
+    project: $(projectName)
+    source: $(pipelineName)
+    trigger:
+      branches:
+        include:
+        - $(Build.SourceBranch)
+
+jobs:
+- job: TriggerSyncMirror
+  dependsOn: []
+  pool: 'ProjectReunionESPool-2022'
+  steps:
+  - task: powerShell@2
+    displayName: 'Shell task'
+    inputs:
+      targetType: 'inline'
+      script: |
+        Write-Host "Triggering $(pipelineName) on $(Build.SourceBranch)"

--- a/build/WindowsAppSDK-SyncTrigger.yml
+++ b/build/WindowsAppSDK-SyncTrigger.yml
@@ -1,15 +1,4 @@
 name: $(BuildDefinitionName)_$(date:yyMM).$(date:dd)$(rev:rrr)
-
-resources:
-  pipelines:
-  - pipeline: SyncMirrorPipeline
-    project: ProjectReunion
-    source: Foundation-ES-SyncMirrorRepos
-    trigger:
-      branches:
-        include:
-        - $(Build.SourceBranch)
-
 jobs:
 - job: TriggerSyncMirror
   dependsOn: []

--- a/build/WindowsAppSDK-SyncTrigger.yml
+++ b/build/WindowsAppSDK-SyncTrigger.yml
@@ -9,4 +9,4 @@ jobs:
     inputs:
       targetType: 'inline'
       script: |
-        Write-Host "Triggering $(pipelineName) on $(Build.SourceBranch)"
+        Write-Host "Triggering Foundation-ES-SyncMirrorRepos"


### PR DESCRIPTION
In order to trigger Foundation-ES-SyncMirrorRepos, this PR stands up a new Foundation-ES-SyncMirrorReposTrigger that will be triggered on CI for main and release/* branches. 

Foundation-ES-SyncMirrorRepos will be setup to run on build completion of Foundation-ES-SyncMirrorReposTrigger on main and release/*branches. 

Documentation [here](https://learn.microsoft.com/en-us/azure/devops/pipelines/process/pipeline-triggers?view=azure-devops) states [Default branch for manual and scheduled builds](https://learn.microsoft.com/en-us/azure/devops/pipelines/process/pipeline-default-branch?view=azure-devops) is ran when build completion is triggered which in our case is the main branch. 