### PR TITLE
Reverts changes to default titlebar template and add a Window title to it

### DIFF
--- a/dev/VSIX/ItemTemplates/Desktop/CSharp/BlankWindow/BlankWindow.xaml
+++ b/dev/VSIX/ItemTemplates/Desktop/CSharp/BlankWindow/BlankWindow.xaml
@@ -7,7 +7,7 @@
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     mc:Ignorable="d"
-    Title="$safeitemname$">
+    Title="$itemname$">
 
     <Grid>
 

--- a/dev/VSIX/ItemTemplates/Desktop/CSharp/BlankWindow/BlankWindow.xaml
+++ b/dev/VSIX/ItemTemplates/Desktop/CSharp/BlankWindow/BlankWindow.xaml
@@ -6,7 +6,8 @@
     xmlns:local="using:$rootnamespace$"
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-    mc:Ignorable="d">
+    mc:Ignorable="d"
+    Title="$safeitemname$">
 
     <Grid>
 

--- a/dev/VSIX/ItemTemplates/Desktop/CSharp/BlankWindow/BlankWindow.xaml.cs
+++ b/dev/VSIX/ItemTemplates/Desktop/CSharp/BlankWindow/BlankWindow.xaml.cs
@@ -26,7 +26,6 @@ namespace $rootnamespace$
         public $safeitemname$()
         {
             this.InitializeComponent();
-            this.ExtendsContentIntoTitleBar = true; // provides default WinUI custom title bar experience
         }
     }
 }

--- a/dev/VSIX/ItemTemplates/Desktop/CppWinRT/BlankWindow/BlankWindow.h
+++ b/dev/VSIX/ItemTemplates/Desktop/CppWinRT/BlankWindow/BlankWindow.h
@@ -10,7 +10,6 @@ namespace winrt::$rootnamespace$::implementation
         {
             // Xaml objects should not call InitializeComponent during construction.
             // See https://github.com/microsoft/cppwinrt/tree/master/nuget#initializecomponent
-            ExtendsContentIntoTitleBar(true); // provides default WinUI custom title bar experience
         }
 
         int32_t MyProperty();

--- a/dev/VSIX/ItemTemplates/Desktop/CppWinRT/BlankWindow/BlankWindow.xaml
+++ b/dev/VSIX/ItemTemplates/Desktop/CppWinRT/BlankWindow/BlankWindow.xaml
@@ -8,13 +8,7 @@
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     mc:Ignorable="d">
 
-    <StackPanel HorizontalAlignment="Stretch" VerticalAlignment="Top">
-        <StackPanel Margin="20,5,0,0" Height="32" HorizontalAlignment="Stretch">
-            <TextBlock>$safeitemname$</TextBlock>
-        </StackPanel>
-        <StackPanel Margin="0,10,0,0" HorizontalAlignment="Center" VerticalAlignment="Center">
-            <Button x:Name="myButton" Click="myButton_Click">Click Me</Button>
-        </StackPanel>
+    <StackPanel Orientation="Horizontal" HorizontalAlignment="Center" VerticalAlignment="Center">
+        <Button x:Name="myButton" Click="myButton_Click">Click Me</Button>
     </StackPanel>
-    
 </Window>

--- a/dev/VSIX/ItemTemplates/Desktop/CppWinRT/BlankWindow/BlankWindow.xaml
+++ b/dev/VSIX/ItemTemplates/Desktop/CppWinRT/BlankWindow/BlankWindow.xaml
@@ -6,7 +6,8 @@
     xmlns:local="using:$rootnamespace$"
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-    mc:Ignorable="d">
+    mc:Ignorable="d"
+    Title="$safeitemname$">
 
     <StackPanel Orientation="Horizontal" HorizontalAlignment="Center" VerticalAlignment="Center">
         <Button x:Name="myButton" Click="myButton_Click">Click Me</Button>

