### PR TITLE
fix: windows.h include on case-sensitive systems

### DIFF
--- a/dev/AccessControl/Security.AccessControl.h
+++ b/dev/AccessControl/Security.AccessControl.h
@@ -3,7 +3,7 @@
 
 #pragma once
 
-#include <Windows.h>
+#include <windows.h>
 
 struct AppContainerNameAndAccess
 {

--- a/dev/AccessControl/SecurityDescriptorHelpers.h
+++ b/dev/AccessControl/SecurityDescriptorHelpers.h
@@ -3,7 +3,7 @@
 
 #pragma once
 
-#include <Windows.h>
+#include <windows.h>
 #include <wil/resource.h>
 #include <wil/result.h>
 #include <processthreadsapi.h>

--- a/dev/Deployment/DeploymentManagerAutoInitializer.cpp
+++ b/dev/Deployment/DeploymentManagerAutoInitializer.cpp
@@ -1,7 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation and Contributors.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
-#include <Windows.h>
+#include <windows.h>
 #include <stdlib.h>
 
 #include <winrt/Windows.Foundation.h>

--- a/dev/DeploymentAgent/pch.h
+++ b/dev/DeploymentAgent/pch.h
@@ -2,7 +2,7 @@
 // Licensed under the MIT License.
 
 #pragma once
-#include <Windows.h>
+#include <windows.h>
 #include <filesystem>
 #include <shellapi.h>
 #include <wil/cppwinrt.h>

--- a/dev/DynamicDependency/API/pch.h
+++ b/dev/DynamicDependency/API/pch.h
@@ -3,7 +3,7 @@
 
 #pragma once
 
-#include <Windows.h>
+#include <windows.h>
 
 #include <appmodel.h>
 #include <shlwapi.h>

--- a/dev/MRTCore/mrt/Core/src/MRM.cpp
+++ b/dev/MRTCore/mrt/Core/src/MRM.cpp
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation and Contributors.
 // Licensed under the MIT License.
 
-#include <Windows.h>
+#include <windows.h>
 #include <Pathcch.h>
 #include "wil/win32_helpers.h"
 #include "wil/filesystem.h"
@@ -255,7 +255,7 @@ static HRESULT LoadResourceCandidate(
         wchar_t rootResourceMap[256] = {};
         unsigned int relativeIdIndex = 0;
         RETURN_IF_FAILED(GetRootAndRelativeIdFromUri(resourceIdOrUri, rootResourceMap, ARRAYSIZE(rootResourceMap), &relativeIdIndex));
-        
+
         const wchar_t* relativeResourceId = &resourceIdOrUri[relativeIdIndex];
         if (relativeResourceId[0] == L'\0')
         {
@@ -686,12 +686,12 @@ STDAPI MrmGetChildResourceMap(
     if (IsResourceUri(childResourceMapName))
     {
         // If a full URI is passed in, we will respect the URI instead of trying to get the child map.
-        
+
         // Root resource maps are the authority of the URI, and are limited to 255 characters.
         wchar_t rootResourceMap[256] = {};
         unsigned int relativeIdIndex = 0;
         RETURN_IF_FAILED(GetRootAndRelativeIdFromUri(childResourceMapName, rootResourceMap, ARRAYSIZE(rootResourceMap), &relativeIdIndex));
-        
+
         const IResourceMapBase* internalRootResourceMap;
         if (rootResourceMap[0] == L'\0')
         {

--- a/dev/MRTCore/mrt/Core/unittests/MrmTests.cpp
+++ b/dev/MRTCore/mrt/Core/unittests/MrmTests.cpp
@@ -1,7 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation and Contributors.
 // Licensed under the MIT License.
 
-#include <Windows.h>
+#include <windows.h>
 #include <WexTestClass.h>
 #include "..\src\MRM.h"
 
@@ -38,7 +38,7 @@ public:
         VERIFY_ARE_NOT_EQUAL(0u, GetCurrentDirectoryW(ARRAYSIZE(previousWorkingDirectory), previousWorkingDirectory));
 
         Log::Comment(String().Format(L"Test Setup: GetCurrentDirectory: %s", previousWorkingDirectory));
-        
+
         String testDeploymentDirectory;
         VERIFY_SUCCEEDED(RuntimeParameters::TryGetValue(L"TestDeploymentDir", testDeploymentDirectory));
         Log::Comment(String().Format(L"Test Setup: TestDeploymentDir: %s", testDeploymentDirectory.GetBuffer()));

--- a/dev/PackageManager/API/pch.h
+++ b/dev/PackageManager/API/pch.h
@@ -3,7 +3,7 @@
 
 #pragma once
 
-#include <Windows.h>
+#include <windows.h>
 
 #include <unknwn.h>
 #include <appmodel.h>

--- a/dev/RestartAgent/pch.h
+++ b/dev/RestartAgent/pch.h
@@ -2,7 +2,7 @@
 // Licensed under the MIT License.
 
 #pragma once
-#include <Windows.h>
+#include <windows.h>
 #include <shellapi.h>
 #include <MddBootstrap.h>
 #include <wil/cppwinrt.h>

--- a/dev/UndockedRegFreeWinRT/UndockedRegFreeWinRT-AutoInitializer.cpp
+++ b/dev/UndockedRegFreeWinRT/UndockedRegFreeWinRT-AutoInitializer.cpp
@@ -1,7 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation and Contributors.
 // Licensed under the MIT License.
 
-#include <Windows.h>
+#include <windows.h>
 #include <stdlib.h>
 
 // Ensure the including PE file has an import reference to

--- a/dev/WindowsAppRuntime_BootstrapDLL/MddBootstrapAutoInitializer.cpp
+++ b/dev/WindowsAppRuntime_BootstrapDLL/MddBootstrapAutoInitializer.cpp
@@ -1,7 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation and Contributors.
 // Licensed under the MIT License.
 
-#include <Windows.h>
+#include <windows.h>
 #include <stdint.h>
 #include <stdlib.h>
 #include <MddBootstrap.h>

--- a/dev/WindowsAppRuntime_DLL/pch.h
+++ b/dev/WindowsAppRuntime_DLL/pch.h
@@ -2,7 +2,7 @@
 // Licensed under the MIT License.
 
 #pragma once
-#include <Windows.h>
+#include <windows.h>
 #include <assert.h>
 #include <unknwn.h>
 #include <ShlObj_core.h>

--- a/test/AccessControlTests/pch.h
+++ b/test/AccessControlTests/pch.h
@@ -11,7 +11,7 @@
 #define PCH_H
 
 #include <unknwn.h>
-#include <Windows.h>
+#include <windows.h>
 #include <sddl.h>
 
 #include <wil/result.h>


### PR DESCRIPTION
A microsoft employee must use /azp run to validate using the pipelines below.

WARNING:
Comments made by azure-pipelines bot maybe inaccurate.
Please see pipeline link to verify that the build is being ran.

For status checks on the main branch, please use TransportPackage-Foundation-PR
(https://microsoft.visualstudio.com/ProjectReunion/_build?definitionId=81063&_a=summary)
and run the build against your PR branch with the default parameters.

When cross compiling a Windows application with MinGW, there's a well-known problem with the missing "Windows.h" header due to filesystem case-sensitivity.
Throughout the project uppercase variant occurs 13 times in 13 files and lowercase one - 55 times in 51 files.
Even though only a single [file](https://github.com/microsoft/WindowsAppSDK/blob/v1.5.3/dev/WindowsAppRuntime_BootstrapDLL/MddBootstrapAutoInitializer.cpp#L4) needs to be changed for my needs, this commit ensures consistency by switching to lowercase everywhere.
