### PR TITLE
[WinAppSDK 1.4 Servicing] Libraries should not merge PRIs from references into their own PRI

### DIFF
--- a/dev/MRTCore/packaging/MrtCore.PriGen.targets
+++ b/dev/MRTCore/packaging/MrtCore.PriGen.targets
@@ -87,6 +87,10 @@
     <AppxGeneratePriEnabled Condition="'$(AppxGeneratePriEnabled)' == ''">true</AppxGeneratePriEnabled>
     <AppxGetPackagePropertiesEnabled Condition="'$(AppxGetPackagePropertiesEnabled)' == ''">true</AppxGetPackagePropertiesEnabled>
 
+    <!-- Only application projects should have the PRIs from references merged into the project's own PRI -->
+    <ShouldComputeInputPris Condition="'$(ShouldComputeInputPris)' == '' AND ('$(OutputType)' == 'WinExe' OR '$(OutputType)' == 'Exe')">true</ShouldComputeInputPris>
+    <ShouldComputeInputPris Condition="'$(ShouldComputeInputPris)' == ''">false</ShouldComputeInputPris>
+
     <!--
       For Centennial apps, we want the resources of the unpackaged app to appear in the root namespace of the app. So, set the value
       of PrependPriInitialPath to false.
@@ -650,9 +654,8 @@
 
   <!--
     Get list of PRI files from the payload.
-    In Microsoft.AppxPackage.Targets, this is run only if $(AppxPackage) is 'true' but here, of course, that shouldn't be the case.
   -->
-  <Target Name="_GetPriFilesFromPayload">
+  <Target Name="_GetPriFilesFromPayload" Condition="'$(ShouldComputeInputPris)' == 'true'">
 
     <ItemGroup>
       <_PriFilesFromPayloadRaw Include="@(PackagingOutputs)"
@@ -676,9 +679,8 @@
 
   <!--
     Compute final list of input PRI files.
-    In Microsoft.AppxPackage.Targets, this is run only if $(AppxPackage) is 'true' but here, of course, that shouldn't be the case.
   -->
-  <Target Name="_ComputeInputPriFiles">
+  <Target Name="_ComputeInputPriFiles" Condition="'$(ShouldComputeInputPris)' == 'true'">
 
     <ItemGroup>
       <_PriFile Include="@(_PriFilesFromPayload)" />


### PR DESCRIPTION
(Addresses https://github.com/microsoft/microsoft-ui-xaml/issues/8857)

The MRT Core targets are incorrectly merging the PRIs of references into the final PRI in all cases. Suppose you have Package A which contains some WinUI controls, which results in some XBFs being inserted as resources into its PRI. There is also a Package B that relies on Package A version 1.0. Finally, there is an App C that relies on both Package A (version 1.1) and Package B. Because Package B is including the PRI resources from Package A version 1.0 in its own PRI, when App C attempts to merge the PRI resources from all of its dependencies a conflict will arise and break the build.

Package B should not be including the PRI resources from Package A in its own PRI, and instead should advertise the dependency and allow App C to resolve it and perform the PRI resource merge itself. In the UWP targets, this was done by checking to see if the project was producing a package but since Windows App SDK needs to also handle unpackaged apps, the correct way to achieve the same goal is to check if the project is a library (i.e. not producing an executable) and not merge PRI resources from dependencies if that is the case.

Note: _**Libraries**_ (including Nuget packages) affected by this bug will need to be recompiled.

Cherry-picked from #4124