### PR TITLE
49601674: [Compliance] Enabled automated APIScan and PREfast scanning

### DIFF
--- a/build/AzurePipelinesTemplates/WindowsAppSDK-Build-Stage.yml
+++ b/build/AzurePipelinesTemplates/WindowsAppSDK-Build-Stage.yml
@@ -5,6 +5,9 @@ parameters:
 - name: "IsOneBranch"
   type: boolean
   default: True
+- name: runStaticAnalysis
+  type: boolean
+  default: True
 
 stages:
 - stage: Build
@@ -52,11 +55,15 @@ stages:
       ob_outputDirectory: '$(REPOROOT)\out'
       ob_sdl_codeSignValidation_excludes: '-|**\Release\**;-|**\packages\**'
       ob_artifactBaseName: "FoundationBinaries_$(buildConfiguration)_$(buildPlatform)"
+      ob_sdl_apiscan_enabled: true
+      ob_sdl_apiscan_softwareFolder: '$(build.SourcesDirectory)\APIScanTarget'
+      ob_sdl_apiscan_symbolsFolder: '$(build.SourcesDirectory)\APIScanTarget;SRV*http://symweb'
     steps:
     - template: WindowsAppSDK-BuildBinaries-Steps.yml@self
       parameters:
         SignOutput: ${{ parameters.SignOutput }}
         IsOneBranch: ${{ parameters.IsOneBranch }}
+        runStaticAnalysis : ${{ parameters.runStaticAnalysis }}
 
   - job: BuildBinaries_release_anycpu
     # For now, this job just builds Microsoft.WindowsAppRuntime.Bootstrap.Net.dll in AnyCPU
@@ -72,11 +79,15 @@ stages:
       ob_outputDirectory: '$(REPOROOT)\out'
       ob_sdl_codeSignValidation_excludes: '-|**\Release\**'
       ob_artifactBaseName: "FoundationBinaries_release_anycpu"
+      ob_sdl_apiscan_enabled: true
+      ob_sdl_apiscan_softwareFolder: '$(build.SourcesDirectory)\BuildOutput\Release\AnyCPU'
+      ob_sdl_apiscan_symbolsFolder: '$(build.SourcesDirectory)\BuildOutput\Release\AnyCPU;SRV*http://symweb'
     steps:
     - template: WindowsAppSDK-BuildBinaries-AnyCPU-Steps.yml@self
       parameters:
         SignOutput: ${{ parameters.SignOutput }}
         IsOneBranch: ${{ parameters.IsOneBranch }}
+        runStaticAnalysis : ${{ parameters.runStaticAnalysis }}
 
   - job: BuildMRT
     pool:
@@ -111,8 +122,12 @@ stages:
       ob_sdl_suppression_suppressionFile: $(Build.SourcesDirectory)\dev\MRTCore\.gdn\mrt.gdnsuppress # This value is set on the job cdpx_engine, it will override the global gdnsuppress for this job
       ob_sdl_suppression_suppressionSet: default
       ob_artifactBaseName: "MrtBinaries_$(buildConfiguration)_$(buildPlatform)"
+      ob_sdl_apiscan_enabled: true
+      ob_sdl_apiscan_softwareFolder: '$(build.SourcesDirectory)\APIScanTarget'
+      ob_sdl_apiscan_symbolsFolder: '$(build.SourcesDirectory)\APIScanTarget;SRV*http://symweb'
     steps:
     - template: WindowsAppSDK-BuildMRT-Steps.yml@self
       parameters:
         SignOutput: ${{ parameters.SignOutput }}
         IsOneBranch: ${{ parameters.IsOneBranch }}
+        runStaticAnalysis : ${{ parameters.runStaticAnalysis }}

--- a/build/AzurePipelinesTemplates/WindowsAppSDK-BuildBinaries-AnyCPU-Steps.yml
+++ b/build/AzurePipelinesTemplates/WindowsAppSDK-BuildBinaries-AnyCPU-Steps.yml
@@ -5,6 +5,9 @@ parameters:
 - name: "IsOneBranch"
   type: boolean
   default: True
+- name: runStaticAnalysis
+  type: boolean
+  default: True
 
 steps:
 - task: NuGetToolInstaller@1
