### PR TITLE
Fix incremental build issue where Microsoft.WindowsAppRuntime.Bootstrap.dll is always written to output

### DIFF
--- a/build/NuSpecs/WindowsAppSDK-Nuget-Native.C.props
+++ b/build/NuSpecs/WindowsAppSDK-Nuget-Native.C.props
@@ -28,9 +28,12 @@
         %(AdditionalDependencies);
       </AdditionalDependencies>
     </Link>
-    <PostBuildEvent>
-      <Command>xcopy.exe /y "$(MSBuildThisFileDirectory)..\..\runtimes\win10-$(_WindowsAppSDKFoundationPlatform)\native\Microsoft.WindowsAppRuntime.Bootstrap.dll" "$(OutDir)"</Command>
-    </PostBuildEvent>
   </ItemDefinitionGroup>
+
+  <Target Name="CopyMicrosoftWindowsAppRuntimeBootstrapdllToOutDir" Condition="'$(AppxPackage)' != 'true'" AfterTargets="Build">
+    <Copy
+      SourceFiles="$(MSBuildThisFileDirectory)..\..\runtimes\win10-$(_WindowsAppSDKFoundationPlatform)\native\Microsoft.WindowsAppRuntime.Bootstrap.dll"
+      DestinationFolder="$(OutDir)"/>
+  </Target>
 
 </Project>


### PR DESCRIPTION
PostBuildEvent is unconditionally run and xcopy always does the copy, making downstream projects think that they need to rebuild too because their references rebuild.

Switch to using a Target that leverages the built-in Copy task that already does the timestamp checks for us.