### PR TITLE
[Cherrypick] CI trigger Foundation-ES-SyncMirrorRepos via Trigger Pipeline

### DIFF
--- a/build/WindowsAppSDK-SyncMirroredRepository.yml
+++ b/build/WindowsAppSDK-SyncMirroredRepository.yml
@@ -3,9 +3,6 @@ parameters:
 - name: "SourceToTargetBranch"
   type: object
   default:
-    main: main
-    release/1.3-stable: release/1.3-stable
-    release/1.4-stable: release/1.4-stable
     release/1.5-stable: release/1.5-stable
 
 jobs:

--- a/build/WindowsAppSDK-SyncTrigger.yml
+++ b/build/WindowsAppSDK-SyncTrigger.yml
@@ -1,0 +1,12 @@
+name: $(BuildDefinitionName)_$(date:yyMM).$(date:dd)$(rev:rrr)
+jobs:
+- job: TriggerSyncMirror
+  dependsOn: []
+  pool: 'ProjectReunionESPool-2022'
+  steps:
+  - task: powerShell@2
+    displayName: 'Shell task'
+    inputs:
+      targetType: 'inline'
+      script: |
+        Write-Host "Triggering Foundation-ES-SyncMirrorRepos"


### PR DESCRIPTION
I initially thought the triggers to sync the release branches was due to a config issue. But turns out it was because I had not port the yml file that was required for the trigger to the release branches. So the trigger pipeline couldn't run.