### PR TITLE
49601674: [Compliance] address pre-existing PREfast errors and enable break-on-error setting for PREfast

### DIFF
--- a/build/WindowsAppSDK-Foundation-Nightly.yml
+++ b/build/WindowsAppSDK-Foundation-Nightly.yml
@@ -91,8 +91,7 @@ extends:
           enabled: true
         ${{ else }}:
           enabled: false
-        # TODO: Once we've cleared away all existing errors, consider setting this to true.
-        break: false
+        break: true
         # Use "severity: 'Warning'" to be more sensitive, break on Warnings+Errors.
         # Use "severity: 'Note'" to be even more sensitive, break on Notes+Warnings+Errors.
         # Use "severity: 'Default'" to get back to default, i.e., break on Errors. Can't get less sensitive than that.

--- a/build/WindowsAppSDK-Foundation-Official.yml
+++ b/build/WindowsAppSDK-Foundation-Official.yml
@@ -76,7 +76,6 @@ extends:
           enabled: true
         ${{ else }}:
           enabled: false
-        # TODO: Once we've cleared away all existing errors, consider setting this to true.
         break: true
         # Use "severity: 'Warning'" to be more sensitive, break on Warnings+Errors.
         # Use "severity: 'Note'" to be even more sensitive, break on Notes+Warnings+Errors.

--- a/build/WindowsAppSDK-Foundation-PR.yml
+++ b/build/WindowsAppSDK-Foundation-PR.yml
@@ -68,8 +68,7 @@ extends:
           enabled: true
         ${{ else }}:
           enabled: false
-        # TODO: Once we've cleared away all existing errors, consider setting this to true.
-        break: false
+        break: true
         # Use "severity: 'Warning'" to be more sensitive, break on Warnings+Errors.
         # Use "severity: 'Note'" to be even more sensitive, break on Notes+Warnings+Errors.
         # Use "severity: 'Default'" to get back to default, i.e., break on Errors. Can't get less sensitive than that.

--- a/dev/AppLifecycle/RedirectionRequestQueue.h
+++ b/dev/AppLifecycle/RedirectionRequestQueue.h
@@ -23,6 +23,7 @@ namespace winrt::Microsoft::Windows::AppLifecycle::implementation
 
             // We store the head pointer at the beginning of the memory, and then items in the queue after.
             m_data.Open(name, (sizeof(QueueItem) * 4096) + sizeof(QueueItem*));
+#pragma warning(suppress: 6305) // C6305: PREFast does not know m_data.Get() is compatible with "sizeof(size_t)".
             m_dataStart = reinterpret_cast<QueueItem*>(m_data.Get() + sizeof(size_t));
         }
 
@@ -122,11 +123,14 @@ namespace winrt::Microsoft::Windows::AppLifecycle::implementation
             QueueItem* upperBounds = reinterpret_cast<QueueItem*>(m_data.Get()) + m_data.Size();
             auto cur = m_dataStart;
 
+#pragma warning(suppress: 6305) // C6305: PREFast does not know upperBounds was also computed in byte count so it is compatible with "sizeof(QueueItem)".
             while (cur < (upperBounds - sizeof(QueueItem)) && cur->inUse)
             {
+#pragma warning(suppress: 6305) // C6305: PREFast does not know cur was also computed in byte count so it is compatible with "sizeof(QueueItem)".
                 cur += sizeof(QueueItem);
             }
 
+#pragma warning(suppress: 6305) // C6305: PREFast does not know upperBounds was also computed in byte count so it is compatible with "sizeof(QueueItem)".
             THROW_HR_IF(E_OUTOFMEMORY, cur >= (upperBounds - sizeof(QueueItem)));
             return cur;
         }

--- a/dev/Deployment/DeploymentManager.cpp
+++ b/dev/Deployment/DeploymentManager.cpp
@@ -414,8 +414,8 @@ namespace winrt::Microsoft::Windows::ApplicationModel::WindowsAppRuntime::implem
                 deploymentResult.ActivityId());
         }
 
-        return !deploymentOperationHResult ? deploymentOperationHResult :
-            (deploymentOperationExtendedHResult ? deploymentOperationExtendedHResult : deploymentOperationHResult);
+        return FAILED(deploymentOperationHResult) ? deploymentOperationHResult :
+            (FAILED(deploymentOperationExtendedHResult) ? deploymentOperationExtendedHResult : deploymentOperationHResult);
     }
     CATCH_RETURN()
 

--- a/dev/Deployment/DeploymentManager.cpp
+++ b/dev/Deployment/DeploymentManager.cpp
@@ -414,7 +414,9 @@ namespace winrt::Microsoft::Windows::ApplicationModel::WindowsAppRuntime::implem
                 deploymentResult.ActivityId());
         }
 
-        return FAILED(deploymentOperationHResult) ? deploymentOperationHResult :
+        // If deploymentOperationHResult indicates success, take that, ignore deploymentOperationExtendedHResult.
+        // Otherwise, return deploymentOperationExtendedHResult if there is an error in it, if not, return deploymentOperationHResult.
+        return SUCCEEDED(deploymentOperationHResult) ? deploymentOperationHResult :
             (FAILED(deploymentOperationExtendedHResult) ? deploymentOperationExtendedHResult : deploymentOperationHResult);
     }
     CATCH_RETURN()

--- a/dev/Deployment/DeploymentTraceLogging.h
+++ b/dev/Deployment/DeploymentTraceLogging.h
@@ -57,7 +57,7 @@ public:
 
         SetStopResult(hresult);
 
