### PR TITLE
Fixed Microsoft.Windows.Management.Deployment.Projection.csproj

### DIFF
--- a/dev/Projections/CS/Microsoft.Windows.Management.Deployment.Projection/Microsoft.Windows.Management.Deployment.Projection.csproj
+++ b/dev/Projections/CS/Microsoft.Windows.Management.Deployment.Projection/Microsoft.Windows.Management.Deployment.Projection.csproj
@@ -26,7 +26,6 @@
 
   <PropertyGroup>
     <CSWinRTIncludes>Microsoft.Windows.Management.Deployment</CSWinRTIncludes>
-    <CSWinRTIncludes>Microsoft.Windows.ApplicationModel.DynamicDependency</CSWinRTIncludes>
     <CSWinRTWindowsMetadata>10.0.17763.0</CSWinRTWindowsMetadata>
     <WindowsSdkPackageVersion>10.0.17763.$(CsWinRTDependencyWindowsSdkVersionSuffixPackageVersion)</WindowsSdkPackageVersion>
     <ProduceReferenceAssembly>false</ProduceReferenceAssembly>
@@ -55,6 +54,10 @@
       <HintPath>$(OutDir)..\WindowsAppRuntime_DLL\StrippedWinMD\Microsoft.Windows.Management.Deployment.winmd</HintPath>
       <IsWinMDFile>true</IsWinMDFile>
     </Reference>
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Microsoft.Windows.ApplicationModel.DynamicDependency\Microsoft.Windows.ApplicationModel.DynamicDependency.Projection.csproj" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Microsoft.Windows.Management.Deployment.Projection.csproj was using 2nd `<CSRWinRTIncludes>` to resolve the DynDep type dependency when that's a singular 'namespace of the project's output' so the projection had DynDep types and not PkgMgmt. Changed it to a `<ProjectReference Include=...\DynDep.csproj>` and happiness.

Verified projection assembly content via ILSpy.

KUDOS to Steve Otteson for the magic incantation!