### PR TITLE
NuGet Installation Optimization for C++ Project Templates 

### DIFF
--- a/dev/VSIX/ProjectTemplates/Desktop/CppWinRT/PackagedApp/WinUI.Desktop.CppWinRT.PackagedApp.vstemplate
+++ b/dev/VSIX/ProjectTemplates/Desktop/CppWinRT/PackagedApp/WinUI.Desktop.CppWinRT.PackagedApp.vstemplate
@@ -32,13 +32,6 @@
     <ProjectCollection>
       <ProjectTemplateLink ProjectName="$projectname$ (Package)" CopyParameters="true">WapProj\WinUI.Desktop.CppWinRT.WapProj.vstemplate</ProjectTemplateLink>
       <ProjectTemplateLink ProjectName="$projectname$" CopyParameters="true">BlankApp\WinUI.Desktop.CppWinRT.BlankApp.vstemplate</ProjectTemplateLink>
-    </ProjectCollection>      
-    <CustomParameters>
-      <CustomParameter Name="$NuGetPackages$" Value="Microsoft.WindowsAppSDK;Microsoft.Windows.SDK.BuildTools"/>
-    </CustomParameters> 
+    </ProjectCollection> 
   </TemplateContent>   
-  <WizardExtension>
-    <Assembly>WindowsAppSDK.Cpp.Extension.Dev17, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null</Assembly>
-    <FullClassName>WindowsAppSDK.TemplateUtilities.Cpp.NuGetPackageInstaller</FullClassName>
-  </WizardExtension>
 </VSTemplate>

--- a/dev/VSIX/ProjectTemplates/Desktop/CppWinRT/SingleProjectPackagedApp/WinUI.Desktop.CppWinRT.SingleProjectPackagedApp.vstemplate
+++ b/dev/VSIX/ProjectTemplates/Desktop/CppWinRT/SingleProjectPackagedApp/WinUI.Desktop.CppWinRT.SingleProjectPackagedApp.vstemplate
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <VSTemplate Version="3.0.0" xmlns="http://schemas.microsoft.com/developer/vstemplate/2005" Type="Project">
   <TemplateData>
     <Name ID="1029" Package="FIXME-PACKAGEGUID" />


### PR DESCRIPTION
This pull request delivers a critical fix to the `WizardImplementationCpp.cs` file, enhancing the NuGet package installation mechanism for C++ projects. The improvement detects the project type via the project's GUID. For `vcxproj` (C++ project files), it bypasses the previously used `SolutionRestoreFinished` event and directly invokes `InstallNugetPackagesAsync`. This ensures both SingleProject C++ and Wapproj C++ projects receive timely and efficient NuGet package installations during project creation, effectively tailoring the process to the project type and optimizing performance.