### PR TITLE
Align MrtCore.PriGen.targets with NET8 Runtime Identifier Defaults

### DIFF
--- a/dev/MRTCore/packaging/MrtCore.PriGen.targets
+++ b/dev/MRTCore/packaging/MrtCore.PriGen.targets
@@ -123,7 +123,8 @@
 
   <PropertyGroup>
     <NuGetTargetFramework Condition="'$(NuGetTargetFramework)'==''">$(TargetPlatformIdentifierAdjusted),Version=v$(TargetPlatformMinVersion)</NuGetTargetFramework>
-    <RuntimeIdentifiers Condition="'$(RuntimeIdentifiers)'==''">win10-arm;win10-arm-aot;win10-arm64-aot;win10-x86;win10-x86-aot;win10-x64;win10-x64-aot</RuntimeIdentifiers>
+    <RuntimeIdentifiers Condition="$([MSBuild]::GetTargetFrameworkVersion('$(TargetFramework)')) >= 8">win-x86;win-x64;win-arm64;win-arm</RuntimeIdentifiers>
+    <RuntimeIdentifiers Condition="$([MSBuild]::GetTargetFrameworkVersion('$(TargetFramework)')) &lt; 8">win10-arm;win10-arm-aot;win10-arm64-aot;win10-x86;win10-x86-aot;win10-x64;win10-x64-aot</RuntimeIdentifiers>
     <ResolveAssemblyConflicts>true</ResolveAssemblyConflicts>
   </PropertyGroup>
 


### PR DESCRIPTION
This PR addresses an inconsistency in `MrtCore.PriGen.targets` where the default `RuntimeIdentifiers` were set to non-portable RIDs, irrespective of the .NET version being targeted. The change aligns the default RIDs with the .NET version specified in the project's TargetFramework.

The previous logic incorrectly defaulted to non-portable RIDs, which was not compatible with .NET 8's portable RIDs. .NET 8 and later support simplified, portable RIDs like win-x86, win-x64, and win-arm64, rendering the more specific win10-* RIDs unnecessary. This update ensures that `MrtCore.PriGen.targets` defaults to the correct set of RIDs based on the targeted .NET version: