### PR TITLE
45977412: [Compliance] On the WindowsAppSDK repo, switch over to reference the LKG package info from a global source

### DIFF
--- a/build/ProjectReunion-BuildFoundation.yml
+++ b/build/ProjectReunion-BuildFoundation.yml
@@ -13,6 +13,7 @@ variables:
 - template: WindowsAppSDK-Versions.yml
 - template: WindowsAppSDK-CommonVariables.yml
 - template: WindowsAppSDK-Foundation-TestConfig.yml@WindowsAppSDKConfig
+- template: ..\eng\common\AzurePipelinesTemplates\WindowsAppSDK-GlobalVariables.yml
 - group: PublicSymbols-Secrets
 
 stages:

--- a/build/ProjectReunion-CI.yml
+++ b/build/ProjectReunion-CI.yml
@@ -3,6 +3,7 @@ name: $(BuildDefinitionName)_$(date:yyMM).$(date:dd)$(rev:rrr)
 variables:
 - template: WindowsAppSDK-Versions.yml
 - template: WindowsAppSDK-CommonVariables.yml
+- template: ..\eng\common\AzurePipelinesTemplates\WindowsAppSDK-GlobalVariables.yml
 - name: buildOutputDir
   value: $(Build.SourcesDirectory)\BuildOutput
 

--- a/build/WindowsAppSDK-Foundation-Nightly.yml
+++ b/build/WindowsAppSDK-Foundation-Nightly.yml
@@ -46,6 +46,7 @@ variables:
 - template: WindowsAppSDK-Versions.yml
 - template: WindowsAppSDK-CommonVariables.yml
 - template: WindowsAppSDK-Foundation-TestConfig.yml@WindowsAppSDKConfig
+- template: ..\eng\common\AzurePipelinesTemplates\WindowsAppSDK-GlobalVariables.yml
 - group: PublicSymbols-Secrets
 
 extends:

--- a/build/WindowsAppSDK-Foundation-Official.yml
+++ b/build/WindowsAppSDK-Foundation-Official.yml
@@ -46,6 +46,7 @@ variables:
 - template: WindowsAppSDK-Versions.yml
 - template: WindowsAppSDK-CommonVariables.yml
 - template: WindowsAppSDK-Foundation-TestConfig.yml@WindowsAppSDKConfig
+- template: ..\eng\common\AzurePipelinesTemplates\WindowsAppSDK-GlobalVariables.yml
 - group: PublicSymbols-Secrets
 
 extends:

--- a/build/WindowsAppSDK-Foundation-PR.yml
+++ b/build/WindowsAppSDK-Foundation-PR.yml
@@ -35,6 +35,7 @@ variables:
 - template: WindowsAppSDK-Versions.yml
 - template: WindowsAppSDK-CommonVariables.yml
 - template: WindowsAppSDK-Foundation-TestConfig.yml@WindowsAppSDKConfig
+- template: ..\eng\common\AzurePipelinesTemplates\WindowsAppSDK-GlobalVariables.yml
 - group: PublicSymbols-Secrets
 
 extends:

--- a/build/WindowsAppSDK-Versions.yml
+++ b/build/WindowsAppSDK-Versions.yml
@@ -3,8 +3,3 @@ variables:
   major: "1"
   minor: "6"
   patch: "0"
-
-  # Native compiler version override for win undock. The two values below are for Ge, defined in:
-  # https://dev.azure.com/microsoft/OS/_git/UndockedES?path=/Pipelines/Config/CompilerToolsSettings.json
-  compilerOverridePackageName: "DevDiv.rel.LKG16.VCTools"    
-  compilerOverridePackageVersion: "19.38.3313310000+DevDivGIT.CI20231130.01-8BB7F026181F5D52D44CA519FF6A47BFA2763E45"

--- a/eng/common/AzurePipelinesTemplates/WindowsAppSDK-GlobalVariables.yml
+++ b/eng/common/AzurePipelinesTemplates/WindowsAppSDK-GlobalVariables.yml
@@ -1,0 +1,9 @@
+# Keep this file in a [ {name}: "{value}" ] format
+
+variables:
+  # Native compiler version override for win undock. The two values below are for Ge, defined in:
+  # https://dev.azure.com/microsoft/OS/_git/UndockedES?path=/Pipelines/Config/CompilerToolsSettings.json
+  compilerOverridePackageName: "DevDiv.rel.LKG16.VCTools"    
+  compilerOverridePackageVersion: "19.38.3313310000+DevDivGIT.CI20231130.01-8BB7F026181F5D52D44CA519FF6A47BFA2763E45"
+  # Use the following corresponding version string instead of the above when calling nuget install directly.
+  compilerOverrideNupkgVersion: "19.38.33133100-v2"


### PR DESCRIPTION
Following the pattern already in use on the Agg and Closed repos, factored out the LKG package info from the local
WindowsAppSDK-Versions.yml, and extract that info from the recently introduced global copy
eng/common/AzurePipelinesTemplates/WindowsAppSDK-GlobalVariables.yml instead.
The copy in this PR was manually fetched from the Agg repo, because the sync is currently not working.

How tested:
- PR validation is in progress
- Verified in the logs of the PR validation pipeline run, the LKG compiler is being used to build the main .sln file and the mrtcore .sln file.
----
A microsoft employee must use /azp run to validate using the pipelines below.

WARNING:
Comments made by azure-pipelines bot maybe inaccurate.
Please see pipeline link to verify that the build is being ran.

For status checks on the main branch, please use TransportPackage-Foundation-PR
(https://microsoft.visualstudio.com/ProjectReunion/_build?definitionId=81063&_a=summary)
and run the build against your PR branch with the default parameters.
