### PR TITLE
Revert " Resolve VSIX Load Failure in Experimental Builds"

### DIFF
--- a/dev/VSIX/Extension/Cpp/Dev17/WindowsAppSDK.Cpp.Extension.Dev17.csproj
+++ b/dev/VSIX/Extension/Cpp/Dev17/WindowsAppSDK.Cpp.Extension.Dev17.csproj
@@ -8,9 +8,10 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>WindowsAppSDK.Cpp.Extension</RootNamespace>
     <BaseAssemblyName>WindowsAppSDK.Cpp.Extension.Dev17</BaseAssemblyName>
+    <AssemblyName Condition="'$(EnableExperimentalVSIXFeatures)'!='true'">$(BaseAssemblyName)</AssemblyName>
+    <AssemblyName Condition="'$(EnableExperimentalVSIXFeatures)'=='true'">$(BaseAssemblyName).Experimental</AssemblyName>
     <JsonName Condition="'$(EnableExperimentalVSIXFeatures)'!='true'">Microsoft.WindowsAppSDK.Cpp.Dev17.json</JsonName>
     <JsonName Condition="'$(EnableExperimentalVSIXFeatures)'=='true'">Microsoft.WindowsAppSDK.Cpp.Dev17.Experimental.json</JsonName>
-    <AssemblyName>$(BaseAssemblyName)</AssemblyName>
     <TargetFramework>net472</TargetFramework>
     <!-- This project may not have any C# source files, so suppress that compiler warning. -->
     <NoWarn>2008</NoWarn>

--- a/dev/VSIX/Extension/Cs/Dev17/WindowsAppSDK.Cs.Extension.Dev17.csproj
+++ b/dev/VSIX/Extension/Cs/Dev17/WindowsAppSDK.Cs.Extension.Dev17.csproj
@@ -8,9 +8,10 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>WindowsAppSDK.Cs.Extension</RootNamespace>
     <BaseAssemblyName>WindowsAppSDK.Cs.Extension.Dev17</BaseAssemblyName>
+    <AssemblyName Condition="'$(EnableExperimentalVSIXFeatures)'!='true'">$(BaseAssemblyName)</AssemblyName>
+    <AssemblyName Condition="'$(EnableExperimentalVSIXFeatures)'=='true'">$(BaseAssemblyName).Experimental</AssemblyName>
     <JsonName Condition="'$(EnableExperimentalVSIXFeatures)'!='true'">Microsoft.WindowsAppSDK.Cs.Dev17.json</JsonName>
     <JsonName Condition="'$(EnableExperimentalVSIXFeatures)'=='true'">Microsoft.WindowsAppSDK.Cs.Dev17.Experimental.json</JsonName>
-    <AssemblyName>$(BaseAssemblyName)</AssemblyName>
     <TargetFramework>net472</TargetFramework>
     <!-- This project may not have any C# source files, so suppress that compiler warning. -->
     <NoWarn>2008</NoWarn>


### PR DESCRIPTION
Reverted changes to `AssemblyName` in `WindowsAppSDK.Cs.Extension.Dev17.csproj` and`WindowsAppSDK.Cpp.Extension.Dev17.csproj` to restore conditional naming for experimental features from this [PR](https://github.com/microsoft/WindowsAppSDK/pull/4121). This addresses the regression affecting YML pipeline builds for experimental versions, reinstating the original mechanism for distinguishing between stable and experimental assembly names.
