### PR TITLE
Fix regression in RuntimeIdentifiers defaulting logic

### DIFF
--- a/dev/MRTCore/packaging/MrtCore.PriGen.targets
+++ b/dev/MRTCore/packaging/MrtCore.PriGen.targets
@@ -124,7 +124,7 @@
   <PropertyGroup>
     <NuGetTargetFramework Condition="'$(NuGetTargetFramework)'==''">$(TargetPlatformIdentifierAdjusted),Version=v$(TargetPlatformMinVersion)</NuGetTargetFramework>
     <RuntimeIdentifiers Condition="'$(RuntimeIdentifiers)'=='' and $([MSBuild]::GetTargetFrameworkVersion('$(TargetFramework)')) >= 8">win-x86;win-x64;win-arm64</RuntimeIdentifiers>
-    <RuntimeIdentifiers Condition="'$(RuntimeIdentifiers)'=='' and $([MSBuild]::GetTargetFrameworkVersion('$(TargetFramework)')) &lt; 8">win10-arm;win10-arm-aot;win10-arm64-aot;win10-x86;win10-x86-aot;win10-x64;win10-x64-aot</RuntimeIdentifiers>
+    <RuntimeIdentifiers Condition="'$(RuntimeIdentifiers)'=='' and $([MSBuild]::GetTargetFrameworkVersion('$(TargetFramework)')) &lt; 8">win10-arm64;win10-arm;win10-arm-aot;win10-arm64-aot;win10-x86;win10-x86-aot;win10-x64;win10-x64-aot</RuntimeIdentifiers>
     <ResolveAssemblyConflicts>true</ResolveAssemblyConflicts>
   </PropertyGroup>
 


### PR DESCRIPTION
Prior to .NET8 support, there was a condition for assigning RuntimeIdentifiers, if it was empty (i.e., making it a default).  This restores that check, fixing build breaks like: error NETSDK1082: There was no runtime pack for Microsoft.WindowsDesktop.App.WPF available for the specified RuntimeIdentifier 'win10-arm'.
