### PR TITLE
[CP to 1.5] C# Unit Test Project: Set PublishTrimmed =false even in Release mode

### DIFF
--- a/dev/VSIX/ProjectTemplates/Desktop/CSharp/UnitTestApp/Properties/PublishProfiles/win-arm64.pubxml
+++ b/dev/VSIX/ProjectTemplates/Desktop/CSharp/UnitTestApp/Properties/PublishProfiles/win-arm64.pubxml
@@ -13,7 +13,6 @@ https://go.microsoft.com/fwlink/?LinkID=208121.
     <PublishSingleFile>False</PublishSingleFile>
     <PublishReadyToRun Condition="'$(Configuration)' == 'Debug'">False</PublishReadyToRun>
     <PublishReadyToRun Condition="'$(Configuration)' != 'Debug'">True</PublishReadyToRun>
-    <PublishTrimmed Condition="'$(Configuration)' == 'Debug'">False</PublishTrimmed>
-    <PublishTrimmed Condition="'$(Configuration)' != 'Debug'">True</PublishTrimmed>
+    <PublishTrimmed>False</PublishTrimmed>
   </PropertyGroup>
 </Project>

--- a/dev/VSIX/ProjectTemplates/Desktop/CSharp/UnitTestApp/Properties/PublishProfiles/win-x64.pubxml
+++ b/dev/VSIX/ProjectTemplates/Desktop/CSharp/UnitTestApp/Properties/PublishProfiles/win-x64.pubxml
@@ -13,7 +13,6 @@ https://go.microsoft.com/fwlink/?LinkID=208121.
     <PublishSingleFile>False</PublishSingleFile>
     <PublishReadyToRun Condition="'$(Configuration)' == 'Debug'">False</PublishReadyToRun>
     <PublishReadyToRun Condition="'$(Configuration)' != 'Debug'">True</PublishReadyToRun>
-    <PublishTrimmed Condition="'$(Configuration)' == 'Debug'">False</PublishTrimmed>
-    <PublishTrimmed Condition="'$(Configuration)' != 'Debug'">True</PublishTrimmed>
+    <PublishTrimmed>False</PublishTrimmed>
   </PropertyGroup>
 </Project>

--- a/dev/VSIX/ProjectTemplates/Desktop/CSharp/UnitTestApp/Properties/PublishProfiles/win-x86.pubxml
+++ b/dev/VSIX/ProjectTemplates/Desktop/CSharp/UnitTestApp/Properties/PublishProfiles/win-x86.pubxml
@@ -13,7 +13,6 @@ https://go.microsoft.com/fwlink/?LinkID=208121.
     <PublishSingleFile>False</PublishSingleFile>
     <PublishReadyToRun Condition="'$(Configuration)' == 'Debug'">False</PublishReadyToRun>
     <PublishReadyToRun Condition="'$(Configuration)' != 'Debug'">True</PublishReadyToRun>
-    <PublishTrimmed Condition="'$(Configuration)' == 'Debug'">False</PublishTrimmed>
-    <PublishTrimmed Condition="'$(Configuration)' != 'Debug'">True</PublishTrimmed>
+    <PublishTrimmed>False</PublishTrimmed>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
Cherry Pick of #4175 to release/1.5-stable.

The unit tests do not work with PublishTrimmed=true. So building the unit test project in Release configuration will result in the tests no working.

The fix is to set PublishTrimmed=false unconditionally instead of basing it on the Configuration.