### PR TITLE
Adjust ResourceLoader(String) to match documents

### DIFF
--- a/dev/MRTCore/mrt/Microsoft.Windows.ApplicationModel.Resources/src/Microsoft.Windows.ApplicationModel.Resources.idl
+++ b/dev/MRTCore/mrt/Microsoft.Windows.ApplicationModel.Resources/src/Microsoft.Windows.ApplicationModel.Resources.idl
@@ -11,7 +11,7 @@ namespace Microsoft.Windows.ApplicationModel.Resources
     runtimeclass ResourceLoader
     {
         ResourceLoader();
-        ResourceLoader(String fileName);
+        ResourceLoader(String resourceMap);
         ResourceLoader(String fileName, String resourceMap);
 
         static String GetDefaultResourceFilePath();

--- a/dev/MRTCore/mrt/Microsoft.Windows.ApplicationModel.Resources/src/ResourceLoader.cpp
+++ b/dev/MRTCore/mrt/Microsoft.Windows.ApplicationModel.Resources/src/ResourceLoader.cpp
@@ -18,10 +18,13 @@ ResourceLoader::ResourceLoader()
     SetDefaultContext();
 }
 
-ResourceLoader::ResourceLoader(hstring const& fileName)
+ResourceLoader::ResourceLoader(hstring const& resourceMap)
 {
+    hstring fileName;
+    winrt::check_hresult(GetDefaultPriFile(fileName));
+
     winrt::check_hresult(MrmCreateResourceManager(fileName.c_str(), &m_resourceManager));
-    winrt::check_hresult(MrmGetChildResourceMap(m_resourceManager, nullptr, L"Resources", &m_currentResourceMap));
+    winrt::check_hresult(MrmGetChildResourceMap(m_resourceManager, nullptr, resourceMap.c_str(), &m_currentResourceMap));
     SetDefaultContext();
 }
 

--- a/dev/MRTCore/mrt/Microsoft.Windows.ApplicationModel.Resources/src/ResourceLoader.h
+++ b/dev/MRTCore/mrt/Microsoft.Windows.ApplicationModel.Resources/src/ResourceLoader.h
@@ -13,7 +13,7 @@ namespace winrt::Microsoft::Windows::ApplicationModel::Resources::implementation
 struct ResourceLoader : ResourceLoaderT<ResourceLoader>
 {
     ResourceLoader();
-    ResourceLoader(hstring const& fileName);
+    ResourceLoader(hstring const& resourceMap);
     ResourceLoader(hstring const& fileName, hstring const& resourceMap);
 
     static hstring GetDefaultResourceFilePath();


### PR DESCRIPTION
In documents [ResourceLoader](https://learn.microsoft.com/en-us/windows/windows-app-sdk/api/winrt/microsoft.windows.applicationmodel.resources.resourceloader.-ctor?view=windows-app-sdk-1.5#microsoft-windows-applicationmodel-resources-resourceloader-ctor(system-string)) and [WindowsAppSDK Localize strings in your UI and the app package manifest](https://learn.microsoft.com/en-us/windows/apps/windows-app-sdk/mrtcore/localize-strings?source=recommendations), str in Microsoft.Windows.ApplicationModel.Resources.ResourceLoader.ResourceLoader(String str) represents resourceMap, usually the file name of resw. In the current implementation, str represents the file name of pri the str of the old obsolete API [Windows.ApplicationModel.Resources.ResourceLoader(String str)](https://learn.microsoft.com/en-us/uwp/api/windows.applicationmodel.resources.resourceloader.-ctor?view=winrt-22621) represents the resourceMap.

So making the two more consistent seems to be a better solution, rather than using Microsoft.Windows.ApplicationModel.Resources.ResourceLoader.GetDefaultResourceFilePath().

documents:

```csharp
ResourceLoader("ErrorMessages") // implicit "resources.pri" or "modulename.pri"
```

implement:
```csharp
ResourceLoader(ResourceLoader.GetDefaultResourceFilePath(), "ErrorMessages")
```

this pr:
same as documents

### breaking change

before:
```csharp
ResourceLoader("filename.pri") // implicit "Resources" subtree
```
after:
```csharp
ResourceLoader("filename.pri", "Resources")
```

Original issue: https://github.com/microsoft/WindowsAppSDK/issues/4312 https://github.com/microsoft/WindowsAppSDK/issues/2406