### PR TITLE
49601674: Fixed a cut-and-paste error

### DIFF
--- a/installer/dev/console.cpp
+++ b/installer/dev/console.cpp
@@ -48,7 +48,7 @@ void WindowsAppRuntimeInstaller::Console::DisplayError(const HRESULT hr)
 
     HRESULT hResult = hr;
 
-    if (FAILED(installActivityContext.GetDeploymentErrorHresult() &&
+    if (FAILED(installActivityContext.GetDeploymentErrorHresult()) &&
         (installActivityContext.GetInstallStage() == InstallStage::StagePackage ||
         installActivityContext.GetInstallStage() == InstallStage::AddPackage ||
         installActivityContext.GetInstallStage() == InstallStage::RegisterPackage))
@@ -70,7 +70,7 @@ void WindowsAppRuntimeInstaller::Console::DisplayError(const HRESULT hr)
     }
 
     // Don't log redundant Hr information
-    if (FAILED(installActivityContext.GetDeploymentErrorExtendedHResult() &&
+    if (FAILED(installActivityContext.GetDeploymentErrorExtendedHResult()) &&
         (installActivityContext.GetDeploymentErrorExtendedHResult() != hResult) &&
         (installActivityContext.GetInstallStage() == InstallStage::StagePackage ||
             installActivityContext.GetInstallStage() == InstallStage::AddPackage ||


### PR DESCRIPTION
Fixed a cut-and-paste error not caught by this PR validation pipeline but caught later by the internal aggregator pipeline while building the Installer.

----

A microsoft employee must use /azp run to validate using the pipelines below.

WARNING:
Comments made by azure-pipelines bot maybe inaccurate.
Please see pipeline link to verify that the build is being ran.

For status checks on the main branch, please use TransportPackage-Foundation-PR
(https://microsoft.visualstudio.com/ProjectReunion/_build?definitionId=81063&_a=summary)
and run the build against your PR branch with the default parameters.
