### PR TITLE
Update to Publish Profile Path for Portable RIDs in Wapproj Template

### DIFF
--- a/dev/VSIX/ProjectTemplates/Desktop/CSharp/PackagedApp/WapProj/WapProjTemplate.wapproj
+++ b/dev/VSIX/ProjectTemplates/Desktop/CSharp/PackagedApp/WapProj/WapProjTemplate.wapproj
@@ -73,7 +73,7 @@
   <ItemGroup>
     <ProjectReference Include="..\$ext_projectname$\$ext_projectname$.csproj">
       <SkipGetTargetFrameworkProperties>True</SkipGetTargetFrameworkProperties>
-      <PublishProfile>Properties\PublishProfiles\win10-$(Platform).pubxml</PublishProfile>
+      <PublishProfile>Properties\PublishProfiles\win-$(Platform).pubxml</PublishProfile>
     </ProjectReference>
   </ItemGroup>
 


### PR DESCRIPTION
The <PublishProfile> path in the project file has been updated to match the newly adopted portable Runtime Identifier (RID). It has been changed from win10-$(Platform).pubxml to win-$(Platform).pubxml.