### PR TITLE
45977412: [Compliance] Enable compiler version override on the 2 main .sln files being built on this repo (Cherrypick)

### DIFF
--- a/build/AzurePipelinesTemplates/WindowsAppSDK-BuildBinaries-Steps.yml
+++ b/build/AzurePipelinesTemplates/WindowsAppSDK-BuildBinaries-Steps.yml
@@ -55,6 +55,14 @@ steps:
     flattenFolders: false
     overWrite: true
 
+- task: WinUndockNativeCompiler@1
+  displayName: 'Setup native compiler version override'
+  inputs:
+    microsoftDropReadPat: $(System.AccessToken)
+    compilerPackageName: $(compilerOverridePackageName)
+    compilerPackageVersion: $(compilerOverridePackageVersion)
+    slnDirectory: $(Build.SourcesDirectory)
+
 - task: PowerShell@2
   name: BuildBinaries
   inputs:

--- a/build/AzurePipelinesTemplates/WindowsAppSDK-BuildMRT-Steps.yml
+++ b/build/AzurePipelinesTemplates/WindowsAppSDK-BuildMRT-Steps.yml
@@ -14,6 +14,14 @@ steps:
   parameters:
     IsOneBranch: ${{ parameters.IsOneBranch }}
 
+- task: WinUndockNativeCompiler@1
+  displayName: 'Setup native compiler version override'
+  inputs:
+    microsoftDropReadPat: $(System.AccessToken)
+    compilerPackageName: $(compilerOverridePackageName)
+    compilerPackageVersion: $(compilerOverridePackageVersion)
+    slnDirectory: $(Build.SourcesDirectory)\dev\MRTCore\mrt
+
 - ${{ if parameters.RunPrefast }}:
   # PREFast scan is enabled in this pipeline run, so we pass PreFastSetup to BuildAll.ps1 to get it to do the commonn setup steps, but short of
   # building the target via MSBuild.exe

--- a/build/WindowsAppSDK-Versions.yml
+++ b/build/WindowsAppSDK-Versions.yml
@@ -3,3 +3,8 @@ variables:
   major: "1"
   minor: "5"
   patch: "0"
+
+  # Native compiler version override for win undock. The two values below are for Ge, defined in:
+  # https://dev.azure.com/microsoft/OS/_git/UndockedES?path=/Pipelines/Config/CompilerToolsSettings.json
+  compilerOverridePackageName: "DevDiv.rel.LKG16.VCTools"    
+  compilerOverridePackageVersion: "19.38.3313310000+DevDivGIT.CI20231130.01-8BB7F026181F5D52D44CA519FF6A47BFA2763E45"


### PR DESCRIPTION
Cherrypick of https://github.com/microsoft/WindowsAppSDK/pull/4178

Enabled compiler version override on the 2 main .sln files being built on this repo, by injecting a call to the WinUndockNativeCompiler task.

How tested:
In the draft pipeline run: [https://microsoft.visualstudio.com/ProjectReunion/_build/results?buildId=90033170&view=results](https://github.com/microsoft/WindowsAppSDK/pull/url), both .sln files were built using the LKG compiler instead of the pre-existing compiler on the VM.

A microsoft employee must use /azp run to validate using the pipelines below.

WARNING:
Comments made by azure-pipelines bot maybe inaccurate.
Please see pipeline link to verify that the build is being ran.

For status checks on the main branch, please use TransportPackage-Foundation-PR
(https://microsoft.visualstudio.com/ProjectReunion/_build?definitionId=81063&_a=summary)
and run the build against your PR branch with the default parameters.