### PR TITLE
[Cherrypick 1.4] Fix Publish symbols to Public Servers not using a PAT

### DIFF
--- a/build/AzurePipelinesTemplates/WindowsAppSDK-BuildTransportPackage-Stage.yml
+++ b/build/AzurePipelinesTemplates/WindowsAppSDK-BuildTransportPackage-Stage.yml
@@ -11,6 +11,9 @@ parameters:
 - name: "IsOneBranch"
   type: boolean
   default: True
+- name: "IsOfficial"
+  type: boolean
+  default: False
 
 stages:
 - stage: TransportPackage
@@ -163,6 +166,7 @@ stages:
       parameters:
         SignOutput: ${{ parameters.SignOutput }}
         IsOneBranch: ${{ parameters.IsOneBranch }}
+        IsOfficial: ${{ parameters.IsOfficial }}
 
   # Build WinAppSDK and Run Integration Test from TestAll.ps1
   - job: WinAppSDKIntegrationBuildAndTest

--- a/build/AzurePipelinesTemplates/WindowsAppSDK-PackNuget-Steps.yml
+++ b/build/AzurePipelinesTemplates/WindowsAppSDK-PackNuget-Steps.yml
@@ -73,20 +73,20 @@ steps:
   env:
     LIB: $(Build.SourcesDirectory)
 
-- task: PublishSymbols@2
-  displayName: 'Publish symbols to public server(without source indexing)'
-  inputs:
-    searchPattern: '$(Build.ArtifactStagingDirectory)\symbols\**\*.pdb'
-    symbolServerType: 'TeamServices'
-  # This ADO task does not support indexing of github sources currently :-(
-    indexSources: false
-    detailedLog: true
-  # # There is a bug which causes this task to fail if LIB includes an inaccessible path (even though it does not depend on it).
-  # # To work around this issue, we just force LIB to be any dir that we know exists.
-  # env:
-  #   LIB: $(Build.SourcesDirectory)
-  #   ArtifactServices_Symbol_AccountName: microsoftpublicsymbols
-  #   ArtifactServices_Symbol_PAT: $(WinSDKLab_microsoftpublicsymbols_PAT)
+  - task: PublishSymbols@2
+    displayName: 'Publish symbols to public server (without source indexing)'
+    inputs:
+      searchPattern: '$(Build.ArtifactStagingDirectory)\symbols\**\*.pdb'
+      symbolServerType: 'TeamServices'
+    # This ADO task does not support indexing of github sources currently :-(
+      indexSources: false
+      detailedLog: true
+    # # There is a bug which causes this task to fail if LIB includes an inaccessible path (even though it does not depend on it).
+    # # To work around this issue, we just force LIB to be any dir that we know exists.
+      Pat: $(WinAppSdkLabSymbolsPAT)
+    env:
+      LIB: $(Build.SourcesDirectory)
+      ArtifactServices_Symbol_AccountName: microsoftpublicsymbols
 
 - task: PowerShell@2
   name: SetVersion

--- a/build/AzurePipelinesTemplates/WindowsAppSDK-PackNuget-Steps.yml
+++ b/build/AzurePipelinesTemplates/WindowsAppSDK-PackNuget-Steps.yml
@@ -73,20 +73,20 @@ steps:
   env:
     LIB: $(Build.SourcesDirectory)
 
-  - task: PublishSymbols@2
-    displayName: 'Publish symbols to public server (without source indexing)'
-    inputs:
-      searchPattern: '$(Build.ArtifactStagingDirectory)\symbols\**\*.pdb'
-      symbolServerType: 'TeamServices'
-    # This ADO task does not support indexing of github sources currently :-(
-      indexSources: false
-      detailedLog: true
-    # # There is a bug which causes this task to fail if LIB includes an inaccessible path (even though it does not depend on it).
-    # # To work around this issue, we just force LIB to be any dir that we know exists.
-      Pat: $(WinAppSdkLabSymbolsPAT)
-    env:
-      LIB: $(Build.SourcesDirectory)
-      ArtifactServices_Symbol_AccountName: microsoftpublicsymbols
+- task: PublishSymbols@2
+  displayName: 'Publish symbols to public server (without source indexing)'
+  inputs:
+    searchPattern: '$(Build.ArtifactStagingDirectory)\symbols\**\*.pdb'
+    symbolServerType: 'TeamServices'
+  # This ADO task does not support indexing of github sources currently :-(
+    indexSources: false
+    detailedLog: true
+  # # There is a bug which causes this task to fail if LIB includes an inaccessible path (even though it does not depend on it).
+  # # To work around this issue, we just force LIB to be any dir that we know exists.
+    Pat: $(WinAppSdkLabSymbolsPAT)
+  env:
+    LIB: $(Build.SourcesDirectory)
+    ArtifactServices_Symbol_AccountName: microsoftpublicsymbols
 
 - task: PowerShell@2
   name: SetVersion

--- a/build/AzurePipelinesTemplates/WindowsAppSDK-PackNuget-Steps.yml
+++ b/build/AzurePipelinesTemplates/WindowsAppSDK-PackNuget-Steps.yml
@@ -5,6 +5,9 @@ parameters:
 - name: "IsOneBranch"
   type: boolean
   default: True