--- a/dev/VSIX/ItemTemplates/Desktop/CppWinRT/BlankWindow/BlankWindow.xaml
+++ b/dev/VSIX/ItemTemplates/Desktop/CppWinRT/BlankWindow/BlankWindow.xaml
@@ -7,7 +7,7 @@
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     mc:Ignorable="d"
-    Title="$safeitemname$">
+    Title="$itemname$">
 
     <StackPanel Orientation="Horizontal" HorizontalAlignment="Center" VerticalAlignment="Center">
         <Button x:Name="myButton" Click="myButton_Click">Click Me</Button>

--- a/dev/VSIX/ProjectTemplates/Desktop/CSharp/PackagedApp/BlankApp/MainWindow.xaml
+++ b/dev/VSIX/ProjectTemplates/Desktop/CSharp/PackagedApp/BlankApp/MainWindow.xaml
@@ -8,12 +8,7 @@
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     mc:Ignorable="d">
 
-    <StackPanel HorizontalAlignment="Stretch" VerticalAlignment="Top">
-        <StackPanel Margin="20,5,0,0" Height="32" HorizontalAlignment="Stretch">
-            <TextBlock>$safeitemname$</TextBlock>
-        </StackPanel>
-        <StackPanel Margin="0,10,0,0" HorizontalAlignment="Center" VerticalAlignment="Center">
-            <Button x:Name="myButton" Click="myButton_Click">Click Me</Button>
-        </StackPanel>
+    <StackPanel Orientation="Horizontal" HorizontalAlignment="Center" VerticalAlignment="Center">
+        <Button x:Name="myButton" Click="myButton_Click">Click Me</Button>
     </StackPanel>
 </Window>

--- a/dev/VSIX/ProjectTemplates/Desktop/CSharp/PackagedApp/BlankApp/MainWindow.xaml
+++ b/dev/VSIX/ProjectTemplates/Desktop/CSharp/PackagedApp/BlankApp/MainWindow.xaml
@@ -6,7 +6,8 @@
     xmlns:local="using:$safeprojectname$"
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-    mc:Ignorable="d">
+    mc:Ignorable="d"
+    Title="$safeitemname$">
 
     <StackPanel Orientation="Horizontal" HorizontalAlignment="Center" VerticalAlignment="Center">
         <Button x:Name="myButton" Click="myButton_Click">Click Me</Button>

--- a/dev/VSIX/ProjectTemplates/Desktop/CSharp/PackagedApp/BlankApp/MainWindow.xaml
+++ b/dev/VSIX/ProjectTemplates/Desktop/CSharp/PackagedApp/BlankApp/MainWindow.xaml
@@ -7,7 +7,7 @@
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     mc:Ignorable="d"
-    Title="$safeitemname$">
+    Title="$projectname$">
 
     <StackPanel Orientation="Horizontal" HorizontalAlignment="Center" VerticalAlignment="Center">
         <Button x:Name="myButton" Click="myButton_Click">Click Me</Button>

--- a/dev/VSIX/ProjectTemplates/Desktop/CSharp/PackagedApp/BlankApp/MainWindow.xaml.cs
+++ b/dev/VSIX/ProjectTemplates/Desktop/CSharp/PackagedApp/BlankApp/MainWindow.xaml.cs
@@ -26,7 +26,6 @@ namespace $safeprojectname$
         public MainWindow()
         {
             this.InitializeComponent();
-            this.ExtendsContentIntoTitleBar = true; // provides default WinUI custom title bar experience
         }
 
         private void myButton_Click(object sender, RoutedEventArgs e)

--- a/dev/VSIX/ProjectTemplates/Desktop/CSharp/SingleProjectPackagedApp/MainWindow.xaml
+++ b/dev/VSIX/ProjectTemplates/Desktop/CSharp/SingleProjectPackagedApp/MainWindow.xaml
@@ -8,12 +8,7 @@
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     mc:Ignorable="d">
 
