### PR TITLE
[main] Update dependencies from microsoft/ProjectReunion/WindowsAppSDKClosed

### DIFF
--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -31,9 +31,9 @@
       <Uri>https://dev.azure.com/microsoft/LiftedIXP/_git/DCPP</Uri>
       <Sha>5190f048458d3dd446318391385a832e081e4e9e</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.WindowsAppSDK.AppLicensingInternal.TransportPackage" Version="1.7.0-main.20240513.0">
+    <Dependency Name="Microsoft.WindowsAppSDK.AppLicensingInternal.TransportPackage" Version="1.7.0-main.20240605.0">
       <Uri>https://dev.azure.com/microsoft/ProjectReunion/_git/WindowsAppSDKClosed</Uri>
-      <Sha>2c1c46a69150a164073a76607be58f10c5a3b94c</Sha>
+      <Sha>3aa432601666c491686072d37bed862fb5f1b51c</Sha>
     </Dependency>
   </ProductDependencies>
   <ToolsetDependencies>

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -31,9 +31,9 @@
       <Uri>https://dev.azure.com/microsoft/LiftedIXP/_git/DCPP</Uri>
       <Sha>5190f048458d3dd446318391385a832e081e4e9e</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.WindowsAppSDK.AppLicensingInternal.TransportPackage" Version="1.7.0-main.20240605.0">
+    <Dependency Name="Microsoft.WindowsAppSDK.AppLicensingInternal.TransportPackage" Version="1.7.0-main.20240611.0">
       <Uri>https://dev.azure.com/microsoft/ProjectReunion/_git/WindowsAppSDKClosed</Uri>
-      <Sha>3aa432601666c491686072d37bed862fb5f1b51c</Sha>
+      <Sha>222456f165ffb76b58b0054bf52ab5a46e624894</Sha>
     </Dependency>
   </ProductDependencies>
   <ToolsetDependencies>


### PR DESCRIPTION
This pull request updates the following dependencies

[marker]: <> (Begin:576bd47a-58f7-41d8-f501-08dbea320c61)
## From https://dev.azure.com/microsoft/ProjectReunion/_git/WindowsAppSDKClosed
- **Subscription**: 576bd47a-58f7-41d8-f501-08dbea320c61
- **Build**: 20240611.1
- **Date Produced**: 6/11/2024 11:52 PM
- **Commit**: 222456f165ffb76b58b0054bf52ab5a46e624894
- **Branch**: refs/heads/main

[DependencyUpdate]: <> (Begin)

- **Updates**:
  - **Microsoft.WindowsAppSDK.AppLicensingInternal.TransportPackage**: [from 1.7.0-main.20240513.0 to 1.7.0-main.20240611.0][1]

[1]: https://dev.azure.com/microsoft/ProjectReunion/_git/WindowsAppSDKClosed/branches?baseVersion=GC2c1c46a&targetVersion=GC222456f&_a=files

[DependencyUpdate]: <> (End)


[marker]: <> (End:576bd47a-58f7-41d8-f501-08dbea320c61)