-        if (hresult)
+        if (FAILED(hresult))
         {
             TraceLoggingClassWriteStop(Initialize,
                 _GENERIC_PARTB_FIELDS_ENABLED,

--- a/dev/DeploymentAgent/main.cpp
+++ b/dev/DeploymentAgent/main.cpp
@@ -79,7 +79,7 @@ int APIENTRY wWinMain(HINSTANCE, HINSTANCE, LPWSTR, int) try
                 deploymentResult.ErrorText().c_str(),
                 deploymentResult.ActivityId());
         }
-        return deploymentOperationExtendedHResult ? deploymentOperationExtendedHResult : deploymentOperationHResult;
+        return static_cast<int>(FAILED(deploymentOperationExtendedHResult) ? deploymentOperationExtendedHResult : deploymentOperationHResult);
     }
 
     WindowsAppRuntimeDeploymentAgent_TraceLogger::Success(

--- a/dev/MRTCore/mrt/mrm/UnitTests/DecisionInfo.UnitTests.cpp
+++ b/dev/MRTCore/mrt/mrm/UnitTests/DecisionInfo.UnitTests.cpp
@@ -85,6 +85,10 @@ void DecisionInfoUnitTests::SimpleBuilderTests()
     }
 
     // Add test data to builders
+    // Although it is tempting to remove the '!' below to address the PREfast issue, doing that broke the build. 
+    // OTOH, 2 instances of the same code pattern are also in OS.2020, therefore, we probably would want to have 
+    // a "global" fix for all instances. Bug 50087117 has been filed for tracking the "global" fix.
+#pragma warning(suppress: 6215) // C6215: Cast between semantically different integer types.
     if (FAILED(!decisionInfo.ApplyTestData(pBuilder)))
     {
         Log::Error(L"[ Error applying test data ]");

--- a/dev/MRTCore/mrt/mrm/UnitTests/ResourceMap.UnitTests.cpp
+++ b/dev/MRTCore/mrt/mrm/UnitTests/ResourceMap.UnitTests.cpp
@@ -215,7 +215,7 @@ void ResourceMapUnitTests::SimpleSubtreeTests()
     }
     else
     {
-        if (FAILED(subtreeStrings.InitFromList(subtreeSpec)))
+        if (!subtreeStrings.InitFromList(subtreeSpec))
         {
             Log::Error(L"[ Couldn't parse subtree spec ]");
         }

--- a/dev/MRTCore/mrt/mrm/UnitTests/ResourceReference.UnitTests.cpp
+++ b/dev/MRTCore/mrt/mrm/UnitTests/ResourceReference.UnitTests.cpp
@@ -75,7 +75,7 @@ _Success_(return ) static bool GetOrigin(_Out_ UINT16* pOriginFlagsOut, _Inout_ 
     // Where "<name>" is the name of the file or package used for the reference
     String originSpecStr;
     TestStringArray originSpec;
-    if (FAILED(TestData::TryGetValue(L"Origin", originSpecStr)) || FAILED(originSpec.InitFromList(originSpecStr)) ||
+    if (FAILED(TestData::TryGetValue(L"Origin", originSpecStr)) || !originSpec.InitFromList(originSpecStr) ||
         ((originSpec.GetNumStrings() != 1) && (originSpec.GetNumStrings() != 2)))
     {
         Log::Warning(tmp.Format(L"[ Missing or malformed Origin specification ]"));
@@ -171,7 +171,7 @@ static bool VerifyBuildReferences(_In_ UINT16 originType, _In_opt_ PCWSTR pszOri
             Log::Comment(tmp.Format(L"[ BuildReference: \"%s\" ]", (PCWSTR)refs[i]));
 
             // Parse the build reference
-            if (FAILED(refSpec.InitFromList(refs[i])) || (refSpec.GetNumStrings() < 2) || (!refSpec.TryGetStringAsInt(1, &expectedStatus)))
+            if (!refSpec.InitFromList(refs[i]) || (refSpec.GetNumStrings() < 2) || (!refSpec.TryGetStringAsInt(1, &expectedStatus)))
             {
                 Log::Warning(tmp.Format(L"[ Malformed BuildReference \"%s\" ignored. ]", (PCWSTR)refs[i]));
                 continue;
@@ -273,7 +273,7 @@ static bool VerifyLookupReferences(
 
     String contextSpec;
     TestStringArray contextStrings;
-    if (SUCCEEDED(TestData::TryGetValue(L"Context", contextSpec)) && SUCCEEDED(contextStrings.InitFromList((PCWSTR)contextSpec)))
+    if (SUCCEEDED(TestData::TryGetValue(L"Context", contextSpec)) && contextStrings.InitFromList((PCWSTR)contextSpec))
     {
 
         for (int i = 0; i < contextStrings.GetNumStrings(); i += 2)
@@ -320,7 +320,7 @@ static bool VerifyLookupReferences(
             Log::Comment(tmp.Format(L"[ LookupReference: \"%s\" ]", (PCWSTR)refs[i]));
 
             // Parse the build reference
-            if (FAILED(refSpec.InitFromList(refs[i])) || (refSpec.GetNumStrings() < 3) || (!refSpec.TryGetStringAsBool(1, &useMap)) ||
+            if (!refSpec.InitFromList(refs[i]) || (refSpec.GetNumStrings() < 3) || (!refSpec.TryGetStringAsBool(1, &useMap)) ||
                 (!refSpec.TryGetStringAsHexadecimal(2, &expectedStatus)))
             {
                 Log::Warning(tmp.Format(L"[ Malformed LookupReference \"%s\" ignored. ]", (PCWSTR)refs[i]));
@@ -467,7 +467,7 @@ void ResourceReferenceUnitTests::BlobFormatTests()
         for (size_t i = 0; i < blobs.GetSize(); i++)
         {
             TestStringArray blobSpecs;
-            if (SUCCEEDED(blobSpecs.InitFromList((PCWSTR)blobs[i])))
+            if (blobSpecs.InitFromList((PCWSTR)blobs[i]))
             {
                 UINT32 flags;
                 UINT32 cbTotal;

--- a/dev/MRTCore/mrt/mrm/UnitTests/TestLinks.cpp
+++ b/dev/MRTCore/mrt/mrm/UnitTests/TestLinks.cpp
@@ -86,7 +86,7 @@ bool TestResourceLinks::TryAddLinksFromTestVars(_In_ IResourceLinkBuilder* linkB
             for (unsigned i = 0; i < links.GetSize(); i++)
             {
                 Log::Comment(tmp.Format(L"[ link %d: \"%s\" ]", i, (PCWSTR)links[i]));
-                if (FAILED(link.InitFromList(links[i])) || ((link.GetNumStrings() < 2) || (link.GetNumStrings() > 3)))
+                if (!link.InitFromList(links[i]) || ((link.GetNumStrings() < 2) || (link.GetNumStrings() > 3)))
                 {
                     Log::Warning(L"  [ Couldn't parse link string ]");
                     continue;
@@ -155,7 +155,7 @@ TestResourceLinks::VerifyAgainstTestVars(_In_ IResourceLinks* links, _In_ PCWSTR
     if (SUCCEEDED(TestData::TryGetValue(tmp.Format(L"%sExpectedInternalLinks", varPrefix), specString)))
     {
         TestStringArray spec;
-        if (SUCCEEDED(spec.InitFromList(specString)))
+        if (spec.InitFromList(specString))
         {
             int expectedIndex;
 
@@ -203,7 +203,7 @@ TestResourceLinks::VerifyAgainstTestVars(_In_ IResourceLinks* links, _In_ PCWSTR
             int linkIndex;
 
             Log::Comment(tmp.Format(L"[     %d: %s ]", i, (PCWSTR)specs[i]));
-            if (SUCCEEDED(spec.InitFromList(specs[i])) && spec.TryGetStringAsInt(0, &linkIndex))
+            if (spec.InitFromList(specs[i]) && spec.TryGetStringAsInt(0, &linkIndex))
             {
                 PCWSTR linkType = spec.GetString(1);
 
@@ -249,7 +249,7 @@ TestResourceLinks::VerifyAgainstTestVars(_In_ IResourceLinks* links, _In_ PCWSTR
         Log::Comment(tmp.Format(L"[ %sExpectedLinksById not defined ]", varPrefix));
     }
 
-    return true;
+    return S_OK;
 }
 
 } // namespace UnitTests

--- a/dev/MRTCore/mrt/mrm/UnitTests/TestReverseMap.cpp
+++ b/dev/MRTCore/mrt/mrm/UnitTests/TestReverseMap.cpp
@@ -147,7 +147,7 @@ TestReverseFileMap::VerifyAllAgainstTestVars(
         for (unsigned iSpec = 0; iSpec < specs.GetSize(); iSpec++)
         {
             Log::Comment(tmp.Format(L"[ Candidate %d: %s ]", iSpec, (PCWSTR)specs[iSpec]));
-            if (FAILED(spec.InitFromList(specs[iSpec])))
+            if (!spec.InitFromList(specs[iSpec]))
             {
                 Log::Warning(tmp.Format(L"[ Error parsing spec %d in %sExpectedCandidateInfo ]", iSpec, pVarPrefix));
                 continue;

--- a/dev/MRTCore/mrt/mrm/UnitTests/UnifiedView.UnitTests.cpp
+++ b/dev/MRTCore/mrt/mrm/UnitTests/UnifiedView.UnitTests.cpp
@@ -1090,7 +1090,7 @@ void UnifiedResourceViewUnitTests::MapLookupTests()
     VERIFY(pView != NULL);
 
     // Load all of the files
-    if (FAILED(TestData::TryGetValue(L"FilesToLoad", filesSpec)) || FAILED(files.InitFromList(filesSpec)))
+    if (FAILED(TestData::TryGetValue(L"FilesToLoad", filesSpec)) || !files.InitFromList(filesSpec))
     {
         Log::Error(L"[ Couldn't load FilesToLoad ]");
         return;
@@ -1110,7 +1110,7 @@ void UnifiedResourceViewUnitTests::MapLookupTests()
     }
 
     // Now make sure that we find all of the names we're expecting
-    if (FAILED(TestData::TryGetValue(L"ExpectedMapNames", expectedMapsSpec)) || FAILED(expectedMaps.InitFromList(expectedMapsSpec)))
+    if (FAILED(TestData::TryGetValue(L"ExpectedMapNames", expectedMapsSpec)) || !expectedMaps.InitFromList(expectedMapsSpec))
     {
         Log::Warning(L"[ Couldn't load ExpectedMapNames ]");
     }
@@ -1126,7 +1126,7 @@ void UnifiedResourceViewUnitTests::MapLookupTests()
     }
 
     // Finally, make sure that we don't find any of the names that shouldn't be there
-    if (FAILED(TestData::TryGetValue(L"UnexpectedMapNames", unexpectedMapsSpec)) || FAILED(unexpectedMaps.InitFromList(unexpectedMapsSpec)))
+    if (FAILED(TestData::TryGetValue(L"UnexpectedMapNames", unexpectedMapsSpec)) || !unexpectedMaps.InitFromList(unexpectedMapsSpec))
     {
         Log::Warning(L"[ UnexpectedMapNames not specified ]");
     }

--- a/dev/MRTCore/mrt/mrm/UnitTests/Util.UnitTests.cpp
+++ b/dev/MRTCore/mrt/mrm/UnitTests/Util.UnitTests.cpp
@@ -40,7 +40,7 @@ private:
 
     void InsertCharacterIntoWideStringWithoutTerminating(
         _In_ unsigned int codePoint,
-        _Out_writes_to_(cchBuffer, *cchWriten) wchar_t* psBuffer,
+        _Out_writes_to_(cchBuffer, *cchWritten) wchar_t* psBuffer,
         _In_range_(>=, 2) unsigned int cchBuffer,
         _Deref_out_range_(1, 2) unsigned int* cchWritten);
 

--- a/dev/MRTCore/mrt/mrm/UnitTests/testEnvironment.cpp
+++ b/dev/MRTCore/mrt/mrm/UnitTests/testEnvironment.cpp
@@ -172,7 +172,7 @@ HRESULT TestEnvironment::InitQualifiers(PCWSTR pVarPrefix, _In_opt_ TestEnvironm
             return E_FAIL;
         }
     }
-    return true;
+    return S_OK;
 }
 
 HRESULT TestEnvironment::CreateInstance(
@@ -245,18 +245,18 @@ HRESULT TestEnvironment::CreateInstance(
     pRtrn->m_pResourceValueLocatorNames = new TestAtomPool();
     pRtrn->m_pConditionOperatorNames = new TestAtomPool();
 
-    if (FAILED(pRtrn->m_pQualifierTypeNames->InitFromTestVarsOrClone(
-            L"QualifierTypes", true, var.Format(L"%sQualifierTypeNames", pVarPrefix), pAtoms, pOtherQualifierTypes)) ||
-        FAILED(pRtrn->m_pQualifierNames->InitFromTestVarsOrClone(
-            L"Qualifiers", true, var.Format(L"%sQualifierNames", pVarPrefix), pAtoms, pOtherQualifiers)) ||
-        FAILED(pRtrn->m_pItemTypeNames->InitFromTestVarsOrClone(
-            L"ItemTypes", true, var.Format(L"%sItemTypeNames", pVarPrefix), pAtoms, pOtherItemTypes)) ||
-        FAILED(pRtrn->m_pResourceValueTypeNames->InitFromTestVarsOrClone(
-            L"ResourceValueTypes", true, var.Format(L"%sResourceValueTypeNames", pVarPrefix), pAtoms, pOtherInstanceTypes)) ||
-        FAILED(pRtrn->m_pResourceValueLocatorNames->InitFromTestVarsOrClone(
-            L"ResourceValueLocators", true, var.Format(L"%sResourceValueLocatorNames", pVarPrefix), pAtoms, pOtherInstanceLocators)) ||
-        FAILED(pRtrn->m_pConditionOperatorNames->InitFromTestVarsOrClone(
-            L"ConditionOperators", true, var.Format(L"%sConditionOperatorNames", pVarPrefix), pAtoms, pOtherConditionOperators)))
+    if (!pRtrn->m_pQualifierTypeNames->InitFromTestVarsOrClone(
+            L"QualifierTypes", true, var.Format(L"%sQualifierTypeNames", pVarPrefix), pAtoms, pOtherQualifierTypes) ||
+        !pRtrn->m_pQualifierNames->InitFromTestVarsOrClone(
+            L"Qualifiers", true, var.Format(L"%sQualifierNames", pVarPrefix), pAtoms, pOtherQualifiers) ||
+        !pRtrn->m_pItemTypeNames->InitFromTestVarsOrClone(
+            L"ItemTypes", true, var.Format(L"%sItemTypeNames", pVarPrefix), pAtoms, pOtherItemTypes) ||
+        !pRtrn->m_pResourceValueTypeNames->InitFromTestVarsOrClone(
+            L"ResourceValueTypes", true, var.Format(L"%sResourceValueTypeNames", pVarPrefix), pAtoms, pOtherInstanceTypes) ||
+        !pRtrn->m_pResourceValueLocatorNames->InitFromTestVarsOrClone(
+            L"ResourceValueLocators", true, var.Format(L"%sResourceValueLocatorNames", pVarPrefix), pAtoms, pOtherInstanceLocators) ||
+        !pRtrn->m_pConditionOperatorNames->InitFromTestVarsOrClone(
+            L"ConditionOperators", true, var.Format(L"%sConditionOperatorNames", pVarPrefix), pAtoms, pOtherConditionOperators))
     {
         delete pRtrn;
         return E_FAIL;

--- a/dev/MRTCore/mrt/mrm/UnitTests/testHSchema.cpp
+++ b/dev/MRTCore/mrt/mrm/UnitTests/testHSchema.cpp
@@ -146,7 +146,7 @@ bool TestHierarchicalSchema::TryVerifyScopes(__in const IHierarchicalSchema* pSc
             TestStringArray expected;
 
             Log::Comment(tmp.Format(L"[ %sExpectedScopes %d: %s ]", pVarPrefix, (int)i, (PCWSTR)specs[i]));
-            if (FAILED(expected.InitFromList(specs[i])) || (expected.GetNumStrings() < 1) || (expected.GetNumStrings() > 3))
+            if (!expected.InitFromList(specs[i]) || (expected.GetNumStrings() < 1) || (expected.GetNumStrings() > 3))
             {
                 Log::Error(L"Malformed ExpectedScopes value");
                 return false;
@@ -189,7 +189,7 @@ bool TestHierarchicalSchema::TryVerifyScopes(__in const IHierarchicalSchema* pSc
     else if (SUCCEEDED(TestData::TryGetValue(tmp.Format(L"%sExpectedScopesList", pVarPrefix), specListString)))
     {
         TestStringArray specList;
-        if (FAILED(specList.InitFromList(specListString)))
+        if (!specList.InitFromList(specListString))
         {
             Log::Warning(tmp.Format(L"[ Couldn't parse %sExpectedScopesList ]", pVarPrefix));
             return false;
@@ -213,7 +213,7 @@ bool TestHierarchicalSchema::TryVerifyScopes(__in const IHierarchicalSchema* pSc
         Log::Comment(tmp.Format(L"[ Found %sUnexpectedScopes ]", pVarPrefix));
 
         TestStringArray specList;
-        if (SUCCEEDED(specList.InitFromList((PCWSTR)unexpectedList)))
+        if (specList.InitFromList((PCWSTR)unexpectedList))
         {
             for (int i = 0; i < specList.GetNumStrings(); i++)
             {
@@ -265,7 +265,7 @@ bool TestHierarchicalSchema::TryVerifyItems(__in const IHierarchicalSchema* pSch
             TestStringArray expected;
 
             Log::Comment(tmp.Format(L"[ %sExpectedItems %d: %s ]", pVarPrefix, (int)i, (PCWSTR)specs[i]));
-            if (FAILED(expected.InitFromList(specs[i])) || (expected.GetNumStrings() < 1) || (expected.GetNumStrings() > 2))
+            if (!expected.InitFromList(specs[i]) || (expected.GetNumStrings() < 1) || (expected.GetNumStrings() > 2))
             {
                 Log::Error(L"Malformed ExpectedItems value");
                 return false;
@@ -293,7 +293,7 @@ bool TestHierarchicalSchema::TryVerifyItems(__in const IHierarchicalSchema* pSch
     else if (SUCCEEDED(TestData::TryGetValue(tmp.Format(L"%sExpectedItemsList", pVarPrefix), specListString)))
     {
         TestStringArray specList;
-        if (SUCCEEDED(specList.InitFromList(specListString)))
+        if (specList.InitFromList(specListString))
         {
             Log::Comment(tmp.Format(L"[ Found %d %sExpectedItemsList ]", specList.GetNumStrings(), pVarPrefix));
             for (int i = 0; i < specList.GetNumStrings(); i++)
@@ -317,7 +317,7 @@ bool TestHierarchicalSchema::TryVerifyItems(__in const IHierarchicalSchema* pSch
     if (SUCCEEDED(TestData::TryGetValue(tmp.Format(L"%sUnexpectedItems", pVarPrefix), unexpectedList)))
     {
         TestStringArray specList;
-        if (SUCCEEDED(specList.InitFromList((PCWSTR)unexpectedList)))
+        if (specList.InitFromList((PCWSTR)unexpectedList))
         {
             for (int i = 0; i < specList.GetNumStrings(); i++)
             {
@@ -410,7 +410,7 @@ TestHierarchicalSchema::CreateNewSchemaFromTestVars(
             Log::Error(tmp.Format(L"Test data for \"%s\" specifies baseline but test supplies no folder", pVarPrefix));
             return E_FAIL;
         }
-        else if (FAILED(baseline.InitFromList((PCWSTR)baselineList)) || (baseline.GetNumStrings() != 2))
+        else if (!baseline.InitFromList((PCWSTR)baselineList) || (baseline.GetNumStrings() != 2))
         {
             Log::Error(tmp.Format(L"Malformed baseline \"%s\" for \"%s\"", (PCWSTR)baselineList, pVarPrefix));
             return E_FAIL;

--- a/dev/MRTCore/mrt/mrm/UnitTests/testMap.cpp
+++ b/dev/MRTCore/mrt/mrm/UnitTests/testMap.cpp
@@ -230,7 +230,7 @@ bool TestResourceMap::TryAddCandidatesFromTestVars(
         for (unsigned i = 0; i < candidates.GetSize(); i++)
         {
             Log::Comment(tmp.Format(L"[ candidate %d: %s ]", i, (PCWSTR)candidates[i]));
-            if (FAILED(candidate.InitFromList(candidates[i])))
+            if (!candidate.InitFromList(candidates[i]))
             {
                 Log::Warning(L" [ Couldn't parse candidate string ] ");
                 continue;
@@ -511,7 +511,7 @@ TestResourceMap::VerifyCandidates(_In_ TestMapPrivate* pMap, _In_ TestDecisionIn
         for (unsigned iSpec = 0; iSpec < specs.GetSize(); iSpec++)
         {
             Log::Comment(tmp.Format(L"[ Candidate %d: %s ]", iSpec, (PCWSTR)specs[iSpec]));
-            if (FAILED(spec.InitFromList(specs[iSpec])))
+            if (!spec.InitFromList(specs[iSpec]))
             {
                 Log::Warning(tmp.Format(L"[ Error parsing spec %d in %sExpectedCandidateInfo ]", iSpec, pVarPrefix));
                 continue;
@@ -596,7 +596,7 @@ TestResourceMap::VerifyNamedResources(_In_ TestMapPrivate* pMap, _In_ PCWSTR pVa
         for (unsigned i = 0; i < specs.GetSize(); i++)
         {
             Log::Comment(tmp.Format(L"[ Resource %d: %s ]", i, (PCWSTR)specs[i]));
-            if (FAILED(spec.InitFromList(specs[i])))
+            if (!spec.InitFromList(specs[i]))
             {
                 Log::Warning(tmp.Format(L"[ Error parsing spec %d in %sExpectedNamedResourcesInfo ]", i, pVarPrefix));
                 continue;
@@ -670,7 +670,7 @@ TestResourceMap::VerifyDescendentResources(_In_ TestMapPrivate* pMap, _In_ PCWST
         for (unsigned i = 0; i < specs.GetSize(); i++)
         {
             Log::Comment(tmp.Format(L"[ Resource %d: %s ]", i, (PCWSTR)specs[i]));
-            if (FAILED(spec.InitFromList(specs[i])))
+            if (!spec.InitFromList(specs[i]))
             {
                 Log::Warning(tmp.Format(L"[ Error parsing spec %d in %sExpectedDescendentResources ]", i, pVarPrefix));
                 continue;
@@ -715,7 +715,7 @@ TestResourceMap::VerifyDescendentScopes(_In_ TestMapPrivate* pMap, _In_ PCWSTR p
     if (pMap->pSubtree == nullptr)
     {
         Log::Warning(tmp.Format(L"[ VerifyDescendentScopess(\"%s\") requires subtree ]", pVarPrefix));
-        return true;
+        return E_FAIL;
     }
 
     Log::Comment(tmp.Format(L"[ VerifyDescendentScopes(\"%s\") ]", pVarPrefix));
@@ -737,7 +737,7 @@ TestResourceMap::VerifyDescendentScopes(_In_ TestMapPrivate* pMap, _In_ PCWSTR p
             TestStringArray expected;
 
             Log::Comment(tmp.Format(L"[ %sExpectedDescendentScopes %d: %s ]", pVarPrefix, (int)i, (PCWSTR)specs[i]));
-            if ((FAILED(expected.InitFromList(specs[i]))) || (expected.GetNumStrings() < 1) || (expected.GetNumStrings() > 3))
+            if ((!expected.InitFromList(specs[i])) || (expected.GetNumStrings() < 1) || (expected.GetNumStrings() > 3))
             {
                 Log::Error(L"Malformed ExpectedDescendentScopes value");
                 return E_FAIL;
@@ -784,7 +784,7 @@ TestResourceMap::VerifyDescendentScopes(_In_ TestMapPrivate* pMap, _In_ PCWSTR p
     else if (SUCCEEDED(TestData::TryGetValue(tmp.Format(L"%sExpectedDescendentScopesList", pVarPrefix), specListString)))
     {
         TestStringArray specList;
-        if (FAILED(specList.InitFromList(specListString)))
+        if (!specList.InitFromList(specListString))
         {
             Log::Warning(tmp.Format(L"[ Couldn't parse %sExpectedDescendentScopesList ]", pVarPrefix));
             return E_FAIL;

--- a/dev/MRTCore/mrt/mrm/UnitTests/testMap.cpp
+++ b/dev/MRTCore/mrt/mrm/UnitTests/testMap.cpp
@@ -714,7 +714,7 @@ TestResourceMap::VerifyDescendentScopes(_In_ TestMapPrivate* pMap, _In_ PCWSTR p
 
     if (pMap->pSubtree == nullptr)
     {
-        Log::Warning(tmp.Format(L"[ VerifyDescendentScopess(\"%s\") requires subtree ]", pVarPrefix));
+        Log::Warning(tmp.Format(L"[ VerifyDescendentScopes(\"%s\") requires subtree ]", pVarPrefix));
         return E_FAIL;
     }
 

--- a/dev/MRTCore/mrt/mrm/UnitTests/testPri.cpp
+++ b/dev/MRTCore/mrt/mrm/UnitTests/testPri.cpp
@@ -144,7 +144,7 @@ TestHPri::InitFromTestVars(
             Log::Error(tmp.Format(L"Test data for \"%s\" specifies baseline but test supplies no folder", varPrefix));
             return E_FAIL;
         }
-        else if (FAILED(baseline.InitFromList((PCWSTR)baselineList)) || (baseline.GetNumStrings() != 2))
+        else if (!baseline.InitFromList((PCWSTR)baselineList) || (baseline.GetNumStrings() != 2))
         {
             Log::Error(tmp.Format(L"Malformed baseline \"%s\" for \"%s\"", (PCWSTR)baselineList, varPrefix));
             return E_FAIL;
@@ -194,7 +194,7 @@ TestHPri::InitFromTestVars(
     TestStringArray mapNamesLocal;
     TestStringArray* mapNames = ((mapNamesOut == nullptr) ? &mapNamesLocal : mapNamesOut);
     if (FAILED(TestData::TryGetValue(tmp.Format(L"%sMapNames", varPrefix), mapNameList)) ||
-        FAILED(mapNames->InitFromList((PCWSTR)mapNameList)))
+        !mapNames->InitFromList((PCWSTR)mapNameList))
     {
         Log::Comment(tmp.Format(L"[ Couldn't get %sMapNames - assuming one map with no prefix ]", varPrefix));
     }
@@ -226,9 +226,9 @@ TestHPri::InitFromTestVars(
         TestStringArray extraSectionNames;
         TestStringArray extraSectionTypes;
 
-        if (FAILED(extraSectionNames.InitFromList(extraSectionNamesString)) ||
+        if (!extraSectionNames.InitFromList(extraSectionNamesString) ||
             (FAILED(TestData::TryGetValue(tmp.Format(L"%s_OtherSectionTypes", varPrefix), extraSectionTypesString))) ||
-            FAILED(extraSectionTypes.InitFromList(extraSectionTypesString)) ||
+            !extraSectionTypes.InitFromList(extraSectionTypesString) ||
             (extraSectionNames.GetNumStrings() != extraSectionTypes.GetNumStrings()))
         {
             Log::Error(tmp.Format(L"%s: OtherSectionNames exists but OtherSectionTypes is missing or inconsistent", varPrefix));
@@ -375,7 +375,7 @@ TestHPri::BuildMultiplePriFilesFromTestVars(
 
     String fileNamesString;
     if (FAILED(TestData::TryGetValue(tmp.Format(L"%sFileNames", varPrefix), fileNamesString)) ||
-        FAILED(mapNamesOut->InitFromList(fileNamesString)))
+        !mapNamesOut->InitFromList(fileNamesString))
     {
         Log::Comment(tmp.Format(L"[ Unable to get file names from %sFileNames, assuming one file with no prefix ]", varPrefix));
         mapNamesOut->InitFromList(L"");
@@ -399,7 +399,7 @@ TestHPri::GetPriFileMapNamesFromTestVars(_In_ PCWSTR varPrefix, _In_ PCWSTR file
     TestStringArray mapVarNames;
 
     if (FAILED(TestData::TryGetValue(tmp.Format(L"%s%sMapNames", varPrefix, fileName), mapVarNamesList)) ||
-        FAILED(mapVarNames.InitFromList((PCWSTR)mapVarNamesList)))
+        !mapVarNames.InitFromList((PCWSTR)mapVarNamesList))
     {
         Log::Comment(tmp.Format(L"[ Couldn't get %s%sMapNames, assuming one map with no prefix ]", varPrefix, fileName));
     }
@@ -432,7 +432,7 @@ TestHPri::GetPriFileMapNamesFromTestVars(_In_ PCWSTR varPrefix, _In_ PCWSTR file
         }
     }
 
-    ok = ok && SUCCEEDED(mapNamesOut->InitFromArray(initStrings, numStrings));
+    ok = ok && mapNamesOut->InitFromArray(initStrings, numStrings);
 
     delete[] initStrings;
 

--- a/dev/MRTCore/mrt/mrm/UnitTests/testQualifier.cpp
+++ b/dev/MRTCore/mrt/mrm/UnitTests/testQualifier.cpp
@@ -78,7 +78,7 @@ TestQualifierCollection::InitFromTestValue(__in PCWSTR pValue, __inout TestStrin
 
     SecureZeroMemory(pQualifierOut, sizeof(TestQualifier));
 
-    if (FAILED(pSpecsOut->InitFromList(pValue)) || (pSpecsOut->GetNumStrings() < 3))
+    if (!pSpecsOut->InitFromList(pValue) || (pSpecsOut->GetNumStrings() < 3))
     {
         Log::Error(tmp.Format(L"[ illegal qualifier spec: \"%s\" ]", pValue));
         return E_FAIL;
@@ -359,7 +359,7 @@ TestQualifierSetCollection::InitFromTestVars(__in PCWSTR pPrefix, __in TestQuali
 
     for (int i = 0; i < m_numQualifierSets; i++)
     {
-        if (FAILED(m_pSpecs[i].InitFromList(m_testStrings[i])) || (m_pSpecs[i].GetNumStrings() < 1))
+        if (!m_pSpecs[i].InitFromList(m_testStrings[i]) || (m_pSpecs[i].GetNumStrings() < 1))
         {
             Log::Warning(tmp.Format(L"[ illegal qualifier set spec: \"%s\" ]", (PCWSTR)m_testStrings[i]));
             return E_FAIL;
@@ -607,7 +607,7 @@ TestDecisionCollection::InitFromTestVars(__in PCWSTR pPrefix, __in TestQualifier
 
     for (int i = 0; i < m_numDecisions; i++)
     {
-        if (FAILED(m_pSpecs[i].InitFromList(m_testStrings[i])) || (m_pSpecs[i].GetNumStrings() < 2))
+        if (!m_pSpecs[i].InitFromList(m_testStrings[i]) || (m_pSpecs[i].GetNumStrings() < 2))
         {
             Log::Warning(tmp.Format(L"[ illegal decision spec: \"%s\" ]", (PCWSTR)m_testStrings[i]));
             return E_FAIL;

--- a/dev/MRTCore/mrt/mrm/UnitTests/testUtils.cpp
+++ b/dev/MRTCore/mrt/mrm/UnitTests/testUtils.cpp
@@ -26,7 +26,7 @@ bool TestUtils::TryVerifyRemap(_In_ PCWSTR pVarName, _Inout_ const RemapUInt16* 
         int expectedValue;
         UINT16 gotValue;
 
-        if (FAILED(expectedStrings.InitFromList(varValue)))
+        if (!expectedStrings.InitFromList(varValue))
         {
             Log::Warning(tmp.Format(L"[ Couldn't parse \"%s\" ]", pVarName));
             return false;

--- a/dev/MRTCore/mrt/mrm/include/mrm/platform/CoreQualifierTypes.h
+++ b/dev/MRTCore/mrt/mrm/include/mrm/platform/CoreQualifierTypes.h
@@ -60,7 +60,7 @@ public:
 
     virtual ~DXFeatureLevelQualifierType() {}
 
-    HRESULT Evaluate(_In_ const IQualifier* pQualifier, _In_ PCWSTR pValue, _Outptr_ double* score) const;
+    HRESULT Evaluate(_In_ const IQualifier* pQualifier, _In_ PCWSTR pValue, _Out_ double* score) const;
 
     inline IBuildQualifierType::PackagingFlags GetDefaultPackagingFlags() const
     {
@@ -82,7 +82,7 @@ public:
 
     virtual ~DeviceFamilyQualifierType() {}
 
-    virtual HRESULT Evaluate(_In_ const IQualifier* pQualifier, _In_ PCWSTR pValue, _Outptr_ double* score) const;
+    virtual HRESULT Evaluate(_In_ const IQualifier* pQualifier, _In_ PCWSTR pValue, _Out_ double* score) const;
 
 protected:
     DeviceFamilyQualifierType() :

--- a/dev/WindowsAppRuntime_BootstrapDLL/MddBootstrapTracelogging.h
+++ b/dev/WindowsAppRuntime_BootstrapDLL/MddBootstrapTracelogging.h
@@ -50,7 +50,7 @@ public:
     {
         SetStopResult(hresult);
 
-        if (hresult)
+        if (FAILED(hresult))
         {
             TraceLoggingClassWriteStop(Initialize,
                 _GENERIC_PARTB_FIELDS_ENABLED,
@@ -99,7 +99,7 @@ public:
     {
         SetStopResult(hresult);
 
-        if (hresult)
+        if (FAILED(hresult))
         {
             TraceLoggingClassWriteStop(Shutdown,
                 _GENERIC_PARTB_FIELDS_ENABLED,

--- a/installer/dev/console.cpp
+++ b/installer/dev/console.cpp
@@ -48,7 +48,7 @@ void WindowsAppRuntimeInstaller::Console::DisplayError(const HRESULT hr)
 
     HRESULT hResult = hr;
 
-    if ((installActivityContext.GetDeploymentErrorHresult() != S_OK) &&
+    if (FAILED(installActivityContext.GetDeploymentErrorHresult() &&
         (installActivityContext.GetInstallStage() == InstallStage::StagePackage ||
         installActivityContext.GetInstallStage() == InstallStage::AddPackage ||
         installActivityContext.GetInstallStage() == InstallStage::RegisterPackage))
@@ -70,7 +70,7 @@ void WindowsAppRuntimeInstaller::Console::DisplayError(const HRESULT hr)
     }
 
     // Don't log redundant Hr information
-    if ((installActivityContext.GetDeploymentErrorExtendedHResult() != S_OK) &&
+    if (FAILED(installActivityContext.GetDeploymentErrorExtendedHResult() &&
         (installActivityContext.GetDeploymentErrorExtendedHResult() != hResult) &&
         (installActivityContext.GetInstallStage() == InstallStage::StagePackage ||
             installActivityContext.GetInstallStage() == InstallStage::AddPackage ||

--- a/installer/dev/console.cpp
+++ b/installer/dev/console.cpp
@@ -48,10 +48,10 @@ void WindowsAppRuntimeInstaller::Console::DisplayError(const HRESULT hr)
 
     HRESULT hResult = hr;
 
-    if (installActivityContext.GetDeploymentErrorHresult() &&
-        installActivityContext.GetInstallStage() == InstallStage::StagePackage ||
+    if ((installActivityContext.GetDeploymentErrorHresult() != S_OK) &&
+        (installActivityContext.GetInstallStage() == InstallStage::StagePackage ||
         installActivityContext.GetInstallStage() == InstallStage::AddPackage ||
-        installActivityContext.GetInstallStage() == InstallStage::RegisterPackage)
+        installActivityContext.GetInstallStage() == InstallStage::RegisterPackage))
     {
         hResult = installActivityContext.GetDeploymentErrorHresult();
     }
@@ -70,8 +70,8 @@ void WindowsAppRuntimeInstaller::Console::DisplayError(const HRESULT hr)
     }
 
     // Don't log redundant Hr information
-    if (installActivityContext.GetDeploymentErrorExtendedHResult() != S_OK &&
-        installActivityContext.GetDeploymentErrorExtendedHResult() != hResult &&
+    if ((installActivityContext.GetDeploymentErrorExtendedHResult() != S_OK) &&
+        (installActivityContext.GetDeploymentErrorExtendedHResult() != hResult) &&
         (installActivityContext.GetInstallStage() == InstallStage::StagePackage ||
             installActivityContext.GetInstallStage() == InstallStage::AddPackage ||
             installActivityContext.GetInstallStage() == InstallStage::RegisterPackage))

--- a/installer/dev/tracelogging.h
+++ b/installer/dev/tracelogging.h
@@ -65,7 +65,7 @@ public:
     {
         SetStopResult(hresult);
 
-        if (hresult)
+        if (FAILED(hresult))
         {
             TraceLoggingClassWriteStop(Install,
                 _GENERIC_PARTB_FIELDS_ENABLED,


### PR DESCRIPTION
Addressed the pre-existing errors reported by PREfast, thus allowing us to enable the "break the build on errors" setting for PREfast. 
Testing was done in the corresponding internal pipeline, the pipeline build was successful with the "break on error" setting. 
PR validation has succeeded.

----

A microsoft employee must use /azp run to validate using the pipelines below.

WARNING:
Comments made by azure-pipelines bot maybe inaccurate.
Please see pipeline link to verify that the build is being ran.

For status checks on the main branch, please use TransportPackage-Foundation-PR
(https://microsoft.visualstudio.com/ProjectReunion/_build?definitionId=81063&_a=summary)
and run the build against your PR branch with the default parameters.
