### PR TITLE
Copy Microsoft.WindowsAppRuntime.Bootstrap.dll from portable RID folder

### DIFF
--- a/build/NuSpecs/WindowsAppSDK-Nuget-Native.C.props
+++ b/build/NuSpecs/WindowsAppSDK-Nuget-Native.C.props
@@ -32,7 +32,7 @@
 
   <Target Name="CopyMicrosoftWindowsAppRuntimeBootstrapdllToOutDir" Condition="'$(AppxPackage)' != 'true'" AfterTargets="Build">
     <Copy
-      SourceFiles="$(MSBuildThisFileDirectory)..\..\runtimes\win10-$(_WindowsAppSDKFoundationPlatform)\native\Microsoft.WindowsAppRuntime.Bootstrap.dll"
+      SourceFiles="$(MSBuildThisFileDirectory)..\..\runtimes\win-$(_WindowsAppSDKFoundationPlatform)\native\Microsoft.WindowsAppRuntime.Bootstrap.dll"
       DestinationFolder="$(OutDir)"/>
   </Target>
 


### PR DESCRIPTION
With this PR: remove conditional support for < NET 8 and get rid of assets under Wi… · microsoft/WindowsAppSDK@8b6c0f8 (github.com) , Microsoft.WindowsAppRuntime.Bootstrap.dll is no longer being copied to the nonportable RID runtime folder (win10-arch)

