### PR TITLE
Disable Async SDL Stage Due to Issues with Artifact Name Recognition

### DIFF
--- a/build/WindowsAppSDK-Foundation-Nightly.yml
+++ b/build/WindowsAppSDK-Foundation-Nightly.yml
@@ -60,6 +60,8 @@ extends:
       tsa:
         enabled: $(TsaEnabled) # onebranch publish all sdl results to TSA. If TSA is disabled all SDL tools will forced into 'break' build mode.  Please provide TSAOptions.json.
       isNativeCode: false #TODO turn back on when bug in CheckCFlags2.exe is fixed
+      asyncSdl: # https://aka.ms/obpipelines/asyncsdl
+        enabled: false
       psscriptanalyzer:
         enable: true
         break: true

--- a/build/WindowsAppSDK-Foundation-Official.yml
+++ b/build/WindowsAppSDK-Foundation-Official.yml
@@ -60,6 +60,8 @@ extends:
       tsa:
         enabled: $(TsaEnabled) # onebranch publish all sdl results to TSA. If TSA is disabled all SDL tools will forced into 'break' build mode.  Please provide TSAOptions.json.
       isNativeCode: false #TODO turn back on when bug in CheckCFlags2.exe is fixed
+      asyncSdl: # https://aka.ms/obpipelines/asyncsdl
+        enabled: false
       binskim:
         enabled: true
         break: false


### PR DESCRIPTION
Async SDL stages were recently deployed to our pipelines.
But due to issues with ArtifactNames not resolving and the stages not being able to download artifacts as a result, we'll disable them to avoid getting orange check marks. 

