### PR TITLE
Fix a test failure due to WindowsCreateString error

### DIFF
--- a/dev/Deployment/DeploymentManager.cpp
+++ b/dev/Deployment/DeploymentManager.cpp
@@ -260,7 +260,7 @@ namespace winrt::Microsoft::Windows::ApplicationModel::WindowsAppRuntime::implem
         }
         else
         {
-            if ((::Microsoft::Windows::ApplicationModel::WindowsAppRuntime::Feature_DeploymentRepair::IsEnabled()) &&
+            if ((::Microsoft::Windows::ApplicationModel::WindowsAppRuntime::Feature_DeploymentRepair::IsEnabled()) && 
                 (isRepair))
             {
                 status = DeploymentStatus::PackageRepairFailed;

--- a/dev/UndockedRegFreeWinRT/typeresolution.cpp
+++ b/dev/UndockedRegFreeWinRT/typeresolution.cpp
@@ -64,14 +64,6 @@ namespace UndockedRegFreeWinRT
         _COM_Outptr_opt_result_maybenull_ IMetaDataImport2** ppMetaDataImport,
         _Out_opt_ mdTypeDef* pmdTypeDef)
     {
-        if (ppMetaDataImport != nullptr)
-        {
-            *ppMetaDataImport = nullptr;
-        }
-        if (pmdTypeDef != nullptr)
-        {
-            *pmdTypeDef = 0;
-        }
         HRESULT hr = S_OK;
         Microsoft::WRL::ComPtr<IMetaDataImport2> spMetaDataImport;
         MetaDataImportersLRUCache* pMetaDataImporterCache = MetaDataImportersLRUCache::GetMetaDataImportersLRUCacheInstance();
@@ -221,17 +213,7 @@ namespace UndockedRegFreeWinRT
         _COM_Outptr_opt_result_maybenull_ IMetaDataImport2** ppMetaDataImport,
         _Out_opt_ mdTypeDef* pmdTypeDef)
     {
-        if (ppMetaDataImport != nullptr)
-        {
-            *ppMetaDataImport = nullptr;
-        }
-        if (pmdTypeDef != nullptr)
-        {
-            *pmdTypeDef = 0;
-        }
-
         wchar_t szCandidateFileName[MAX_PATH + 1]{};
-        RETURN_IF_FAILED(WindowsCreateString(L"", 0, phstrMetaDataFilePath));
         HRESULT hr{ StringCchCopy(szCandidateFileName, ARRAYSIZE(szCandidateFileName), pszFullName) };
         if (SUCCEEDED(hr))
         {


### PR DESCRIPTION
This reverts commit 8d366d91b7d786a8130f307bd52286d45c46effc.

We're getting some test failures due to this line, because phstrMetaDataFilePath can be null:
 RETURN_IF_FAILED(WindowsCreateString(L"", 0, phstrMetaDataFilePath));

A microsoft employee must use /azp run to validate using the pipelines below.


