### PR TITLE
49021373: added PreferredToolArchitecture=x64

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -22,6 +22,9 @@
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>$(RepoRoot)\WasdkStrongNameSign.snk</AssemblyOriginatorKeyFile>
   </PropertyGroup>
+  <PropertyGroup>
+    <PreferredToolArchitecture>x64</PreferredToolArchitecture>
+  </PropertyGroup>
 
   <!-- Compilation differs for the build pipeline vs local development -->
   <PropertyGroup Condition="$(WindowsAppSDKBuildPipeline) != '1'">


### PR DESCRIPTION
Updated Directory.Build.props at the repo root to specify PreferredToolArchitecture=x64, to align with other WASDK repos.
-----------
For status checks on the main branch, please use TransportPackage-Foundation-PR
(https://microsoft.visualstudio.com/ProjectReunion/_build?definitionId=81063&_a=summary)
and run the build against your PR branch with the default parameters.
