### PR TITLE
[mrtcore] Microsoft.Windows.Globalization.ApplicationLanguages API specs

### DIFF
--- a/specs/mrtcore/PrimaryLanguageOverride/PrimaryLanguageOverride.md
+++ b/specs/mrtcore/PrimaryLanguageOverride/PrimaryLanguageOverride.md
@@ -44,9 +44,10 @@ Note that these extensions can affect the numeral system or calendar used by glo
 ## ApplicationLanguages.PrimaryLanguageOverride property
 
 Gets or sets an override for the app's preferred language, expressed as a
-[BCP-47 language tag](https://tools.ietf.org/html/bcp47). Unlike
+[BCP-47 language tag](https://tools.ietf.org/html/bcp47). This setting is global for the running
+process. Unlike
 [Windows.Globalization.ApplicationLanguages.PrimaryLanguageOverride](https://learn.microsoft.com/uwp/api/windows.globalization.applicationlanguages.primarylanguageoverride),
-this setting is global for the running process and is not persisted.
+this setting is not persisted between app sessions.
 
 ```c#
 public static string PrimaryLanguageOverride { get; set; }

--- a/specs/mrtcore/PrimaryLanguageOverride/PrimaryLanguageOverride.md
+++ b/specs/mrtcore/PrimaryLanguageOverride/PrimaryLanguageOverride.md
@@ -1,24 +1,23 @@
 # ApplicationLanguages
 
-This new type (`Microsoft.Windows.ApplicationModel.Resources.ApplicationLanguages`) is a wrapper for
-the OS `Windows.Globalization.ApplicationLanguages` type with the updated behavior for the
-`PrimaryLanguageOverride` property to be supported for un-packaged apps.
+This new type (`Microsoft.Windows.Globalization.ApplicationLanguages`) is a wrapper for the OS
+`Windows.Globalization.ApplicationLanguages` type with the updated behavior for the
+`PrimaryLanguageOverride` property to be supported for unpackaged apps.
 
 # Background
 
 Changing the application language using
 [PrimaryLanguageOverride](https://learn.microsoft.com/uwp/api/windows.globalization.applicationlanguages.primarylanguageoverride)
 property from `Windows.Globalization.ApplicationLanguages` namespace is not supported for
-WindowsAppSDK un-packaged apps, only for packaged. To support language change for un-packaged
-applications `ApplicationLanguages` type is introduced in
-`Microsoft.Windows.ApplicationModel.Resources` MRTCore namespace.
-`Microsoft.Windows.ApplicationModel.Resources.ApplicationLanguages.PrimaryLanguageOverride` property
-is supported both for packaged and un-packaged WindowsAppSDK apps.
+WindowsAppSDK unpackaged apps, only for packaged. To support language change for unpackaged
+applications, `Microsoft.Windows.Globalization.ApplicationLanguages` type is introduced in
+MRTCore.`Microsoft.Windows.Globalization.ApplicationLanguages.PrimaryLanguageOverride` property is
+supported both for packaged and unpackaged WindowsAppSDK apps.
 
-This new type (`Microsoft.Windows.ApplicationModel.Resources.ApplicationLanguages`) is a wrapper for
-the OS type with the updated behavior for the `PrimaryLanguageOverride` to support un-packaged apps.
-`Microsoft.Windows.ApplicationModel.Resources.ApplicationLanguages` should serve as a replacement
-for the existing OS type (`Windows.Globalization.ApplicationLanguages.PrimaryLanguageOverride`).
+This new type (`Microsoft.Windows.Globalization.ApplicationLanguages`) is a wrapper for the OS type
+with the updated behavior for the `PrimaryLanguageOverride` to support unpackaged apps.
+`Microsoft.Windows.Globalization.ApplicationLanguages` should serve as a replacement for the
+existing OS type (`Windows.Globalization.ApplicationLanguages.PrimaryLanguageOverride`).
 
 `GetLanguagesForUser(User)` method from `Windows.Globalization.ApplicationLanguages` is being
 intentionally left off due to not being relevant for WinAppSDK.
@@ -44,10 +43,10 @@ claims about conventions that are used in the US such as the measurement system 
 Example:
 
 ```c#
-Microsoft.Windows.ApplicationModel.Resources.ApplicationLanguages.PrimaryLanguageOverride = "en-US";
+Microsoft.Windows.Globalization.ApplicationLanguages.PrimaryLanguageOverride = "en-US";
 ```
 
-Language tags support the Unicode extensions "ca-" and "nu-". (See Unicode Key/Type Definitions.)
+Language tags support the Unicode extensions "ca-" and "nu-" (See Unicode Key/Type Definitions.).
 Note that these extensions can affect the numeral system or calendar used by globalization objects.
 
 ## ApplicationLanguages.Languages property
@@ -78,18 +77,17 @@ section in
 
 ## ApplicationLanguages.ManifestLanguages property
 
-Gets the app's declared list of supported languages.
+Gets the declared list of supported languages in the app's manifest, or empty list for unpackaged
+applications.
 
 # Property Value
 
 [IReadOnlyList](https://learn.microsoft.com/dotnet/api/system.collections.generic.ireadonlylist-1)<[String](https://learn.microsoft.com/dotnet/api/system.string)>
 
-The list of supported languages declared in the app's manifest. For un-packaged applications,
-exception is thrown.
-
-Note: This property returns the same values as the language list exposed by
+For packaged applications, the list of supported languages declared in the app's manifest, same as
+the language list exposed by
 [Windows.Globalization.ApplicationLanguages.ManifestLanguages](https://learn.microsoft.com/uwp/api/windows.globalization.applicationlanguages.manifestlanguages)
-property.
+property. For unpackaged applications, empty list.
 
 # Remarks
 
@@ -108,7 +106,7 @@ Gets or sets an override for the app's preferred language, expressed as a
 wrapper for
 [Windows.Globalization.ApplicationLanguages.PrimaryLanguageOverride](https://learn.microsoft.com/uwp/api/windows.globalization.applicationlanguages.primarylanguageoverride)
 property and behaves the same. This setting is global for the running process. Unlike for packaged
-apps, for un-packaged apps, this setting is not persisted between app sessions.
+apps, for unpackaged apps, this setting is not persisted between app sessions.
 
 ```c#
 public static string PrimaryLanguageOverride { get; set; }
@@ -119,10 +117,16 @@ public static string PrimaryLanguageOverride { get; set; }
 [String](https://learn.microsoft.com/dotnet/api/system.string)
 
 A [BCP-47 language tag](https://tools.ietf.org/html/bcp47). The app can set it to override the
-language. It must be a single language tag; a delimited list of language tags will result in default
-language being used.
+language. It must be a single language tag; if delimited list of language tags or any value not
+representing a language tag is used, exception is thrown.
 
-The PrimaryLanguageOverride property should only be set to languages available for the app.
+The PrimaryLanguageOverride property should only be set to languages available for the app. For
+packaged apps, languages available for the app to use are limited to those languages included in the
+main app package manifest. The ApplicationLanguages.ManifestLanguages property reflects language
+resource packages that are available for the user, and returns an appropriate set of languages that
+can be used for setting the PrimaryLanguageOverride property. For unpackaged apps, languages
+available for the app to use are limited to languages for which your app has explicitely declared
+support.
 
 When your app gets the value, PrimaryLanguageOverride returns either a single language tag (if your
 app has previously set the property) or an empty string.
@@ -135,14 +139,15 @@ is used to override that behavior by setting a single specific language.
 
 For packaged apps, `PrimaryLanguageOverride` setting is a wrapper for
 [Windows.Globalization.ApplicationLanguages.PrimaryLanguageOverride](https://learn.microsoft.com/uwp/api/windows.globalization.applicationlanguages.primarylanguageoverride)
-property and behaves the same. It is persisted between app sessions.
+property and behaves the same. It is persisted between app sessions. The property should only be set
+based on user input presented in settings UI.
 
-For un-packaged apps, `PrimaryLanguageOverride` setting is not persisted between sessions. It should
+For unpackaged apps, `PrimaryLanguageOverride` setting is not persisted between sessions. It should
 be set each time the app is loaded. You should set PrimaryLanguageOverride setting in early stage of
 app loading, before any resource is loaded.
 
-The property should only be set based on user input presented in settings UI. It can be read at any
-time. If the property has never been set, it returns an empty string.
+The property can be read at any time. If the property has never been set, it returns an empty
+string.
 
 When you set the PrimaryLanguageOverride, this will be immediately reflected in resources loaded
 afterwards, both resources loaded from the code and the resources loaded by XAML. However, this
@@ -162,9 +167,9 @@ public partial class App : Application
         // This will cause the app to use the German (Germany) resources
         // Both resources loaded manually with ResourceLoader and XAML resources fetched with x:Uid
         // will be German (Germany)
-        Microsoft.Windows.ApplicationModel.Resources.ApplicationLanguages.PrimaryLanguageOverride = "de-DE";
+        Microsoft.Windows.Globalization.ApplicationLanguages.PrimaryLanguageOverride = "de-DE";
 
-        Microsoft.Windows.ApplicationModel.Resources.ResourceLoader resourceLoader = new Microsoft.Windows.ApplicationModel.Resources.ResourceLoader();
+        var resourceLoader = new Microsoft.Windows.ApplicationModel.Resources.ResourceLoader();
         var resourceString = resourceLoader.GetString("SampleString");
 
         this.InitializeComponent();
@@ -176,7 +181,7 @@ public partial class App : Application
 # API Details
 
 ```c# (but really MIDL3)
-namespace Microsoft.Windows.ApplicationModel.Resources
+namespace Microsoft.Windows.Globalization
 {
   // ...
   [contract(MrtCoreContract, 2)]

--- a/specs/mrtcore/PrimaryLanguageOverride/PrimaryLanguageOverride.md
+++ b/specs/mrtcore/PrimaryLanguageOverride/PrimaryLanguageOverride.md
@@ -1,27 +1,36 @@
-# ApplicationLanguages.PrimaryLanguageOverride
+# ApplicationLanguages
 
-This feature provides the ability to change the application language for WindowsAppSDK applications,
-comparable to the one in
-[Windows.Globalization.ApplicationLanguages.PrimaryLanguageOverride](https://learn.microsoft.com/uwp/api/windows.globalization.applicationlanguages).
-The benefit of this addition is that it applies to both packaged and un-packaged WindowsAppSDK
-applications, whereas the existing one is not supported for un-packaged.
+This new type (`Microsoft.Windows.ApplicationModel.Resources.ApplicationLanguages`) is a wrapper for
+the OS `Windows.Globalization.ApplicationLanguages` type with the updated behavior for the
+`PrimaryLanguageOverride` property to be supported for un-packaged apps.
 
 # Background
 
 Changing the application language using
 [PrimaryLanguageOverride](https://learn.microsoft.com/uwp/api/windows.globalization.applicationlanguages.primarylanguageoverride)
 property from `Windows.Globalization.ApplicationLanguages` namespace is not supported for
-WindowsAppSDK un-packaged apps, only for packaged. To support the same behavior for un-packaged
-applications `PrimaryLanguageOverride` property is introduced in
-`Microsoft.Windows.ApplicationModel.Resources` MRTCore namespace. This property
-(`Microsoft.Windows.ApplicationModel.Resources.PrimaryLanguageOverride`) overrides the behavior of
-the existing one (`Windows.Globalization.ApplicationLanguages.PrimaryLanguageOverride`).
+WindowsAppSDK un-packaged apps, only for packaged. To support language change for un-packaged
+applications `ApplicationLanguages` type is introduced in
+`Microsoft.Windows.ApplicationModel.Resources` MRTCore namespace.
+`Microsoft.Windows.ApplicationModel.Resources.ApplicationLanguages.PrimaryLanguageOverride` property
+is supported both for packaged and un-packaged WindowsAppSDK apps.
+
+This new type (`Microsoft.Windows.ApplicationModel.Resources.ApplicationLanguages`) is a wrapper for
+the OS type with the updated behavior for the `PrimaryLanguageOverride` to support un-packaged apps.
+`Microsoft.Windows.ApplicationModel.Resources.ApplicationLanguages` should serve as a replacement
+for the existing OS type (`Windows.Globalization.ApplicationLanguages.PrimaryLanguageOverride`).
+
+`GetLanguagesForUser(User)` method from `Windows.Globalization.ApplicationLanguages` is being
+intentionally left off due to not being relevant for WinAppSDK.
 
 # API Pages
 
 ## ApplicationLanguages class
 
-Specifies the language-related preferences that the app can use and maintain.
+Specifies the language-related preferences that the app can use and maintain. This class is based on
+OS
+[Windows.Globalization.ApplicationLanguages](https://learn.microsoft.com/uwp/api/windows.globalization.applicationlanguages)
+class. You should prefer this type for WinAppSDK apps over the OS one.
 
 # Remarks
 
@@ -53,7 +62,7 @@ A computed list of languages that merges the app's declared supported languages
 (ApplicationLanguages.ManifestLanguages) with the user's ranked list of preferred languages.
 
 Note: This property returns the same values as the language list exposed by
-[Windows.Globalization.ApplicationLanguages.Languages](https://learn.microsoft.com/uwp/api/windows.globalization.applicationlanguages.languages1)
+[Windows.Globalization.ApplicationLanguages.Languages](https://learn.microsoft.com/uwp/api/windows.globalization.applicationlanguages.languages)
 property.
 
 # Remarks
@@ -95,10 +104,11 @@ at the time the property is accessed.
 ## ApplicationLanguages.PrimaryLanguageOverride property
 
 Gets or sets an override for the app's preferred language, expressed as a
-[BCP-47 language tag](https://tools.ietf.org/html/bcp47). This setting is global for the running
-process. Unlike
-[Windows.Globalization.ApplicationLanguages.PrimaryLanguageOverride](https://learn.microsoft.com/uwp/api/windows.globalization.applicationlanguages.primarylanguageoverride),
-this setting is not persisted between app sessions.
+[BCP-47 language tag](https://tools.ietf.org/html/bcp47). For packaged apps, this property is a
+wrapper for
+[Windows.Globalization.ApplicationLanguages.PrimaryLanguageOverride](https://learn.microsoft.com/uwp/api/windows.globalization.applicationlanguages.primarylanguageoverride)
+property and behaves the same. This setting is global for the running process. Unlike for packaged
+apps, for un-packaged apps, this setting is not persisted between app sessions.
 
 ```c#
 public static string PrimaryLanguageOverride { get; set; }
@@ -123,21 +133,22 @@ Apps normally run with language settings determined by the system by comparing t
 supported by the app with the language preferences of the user. The PrimaryLanguageOverride property
 is used to override that behavior by setting a single specific language.
 
-The PrimaryLanguageOverride setting is not persisted between sessions. It should be set each time
-the app is loaded. You should set PrimaryLanguageOverride setting in early stage of app loading,
-before any resource is loaded. It should only be set based on user input presented in settings UI.
-The property can be read at any time. If the property has never been set, it returns an empty
-string.
+For packaged apps, `PrimaryLanguageOverride` setting is a wrapper for
+[Windows.Globalization.ApplicationLanguages.PrimaryLanguageOverride](https://learn.microsoft.com/uwp/api/windows.globalization.applicationlanguages.primarylanguageoverride)
+property and behaves the same. It is persisted between app sessions.
+
+For un-packaged apps, `PrimaryLanguageOverride` setting is not persisted between sessions. It should
+be set each time the app is loaded. You should set PrimaryLanguageOverride setting in early stage of
+app loading, before any resource is loaded.
+
+The property should only be set based on user input presented in settings UI. It can be read at any
+time. If the property has never been set, it returns an empty string.
 
 When you set the PrimaryLanguageOverride, this will be immediately reflected in resources loaded
 afterwards, both resources loaded from the code and the resources loaded by XAML. However, this
 change may not take effect immediately on resources already loaded in the app UI. To make sure the
 app responds to such changes, actions may be needed to reload resources. Those requirements may vary
 depending on the UI framework used by the app, and it may be necessary to restart the app.
-
-This property (Microsoft.Windows.ApplicationModel.Resources.PrimaryLanguageOverride) takes
-precedence over the existing one
-[Windows.Globalization.ApplicationLanguages.PrimaryLanguageOverride](https://learn.microsoft.com/uwp/api/windows.globalization.applicationlanguages.primarylanguageoverride).
 
 Example:
 
@@ -162,31 +173,6 @@ public partial class App : Application
 }
 ```
 
-## ApplicationLanguages.GetLanguagesForUser(User) Method
-
-Retrieves the language preferences of the specified user. This API is part of support for multi-user
-apps (MUA).
-
-```c#
-public static IReadOnlyList<string> GetLanguagesForUser(User user);
-```
-
-# Parameters
-
-`user` [User](https://learn.microsoft.com/uwp/api/windows.system.user?view=winrt-22621) \
-The user to retrieve preferences for.
-
-# Returns
-
-[IReadOnlyList](https://learn.microsoft.com/dotnet/api/system.collections.generic.ireadonlylist-1)<[String](https://learn.microsoft.com/dotnet/api/system.string)>
-
-A list of normalized [BCP-47](https://www.rfc-editor.org/info/bcp47) language tags representing the
-language preferences of the specified user.
-
-Note: This method returns the same values as the language list returned by
-[Windows.Globalization.ApplicationLanguages.GetLanguagesForUser](https://learn.microsoft.com/uwp/api/windows.globalization.applicationlanguages.getlanguagesforuser)
-property.
-
 # API Details
 
 ```c# (but really MIDL3)
@@ -199,8 +185,6 @@ namespace Microsoft.Windows.ApplicationModel.Resources
       static IVectorView<String> Languages { get; };
       static IVectorView<String> ManifestLanguages { get; };
       static String PrimaryLanguageOverride;
-
-      static IVectorView<String> GetLanguagesForUser(Windows.System.User user);
   }
 }
 ```

--- a/specs/mrtcore/PrimaryLanguageOverride/PrimaryLanguageOverride.md
+++ b/specs/mrtcore/PrimaryLanguageOverride/PrimaryLanguageOverride.md
@@ -26,35 +26,85 @@ Specifies the language-related preferences that the app can use and maintain.
 # Remarks
 
 The languages referenced in this class are represented by
-[BCP-47](https://tools.ietf.org/html/bcp47) language tags.
-
-_Spec note: Should there be more details about language format, like in Remarks section from
-https://learn.microsoft.com/uwp/api/windows.globalization.applicationlanguages?_
+[BCP-47](https://tools.ietf.org/html/bcp47) language tags. Each of these is a language identifier
+and not a locale name, although the two structurally can be the same. As a language tag, "en-US"
+means American English (or the dialect of English spoken in the United States). It makes no claims
+about the actual location of the speakers (though many of them do reside in the US) and no other
+claims about conventions that are used in the US such as the measurement system or currency.
 
 Example:
 
 ```c#
 Microsoft.Windows.ApplicationModel.Resources.ApplicationLanguages.PrimaryLanguageOverride = "en-US";
 ```
+
+Language tags support the Unicode extensions "ca-" and "nu-". (See Unicode Key/Type Definitions.)
+Note that these extensions can affect the numeral system or calendar used by globalization objects.
 
 ## ApplicationLanguages.PrimaryLanguageOverride property
 
-Specifies the language-related preferences that the app can use and maintain.
-
 Gets or sets an override for the app's preferred language, expressed as a
-[BCP-47 language tag](https://tools.ietf.org/html/bcp47).
-
-Example:
+[BCP-47 language tag](https://tools.ietf.org/html/bcp47). This setting is global for the running
+process and is not persisted.
 
 ```c#
-Microsoft.Windows.ApplicationModel.Resources.ApplicationLanguages.PrimaryLanguageOverride = "en-US";
+public static string PrimaryLanguageOverride { get; set; }
 ```
 
+# Property Value
+
+[String](https://learn.microsoft.com/dotnet/api/system.string)
+
+A [BCP-47 language tag](https://tools.ietf.org/html/bcp47). The app can set it to override the
+language. It must be a single language tag; a delimited list of language tags will result in default
+language being used.
+
+The PrimaryLanguageOverride property should only be set to languages available for the app.
+
+When your app gets the value, PrimaryLanguageOverride returns either a single language tag (if your
+app has previously set the property) or an empty string.
+
 # Remarks
+
+Apps normally run with language settings determined by the system by comparing the languages
+supported by the app with the language preferences of the user. The PrimaryLanguageOverride property
+is used to override that behavior by setting a single specific language.
+
+The PrimaryLanguageOverride setting is not persisted between sessions. It should be set each time
+the app is loaded. You should set PrimaryLanguageOverride setting in early stage of app loading,
+before any resource is loaded. It should only be set based on user input presented in settings UI.
+The property can be read at any time. If the property has never been set, it returns an empty
+string.
+
+When you set the PrimaryLanguageOverride, this will be immediately reflected in resources loaded
+afterwards, both resources loaded from the code and the resources loaded by XAML. However, this
+change may not take effect immediately on resources already loaded in the app UI. To make sure the
+app responds to such changes, actions may be needed to reload resources. Those requirements may vary
+depending on the UI framework used by the app, and it may be necessary to restart the app.
 
 This property overrides the behavior of
 [PrimaryLanguageOverride](https://learn.microsoft.com/uwp/api/windows.globalization.applicationlanguages.primarylanguageoverride)
 property from Windows.Globalization.ApplicationLanguages namespace property.
+
+Example:
+
+```c#
+public partial class App : Application
+{
+    // ...
+    public App()
+    {
+        // Set the primary language override to German (Germany)
+        // This will cause the app to use the German (Germany) resources
+        // Both resources loaded manually with ResourceLoader and XAML resources fetched with x:Uid
+        // will be German (Germany)
+        Microsoft.Windows.ApplicationModel.Resources.ApplicationLanguages.PrimaryLanguageOverride = "de-DE";
+
+        this.InitializeComponent();
+    }
+    // ...
+}
+```
 
 # API Details
 
@@ -62,7 +112,7 @@ property from Windows.Globalization.ApplicationLanguages namespace property.
 namespace Microsoft.Windows.ApplicationModel.Resources
 {
   // ...
-  [contract(MrtCoreContract, 1)]
+  [contract(MrtCoreContract, 2)]
   runtimeclass ApplicationLanguages
   {
       static String PrimaryLanguageOverride;

--- a/specs/mrtcore/PrimaryLanguageOverride/PrimaryLanguageOverride.md
+++ b/specs/mrtcore/PrimaryLanguageOverride/PrimaryLanguageOverride.md
@@ -41,6 +41,57 @@ Microsoft.Windows.ApplicationModel.Resources.ApplicationLanguages.PrimaryLanguag
 Language tags support the Unicode extensions "ca-" and "nu-". (See Unicode Key/Type Definitions.)
 Note that these extensions can affect the numeral system or calendar used by globalization objects.
 
+## ApplicationLanguages.Languages property
+
+Gets a ranked list of current runtime language values preferred by the user.
+
+# Property Value
+
+[IReadOnlyList](https://learn.microsoft.com/dotnet/api/system.collections.generic.ireadonlylist-1)<[String](https://learn.microsoft.com/dotnet/api/system.string)>
+
+A computed list of languages that merges the app's declared supported languages
+(ApplicationLanguages.ManifestLanguages) with the user's ranked list of preferred languages.
+
+Note: This property returns the same values as the language list exposed by
+[Windows.Globalization.ApplicationLanguages.Languages](https://learn.microsoft.com/uwp/api/windows.globalization.applicationlanguages.languages1)
+property.
+
+# Remarks
+
+At runtime, the list of languages for which your app has declared support (the app manifest language
+list) is compared with the list of languages for which the user has declared a preference (the user
+profile language list). The app runtime language list is set to this intersection (if the
+intersection is not empty), or to just the app's default language (if the intersection is empty).
+For more detail, see the
+[App runtime language list](https://learn.microsoft.com/windows/apps/design/globalizing/manage-language-and-region#app-runtime-language-list)
+section in
+[Understand user profile languages and app manifest languages](https://learn.microsoft.com/windows/apps/design/globalizing/manage-language-and-region).
+
+## ApplicationLanguages.ManifestLanguages property
+
+Gets the app's declared list of supported languages.
+
+# Property Value
+
+[IReadOnlyList](https://learn.microsoft.com/dotnet/api/system.collections.generic.ireadonlylist-1)<[String](https://learn.microsoft.com/dotnet/api/system.string)>
+
+The list of supported languages declared in the app's manifest. For un-packaged applications,
+exception is thrown.
+
+Note: This property returns the same values as the language list exposed by
+[Windows.Globalization.ApplicationLanguages.ManifestLanguages](https://learn.microsoft.com/uwp/api/windows.globalization.applicationlanguages.manifestlanguages)
+property.
+
+# Remarks
+
+When language resource packages are used, the packages that are installed and registered for a given
+user are determined by the languages in the user's language profile. The set of languages returned
+by the ManifestLanguages property is limited to the languages currently available on the system for
+the user. Languages included in the main app package manifest will always be returned; languages
+from resource packages will be returned only if the language is applicable for the user (that is, is
+in the user's preferences) and the resource package has been installed and registered for the user
+at the time the property is accessed.
+
 ## ApplicationLanguages.PrimaryLanguageOverride property
 
 Gets or sets an override for the app's preferred language, expressed as a
@@ -111,6 +162,31 @@ public partial class App : Application
 }
 ```
 
+## ApplicationLanguages.GetLanguagesForUser(User) Method
+
+Retrieves the language preferences of the specified user. This API is part of support for multi-user
+apps (MUA).
+
+```c#
+public static IReadOnlyList<string> GetLanguagesForUser(User user);
+```
+
+# Parameters
+
+`user` [User](https://learn.microsoft.com/uwp/api/windows.system.user?view=winrt-22621) \
+The user to retrieve preferences for.
+
+# Returns
+
+[IReadOnlyList](https://learn.microsoft.com/dotnet/api/system.collections.generic.ireadonlylist-1)<[String](https://learn.microsoft.com/dotnet/api/system.string)>
+
+A list of normalized [BCP-47](https://www.rfc-editor.org/info/bcp47) language tags representing the
+language preferences of the specified user.
+
+Note: This method returns the same values as the language list returned by
+[Windows.Globalization.ApplicationLanguages.GetLanguagesForUser](https://learn.microsoft.com/uwp/api/windows.globalization.applicationlanguages.getlanguagesforuser)
+property.
+
 # API Details
 
 ```c# (but really MIDL3)
@@ -120,7 +196,11 @@ namespace Microsoft.Windows.ApplicationModel.Resources
   [contract(MrtCoreContract, 2)]
   runtimeclass ApplicationLanguages
   {
+      static IVectorView<String> Languages { get; };
+      static IVectorView<String> ManifestLanguages { get; };
       static String PrimaryLanguageOverride;
+
+      static IVectorView<String> GetLanguagesForUser(Windows.System.User user);
   }
 }
 ```

--- a/specs/mrtcore/PrimaryLanguageOverride/PrimaryLanguageOverride.md
+++ b/specs/mrtcore/PrimaryLanguageOverride/PrimaryLanguageOverride.md
@@ -1,0 +1,71 @@
+# ApplicationLanguages.PrimaryLanguageOverride
+
+This feature provides the ability to change the application language for WindowsAppSDK applications,
+comparable to the one in
+[Windows.Globalization.ApplicationLanguages.PrimaryLanguageOverride](https://learn.microsoft.com/uwp/api/windows.globalization.applicationlanguages).
+The benefit of this addition is that it applies to both packaged and un-packaged WindowsAppSDK
+applications, whereas the existing one is not supported for un-packaged.
+
+# Background
+
+Changing the application language using
+[PrimaryLanguageOverride](https://learn.microsoft.com/uwp/api/windows.globalization.applicationlanguages.primarylanguageoverride)
+property from `Windows.Globalization.ApplicationLanguages` namespace is not supported for
+WindowsAppSDK un-packaged apps, only for packaged. To support the same behavior for un-packaged
+applications `PrimaryLanguageOverride` property is introduced in
+`Microsoft.Windows.ApplicationModel.Resources` MRTCore namespace. This property
+(`Microsoft.Windows.ApplicationModel.Resources.PrimaryLanguageOverride`) overrides the behavior of
+the existing one (`Windows.Globalization.ApplicationLanguages.PrimaryLanguageOverride`).
+
+# API Pages
+
+## ApplicationLanguages class
+
+Specifies the language-related preferences that the app can use and maintain.
+
+# Remarks
+
+The languages referenced in this class are represented by
+[BCP-47](https://tools.ietf.org/html/bcp47) language tags.
+
+_Spec note: Should there be more details about language format, like in Remarks section from
+https://learn.microsoft.com/uwp/api/windows.globalization.applicationlanguages?_
+
+Example:
+
+```c#
+Microsoft.Windows.ApplicationModel.Resources.ApplicationLanguages.PrimaryLanguageOverride = "en-US";
+```
+
+## ApplicationLanguages.PrimaryLanguageOverride property
+
+Specifies the language-related preferences that the app can use and maintain.
+
+Gets or sets an override for the app's preferred language, expressed as a
+[BCP-47 language tag](https://tools.ietf.org/html/bcp47).
+
+Example:
+
+```c#
+Microsoft.Windows.ApplicationModel.Resources.ApplicationLanguages.PrimaryLanguageOverride = "en-US";
+```
+
+# Remarks
+
+This property overrides the behavior of
+[PrimaryLanguageOverride](https://learn.microsoft.com/uwp/api/windows.globalization.applicationlanguages.primarylanguageoverride)
+property from Windows.Globalization.ApplicationLanguages namespace property.
+
+# API Details
+
+```c# (but really MIDL3)
+namespace Microsoft.Windows.ApplicationModel.Resources
+{
+  // ...
+  [contract(MrtCoreContract, 1)]
+  runtimeclass ApplicationLanguages
+  {
+      static String PrimaryLanguageOverride;
+  }
+}
+```

--- a/specs/mrtcore/PrimaryLanguageOverride/PrimaryLanguageOverride.md
+++ b/specs/mrtcore/PrimaryLanguageOverride/PrimaryLanguageOverride.md
@@ -44,8 +44,9 @@ Note that these extensions can affect the numeral system or calendar used by glo
 ## ApplicationLanguages.PrimaryLanguageOverride property
 
 Gets or sets an override for the app's preferred language, expressed as a
-[BCP-47 language tag](https://tools.ietf.org/html/bcp47). This setting is global for the running
-process and is not persisted.
+[BCP-47 language tag](https://tools.ietf.org/html/bcp47). Unlike
+[Windows.Globalization.ApplicationLanguages.PrimaryLanguageOverride](https://learn.microsoft.com/uwp/api/windows.globalization.applicationlanguages.primarylanguageoverride),
+this setting is global for the running process and is not persisted.
 
 ```c#
 public static string PrimaryLanguageOverride { get; set; }
@@ -82,9 +83,9 @@ change may not take effect immediately on resources already loaded in the app UI
 app responds to such changes, actions may be needed to reload resources. Those requirements may vary
 depending on the UI framework used by the app, and it may be necessary to restart the app.
 
-This property overrides the behavior of
-[PrimaryLanguageOverride](https://learn.microsoft.com/uwp/api/windows.globalization.applicationlanguages.primarylanguageoverride)
-property from Windows.Globalization.ApplicationLanguages namespace property.
+This property (Microsoft.Windows.ApplicationModel.Resources.PrimaryLanguageOverride) takes
+precedence over the existing one
+[Windows.Globalization.ApplicationLanguages.PrimaryLanguageOverride](https://learn.microsoft.com/uwp/api/windows.globalization.applicationlanguages.primarylanguageoverride).
 
 Example:
 
@@ -99,6 +100,9 @@ public partial class App : Application
         // Both resources loaded manually with ResourceLoader and XAML resources fetched with x:Uid
         // will be German (Germany)
         Microsoft.Windows.ApplicationModel.Resources.ApplicationLanguages.PrimaryLanguageOverride = "de-DE";
+
+        Microsoft.Windows.ApplicationModel.Resources.ResourceLoader resourceLoader = new Microsoft.Windows.ApplicationModel.Resources.ResourceLoader();
+        var resourceString = resourceLoader.GetString("SampleString");
 
         this.InitializeComponent();
     }


### PR DESCRIPTION
A microsoft employee must use /azp run to validate using the pipelines below.

Changing the application language using [PrimaryLanguageOverride](https://learn.microsoft.com/uwp/api/windows.globalization.applicationlanguages.primarylanguageoverride) property from `Windows.Globalization.ApplicationLanguages` namespace is not supported for WindowsAppSDK un-packaged apps, only for packaged. To support language change for unpackaged applications `Microsoft.Windows.Globalization.ApplicationLanguages` type is introduced in
MRTCore. `Microsoft.Windows.Globalization.ApplicationLanguages.PrimaryLanguageOverride` property is supported both for packaged and unpackaged WindowsAppSDK apps.

WARNING:
Comments made by azure-pipelines bot maybe inaccurate.
Please see pipeline link to verify that the build is being ran.

For status checks on the main branch, please use TransportPackage-Foundation-PR
(https://microsoft.visualstudio.com/ProjectReunion/_build?definitionId=81063&_a=summary)
and run the build against your PR branch with the default parameters.
