### PR TITLE
Pipelines: PublishBuildArtifacts -> PublishPipelineArtifact

### DIFF
--- a/build/AzurePipelinesTemplates/WindowsAppSDK-BuildBinaries-AnyCPU-Steps.yml
+++ b/build/AzurePipelinesTemplates/WindowsAppSDK-BuildBinaries-AnyCPU-Steps.yml
@@ -107,7 +107,5 @@ steps:
     TargetFolder: '$(ob_outputDirectory)'
 
 - ${{ if not( parameters.IsOneBranch ) }}:
-  - task: PublishBuildArtifacts@1
-    inputs:
-      PathtoPublish: '$(ob_outputDirectory)'
-      artifactName: '$(ob_artifactBaseName)'
+  - publish: $(ob_outputDirectory)
+    artifact: $(ob_artifactBaseName)

--- a/build/AzurePipelinesTemplates/WindowsAppSDK-BuildBinaries-Steps.yml
+++ b/build/AzurePipelinesTemplates/WindowsAppSDK-BuildBinaries-Steps.yml
@@ -172,7 +172,5 @@ steps:
     TargetFolder: '$(ob_outputDirectory)\packages'
 
 - ${{ if not( parameters.IsOneBranch ) }}:
-  - task: PublishBuildArtifacts@1
-    inputs:
-      PathtoPublish: '$(ob_outputDirectory)'
-      artifactName: '$(ob_artifactBaseName)'
+  - publish: $(ob_outputDirectory)
+    artifact: $(ob_artifactBaseName)

--- a/build/AzurePipelinesTemplates/WindowsAppSDK-BuildMRT-Steps.yml
+++ b/build/AzurePipelinesTemplates/WindowsAppSDK-BuildMRT-Steps.yml
@@ -118,7 +118,5 @@ steps:
     TargetFolder: '$(ob_outputDirectory)'
 
 - ${{ if not( parameters.IsOneBranch ) }}:
-  - task: PublishBuildArtifacts@1
-    inputs:
-      PathtoPublish: '$(ob_outputDirectory)'
-      artifactName: '$(ob_artifactBaseName)'
+  - publish: $(ob_outputDirectory)
+    artifact: $(ob_artifactBaseName)

--- a/build/AzurePipelinesTemplates/WindowsAppSDK-PackTransportPackage-Stage.yml
+++ b/build/AzurePipelinesTemplates/WindowsAppSDK-PackTransportPackage-Stage.yml
@@ -238,10 +238,8 @@ stages:
         TargetFolder: '$(ob_outputDirectory)'
 
     - ${{ if not( parameters.IsOneBranch ) }}:
-      - task: PublishBuildArtifacts@1
-        inputs:
-          PathtoPublish: '$(ob_outputDirectory)'
-          artifactName: '$(ob_artifactBaseName)'
+      - publish: $(ob_outputDirectory)
+        artifact: $(ob_artifactBaseName)
 
     - ${{ if eq(parameters.PublishPackage, 'true') }}:
       # this mysterious guid fixes the "NuGetCommand@2 is ambiguous" error :-(

--- a/build/ProjectReunion-CI.yml
+++ b/build/ProjectReunion-CI.yml
@@ -101,11 +101,9 @@ jobs:
       SourceFolder: '$(build.SourcesDirectory)\packages'
       TargetFolder: '$(build.SourcesDirectory)\BuildOutput\packages'
 
-  - task: PublishBuildArtifacts@1
+  - publish: $(build.SourcesDirectory)\BuildOutput
     displayName: 'Publish artifact: Full Nuget'
-    inputs:
-      PathtoPublish: '$(build.SourcesDirectory)\BuildOutput'
-      artifactName: 'FoundationBinaries_$(buildConfiguration)_$(buildPlatform)'
+    artifact: 'FoundationBinaries_$(buildConfiguration)_$(buildPlatform)'
 
 - job: BuildBinaries_release_anycpu
   pool:
@@ -123,11 +121,9 @@ jobs:
       filePath: 'BuildAll.ps1'
       arguments: -AzureBuildStep "BuildAnyCPU"
 
-  - task: PublishBuildArtifacts@1
+  - publish: $(build.SourcesDirectory)\BuildOutput
     displayName: 'Publish artifact: Full Nuget'
-    inputs:
-      PathtoPublish: '$(build.SourcesDirectory)\BuildOutput'
-      artifactName: 'FoundationBinaries_Release_AnyCPU'
+    artifact: 'FoundationBinaries_Release_AnyCPU'
 
 - job: BuildMRT
   pool:

--- a/eng/common/AzurePipelinesTemplates/WindowsAppSDK-Build-Steps.yml
+++ b/eng/common/AzurePipelinesTemplates/WindowsAppSDK-Build-Steps.yml
@@ -77,11 +77,9 @@ steps:
         -AzurePipelineBuild
 
   - ${{ if not( parameters.IsOneBranch ) }}:
-    - task: PublishBuildArtifacts@1
+    - publish: $(Build.SourcesDirectory)\PackLocation
       displayName: 'Publish Windows App SDK Packages'
-      inputs:
-        PathtoPublish: '$(Build.SourcesDirectory)\PackLocation'
-        artifactName: 'WindowsAppSDKNugetPackage'
+      artifact: WindowsAppSDKNugetPackage
 
   - ${{ if parameters.IsOneBranch }}:
     - task: CopyFiles@2

--- a/eng/common/AzurePipelinesTemplates/WindowsAppSDK-IntegrationTest-Steps.yml
+++ b/eng/common/AzurePipelinesTemplates/WindowsAppSDK-IntegrationTest-Steps.yml
@@ -92,12 +92,9 @@ steps:
         -AzurePipelineBuild
 
   - ${{ if not( parameters.IsOneBranch ) }}:
-    - task: PublishBuildArtifacts@1
+    - publish: $(Build.SourcesDirectory)\PipelineTestOutput
       displayName: 'Publish test results'
-      condition: succeededOrFailed()
-      inputs:
-        PathtoPublish: '$(Build.SourcesDirectory)\PipelineTestOutput'
-        artifactName: 'TestResults-WindowsAppSDKIntegration'
+      artifact: TestResults-WindowsAppSDKIntegration
 
   - ${{ if parameters.IsOneBranch }}:
     - task: CopyFiles@2


### PR DESCRIPTION
The `PublishPipelineArtifact` task is *significantly* faster than the `PublishBuildArtifacts` task.

Docs for reference: https://learn.microsoft.com/en-us/azure/devops/pipelines/artifacts/pipeline-artifacts

Exact perf numbers TBD. Will edit the description once I have them.