### PR TITLE
Remove condition for develop and main branch on versioning and always add $(PipelineType) to the tag

### DIFF
--- a/build/AzurePipelinesTemplates/WindowsAppSDK-PackTransportPackage-Stage.yml
+++ b/build/AzurePipelinesTemplates/WindowsAppSDK-PackTransportPackage-Stage.yml
@@ -169,11 +169,7 @@ stages:
         script: |
           $packageVersion = '$(version)'
           $pipelineType = '$(PipelineType)'
-          $sourceBranchName = '$(Build.SourceBranchName)'
-          if ($sourceBranchName -eq 'main' -or $sourceBranchName -eq 'develop')
-          {
-            $packageVersion = $packageVersion + '.' + $sourceBranchName + '.' + $pipelineType
-          }
+          $packageVersion = $packageVersion + '.' + $pipelineType
           Write-Host "##vso[task.setvariable variable=packageVersion;]$packageVersion"
           Write-Host "##vso[task.setvariable variable=packageVersion;isOutput=true;]$packageVersion"
 


### PR DESCRIPTION
There is an issue with versioning collision if the release branch is run on both nightly and official pipeline because the $PipelineType variable is only tagged on to the version on the main branch.
While the original intent was that the release would only run on official, this is not always the case and does not match reality.
The fix is to always tag on the $PipelineType variable to the versioning no matter what branch. 

We also don't need to condition on the develop branch anymore so this is archaic.