### PR TITLE
Add Support Offline Mode for VSIX ProjectTemplate

### DIFF
--- a/dev/VSIX/Extension/Cs/Dev16/WindowsAppSDK.Cs.Extension.Dev16.csproj
+++ b/dev/VSIX/Extension/Cs/Dev16/WindowsAppSDK.Cs.Extension.Dev16.csproj
@@ -73,6 +73,9 @@
     <PackageReference Include="Microsoft.Windows.SDK.BuildTools" Version="[$(WindowsSDKBuildToolsVersion)]" GeneratePathProperty="true">
       <ExcludeAssets>All</ExcludeAssets>
     </PackageReference>
+    <PackageReference Include="NuGet.Protocol">
+      <Version>6.9.1</Version>
+    </PackageReference>
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="$(ItemTemplatesDir)Desktop\CSharp\BlankWindow\WinUI.Desktop.Cs.BlankWindow.csproj">

--- a/dev/VSIX/Extension/Cs/Dev17/NugetClientHelper.cs
+++ b/dev/VSIX/Extension/Cs/Dev17/NugetClientHelper.cs
@@ -1,0 +1,51 @@
+using NuGet.Common;
+using NuGet.Configuration;
+using NuGet.Packaging.Core;
+using NuGet.Protocol;
+using NuGet.Protocol.Core.Types;
+using NuGet.Versioning;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace WindowsAppSDK.TemplateUtilities
+{
+    public static class NugetClientHelper
+    {
+        private static ISettings? settings = Settings.LoadDefaultSettings(null);
+        public static string globalPackagesFolder = SettingsUtility.GetGlobalPackagesFolder(settings);
+
+        [System.Runtime.InteropServices.DllImport("wininet.dll")]
+        private extern static bool InternetGetConnectedState(out int Description, int ReservedValue);
+
+        public static bool IsInternetAvailable()
+        {
+            int desc;
+            return InternetGetConnectedState(out desc, 0);
+        }
+
+        public async static Task<IPackageSearchMetadata> GetPackageMetaDataAsync(string packageId, bool includePrerelease = false)
+        {
+            var repository = Repository.Factory.GetCoreV3("https://api.nuget.org/v3/index.json");
+            var resource = await repository.GetResourceAsync<PackageSearchResource>();
+            var searchFilter = new SearchFilter(includePrerelease: includePrerelease);
+
+            var results = await resource.SearchAsync(
+                packageId,
+                searchFilter,
+                skip: 0,
+                take: 1,
+                NullLogger.Instance,
+                CancellationToken.None);
+
+            return results?.FirstOrDefault();
+        }
+
+        public static bool IsCacheAvailableForPackage(string packageId, string packageVersion)
+        {
+            NuGetVersion version = new NuGetVersion(packageVersion);
+            var package = GlobalPackagesFolderUtility.GetPackage(new PackageIdentity(packageId, version), globalPackagesFolder);
+            return package != null;
+        }
+    }
+}

--- a/dev/VSIX/Extension/Cs/Dev17/WindowsAppSDK.Cs.Extension.Dev17.csproj
+++ b/dev/VSIX/Extension/Cs/Dev17/WindowsAppSDK.Cs.Extension.Dev17.csproj
@@ -52,6 +52,9 @@
     <PackageReference Include="Microsoft.Windows.SDK.BuildTools" Version="[$(WindowsSDKBuildToolsVersion)]" GeneratePathProperty="true">
       <ExcludeAssets>All</ExcludeAssets>
     </PackageReference>
+    <PackageReference Include="NuGet.Protocol">
+      <Version>6.9.1</Version>
+    </PackageReference>
   </ItemGroup>
   <ItemGroup>
     <ExtensionDependencies Condition=" '$(ExcludeRestorePackageImports)' != 'true' " Include="$(PkgNuget_VisualStudio)\**\NuGet.VisualStudio.dll" />

--- a/dev/VSIX/Extension/Cs/Dev17/WizardImplementation.cs
+++ b/dev/VSIX/Extension/Cs/Dev17/WizardImplementation.cs
@@ -73,7 +73,7 @@ namespace WindowsAppSDK.TemplateUtilities
 			joinableTaskFactory.RunAsync(InstallNuGetPackageAsync);
 
 		}
-		private Task InstallNuGetPackageAsync()
+		private async Task<Task> InstallNuGetPackageAsync()
 		{
             if (string.IsNullOrEmpty(_packageId))
             {
@@ -82,10 +82,33 @@ namespace WindowsAppSDK.TemplateUtilities
                 LogError(message);
                 return Task.CompletedTask;
             }
-            IVsPackageInstaller installer = _componentModel.GetService<IVsPackageInstaller>();
+
+            IVsPackageInstaller2 installer2 = _componentModel.GetService<IVsPackageInstaller2>();
+            
             try
             {
-                installer.InstallPackage(null, _project, _packageId, "", false);
+                if (NugetClientHelper.IsInternetAvailable()) 
+                {
+                    // Get Latest Version from Nuget.org
+                    var packageMeta = await NugetClientHelper.GetPackageMetaDataAsync(_packageId);
+                    var isCacheAvailable = NugetClientHelper.IsCacheAvailableForPackage(_packageId, packageMeta.Identity.Version.ToString());
+
+                    if (isCacheAvailable)
+                    {
+                        // The latest version is available locally/cached and The latest version will be installed from Local/Cache
+                        installer2.InstallLatestPackage(NugetClientHelper.globalPackagesFolder, _project, _packageId, false, false);
+                    }
+                    else
+                    {
+                        // The latest version is not available locally/cached and The latest version will be installed from nuget.org
+                        installer2.InstallLatestPackage(null, _project, _packageId, false, false);
+                    }
+                }
+                else
+                {
+                    // Internet is not connected, the latest cached version will be installed
+                    installer2.InstallLatestPackage(NugetClientHelper.globalPackagesFolder, _project, _packageId, false, false);
+                }
             }
             catch (Exception ex)
             {


### PR DESCRIPTION
Fix #4325 

If there is no internet connection, the project will not be created Because of adding nuget package (wasdk) [dynamically](https://github.com/microsoft/WindowsAppSDK/commit/514f12a81ea0944e52c97b46552c8f969663c25d)

This PR checks the internet connection: 
- If the internet is available And the latest version is available as a cache/Locally, Installs the latest cached version.
- If the cached/Local version is not available, the latest version will be installed from nuget.org
- If the internet is not available, then the latest version will be installed from cache/Local

Also i Changed `IVsPackageInstaller` to `IVsPackageInstaller2` because there is a Method Called `InstallLatestPackage` which can install latest version.

A microsoft employee must use /azp run to validate using the pipelines below.

WARNING:
Comments made by azure-pipelines bot maybe inaccurate.
Please see pipeline link to verify that the build is being ran.

For status checks on the main branch, please use TransportPackage-Foundation-PR
(https://microsoft.visualstudio.com/ProjectReunion/_build?definitionId=81063&_a=summary)
and run the build against your PR branch with the default parameters.
