### PR TITLE
Fix missing trimming annotation and set couple cswinrt properties

### DIFF
--- a/dev/Projections/Directory.Build.props
+++ b/dev/Projections/Directory.Build.props
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT License. See LICENSE-CODE in the project root for license information. -->
+<!-- This is a special MSBuild file that is parsed before everything else when MSBuild detects it in our directory structure.
+     Adding Sdk="Microsoft.NET.Sdk" to a project causes NuGet files to be generated very early on, so we need these defines to be here
+     to ensure that all of our build output files end up in the same location. -->
+<Project ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="..\..\Directory.Build.props" />
+
+  <PropertyGroup>
+    <!-- Both the IID optimizer and the CsWinRT lookup table aren't needed with the new CsWinRT version,
+         so disabling them here until they are disabled automatically by CsWinRT. -->
+    <CsWinRTIIDOptimizerOptOut>true</CsWinRTIIDOptimizerOptOut>
+    <CsWinRTCcwLookupTableGeneratorEnabled>false</CsWinRTCcwLookupTableGeneratorEnabled>
+  </PropertyGroup>
+</Project>

--- a/eng/common/VersionInfo/AssemblyInfo.cs
+++ b/eng/common/VersionInfo/AssemblyInfo.cs
@@ -15,3 +15,5 @@ using System.Runtime.InteropServices;
 
 [assembly: AssemblyVersion("0.0")]
 [assembly: AssemblyFileVersion("0.0")]
+
+[assembly: AssemblyMetadata("IsTrimmable", "True")]

--- a/eng/common/VersionInfo/GenerateVersionInfo.ps1
+++ b/eng/common/VersionInfo/GenerateVersionInfo.ps1
@@ -44,6 +44,8 @@ using System.Runtime.InteropServices;
 
 [assembly: AssemblyVersion("$ProductMajor.$ProductMinor")]
 [assembly: AssemblyFileVersion("$ProductMajor.$ProductMinor")]
+
+[assembly: AssemblyMetadata("IsTrimmable", "True")]
 "@
 
 Write-Verbose $assemblyInfoCs


### PR DESCRIPTION
We have `IsTrimmable` set in our projection projects.  But this doesn't show up in the resulting assembly as an assembly attribute.  This turns out it is due to at some point we started using a custom `AssemblyInfo.cs` which meant the attribute that was generated in the default one is no longer there.  While checking the assembly I also noticed the `IIDOptimizer` is inserting a type that is unused given nothing needs to be optimized and that the vtable lookup generation table was generated because CsWinRT failed to properly detect this as a projection project.  So, disabling those with the respective properties to control them.

A microsoft employee must use /azp run to validate using the pipelines below.

WARNING:
Comments made by azure-pipelines bot maybe inaccurate.
Please see pipeline link to verify that the build is being ran.

For status checks on the main branch, please use TransportPackage-Foundation-PR
(https://microsoft.visualstudio.com/ProjectReunion/_build?definitionId=81063&_a=summary)
and run the build against your PR branch with the default parameters.
