### PR TITLE
Revert "Update PR Template MD to warn about PullRequests on Forks"

### DIFF
--- a/docs/pull_request_template.md
+++ b/docs/pull_request_template.md
@@ -4,9 +4,6 @@ WARNING:
 Comments made by azure-pipelines bot maybe inaccurate.
 Please see pipeline link to verify that the build is being ran.
 
-PullRequest from Forks will also fail to trigger validation.
-Please create your PullRequest directly on the repository.
-
 For status checks on the main branch, please use TransportPackage-Foundation-PR
 (https://microsoft.visualstudio.com/ProjectReunion/_build?definitionId=81063&_a=summary)
 and run the build against your PR branch with the default parameters.


### PR DESCRIPTION
This reverts commit 0b3c0da393f667fec85c6e62d5a7b1114045784d.

A microsoft employee must use /azp run to validate using the pipelines below.

WARNING:
Comments made by azure-pipelines bot maybe inaccurate.
Please see pipeline link to verify that the build is being ran.

PullRequest from Forks will also fail to trigger validation.
Please create your PullRequest directly on the repository.

For status checks on the main branch, please use TransportPackage-Foundation-PR
(https://microsoft.visualstudio.com/ProjectReunion/_build?definitionId=81063&_a=summary)
and run the build against your PR branch with the default parameters.
