### PR TITLE
Regression with NuGet.VisualStudio DLL Discovery in MSBuild 

### DIFF
--- a/dev/VSIX/Extension/Cs/Dev17/WindowsAppSDK.Cs.Extension.Dev17.csproj
+++ b/dev/VSIX/Extension/Cs/Dev17/WindowsAppSDK.Cs.Extension.Dev17.csproj
@@ -54,7 +54,7 @@
     </PackageReference>
   </ItemGroup>
   <ItemGroup>
-    <ExtensionDependencies Include="$(PkgNuget_VisualStudio)\**\NuGet.VisualStudio.dll" />
+    <ExtensionDependencies Condition=" '$(ExcludeRestorePackageImports)' != 'true' " Include="$(PkgNuget_VisualStudio)\**\NuGet.VisualStudio.dll" />
     <Content Include="@(ExtensionDependencies)">
       <VSIXSubPath>.</VSIXSubPath>
       <IncludeInVSIX>true</IncludeInVSIX>


### PR DESCRIPTION
MSBuild incorrectly searched the entire filesystem for NuGet.VisualStudio.dll due to an undefined path property.  The fix outlined in https://github.com/microsoft/WindowsAppSDK/pull/4166 was not working as PkgNuget_VisualStudio was undefined at that point, so an exhaustive search was still happening. This addresses that problem.