@@ -28,6 +31,16 @@ steps:
   inputs:
     filePath: 'BuildAll.ps1'
     arguments: -AzureBuildStep "BuildAnyCPU"
+
+- ${{ if eq(parameters.runStaticAnalysis, 'True') }}:
+  - task: SDLNativeRules@3
+    displayName: Run PREfast SDL Native Rules 
+    inputs:
+      setupCommandlines: '"C:\Program Files\Microsoft Visual Studio\2022\Enterprise\Common7\Tools\VsMSBuildCmd.bat"'
+      msBuildCommandline: 'msbuild.exe /restore /nologo /nr:false $(Build.SourcesDirectory)\dev\Bootstrap\CS\Microsoft.WindowsAppRuntime.Bootstrap.Net\Microsoft.WindowsAppRuntime.Bootstrap.Net.csproj'
+    continueOnError: true
+    env:
+      SYSTEM_ACCESSTOKEN: $(System.AccessToken)
 
 # component detection must happen *within* the build task
 - task: ms.vss-governance-buildtask.governance-build-task-component-detection.ComponentGovernanceComponentDetection@0

--- a/build/AzurePipelinesTemplates/WindowsAppSDK-BuildBinaries-Steps.yml
+++ b/build/AzurePipelinesTemplates/WindowsAppSDK-BuildBinaries-Steps.yml
@@ -5,6 +5,9 @@ parameters:
 - name: "IsOneBranch"
   type: boolean
   default: True
+- name: runStaticAnalysis
+  type: boolean
+  default: True
 
 steps:
 - task: NuGetToolInstaller@1
@@ -66,6 +69,46 @@ steps:
   inputs:
     filePath: 'BuildAll.ps1'
     arguments: -Platform "$(buildPlatform)" -Configuration "$(buildConfiguration)" -AzureBuildStep "BuildBinaries"
+
+- ${{ if eq(parameters.runStaticAnalysis, 'True') }}:
+  - task: SDLNativeRules@3
+    displayName: Run PREfast SDL Native Rules 
+    condition: and(succeeded(), eq(variables['buildConfiguration'], 'Release'), eq(variables['buildPlatform'], 'x64'))
+    inputs:
+      setupCommandlines: '"C:\Program Files\Microsoft Visual Studio\2022\Enterprise\Common7\Tools\VsMSBuildCmd.bat"'
+      msBuildArchitecture: amd64
+      msBuildCommandline: 'msbuild.exe /restore /nologo /nr:false /p:configuration=Release /p:platform=x64 $(Build.SourcesDirectory)\WindowsAppRuntime.sln'
+    env:
+      SYSTEM_ACCESSTOKEN: $(System.AccessToken)
+    continueOnError: true
+
+  # Copy build output to folder APIScanTarget for APIScan to scan later, in the mean time, exclude some folders/files.
+  - task: CopyFiles@2
+    displayName: Populate APIScanTarget
+    condition: and(succeeded(), eq(variables['ob_sdl_apiscan_enabled'], 'true'))
+    inputs:
+      SourceFolder: '$(build.SourcesDirectory)\BuildOutput'
+      TargetFolder: '$(build.SourcesDirectory)\APIScanTarget'
+      contents: |
+        **
+        !**\*test*\**
+        !**\*Demoapp*\**
+        !**\*Demopackage\**
+        !**\*.json
+        !**\*.msix
+        !**\*.png
+        !**\*.binlog
+        !**\*.cs
+        !**\*.cpp
+        !**\*.idl
+        !**\*.h
+    continueOnError: true
+
+  #- script: |
+  #    dir /s $(Build.SourcesDirectory)\APIScanTarget
+  #  displayName: 'DIAG: dir $(Build.SourcesDirectory)\APIScanTarget'
+  #  condition: and(succeededOrFailed(), eq(variables['ob_sdl_apiscan_enabled'], 'true'))
+  #  continueOnError: true
 
 - ${{ if eq(parameters.SignOutput, 'true') }}:
   - task: EsrpCodeSigning@2

