### PR TITLE
Update ESRPCodeSigningTask to Version 5; Use WindowsAppSDK-EsrpCodeSigning-Steps.yml From WindowsAppSDKConfig Repository

### DIFF
--- a/build/AzurePipelinesTemplates/WindowsAppSDK-BuildBinaries-AnyCPU-Steps.yml
+++ b/build/AzurePipelinesTemplates/WindowsAppSDK-BuildBinaries-AnyCPU-Steps.yml
@@ -34,7 +34,7 @@ steps:
 
 - ${{ if eq(parameters.runStaticAnalysis, 'True') }}:
   - task: SDLNativeRules@3
-    displayName: Run PREfast SDL Native Rules 
+    displayName: Run PREfast SDL Native Rules
     inputs:
       setupCommandlines: '"C:\Program Files\Microsoft Visual Studio\2022\Enterprise\Common7\Tools\VsMSBuildCmd.bat"'
       msBuildCommandline: 'msbuild.exe /restore /nologo /nr:false $(Build.SourcesDirectory)\dev\Bootstrap\CS\Microsoft.WindowsAppRuntime.Bootstrap.Net\Microsoft.WindowsAppRuntime.Bootstrap.Net.csproj'
@@ -56,50 +56,16 @@ steps:
     failOnAlert: true
 
 - ${{ if eq(parameters.SignOutput, 'true') }}:
-  - task: EsrpCodeSigning@2
-    inputs:
-      ConnectedServiceName: 'Project Reunion ESRP Code Signing Connection'
+  - template: AzurePipelinesTemplates/WindowsAppSDK-EsrpCodeSigning-Steps.yml@WindowsAppSDKConfig
+    parameters:
       FolderPath: '$(build.SourcesDirectory)\BuildOutput'
+      UseMinimatch: true
       Pattern: |
         **/*.winmd
         **/*.dll
         **/*.exe
-      UseMinimatch: true
-      signConfigType: 'inlineSignParams'
-      inlineOperation: |
-        [
-          {
-            "keyCode": "CP-230012",
-            "operationSetCode": "SigntoolSign",
-            "parameters": [
-              {
-                "parameterName": "OpusName",
-                "parameterValue": "Microsoft"
-              },
-              {
-                "parameterName": "OpusInfo",
-                "parameterValue": "http://www.microsoft.com"
-              },
-              {
-                "parameterName": "PageHash",
-                "parameterValue": "/NPH"
-              },
-              {
-                "parameterName": "FileDigest",
-                "parameterValue": "/fd sha256"
-              },
-              {
-                "parameterName": "TimeStamp",
-                "parameterValue": "/tr \"http://rfc3161.gtm.corp.microsoft.com/TSS/HttpTspServer\" /td sha256"
-              }
-            ],
-            "toolName": "signtool.exe",
-            "toolVersion": "6.2.9304.0"
-          }
-        ]
-      SessionTimeout: '60'
-      MaxConcurrency: '50'
-      MaxRetryAttempts: '5'
+      KeyCode: 'CP-230012'
+      displayName: 'Authenticode CodeSign Binaries'
 
 # Artifacts are uploaded via ob_outputDirectory where the each vPack Push jobs downloads from
 # so the CopyFiles below are to move all the vPack files to the right locations

--- a/build/AzurePipelinesTemplates/WindowsAppSDK-BuildBinaries-Steps.yml
+++ b/build/AzurePipelinesTemplates/WindowsAppSDK-BuildBinaries-Steps.yml
@@ -118,8 +118,7 @@ steps:
   - template: AzurePipelinesTemplates/WindowsAppSDK-EsrpCodeSigning-Steps.yml@WindowsAppSDKConfig
     parameters:
       FolderPath: '$(build.SourcesDirectory)\BuildOutput'
-          UseMinimatch: true
-
+      UseMinimatch: true
       Pattern: |
         **/*.winmd
         **/*.dll

--- a/build/AzurePipelinesTemplates/WindowsAppSDK-BuildBinaries-Steps.yml
+++ b/build/AzurePipelinesTemplates/WindowsAppSDK-BuildBinaries-Steps.yml
@@ -115,50 +115,17 @@ steps:
   #  continueOnError: true
 
 - ${{ if eq(parameters.SignOutput, 'true') }}:
-  - task: EsrpCodeSigning@2
-    inputs:
-      ConnectedServiceName: 'Project Reunion ESRP Code Signing Connection'
+  - template: AzurePipelinesTemplates/WindowsAppSDK-EsrpCodeSigning-Steps.yml@WindowsAppSDKConfig
+    parameters:
       FolderPath: '$(build.SourcesDirectory)\BuildOutput'
+          UseMinimatch: true
+
       Pattern: |
         **/*.winmd
         **/*.dll
         **/*.exe
-      UseMinimatch: true
-      signConfigType: 'inlineSignParams'
-      inlineOperation: |
-        [
-          {
-            "keyCode": "CP-230012",
-            "operationSetCode": "SigntoolSign",
-            "parameters": [
-              {
-                "parameterName": "OpusName",
-                "parameterValue": "Microsoft"
-              },
-              {
-                "parameterName": "OpusInfo",
-                "parameterValue": "http://www.microsoft.com"
-              },
-              {
-                "parameterName": "PageHash",
-                "parameterValue": "/NPH"
-              },
-              {
-                "parameterName": "FileDigest",
-                "parameterValue": "/fd sha256"
-              },
-              {
-                "parameterName": "TimeStamp",
-                "parameterValue": "/tr \"http://rfc3161.gtm.corp.microsoft.com/TSS/HttpTspServer\" /td sha256"
-              }
-            ],
-            "toolName": "signtool.exe",
-            "toolVersion": "6.2.9304.0"
-          }
-        ]
-      SessionTimeout: '60'
-      MaxConcurrency: '50'
-      MaxRetryAttempts: '5'
+      KeyCode: 'CP-230012'
+      displayName: 'Authenticode CodeSign Binaries'
 
 # Artifacts are uploaded via ob_outputDirectory where the each vPack Push jobs downloads from
 # so the CopyFiles below are to move all the vPack files to the right locations

