### PR TITLE
49601674: Exclude the \Packages folder from PREfast scans

### DIFF
--- a/build/AzurePipelinesTemplates/WindowsAppSDK-BuildBinaries-AnyCPU-Steps.yml
+++ b/build/AzurePipelinesTemplates/WindowsAppSDK-BuildBinaries-AnyCPU-Steps.yml
@@ -41,6 +41,9 @@ steps:
     continueOnError: true
     env:
       SYSTEM_ACCESSTOKEN: $(System.AccessToken)
+    # Generally speaking, we leave it to the external repos to scan the bits in their packages.
+    excludedPaths: |
+      $(Build.SourcesDirectory)\packages
 
 # component detection must happen *within* the build task
 - task: ms.vss-governance-buildtask.governance-build-task-component-detection.ComponentGovernanceComponentDetection@0

--- a/build/AzurePipelinesTemplates/WindowsAppSDK-BuildBinaries-Steps.yml
+++ b/build/AzurePipelinesTemplates/WindowsAppSDK-BuildBinaries-Steps.yml
@@ -81,6 +81,9 @@ steps:
     env:
       SYSTEM_ACCESSTOKEN: $(System.AccessToken)
     continueOnError: true
+    # Generally speaking, we leave it to the external repos to scan the bits in their packages.
+    excludedPaths: |
+      $(Build.SourcesDirectory)\packages
 
   # Copy build output to folder APIScanTarget for APIScan to scan later, in the mean time, exclude some folders/files.
   - task: CopyFiles@2

--- a/build/AzurePipelinesTemplates/WindowsAppSDK-BuildMRT-Steps.yml
+++ b/build/AzurePipelinesTemplates/WindowsAppSDK-BuildMRT-Steps.yml
@@ -40,6 +40,9 @@ steps:
     env:
       SYSTEM_ACCESSTOKEN: $(System.AccessToken)
     continueOnError: true
+    # Generally speaking, we leave it to the external repos to scan the bits in their packages.
+    excludedPaths: |
+      $(Build.SourcesDirectory)\packages
 
   # Copy build output to folder APIScanTarget for APIScan to scan, in the mean time, exclude some folders/files.
   - task: CopyFiles@2


### PR DESCRIPTION
Exclude the \Packages folder from PREfast scans, as we are adopting the policy of "each repo should focus on scanning its own bits". These changes are already in use in WinUI pipelines, just porting them to the Foundation pipelines
.
--------------

A microsoft employee must use /azp run to validate using the pipelines below.

WARNING:
Comments made by azure-pipelines bot maybe inaccurate.
Please see pipeline link to verify that the build is being ran.

For status checks on the main branch, please use TransportPackage-Foundation-PR
(https://microsoft.visualstudio.com/ProjectReunion/_build?definitionId=81063&_a=summary)
and run the build against your PR branch with the default parameters.