--- a/build/AzurePipelinesTemplates/WindowsAppSDK-BuildMRT-Steps.yml
+++ b/build/AzurePipelinesTemplates/WindowsAppSDK-BuildMRT-Steps.yml
@@ -5,9 +5,9 @@ parameters:
 - name: "IsOneBranch"
   type: boolean
   default: True
-- name: "RunPrefast"
+- name: runStaticAnalysis
   type: boolean
-  default: False
+  default: True
 
 steps:
 - template: WindowsAppSDK-SetupBuildEnvironment-Steps.yml
@@ -22,43 +22,44 @@ steps:
     compilerPackageVersion: $(compilerOverridePackageVersion)
     slnDirectory: $(Build.SourcesDirectory)\dev\MRTCore\mrt
 
-- ${{ if parameters.RunPrefast }}:
-  # PREFast scan is enabled in this pipeline run, so we pass PreFastSetup to BuildAll.ps1 to get it to do the commonn setup steps, but short of
-  # building the target via MSBuild.exe
-  - task: PowerShell@2
-    name: PreFastSetup
-    inputs:
-      filePath: 'BuildAll.ps1'
-      arguments: -Platform "$(buildPlatform)" -Configuration "$(buildConfiguration)" -AzureBuildStep "PreFastSetup"
+- task: PowerShell@2
+  name: BuildBinaries
+  retryCountOnTaskFailure: 10
+  inputs:
+    filePath: 'BuildAll.ps1'
+    arguments: -Platform "$(buildPlatform)" -Configuration "$(buildConfiguration)" -AzureBuildStep "BuildMRT"
 
-  # The PREFast task below only supports the VSBuild/MSbuild task, _not_ a direct call to MSBuild.exe.
-  - task: MSBuild@1
-    displayName: 'build MrtCore with MSBuild'
-    inputs:
-      platform: '$(buildPlatform)'
-      solution: '$(Build.SourcesDirectory)\dev\MRTCore\mrt\MrtCore.sln'
-      configuration: '$(buildConfiguration)'
-      msbuildArguments: '/restore /binaryLogger:$(Build.SourcesDirectory)\dev\MRTCore\mrt\mrtcore.$(buildPlatform).$(buildConfiguration).binlog'
-
-  # ToDo: WindowsAppSDK-BinaryAnalysis-steps.yml below ultimately invokes SDLNativeRules@2, which is out of support.
-  # So for the time being, we explicitly call SDLNativeRules@3, which is currently supported. Consider eliminating this
-  # extra step when we run PREFast as part of WindowsAppSDK-BinaryAnalysis-steps.yml below.
+- ${{ if eq(parameters.runStaticAnalysis, 'True') }}:
   - task: SDLNativeRules@3
-    displayName: 'Guardian: PreFast@3'
+    displayName: Run PREfast SDL Native Rules 
+    condition: and(succeeded(), eq(variables['buildPlatform'], 'x64'), eq(variables['buildConfiguration'], 'Release'))
+    inputs:
+      setupCommandlines: '"C:\Program Files\Microsoft Visual Studio\2022\Enterprise\Common7\Tools\VsMSBuildCmd.bat"'
+      msBuildArchitecture: amd64
+      msBuildCommandline: 'msbuild.exe /nologo /nr:false /p:configuration=Release /p:platform=x64 $(Build.SourcesDirectory)\dev\MRTCore\mrt\MrtCore.sln'
     env:
       SYSTEM_ACCESSTOKEN: $(System.AccessToken)
     continueOnError: true
-    inputs:
-      userProvideBuildInfo: 'auto'
-      toolVersion: Latest
 
-- ${{ if not( parameters.RunPrefast ) }}:
-  - task: PowerShell@2
-    name: BuildBinaries
-    retryCountOnTaskFailure: 10
+  # Copy build output to folder APIScanTarget for APIScan to scan, in the mean time, exclude some folders/files.
+  - task: CopyFiles@2
+    displayName: Populate APIScanTarget
+    condition: and(succeeded(), eq(variables['ob_sdl_apiscan_enabled'], 'true'))
     inputs:
