### PR TITLE
Print unique set of PDBs to a text file

### DIFF
--- a/build/AzurePipelinesTemplates/WindowsAppSDK-PackTransportPackage-Stage.yml
+++ b/build/AzurePipelinesTemplates/WindowsAppSDK-PackTransportPackage-Stage.yml
@@ -161,6 +161,7 @@ stages:
           {
             Write-Host $value
           }
+          New-Item "$(ob_outputDirectory)\pdbs.txt"
           $pdbSet.Keys | Out-File "$(ob_outputDirectory)\pdbs.txt"
 
     # Publishing symbols publicly requires making an API call to the service and is handled by PublishPublicSymbols.ps1

--- a/build/AzurePipelinesTemplates/WindowsAppSDK-PackTransportPackage-Stage.yml
+++ b/build/AzurePipelinesTemplates/WindowsAppSDK-PackTransportPackage-Stage.yml
@@ -142,6 +142,27 @@ stages:
       env:
         LIB: $(Build.SourcesDirectory)
 
+  # In the "Publish symbols to SymWeb and MSDL" step, the symbols are automatically stripped in the API.
+  # However, since WindowsAppSDK is public, we don't need to strip them.
+  # So we need to send a list of pdbs to the symbols team that is not needed to be stripped
+  # This task facilitates this.
+  - task: PowerShell@2
+    name: ListUniquePDBs
+    displayName: 'List Unique PDBs and write to pdbs.txt'
+    inputs:
+      targetType: 'inline'
+      script: |
+        $pdbSet = @{}
+        $inputPath = "$(Build.ArtifactStagingDirectory)\symbols"
+        Get-ChildItem *.pdb -Path $inputPath -Recurse | foreach-object {
+          $pdbSet[$_.Name] = $true
+        }
+        foreach ($value in $pdbSet.Keys)
+        {
+          Write-Host $value
+        }
+        $pdbSet.Keys | Out-File "$(ob_outputDirectory)\pdbs.txt"
+
     # Publishing symbols publicly requires making an API call to the service and is handled by PublishPublicSymbols.ps1
     # in eng/common
     # See this page for more info:

--- a/build/AzurePipelinesTemplates/WindowsAppSDK-PackTransportPackage-Stage.yml
+++ b/build/AzurePipelinesTemplates/WindowsAppSDK-PackTransportPackage-Stage.yml
@@ -142,26 +142,26 @@ stages:
       env:
         LIB: $(Build.SourcesDirectory)
 
-  # In the "Publish symbols to SymWeb and MSDL" step, the symbols are automatically stripped in the API.
-  # However, since WindowsAppSDK is public, we don't need to strip them.
-  # So we need to send a list of pdbs to the symbols team that is not needed to be stripped
-  # This task facilitates this.
-  - task: PowerShell@2
-    name: ListUniquePDBs
-    displayName: 'List Unique PDBs and write to pdbs.txt'
-    inputs:
-      targetType: 'inline'
-      script: |
-        $pdbSet = @{}
-        $inputPath = "$(Build.ArtifactStagingDirectory)\symbols"
-        Get-ChildItem *.pdb -Path $inputPath -Recurse | foreach-object {
-          $pdbSet[$_.Name] = $true
-        }
-        foreach ($value in $pdbSet.Keys)
-        {
-          Write-Host $value
-        }
-        $pdbSet.Keys | Out-File "$(ob_outputDirectory)\pdbs.txt"
+    # In the "Publish symbols to SymWeb and MSDL" step, the symbols are automatically stripped in the API.
+    # However, since WindowsAppSDK is public, we don't need to strip them.
+    # So we need to send a list of pdbs to the symbols team that is not needed to be stripped
+    # This task facilitates this.
+    - task: PowerShell@2
+      name: ListUniquePDBs
+      displayName: 'List Unique PDBs and write to pdbs.txt'
+      inputs:
+        targetType: 'inline'
+        script: |
+          $pdbSet = @{}
+          $inputPath = "$(Build.ArtifactStagingDirectory)\symbols"
+          Get-ChildItem *.pdb -Path $inputPath -Recurse | foreach-object {
+            $pdbSet[$_.Name] = $true
+          }
+          foreach ($value in $pdbSet.Keys)
+          {
+            Write-Host $value
+          }
+          $pdbSet.Keys | Out-File "$(ob_outputDirectory)\pdbs.txt"
 
     # Publishing symbols publicly requires making an API call to the service and is handled by PublishPublicSymbols.ps1
     # in eng/common

--- a/build/AzurePipelinesTemplates/WindowsAppSDK-PackTransportPackage-Stage.yml
+++ b/build/AzurePipelinesTemplates/WindowsAppSDK-PackTransportPackage-Stage.yml
@@ -161,7 +161,7 @@ stages:
           {
             Write-Host $value
           }
-          New-Item "$(ob_outputDirectory)\pdbs.txt"
+          New-Item "$(ob_outputDirectory)\pdbs.txt" -Force
           $pdbSet.Keys | Out-File "$(ob_outputDirectory)\pdbs.txt"
 
     # Publishing symbols publicly requires making an API call to the service and is handled by PublishPublicSymbols.ps1


### PR DESCRIPTION
A microsoft employee must use /azp run to validate using the pipelines below.

WARNING:
Comments made by azure-pipelines bot maybe inaccurate.
Please see pipeline link to verify that the build is being ran.

For status checks on the main branch, please use TransportPackage-Foundation-PR
(https://microsoft.visualstudio.com/ProjectReunion/_build?definitionId=81063&_a=summary)
and run the build against your PR branch with the default parameters.