-    <StackPanel HorizontalAlignment="Stretch" VerticalAlignment="Top">
-        <StackPanel Margin="20,5,0,0" Height="32" HorizontalAlignment="Stretch">
-            <TextBlock>$safeitemname$</TextBlock>
-        </StackPanel>
-        <StackPanel Margin="0,10,0,0" HorizontalAlignment="Center" VerticalAlignment="Center">
-            <Button x:Name="myButton" Click="myButton_Click">Click Me</Button>
-        </StackPanel>
+    <StackPanel Orientation="Horizontal" HorizontalAlignment="Center" VerticalAlignment="Center">
+        <Button x:Name="myButton" Click="myButton_Click">Click Me</Button>
     </StackPanel>
 </Window>

--- a/dev/VSIX/ProjectTemplates/Desktop/CSharp/SingleProjectPackagedApp/MainWindow.xaml
+++ b/dev/VSIX/ProjectTemplates/Desktop/CSharp/SingleProjectPackagedApp/MainWindow.xaml
@@ -6,7 +6,8 @@
     xmlns:local="using:$safeprojectname$"
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-    mc:Ignorable="d">
+    mc:Ignorable="d"
+    Title="$safeitemname$">
 
     <StackPanel Orientation="Horizontal" HorizontalAlignment="Center" VerticalAlignment="Center">
         <Button x:Name="myButton" Click="myButton_Click">Click Me</Button>

--- a/dev/VSIX/ProjectTemplates/Desktop/CSharp/SingleProjectPackagedApp/MainWindow.xaml
+++ b/dev/VSIX/ProjectTemplates/Desktop/CSharp/SingleProjectPackagedApp/MainWindow.xaml
@@ -7,7 +7,7 @@
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     mc:Ignorable="d"
-    Title="$safeitemname$">
+    Title="$projectname$">
 
     <StackPanel Orientation="Horizontal" HorizontalAlignment="Center" VerticalAlignment="Center">
         <Button x:Name="myButton" Click="myButton_Click">Click Me</Button>

--- a/dev/VSIX/ProjectTemplates/Desktop/CSharp/SingleProjectPackagedApp/MainWindow.xaml.cs
+++ b/dev/VSIX/ProjectTemplates/Desktop/CSharp/SingleProjectPackagedApp/MainWindow.xaml.cs
@@ -26,7 +26,6 @@ namespace $safeprojectname$
         public MainWindow()
         {
             this.InitializeComponent();
-            this.ExtendsContentIntoTitleBar = true; // provides default WinUI custom title bar experience
         }
 
         private void myButton_Click(object sender, RoutedEventArgs e)

--- a/dev/VSIX/ProjectTemplates/Desktop/CSharp/UnitTestApp/UnitTestApp.xaml.cs
+++ b/dev/VSIX/ProjectTemplates/Desktop/CSharp/UnitTestApp/UnitTestApp.xaml.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;

--- a/dev/VSIX/ProjectTemplates/Desktop/CSharp/UnitTestApp/UnitTestAppWindow.xaml
+++ b/dev/VSIX/ProjectTemplates/Desktop/CSharp/UnitTestApp/UnitTestAppWindow.xaml
@@ -6,7 +6,8 @@
     xmlns:local="using:$safeprojectname$"
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-    mc:Ignorable="d">
+    mc:Ignorable="d"
+    Title="$safeitemname$">
 
     <Grid>
 

--- a/dev/VSIX/ProjectTemplates/Desktop/CSharp/UnitTestApp/UnitTestAppWindow.xaml
+++ b/dev/VSIX/ProjectTemplates/Desktop/CSharp/UnitTestApp/UnitTestAppWindow.xaml
@@ -7,7 +7,7 @@
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     mc:Ignorable="d"
-    Title="$safeitemname$">
+    Title="$projectname$">
 
     <Grid>
 

--- a/dev/VSIX/ProjectTemplates/Desktop/CSharp/UnitTestApp/UnitTestAppWindow.xaml.cs
+++ b/dev/VSIX/ProjectTemplates/Desktop/CSharp/UnitTestApp/UnitTestAppWindow.xaml.cs
@@ -23,8 +23,6 @@ namespace $safeprojectname$
         public UnitTestAppWindow()
         {
             this.InitializeComponent();
-            this.ExtendsContentIntoTitleBar = true; // provides default WinUI custom title bar experience
-
+        }
     }