-      filePath: 'BuildAll.ps1'
-      arguments: -Platform "$(buildPlatform)" -Configuration "$(buildConfiguration)" -AzureBuildStep "BuildMRT"
+      SourceFolder: '$(build.SourcesDirectory)\BuildOutput'
+      TargetFolder: '$(build.SourcesDirectory)\APIScanTarget'
+      contents: |
+        **
+        !**\*test*\**
+        !**\*.binlog
+        !**\*.json
+    continueOnError: true
+
+  #- script: |
+  #    dir /s $(Build.SourcesDirectory)\APIScanTarget
+  #  displayName: 'DIAG: dir $(Build.SourcesDirectory)\APIScanTarget'
+  #  condition: and(succeededOrFailed(), eq(variables['ob_sdl_apiscan_enabled'], 'true'))
+  #  continueOnError: true
 
 # component detection must happen *within* the build task
 - task: ms.vss-governance-buildtask.governance-build-task-component-detection.ComponentGovernanceComponentDetection@0

--- a/build/WindowsAppSDK-Foundation-Nightly.yml
+++ b/build/WindowsAppSDK-Foundation-Nightly.yml
@@ -30,6 +30,10 @@ parameters:
 - name: "SignOutput"
   type: boolean
   default: True
+- name: runStaticAnalysis
+  displayName: "Run Static Analysis (e.g., PREFast, APIScan)"
+  type: boolean
+  default: True
 
 resources:
   repositories:
@@ -79,11 +83,32 @@ extends:
       policheck:
         enable: true
         break: true
+      binskim:
+        enabled: true
+        break: true
+      prefast:
+        ${{ if eq(parameters.runStaticAnalysis, 'True') }}:
+          enabled: true
+        ${{ else }}:
+          enabled: false
+        # TODO: Once we've cleared away all existing errors, consider setting this to true.
+        break: false
+        # Use "severity: 'Warning'" to be more sensitive, break on Warnings+Errors.
+        # Use "severity: 'Note'" to be even more sensitive, break on Notes+Warnings+Errors.
+        # Use "severity: 'Default'" to get back to default, i.e., break on Errors. Can't get less sensitive than that.
+        severity: Default
+        # Use "exclusionsFile: <<FILE PATH>>" to apply a local exclusion file.
+      apiscan:
+        # We will enable APIScan on a per-job basis downstream as needed.
+        enabled: false
+        # TODO: Once we've cleared away all existing errors, consider setting this to true.
+        break: false
 
     stages:
     - template: AzurePipelinesTemplates\WindowsAppSDK-Build-Stage.yml@self
       parameters:
         SignOutput: ${{ parameters.SignOutput }}
+        runStaticAnalysis : ${{ parameters.runStaticAnalysis }}
 
     - template: AzurePipelinesTemplates\WindowsAppSDK-Test-Stage.yml@self
 

--- a/build/WindowsAppSDK-Foundation-Official.yml
+++ b/build/WindowsAppSDK-Foundation-Official.yml
@@ -30,6 +30,10 @@ parameters:
 - name: "SignOutput"
   type: boolean
   default: True
+- name: runStaticAnalysis
+  displayName: "Run Static Analysis (e.g., PREFast, APIScan)"
+  type: boolean
+  default: True
 
 resources:
   repositories:
@@ -66,12 +70,30 @@ extends:
         enabled: false
       binskim:
         enabled: true
+        break: true
+      prefast:
+        ${{ if eq(parameters.runStaticAnalysis, 'True') }}:
+          enabled: true
+        ${{ else }}:
+          enabled: false
+        # TODO: Once we've cleared away all existing errors, consider setting this to true.
+        break: true
+        # Use "severity: 'Warning'" to be more sensitive, break on Warnings+Errors.
+        # Use "severity: 'Note'" to be even more sensitive, break on Notes+Warnings+Errors.
+        # Use "severity: 'Default'" to get back to default, i.e., break on Errors. Can't get less sensitive than that.
+        severity: Default
+        # Use "exclusionsFile: <<FILE PATH>>" to apply a local exclusion file.
+      apiscan:
+        # We will enable APIScan on a per-job basis downstream as needed.
+        enabled: false
+        # TODO: Once we've cleared away all existing errors, consider setting this to true.
         break: false
 
     stages:
     - template: AzurePipelinesTemplates\WindowsAppSDK-Build-Stage.yml@self
       parameters:
         SignOutput: ${{ parameters.SignOutput }}
