### PR TITLE
[BuildFix] Fix APIScan config to properly honor parameters.runStaticAnalysis

### DIFF
--- a/build/AzurePipelinesTemplates/WindowsAppSDK-Build-Stage.yml
+++ b/build/AzurePipelinesTemplates/WindowsAppSDK-Build-Stage.yml
@@ -55,7 +55,10 @@ stages:
       ob_outputDirectory: '$(REPOROOT)\out'
       ob_sdl_codeSignValidation_excludes: '-|**\Release\**;-|**\packages\**'
       ob_artifactBaseName: "FoundationBinaries_$(buildConfiguration)_$(buildPlatform)"
-      ob_sdl_apiscan_enabled: true
+      ${{ if parameters.runStaticAnalysis }}:
+        ob_sdl_apiscan_enabled: true
+      ${{ if not( parameters.runStaticAnalysis ) }}:
+        ob_sdl_apiscan_enabled: false
       ob_sdl_apiscan_softwareFolder: '$(build.SourcesDirectory)\APIScanTarget'
       ob_sdl_apiscan_symbolsFolder: '$(build.SourcesDirectory)\APIScanTarget;SRV*http://symweb'
     steps:
@@ -79,7 +82,10 @@ stages:
       ob_outputDirectory: '$(REPOROOT)\out'
       ob_sdl_codeSignValidation_excludes: '-|**\Release\**'
       ob_artifactBaseName: "FoundationBinaries_release_anycpu"
-      ob_sdl_apiscan_enabled: true
+      ${{ if parameters.runStaticAnalysis }}:
+        ob_sdl_apiscan_enabled: true
+      ${{ if not( parameters.runStaticAnalysis ) }}:
+        ob_sdl_apiscan_enabled: false
       ob_sdl_apiscan_softwareFolder: '$(build.SourcesDirectory)\BuildOutput\Release\AnyCPU'
       ob_sdl_apiscan_symbolsFolder: '$(build.SourcesDirectory)\BuildOutput\Release\AnyCPU;SRV*http://symweb'
     steps:
@@ -122,7 +128,10 @@ stages:
       ob_sdl_suppression_suppressionFile: $(Build.SourcesDirectory)\dev\MRTCore\.gdn\mrt.gdnsuppress # This value is set on the job cdpx_engine, it will override the global gdnsuppress for this job
       ob_sdl_suppression_suppressionSet: default
       ob_artifactBaseName: "MrtBinaries_$(buildConfiguration)_$(buildPlatform)"
-      ob_sdl_apiscan_enabled: true
+      ${{ if parameters.runStaticAnalysis }}:
+        ob_sdl_apiscan_enabled: true
+      ${{ if not( parameters.runStaticAnalysis ) }}:
+        ob_sdl_apiscan_enabled: false
       ob_sdl_apiscan_softwareFolder: '$(build.SourcesDirectory)\APIScanTarget'
       ob_sdl_apiscan_symbolsFolder: '$(build.SourcesDirectory)\APIScanTarget;SRV*http://symweb'
     steps:


### PR DESCRIPTION
Enable APIScan according to parameters.runStaticAnalysis, instead of hardwiring it to be always enabled.

How built:
- The changes built successfully in a [private pipeline run](https://microsoft.visualstudio.com/ProjectReunion/_build/results?buildId=99974019&view=results)

How tested:
- When parameters.runStaticAnalysis is set to true, APIScan was enabled as expected in a successful [private pipeline run](https://microsoft.visualstudio.com/ProjectReunion/_build/results?buildId=99976947&view=results)
- When parameters.runStaticAnalysis is set to false, APIScan was disabled as expected in a successful [private pipeline run](https://microsoft.visualstudio.com/ProjectReunion/_build/results?buildId=99974019&view=results)
---
A microsoft employee must use /azp run to validate using the pipelines below.

WARNING:
Comments made by azure-pipelines bot maybe inaccurate.
Please see pipeline link to verify that the build is being ran.

For status checks on the main branch, please use TransportPackage-Foundation-PR
(https://microsoft.visualstudio.com/ProjectReunion/_build?definitionId=81063&_a=summary)
and run the build against your PR branch with the default parameters.
