### PR TITLE
Fix initialization of _InOut_ variable

### DIFF
--- a/dev/Deployment/DeploymentManager.cpp
+++ b/dev/Deployment/DeploymentManager.cpp
@@ -326,9 +326,8 @@ namespace winrt::Microsoft::Windows::ApplicationModel::WindowsAppRuntime::implem
     }
 
     HRESULT DeploymentManager::VerifyPackage(const std::wstring& packageFamilyName, const PACKAGE_VERSION targetVersion,
-        __out std::wstring& packageIdentifier) try
+        const std::wstring& packageIdentifier) try
     {
-        packageIdentifier = L"";
         auto packageFullNames{ FindPackagesByFamily(packageFamilyName) };
         bool match{};
         for (const auto& packageFullName : packageFullNames)

--- a/dev/Deployment/DeploymentManager.cpp
+++ b/dev/Deployment/DeploymentManager.cpp
@@ -107,7 +107,7 @@ namespace winrt::Microsoft::Windows::ApplicationModel::WindowsAppRuntime::implem
         // (i.e. if any of the target packages is not installed, GetStatus should return PackageInstallRequired).
         HRESULT verifyResult{};
 
-        for (auto package : c_targetPackages)
+        for (const auto package : c_targetPackages)
         {
             // Build package family name based on the framework naming scheme.
             std::wstring packageFamilyName{};

--- a/dev/Deployment/DeploymentManager.h
+++ b/dev/Deployment/DeploymentManager.h
@@ -37,7 +37,7 @@ namespace winrt::Microsoft::Windows::ApplicationModel::WindowsAppRuntime::implem
     private:
         static MddCore::PackageInfo GetPackageInfoForPackage(std::wstring const& packageFullName);
         static std::vector<std::wstring> FindPackagesByFamily(std::wstring const& packageFamilyName);
-        static HRESULT VerifyPackage(const std::wstring& packageFamilyName, const PACKAGE_VERSION targetVersion, __out std::wstring& matchedPackageFullName);
+        static HRESULT VerifyPackage(const std::wstring& packageFamilyName, const PACKAGE_VERSION targetVersion, const std::wstring& matchedPackageFullName);
         static std::wstring GetPackagePath(std::wstring const& packageFullName);
         static HRESULT AddOrRegisterPackageInBreakAwayProcess(const std::filesystem::path& packagePath, const bool regiterHigherVersionPackage, const bool forceDeployment);
         static std::wstring GenerateDeploymentAgentPath();


### PR DESCRIPTION
A recent prefast bug fix initialized an _Out_ variable athat was actually an _InOut_, so that the initialization clobbered the existing value. The parameter was not being used as an out param, so the correct fix is to change it to a const.