+        runStaticAnalysis : ${{ parameters.runStaticAnalysis }}
 
     - template: AzurePipelinesTemplates\WindowsAppSDK-Test-Stage.yml@self
 

--- a/build/WindowsAppSDK-Foundation-PR.yml
+++ b/build/WindowsAppSDK-Foundation-PR.yml
@@ -20,6 +20,12 @@
 # https://aka.ms/obpipelines/triggers
 trigger: none
 
+parameters: # parameters are shown up in ADO UI in a build queue time
+- name: runStaticAnalysis
+  displayName: "Run Static Analysis (e.g., PREFast, APIScan)"
+  type: boolean
+  default: True
+
 resources:
   repositories:
     - repository: templates
@@ -54,11 +60,32 @@ extends:
       psscriptanalyzer:
         enable: true
         break: true
+      binskim:
+        enabled: true
+        break: true
+      prefast:
+        ${{ if eq(parameters.runStaticAnalysis, 'True') }}:
+          enabled: true
+        ${{ else }}:
+          enabled: false
+        # TODO: Once we've cleared away all existing errors, consider setting this to true.
+        break: false
+        # Use "severity: 'Warning'" to be more sensitive, break on Warnings+Errors.
+        # Use "severity: 'Note'" to be even more sensitive, break on Notes+Warnings+Errors.
+        # Use "severity: 'Default'" to get back to default, i.e., break on Errors. Can't get less sensitive than that.
+        severity: Default
+        # Use "exclusionsFile: <<FILE PATH>>" to apply a local exclusion file.
+      apiscan:
+        # We will enable APIScan on a per-job basis downstream as needed.
+        enabled: false
+        # TODO: Once we've cleared away all existing errors, consider setting this to true.
+        break: false
 
     stages:
     - template: AzurePipelinesTemplates\WindowsAppSDK-Build-Stage.yml@self
       parameters:
         SignOutput: false
+        runStaticAnalysis : ${{ parameters.runStaticAnalysis }}
 
     - template: AzurePipelinesTemplates\WindowsAppSDK-Test-Stage.yml@self
 


### PR DESCRIPTION
Enabled automated APIScan and PREfast scans.
This a straight port of a [`reviewed PR`](https://dev.azure.com/microsoft/ProjectReunion/_git/WindowsAppSDK/pullrequest/10567664?path=/build/AzurePipelinesTemplates/WindowsAppSDK-BuildMRT-Steps.yml).

PREFast:
- There are pre-existing errors, to avoid breaking the pipelines, disabled the "break on error" setting until those errors are resolved.
- Focus on scanning x64fre as a start.

APIScan:
- There are pre-existing errors, to avoid breaking the pipelines, disabled the "break on error" setting until those errors are resolved.
- Pointed APIScan to a APIScanTarget folder where we put binaries to be scanned. This allows us to exclude files and folders from being scanned.

Genera notes:
- The non-OneBranch public pipeline does not seem to support APIScan/PREFast scanning, hence, adding APIScan/PREFast scanning to the internal OneBranch pipelines that are already running BinSkim/PoliCheck etc. scans.
- When a developer manually triggers a pipeline run, a checkbox is exposed to allow the developer to disable static analysis (currently covers PREFast and APIScan) to shorten pipeline runs, say, in the developer's inner loop.

How built:
- A [private pipeline run](https://microsoft.visualstudio.com/ProjectReunion/_build/results?buildId=95371738&view=results)  passed
- PR validation succeeded.

How tested:
- In the Scans tab of the private pipeline run linked above, meaningful APIScan and PREFast results are available.

---
A microsoft employee must use /azp run to validate using the pipelines below.

WARNING:
Comments made by azure-pipelines bot maybe inaccurate.
Please see pipeline link to verify that the build is being ran.

For status checks on the main branch, please use TransportPackage-Foundation-PR
(https://microsoft.visualstudio.com/ProjectReunion/_build?definitionId=81063&_a=summary)
and run the build against your PR branch with the default parameters.