--- a/build/AzurePipelinesTemplates/WindowsAppSDK-BuildMRT-Steps.yml
+++ b/build/AzurePipelinesTemplates/WindowsAppSDK-BuildMRT-Steps.yml
@@ -31,7 +31,7 @@ steps:
 
 - ${{ if eq(parameters.runStaticAnalysis, 'True') }}:
   - task: SDLNativeRules@3
-    displayName: Run PREfast SDL Native Rules 
+    displayName: Run PREfast SDL Native Rules
     condition: and(succeeded(), eq(variables['buildPlatform'], 'x64'), eq(variables['buildConfiguration'], 'Release'))
     inputs:
       setupCommandlines: '"C:\Program Files\Microsoft Visual Studio\2022\Enterprise\Common7\Tools\VsMSBuildCmd.bat"'
@@ -68,50 +68,16 @@ steps:
 - task: ms.vss-governance-buildtask.governance-build-task-component-detection.ComponentGovernanceComponentDetection@0
 
 - ${{ if eq(parameters.SignOutput, 'true') }}:
-  - task: EsrpCodeSigning@2
-    inputs:
-      ConnectedServiceName: 'Project Reunion ESRP Code Signing Connection'
+  - template: AzurePipelinesTemplates/WindowsAppSDK-EsrpCodeSigning-Steps.yml@WindowsAppSDKConfig
+    parameters:
       FolderPath: '$(build.SourcesDirectory)\BuildOutput'
+      UseMinimatch: true
       Pattern: |
         **/*.winmd
         **/*.dll
         **/*.exe
-      UseMinimatch: true
-      signConfigType: 'inlineSignParams'
-      inlineOperation: |
-        [
-          {
-            "keyCode": "CP-230012",
-            "operationSetCode": "SigntoolSign",
-            "parameters": [
-              {
-                "parameterName": "OpusName",
-                "parameterValue": "Microsoft"
-              },
-              {
-                "parameterName": "OpusInfo",
-                "parameterValue": "http://www.microsoft.com"
-              },
-              {
-                "parameterName": "PageHash",
-                "parameterValue": "/NPH"
-              },
-              {
-                "parameterName": "FileDigest",
-                "parameterValue": "/fd sha256"
-              },
-              {
-                "parameterName": "TimeStamp",
-                "parameterValue": "/tr \"http://rfc3161.gtm.corp.microsoft.com/TSS/HttpTspServer\" /td sha256"
-              }
-            ],
-            "toolName": "signtool.exe",
-            "toolVersion": "6.2.9304.0"
-          }
-        ]
-      SessionTimeout: '60'
-      MaxConcurrency: '50'
-      MaxRetryAttempts: '5'
+      KeyCode: 'CP-230012'
+      displayName: 'Authenticode CodeSign Binaries'
 
 - task: CopyFiles@2
   displayName: MoveToOutputDirectory

--- a/build/AzurePipelinesTemplates/WindowsAppSDK-PackTransportPackage-Stage.yml
+++ b/build/AzurePipelinesTemplates/WindowsAppSDK-PackTransportPackage-Stage.yml
@@ -193,33 +193,12 @@ stages:
     #       arguments: -Platform "x64" -Configuration "release" -AzureBuildStep "BuildMock" -OutputDirectory "$(build.artifactStagingDirectory)\FullNuget" -PackageVersion "$(packageVersion)"
 
     - ${{ if eq(parameters.SignOutput, 'true') }}:
-      - task: EsrpCodeSigning@2
-        inputs:
-          ConnectedServiceName: 'Project Reunion ESRP Code Signing Connection'
+      - template: AzurePipelinesTemplates/WindowsAppSDK-EsrpCodeSigning-Steps.yml@WindowsAppSDKConfig
+        parameters:
           FolderPath: $(build.artifactStagingDirectory)\FullNuget
           Pattern: 'Microsoft.WindowsAppSDK.Foundation*.nupkg'
+          KeyCode: 'CP-401405'
           UseMinimatch: true
-          signConfigType: 'inlineSignParams'
-          inlineOperation: |
-            [
-              {
-                "KeyCode" : "CP-401405",
-                "OperationCode" : "NuGetSign",
-                "Parameters" : {},
-                "ToolName" : "sign",
-                "ToolVersion" : "1.0"
-              },
-              {
-                  "KeyCode" : "CP-401405",
-                  "OperationCode" : "NuGetVerify",
-                  "Parameters" : {},
-                  "ToolName" : "sign",
-                  "ToolVersion" : "1.0"
-              }
-            ]
-          SessionTimeout: '60'
-          MaxConcurrency: '50'
-          MaxRetryAttempts: '5'
 
     - task: CopyFiles@2
       displayName: MoveToOutputDirectory


### PR DESCRIPTION
This template uses ESRPCodeSigningTask to version 5 which eliminates the use of secrets from the App Registration by using Federated Credentials.