-}
 }

--- a/dev/VSIX/ProjectTemplates/Desktop/CppWinRT/PackagedApp/BlankApp/MainWindow.h
+++ b/dev/VSIX/ProjectTemplates/Desktop/CppWinRT/PackagedApp/BlankApp/MainWindow.h
@@ -10,7 +10,6 @@ namespace winrt::$safeprojectname$::implementation
         {
             // Xaml objects should not call InitializeComponent during construction.
             // See https://github.com/microsoft/cppwinrt/tree/master/nuget#initializecomponent
-            ExtendsContentIntoTitleBar(true); // provides default WinUI custom title bar experience
         }
 
         int32_t MyProperty();

--- a/dev/VSIX/ProjectTemplates/Desktop/CppWinRT/PackagedApp/BlankApp/MainWindow.xaml
+++ b/dev/VSIX/ProjectTemplates/Desktop/CppWinRT/PackagedApp/BlankApp/MainWindow.xaml
@@ -8,12 +8,7 @@
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     mc:Ignorable="d">
 
-    <StackPanel HorizontalAlignment="Stretch" VerticalAlignment="Top">
-        <StackPanel Margin="20,5,0,0" Height="32" HorizontalAlignment="Stretch">
-            <TextBlock>$safeitemname$</TextBlock>
-        </StackPanel>
-        <StackPanel Margin="0,10,0,0" HorizontalAlignment="Center" VerticalAlignment="Center">
-            <Button x:Name="myButton" Click="myButton_Click">Click Me</Button>
-        </StackPanel>
+    <StackPanel Orientation="Horizontal" HorizontalAlignment="Center" VerticalAlignment="Center">
+        <Button x:Name="myButton" Click="myButton_Click">Click Me</Button>
     </StackPanel>
 </Window>

--- a/dev/VSIX/ProjectTemplates/Desktop/CppWinRT/PackagedApp/BlankApp/MainWindow.xaml
+++ b/dev/VSIX/ProjectTemplates/Desktop/CppWinRT/PackagedApp/BlankApp/MainWindow.xaml
@@ -6,7 +6,8 @@
     xmlns:local="using:$safeprojectname$"
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-    mc:Ignorable="d">
+    mc:Ignorable="d"
+    Title="$safeitemname$">
 
     <StackPanel Orientation="Horizontal" HorizontalAlignment="Center" VerticalAlignment="Center">
         <Button x:Name="myButton" Click="myButton_Click">Click Me</Button>

--- a/dev/VSIX/ProjectTemplates/Desktop/CppWinRT/PackagedApp/BlankApp/MainWindow.xaml
+++ b/dev/VSIX/ProjectTemplates/Desktop/CppWinRT/PackagedApp/BlankApp/MainWindow.xaml
@@ -7,7 +7,7 @@
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     mc:Ignorable="d"
-    Title="$safeitemname$">
+    Title="$projectname$">
 
     <StackPanel Orientation="Horizontal" HorizontalAlignment="Center" VerticalAlignment="Center">
         <Button x:Name="myButton" Click="myButton_Click">Click Me</Button>

--- a/dev/VSIX/ProjectTemplates/Desktop/CppWinRT/SingleProjectPackagedApp/MainWindow.h
+++ b/dev/VSIX/ProjectTemplates/Desktop/CppWinRT/SingleProjectPackagedApp/MainWindow.h
@@ -10,7 +10,6 @@ namespace winrt::$safeprojectname$::implementation
         {
             // Xaml objects should not call InitializeComponent during construction.
             // See https://github.com/microsoft/cppwinrt/tree/master/nuget#initializecomponent
-            ExtendsContentIntoTitleBar(true); // provides default WinUI custom title bar experience
         }
 
         int32_t MyProperty();

--- a/dev/VSIX/ProjectTemplates/Desktop/CppWinRT/SingleProjectPackagedApp/MainWindow.xaml
+++ b/dev/VSIX/ProjectTemplates/Desktop/CppWinRT/SingleProjectPackagedApp/MainWindow.xaml
@@ -8,12 +8,7 @@
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     mc:Ignorable="d">
 
