### PR TITLE
[Cherrypick 1.5] Fix Publish symbols to Public Servers not using a PAT

### DIFF
--- a/build/AzurePipelinesTemplates/WindowsAppSDK-PackTransportPackage-Stage.yml
+++ b/build/AzurePipelinesTemplates/WindowsAppSDK-PackTransportPackage-Stage.yml
@@ -8,6 +8,9 @@ parameters:
 - name: "IsOneBranch"
   type: boolean
   default: True
+- name: "IsOfficial"
+  type: boolean
+  default: False
 - name: "BuildMockWindowsAppSDK"
   type: boolean
   default: True
@@ -140,21 +143,21 @@ stages:
       env:
         LIB: $(Build.SourcesDirectory)
 
-    - task: PublishSymbols@2
-      displayName: 'Publish symbols to public server (without source indexing)'
-      inputs:
-        searchPattern: '$(Build.ArtifactStagingDirectory)\symbols\**\*.pdb'
-        symbolServerType: 'TeamServices'
-      # This ADO task does not support indexing of github sources currently :-(
-        indexSources: false
-        detailedLog: true
-      # # There is a bug which causes this task to fail if LIB includes an inaccessible path (even though it does not depend on it).
-      # # To work around this issue, we just force LIB to be any dir that we know exists.
-        Pat: $(WinAppSdkLabSymbolsPAT)
-      env:
-        LIB: $(Build.SourcesDirectory)
-        ArtifactServices_Symbol_AccountName: microsoftpublicsymbols
-      #   ArtifactServices_Symbol_PAT: $(WinSDKLab_microsoftpublicsymbols_PAT)
+    - ${{ if eq(parameters.isOfficial, 'true') }}:
+      - task: PublishSymbols@2
+        displayName: 'Publish symbols to public server (without source indexing)'
+        inputs:
+          searchPattern: '$(Build.ArtifactStagingDirectory)\symbols\**\*.pdb'
+          symbolServerType: 'TeamServices'
+        # This ADO task does not support indexing of github sources currently :-(
+          indexSources: false
+          detailedLog: true
+        # # There is a bug which causes this task to fail if LIB includes an inaccessible path (even though it does not depend on it).
+        # # To work around this issue, we just force LIB to be any dir that we know exists.
+          Pat: $(WinAppSdkLabSymbolsPAT)
+        env:
+          LIB: $(Build.SourcesDirectory)
+          ArtifactServices_Symbol_AccountName: microsoftpublicsymbols
 
     - task: PowerShell@2
       name: SetVersion

--- a/build/AzurePipelinesTemplates/WindowsAppSDK-PackTransportPackage-Stage.yml
+++ b/build/AzurePipelinesTemplates/WindowsAppSDK-PackTransportPackage-Stage.yml
@@ -150,9 +150,10 @@ stages:
         detailedLog: true
       # # There is a bug which causes this task to fail if LIB includes an inaccessible path (even though it does not depend on it).
       # # To work around this issue, we just force LIB to be any dir that we know exists.
-      # env:
-      #   LIB: $(Build.SourcesDirectory)
-      #   ArtifactServices_Symbol_AccountName: microsoftpublicsymbols
+        Pat: $(WinAppSdkLabSymbolsPAT)
+      env:
+        LIB: $(Build.SourcesDirectory)
+        ArtifactServices_Symbol_AccountName: microsoftpublicsymbols
       #   ArtifactServices_Symbol_PAT: $(WinSDKLab_microsoftpublicsymbols_PAT)
 
     - task: PowerShell@2

--- a/build/ProjectReunion-BuildFoundation.yml
+++ b/build/ProjectReunion-BuildFoundation.yml
@@ -13,6 +13,7 @@ variables:
 - template: WindowsAppSDK-Versions.yml
 - template: WindowsAppSDK-CommonVariables.yml
 - template: WindowsAppSDK-Foundation-TestConfig.yml@WindowsAppSDKConfig
+- group: PublicSymbols-Secrets
 
 stages:
 - template: AzurePipelinesTemplates\WindowsAppSDK-Build-Stage.yml@self

--- a/build/WindowsAppSDK-Foundation-Nightly.yml
+++ b/build/WindowsAppSDK-Foundation-Nightly.yml
@@ -46,6 +46,7 @@ variables:
 - template: WindowsAppSDK-Versions.yml
 - template: WindowsAppSDK-CommonVariables.yml
 - template: WindowsAppSDK-Foundation-TestConfig.yml@WindowsAppSDKConfig
+- group: PublicSymbols-Secrets
 
 extends:
   template: v2/Microsoft.NonOfficial.yml@templates # https://aka.ms/obpipelines/templates

--- a/build/WindowsAppSDK-Foundation-Official.yml
+++ b/build/WindowsAppSDK-Foundation-Official.yml
@@ -46,6 +46,7 @@ variables:
 - template: WindowsAppSDK-Versions.yml
 - template: WindowsAppSDK-CommonVariables.yml
 - template: WindowsAppSDK-Foundation-TestConfig.yml@WindowsAppSDKConfig
+- group: PublicSymbols-Secrets
 
 extends:
   template: v2/Microsoft.Official.yml@templates # https://aka.ms/obpipelines/templates

--- a/build/WindowsAppSDK-Foundation-Official.yml
+++ b/build/WindowsAppSDK-Foundation-Official.yml
@@ -78,6 +78,7 @@ extends:
       parameters:
         SignOutput: ${{ parameters.SignOutput }}
         PublishPackage: true
+        IsOfficial: true
 
     - template: AzurePipelinesTemplates\WindowsAppSDK-Publish-Stage.yml@self
       parameters:

--- a/build/WindowsAppSDK-Foundation-PR.yml
+++ b/build/WindowsAppSDK-Foundation-PR.yml
@@ -35,6 +35,7 @@ variables:
 - template: WindowsAppSDK-Versions.yml
 - template: WindowsAppSDK-CommonVariables.yml
 - template: WindowsAppSDK-Foundation-TestConfig.yml@WindowsAppSDKConfig
+- group: PublicSymbols-Secrets
 
 extends:
   template: v2/Microsoft.NonOfficial.yml@templates # https://aka.ms/obpipelines/templates


### PR DESCRIPTION
* Use PAT

* Use - group: PublicSymbols-Secrets

* Add to public pipleine

A microsoft employee must use /azp run to validate using the pipelines below.

WARNING:
Comments made by azure-pipelines bot maybe inaccurate.
Please see pipeline link to verify that the build is being ran.

For status checks on the main branch, please use TransportPackage-Foundation-PR
(https://microsoft.visualstudio.com/ProjectReunion/_build?definitionId=81063&_a=summary)
and run the build against your PR branch with the default parameters.
