### PR TITLE
[PowerNotifications] Suspend status fix

### DIFF
--- a/dev/PowerNotifications/PowerNotifications.h
+++ b/dev/PowerNotifications/PowerNotifications.h
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft Corporation and Contributors.
+// Copyright (c) Microsoft Corporation and Contributors.
 // Licensed under the MIT License.
 
 #pragma once
@@ -633,8 +633,6 @@ namespace winrt::Microsoft::Windows::System::Power
                     m_systemSuspendStatus = SystemSuspendStatus::ManualResume;
                     RaiseEvent(systemSuspendFunc);
                 }
-                // Resetting the value after the callback
-                m_systemSuspendStatus = SystemSuspendStatus::Uninitialized;
             }
 
         };


### PR DESCRIPTION
This is a fix for PowerNotifications' Suspend Status callback throwing an exception. 

This was due to the code resetting the status and throwing an exception if the status is checked before it has been set/after it had been reset. The error here was that since there are multiple suspend callbacks from the system, the status was being reset before there was a chance to read it. The fix removes the resetting of the status as it isn't needed.

Fixes:
#2833 
