### PR TITLE
Remove ProjectReunionInternal Service Connection in NuGetAuthenticate taks

### DIFF
--- a/build/AzurePipelinesTemplates/WindowsAppSDK-BuildBinaries-Steps.yml
+++ b/build/AzurePipelinesTemplates/WindowsAppSDK-BuildBinaries-Steps.yml
@@ -24,8 +24,6 @@ steps:
     IsOneBranch: ${{ parameters.IsOneBranch }}
 
 - task: NuGetAuthenticate@1
-  inputs:
-    nuGetServiceConnections: 'ProjectReunionInternal'
 
   # Copy MSIX license installation header into the correct source location.
   # Restore transport package dependencies. This is only enbaled in release-signed builds.

--- a/build/AzurePipelinesTemplates/WindowsAppSDK-PackTransportPackage-Stage.yml
+++ b/build/AzurePipelinesTemplates/WindowsAppSDK-PackTransportPackage-Stage.yml
@@ -35,8 +35,6 @@ stages:
       ob_artifactBaseName: "TransportPackage"
     steps:
     - task: NuGetAuthenticate@1
-      inputs:
-        nuGetServiceConnections: 'ProjectReunionInternal'
 
     - task: DownloadPipelineArtifact@2
       displayName: 'Download Foundation x64'


### PR DESCRIPTION
To eliminate the use of our PAT in ProjectReunionInternal service connection