+- name: "IsOfficial"
+  type: boolean
+  default: False
 
 steps:
 - task: DownloadPipelineArtifact@2
@@ -73,20 +76,21 @@ steps:
   env:
     LIB: $(Build.SourcesDirectory)
 
-- task: PublishSymbols@2
-  displayName: 'Publish symbols to public server (without source indexing)'
-  inputs:
-    searchPattern: '$(Build.ArtifactStagingDirectory)\symbols\**\*.pdb'
-    symbolServerType: 'TeamServices'
-  # This ADO task does not support indexing of github sources currently :-(
-    indexSources: false
-    detailedLog: true
-  # # There is a bug which causes this task to fail if LIB includes an inaccessible path (even though it does not depend on it).
-  # # To work around this issue, we just force LIB to be any dir that we know exists.
-    Pat: $(WinAppSdkLabSymbolsPAT)
-  env:
-    LIB: $(Build.SourcesDirectory)
-    ArtifactServices_Symbol_AccountName: microsoftpublicsymbols
+- ${{ if eq(parameters.isOfficial, 'true') }}:
+  - task: PublishSymbols@2
+    displayName: 'Publish symbols to public server (without source indexing)'
+    inputs:
+      searchPattern: '$(Build.ArtifactStagingDirectory)\symbols\**\*.pdb'
+      symbolServerType: 'TeamServices'
+    # This ADO task does not support indexing of github sources currently :-(
+      indexSources: false
+      detailedLog: true
+    # # There is a bug which causes this task to fail if LIB includes an inaccessible path (even though it does not depend on it).
+    # # To work around this issue, we just force LIB to be any dir that we know exists.
+      Pat: $(WinAppSdkLabSymbolsPAT)
+    env:
+      LIB: $(Build.SourcesDirectory)
+      ArtifactServices_Symbol_AccountName: microsoftpublicsymbols
 
 - task: PowerShell@2
   name: SetVersion

--- a/build/AzurePipelinesTemplates/WindowsAppSDK-PackNuget-Steps.yml
+++ b/build/AzurePipelinesTemplates/WindowsAppSDK-PackNuget-Steps.yml
@@ -76,7 +76,7 @@ steps:
   env:
     LIB: $(Build.SourcesDirectory)
 
-- ${{ if eq(parameters.isOfficial, 'true') }}:
+- ${{ if eq(parameters.IsOfficial, 'true') }}:
   - task: PublishSymbols@2
     displayName: 'Publish symbols to public server (without source indexing)'
     inputs:

--- a/build/ProjectReunion-BuildFoundation.yml
+++ b/build/ProjectReunion-BuildFoundation.yml
@@ -5,6 +5,7 @@ trigger: none
 variables:
 - template: WindowsAppSDK-Versions.yml
 - template: WindowsAppSDK-CommonVariables.yml
+- group: PublicSymbols-Secrets
 
 stages:
 - template: AzurePipelinesTemplates\WindowsAppSDK-BuildTransportPackage-Stage.yml@self

--- a/build/WindowsAppSDK-Foundation-Nightly.yml
+++ b/build/WindowsAppSDK-Foundation-Nightly.yml
@@ -34,6 +34,7 @@ parameters:
 variables:
 - template: WindowsAppSDK-Versions.yml
 - template: WindowsAppSDK-CommonVariables.yml
+- group: PublicSymbols-Secrets
 
 resources:
   repositories:

--- a/build/WindowsAppSDK-Foundation-Official.yml
+++ b/build/WindowsAppSDK-Foundation-Official.yml
@@ -34,6 +34,7 @@ parameters:
 variables:
 - template: WindowsAppSDK-Versions.yml
 - template: WindowsAppSDK-CommonVariables.yml
+- group: PublicSymbols-Secrets
 
 resources:
   repositories:

--- a/build/WindowsAppSDK-Foundation-Official.yml
+++ b/build/WindowsAppSDK-Foundation-Official.yml
@@ -68,3 +68,4 @@ extends:
         PublishToMaestro: ${{ parameters.PublishToMaestro }}
         IgnoreFailures: ${{ parameters.IgnoreFailures }}
         SignOutput: ${{ parameters.SignOutput }}
+        IsOfficial: true

--- a/build/WindowsAppSDK-Foundation-PR.yml
+++ b/build/WindowsAppSDK-Foundation-PR.yml
@@ -23,6 +23,7 @@ trigger: none
 variables:
 - template: WindowsAppSDK-Versions.yml
 - template: WindowsAppSDK-CommonVariables.yml
+- group: PublicSymbols-Secrets
 
 resources:
   repositories:


### PR DESCRIPTION
A microsoft employee must use /azp run to validate using the pipelines below.

WARNING:
Comments made by azure-pipelines bot maybe inaccurate.
Please see pipeline link to verify that the build is being ran.

For status checks on the main branch, please use TransportPackage-Foundation-PR
(https://microsoft.visualstudio.com/ProjectReunion/_build?definitionId=81063&_a=summary)
and run the build against your PR branch with the default parameters.
