### PR TITLE
Remove unused variable group: PublicSymbols-Secrets

### DIFF
--- a/build/ProjectReunion-BuildFoundation.yml
+++ b/build/ProjectReunion-BuildFoundation.yml
@@ -14,7 +14,6 @@ variables:
 - template: WindowsAppSDK-CommonVariables.yml
 - template: WindowsAppSDK-Foundation-TestConfig.yml@WindowsAppSDKConfig
 - template: ..\eng\common\AzurePipelinesTemplates\WindowsAppSDK-GlobalVariables.yml
-- group: PublicSymbols-Secrets
 
 stages:
 - template: AzurePipelinesTemplates\WindowsAppSDK-Build-Stage.yml@self

--- a/build/WindowsAppSDK-Foundation-Nightly.yml
+++ b/build/WindowsAppSDK-Foundation-Nightly.yml
@@ -51,7 +51,6 @@ variables:
 - template: WindowsAppSDK-CommonVariables.yml
 - template: WindowsAppSDK-Foundation-TestConfig.yml@WindowsAppSDKConfig
 - template: ..\eng\common\AzurePipelinesTemplates\WindowsAppSDK-GlobalVariables.yml
-- group: PublicSymbols-Secrets
 
 extends:
   template: v2/Microsoft.NonOfficial.yml@templates # https://aka.ms/obpipelines/templates

--- a/build/WindowsAppSDK-Foundation-Official.yml
+++ b/build/WindowsAppSDK-Foundation-Official.yml
@@ -51,7 +51,6 @@ variables:
 - template: WindowsAppSDK-CommonVariables.yml
 - template: WindowsAppSDK-Foundation-TestConfig.yml@WindowsAppSDKConfig
 - template: ..\eng\common\AzurePipelinesTemplates\WindowsAppSDK-GlobalVariables.yml
-- group: PublicSymbols-Secrets
 
 extends:
   template: v2/Microsoft.Official.yml@templates # https://aka.ms/obpipelines/templates

--- a/build/WindowsAppSDK-Foundation-PR.yml
+++ b/build/WindowsAppSDK-Foundation-PR.yml
@@ -42,7 +42,6 @@ variables:
 - template: WindowsAppSDK-CommonVariables.yml
 - template: WindowsAppSDK-Foundation-TestConfig.yml@WindowsAppSDKConfig
 - template: ..\eng\common\AzurePipelinesTemplates\WindowsAppSDK-GlobalVariables.yml
-- group: PublicSymbols-Secrets
 
 extends:
   template: v2/Microsoft.NonOfficial.yml@templates # https://aka.ms/obpipelines/templates


### PR DESCRIPTION
Originally used in Symbols Publishing but is no longer needed