-    <StackPanel HorizontalAlignment="Stretch" VerticalAlignment="Top">
-        <StackPanel Margin="20,5,0,0" Height="32" HorizontalAlignment="Stretch">
-            <TextBlock>$safeitemname$</TextBlock>
-        </StackPanel>
-        <StackPanel Margin="0,10,0,0" HorizontalAlignment="Center" VerticalAlignment="Center">
-            <Button x:Name="myButton" Click="myButton_Click">Click Me</Button>
-        </StackPanel>
+    <StackPanel Orientation="Horizontal" HorizontalAlignment="Center" VerticalAlignment="Center">
+        <Button x:Name="myButton" Click="myButton_Click">Click Me</Button>
     </StackPanel>
 </Window>

--- a/dev/VSIX/ProjectTemplates/Desktop/CppWinRT/SingleProjectPackagedApp/MainWindow.xaml
+++ b/dev/VSIX/ProjectTemplates/Desktop/CppWinRT/SingleProjectPackagedApp/MainWindow.xaml
@@ -6,7 +6,8 @@
     xmlns:local="using:$safeprojectname$"
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-    mc:Ignorable="d">
+    mc:Ignorable="d"
+    Title="$safeitemname$">
 
     <StackPanel Orientation="Horizontal" HorizontalAlignment="Center" VerticalAlignment="Center">
         <Button x:Name="myButton" Click="myButton_Click">Click Me</Button>

--- a/dev/VSIX/ProjectTemplates/Desktop/CppWinRT/SingleProjectPackagedApp/MainWindow.xaml
+++ b/dev/VSIX/ProjectTemplates/Desktop/CppWinRT/SingleProjectPackagedApp/MainWindow.xaml
@@ -7,7 +7,7 @@
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     mc:Ignorable="d"
-    Title="$safeitemname$">
+    Title="$projectname$">
 
     <StackPanel Orientation="Horizontal" HorizontalAlignment="Center" VerticalAlignment="Center">
         <Button x:Name="myButton" Click="myButton_Click">Click Me</Button>

--- a/dev/VSIX/ProjectTemplates/Desktop/CppWinRT/UnitTestApp/MainWindow.cpp
+++ b/dev/VSIX/ProjectTemplates/Desktop/CppWinRT/UnitTestApp/MainWindow.cpp
@@ -14,6 +14,6 @@ namespace winrt::$safeprojectname$::implementation
 {
     MainWindow::MainWindow()
     {
-        ExtendsContentIntoTitleBar(true); // provides default WinUI custom title bar experience
+        
     }
 }

--- a/dev/VSIX/ProjectTemplates/Desktop/CppWinRT/UnitTestApp/MainWindow.xaml
+++ b/dev/VSIX/ProjectTemplates/Desktop/CppWinRT/UnitTestApp/MainWindow.xaml
@@ -6,7 +6,8 @@
     xmlns:local="using:$safeprojectname$"
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-    mc:Ignorable="d">
+    mc:Ignorable="d"
+    Title="$safeitemname$">
 
     <Grid>
   

--- a/dev/VSIX/ProjectTemplates/Desktop/CppWinRT/UnitTestApp/MainWindow.xaml
+++ b/dev/VSIX/ProjectTemplates/Desktop/CppWinRT/UnitTestApp/MainWindow.xaml
@@ -7,7 +7,7 @@
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     mc:Ignorable="d"
-    Title="$safeitemname$">
+    Title="$projectname$">
 
     <Grid>
   


### PR DESCRIPTION
It is doing 2 things.
1. reverts #4035 Add custom titlebar to default Cs and Cpp WinUI template as there are changes coming later which will address some of the issues this PR was trying to solve, but better.
2. Adds window title in default template. As a result, every window will have a title by default, which would be name of the project (app).
Obviously, the user can choose to change it by using `<Title>` markdown in Window or `Window.Title` api, if they wish.

Solving https://task.ms/50309832