### PR TITLE
Allow use of WindowsAppSDK-BuildInstaller-Steps.yml from the WindowsAppSDKAggregator Repository

### DIFF
--- a/build/AzurePipelinesTemplates/WindowsAppSDK-BuildInstaller-Stage.yml
+++ b/build/AzurePipelinesTemplates/WindowsAppSDK-BuildInstaller-Stage.yml
@@ -25,8 +25,6 @@ stages:
       ob_outputDirectory: '$(REPOROOT)\out'
       ob_artifactSuffix: '_$(buildConfiguration)_$(buildPlatform)'
       ob_artifactBaseName: "Installer$(ob_artifactSuffix)"
-      FoundationRepoName: "WindowsAppSDK"
+      FoundationRepoPath: ""
     steps:
-    - checkout: self
-      path: $(FoundationRepoName)
     - template: WindowsAppSDK-BuildInstaller-Steps.yml@self

--- a/build/AzurePipelinesTemplates/WindowsAppSDK-BuildInstaller-Stage.yml
+++ b/build/AzurePipelinesTemplates/WindowsAppSDK-BuildInstaller-Stage.yml
@@ -28,5 +28,5 @@ stages:
       FoundationRepoName: "WindowsAppSDK"
     steps:
     - checkout: self
-      path: "$(Pipeline.Workspace)/$(FoundationRepoName)"
+      path: "$(Pipeline.Workspace)\$(FoundationRepoName)"
     - template: WindowsAppSDK-BuildInstaller-Steps.yml@self

--- a/build/AzurePipelinesTemplates/WindowsAppSDK-BuildInstaller-Stage.yml
+++ b/build/AzurePipelinesTemplates/WindowsAppSDK-BuildInstaller-Stage.yml
@@ -25,6 +25,8 @@ stages:
       ob_outputDirectory: '$(REPOROOT)\out'
       ob_artifactSuffix: '_$(buildConfiguration)_$(buildPlatform)'
       ob_artifactBaseName: "Installer$(ob_artifactSuffix)"
-      FoundationRepoPath: ""
+      # foundationRepoPath should be empty because we are not doing multiple checkouts hence
+      # it is not under $(Build.SourcesDirectory)\WindowsAppSDK
+      foundationRepoPath: ""
     steps:
     - template: WindowsAppSDK-BuildInstaller-Steps.yml@self

--- a/build/AzurePipelinesTemplates/WindowsAppSDK-BuildInstaller-Stage.yml
+++ b/build/AzurePipelinesTemplates/WindowsAppSDK-BuildInstaller-Stage.yml
@@ -28,5 +28,5 @@ stages:
       FoundationRepoName: "WindowsAppSDK"
     steps:
     - checkout: self
-      path: "$(Pipeline.Workspace)\$(FoundationRepoName)"
+      path: "$(Pipeline.Workspace)\\$(FoundationRepoName)"
     - template: WindowsAppSDK-BuildInstaller-Steps.yml@self

--- a/build/AzurePipelinesTemplates/WindowsAppSDK-BuildInstaller-Stage.yml
+++ b/build/AzurePipelinesTemplates/WindowsAppSDK-BuildInstaller-Stage.yml
@@ -28,5 +28,5 @@ stages:
       FoundationRepoName: "WindowsAppSDK"
     steps:
     - checkout: self
-      path: "$(Pipeline.Workspace)\\$(FoundationRepoName)"
+      path: "$(Build.SourcesDirectory)\\$(FoundationRepoName)"
     - template: WindowsAppSDK-BuildInstaller-Steps.yml@self

--- a/build/AzurePipelinesTemplates/WindowsAppSDK-BuildInstaller-Stage.yml
+++ b/build/AzurePipelinesTemplates/WindowsAppSDK-BuildInstaller-Stage.yml
@@ -28,5 +28,5 @@ stages:
       FoundationRepoName: "WindowsAppSDK"
     steps:
     - checkout: self
-      path: "$(Build.SourcesDirectory)\\$(FoundationRepoName)"
+      path: $(FoundationRepoName)
     - template: WindowsAppSDK-BuildInstaller-Steps.yml@self

--- a/build/AzurePipelinesTemplates/WindowsAppSDK-BuildInstaller-Stage.yml
+++ b/build/AzurePipelinesTemplates/WindowsAppSDK-BuildInstaller-Stage.yml
@@ -1,7 +1,7 @@
 # This Installer Stage is purely for validation
 # The actual installer is built with the Aggregator build
 stages:
-- stage: InstallerValidation
+- stage: Installer
   jobs:
   - job: BuildInstaller
     dependsOn: []

--- a/build/AzurePipelinesTemplates/WindowsAppSDK-BuildInstaller-Stage.yml
+++ b/build/AzurePipelinesTemplates/WindowsAppSDK-BuildInstaller-Stage.yml
@@ -25,5 +25,8 @@ stages:
       ob_outputDirectory: '$(REPOROOT)\out'
       ob_artifactSuffix: '_$(buildConfiguration)_$(buildPlatform)'
       ob_artifactBaseName: "Installer$(ob_artifactSuffix)"
+      FoundationRepoName: "WindowsAppSDK"
     steps:
+    - checkout: self
+      path: "$(Pipeline.Workspace)/$(FoundationRepoName)"
     - template: WindowsAppSDK-BuildInstaller-Steps.yml@self

--- a/build/AzurePipelinesTemplates/WindowsAppSDK-BuildInstaller-Steps.yml
+++ b/build/AzurePipelinesTemplates/WindowsAppSDK-BuildInstaller-Steps.yml
@@ -55,7 +55,7 @@ steps:
   inputs:
     restoreSolution: WindowsAppSDK/build/packages.config
     feedsToUse: config
-    nugetConfigPath: WindowsAppSDK/build/nuget.config
+    nugetConfigPath: WindowsAppSDK/nuget.config
     restoreDirectory: packages
 
 - task: powershell@2

--- a/build/AzurePipelinesTemplates/WindowsAppSDK-BuildInstaller-Steps.yml
+++ b/build/AzurePipelinesTemplates/WindowsAppSDK-BuildInstaller-Steps.yml
@@ -47,22 +47,22 @@ steps:
   name: ConvertVersionDetailsToPackageConfig
   displayName: "Convert VersionDetails To PackageConfig"
   inputs:
-    filePath: '$(Build.SourcesDirectory)\$(FoundationRepoName)\build\Scripts\ConvertVersionDetailsToPackageConfig.ps1'
-    arguments: -versionDetailsPath '$(Build.SourcesDirectory)\$(FoundationRepoName)\eng\Version.Details.xml' -packageConfigPath '$(Build.SourcesDirectory)\$(FoundationRepoName)\build\packages.config'
+    filePath: '$(Build.SourcesDirectory)\WindowsAppSDK\build\Scripts\ConvertVersionDetailsToPackageConfig.ps1'
+    arguments: -versionDetailsPath '$(Build.SourcesDirectory)\WindowsAppSDK\eng\Version.Details.xml' -packageConfigPath '$(Build.SourcesDirectory)\WindowsAppSDK\build\packages.config'
 
 - task: 333b11bd-d341-40d9-afcf-b32d5ce6f23b@2
   displayName: RestoreNuGetPackages
   inputs:
-    restoreSolution: $(FoundationRepoName)/build/packages.config
+    restoreSolution: WindowsAppSDK/build/packages.config
     feedsToUse: config
-    nugetConfigPath: $(FoundationRepoName)/build/nuget.config
+    nugetConfigPath: WindowsAppSDK/build/nuget.config
     restoreDirectory: packages
 
 - task: powershell@2
   displayName: 'Create test pfx to sign MSIX test packages (DevCheck)'
   inputs:
     targetType: filePath
-    filePath: $(FoundationRepoName)\eng\common\DevCheck.ps1
+    filePath: WindowsAppSDK\eng\common\DevCheck.ps1
     arguments: -NoInteractive -Offline -Verbose -CertPassword 'BuildPipeline' -CheckTestPfx -Clean
     workingDirectory: '$(Build.SourcesDirectory)'
 
@@ -70,7 +70,7 @@ steps:
   displayName: 'Install test certificate for MSIX test packages (DevCheck)'
   inputs:
     targetType: filePath
-    filePath: $(FoundationRepoName)\eng\common\DevCheck.ps1
+    filePath: WindowsAppSDK\eng\common\DevCheck.ps1
     arguments: -NoInteractive -Offline -Verbose -CheckTestCert
     workingDirectory: '$(Build.SourcesDirectory)'
 
@@ -81,7 +81,7 @@ steps:
 - task: CopyFiles@2
   displayName: 'Copy licenses to target folder'
   inputs:
-    SourceFolder: '$(Build.SourcesDirectory)\$(FoundationRepoName)\build\packages\$(AppLicensingInternalPackageName).$(AppLicensingInternalPackageVersion)\licenses'
+    SourceFolder: '$(Build.SourcesDirectory)\WindowsAppSDK\build\packages\$(AppLicensingInternalPackageName).$(AppLicensingInternalPackageVersion)\licenses'
     Contents: |
       *.xml
     TargetFolder: '$(Build.SourcesDirectory)\InstallerInput'
@@ -91,10 +91,10 @@ steps:
 - task: CopyFiles@2
   displayName: 'Extract files needed for Nuget package'
   inputs:
-    SourceFolder: '$(Build.SourcesDirectory)\$(FoundationRepoName)\build\packages\$(AppLicensingInternalPackageName).$(AppLicensingInternalPackageVersion)\src'
+    SourceFolder: '$(Build.SourcesDirectory)\WindowsAppSDK\build\packages\$(AppLicensingInternalPackageName).$(AppLicensingInternalPackageVersion)\src'
     Contents: |
       *.h
-    TargetFolder: '$(Build.SourcesDirectory)\$(FoundationRepoName)\installer\dev'
+    TargetFolder: '$(Build.SourcesDirectory)\WindowsAppSDK\installer\dev'
     flattenFolders: false
     overWrite: true
 
@@ -105,7 +105,7 @@ steps:
 - task: PowerShell@2
   displayName: ExtractMSIXPackagesFromNuget
   inputs:
-    filePath: '$(Build.SourcesDirectory)\$(FoundationRepoName)\build\Scripts\ExtractMSIXFromNuget.ps1'
+    filePath: '$(Build.SourcesDirectory)\WindowsAppSDK\build\Scripts\ExtractMSIXFromNuget.ps1'
     arguments: >
       -Source '$(System.ArtifactsDirectory)'
       -Dest '$(Build.SourcesDirectory)\InstallerInput'
@@ -113,7 +113,7 @@ steps:
 - task: PowerShell@2
   displayName: CreateInstallerOverrideHeader
   inputs:
-    filePath: '$(Build.SourcesDirectory)\$(FoundationRepoName)\build\Scripts\CreateInstallerOverrideHeader.ps1'
+    filePath: '$(Build.SourcesDirectory)\WindowsAppSDK\build\Scripts\CreateInstallerOverrideHeader.ps1'
     arguments: >
       -SourceFolder '$(Build.SourcesDirectory)\InstallerInput'
       -DestinationFolder '$(Build.SourcesDirectory)\InstallerInput'
@@ -123,9 +123,9 @@ steps:
   displayName: 'Restore Windows App Runtime Install Nuget'
   inputs:
     command: 'restore'
-    restoreSolution: $(FoundationRepoName)\installer\WindowsAppRuntimeInstall.sln
+    restoreSolution: WindowsAppSDK\installer\WindowsAppRuntimeInstall.sln
     feedsToUse: config
-    nugetConfigPath: $(Build.SourcesDirectory)\$(FoundationRepoName)\nuget.config
+    nugetConfigPath: $(Build.SourcesDirectory)\WindowsAppSDK\nuget.config
 
 - task: CopyFiles@2
   displayName: 'Copy installer override header'
@@ -133,7 +133,7 @@ steps:
     SourceFolder: '$(Build.SourcesDirectory)\InstallerInput'
     Contents: |
       windowsappruntime_definitions_override.h
-    TargetFolder: $(FoundationRepoName)\installer\dev
+    TargetFolder: WindowsAppSDK\installer\dev
     flattenFolders: false
 
 - task: NuGetAuthenticate@1
@@ -147,7 +147,7 @@ steps:
   inputs:
     command: "custom"
     arguments:
-        'restore $(Build.SourcesDirectory)\$(FoundationRepoName)\installer\dev\telemetry\packages.config -ConfigFile $(Build.SourcesDirectory)\$(FoundationRepoName)\nuget.config -PackagesDirectory $(Build.SourcesDirectory)\$(FoundationRepoName)\packages'
+        'restore $(Build.SourcesDirectory)\WindowsAppSDK\installer\dev\telemetry\packages.config -ConfigFile $(Build.SourcesDirectory)\WindowsAppSDK\nuget.config -PackagesDirectory $(Build.SourcesDirectory)\WindowsAppSDK\packages'
 
 # Overwrite wil\Traceloggingconfig.h content in public nuget with that of MicrosoftTelemetry.h from internal nuget
 # This step enables telemetry in the Installer
@@ -156,10 +156,10 @@ steps:
   inputs:
     targetType: "inline"
     script: |
-        $srcPath = Get-Childitem -Path '$(Build.SourcesDirectory)\$(FoundationRepoName)\packages\' -File 'MicrosoftTelemetry.h' -Recurse
+        $srcPath = Get-Childitem -Path '$(Build.SourcesDirectory)\WindowsAppSDK\packages\' -File 'MicrosoftTelemetry.h' -Recurse
         if ($srcPath -ne $null)
         {
-          $destinationPaths = Get-Childitem -Path '$(Build.SourcesDirectory)\$(FoundationRepoName)\packages\' -File 'Traceloggingconfig.h' -Recurse
+          $destinationPaths = Get-Childitem -Path '$(Build.SourcesDirectory)\WindowsAppSDK\packages\' -File 'Traceloggingconfig.h' -Recurse
           if ($destinationPaths -ne $null)
           {
             foreach ($destPath in $destinationPaths)
@@ -169,14 +169,14 @@ steps:
           }
           else
           {
-            Write-Host Did not find the destination wil/traceloggingconfig.h under $(Build.SourcesDirectory)\$(FoundationRepoName)\packages\
-            Get-Childitem -Path '$(Build.SourcesDirectory)\$(FoundationRepoName)\packages\' -Recurse
+            Write-Host Did not find the destination wil/traceloggingconfig.h under $(Build.SourcesDirectory)\WindowsAppSDK\packages\
+            Get-Childitem -Path '$(Build.SourcesDirectory)\WindowsAppSDK\packages\' -Recurse
           }
         }
         else
         {
-          Write-Host Did not find the source MicrosoftTelemetry.h under $(Build.SourcesDirectory)\$(FoundationRepoName)\packages\
-          Get-Childitem -Path '$(Build.SourcesDirectory)\$(FoundationRepoName)\packages\' -Recurse
+          Write-Host Did not find the source MicrosoftTelemetry.h under $(Build.SourcesDirectory)\WindowsAppSDK\packages\
+          Get-Childitem -Path '$(Build.SourcesDirectory)\WindowsAppSDK\packages\' -Recurse
         }
 
 # Extract Microsoft.WindowsAppSDK Nuget package artifact published by BuildWindowsAppSDKPackages job of Aggregate stage,
@@ -188,12 +188,12 @@ steps:
     targetType: "inline"
     script: |
       $srcWinAppSDKNupkgPath = Get-Childitem -Path '$(System.ArtifactsDirectory)\NugetPackages' -File '*Microsoft.WindowsAppSDK*'
-      Copy-Item -Force $srcWinAppSDKNupkgPath.FullName '$(Build.SourcesDirectory)\$(FoundationRepoName)\packages\'
-      $destWinAppSDKNupkgPath = Get-Childitem -Path '$(Build.SourcesDirectory)\$(FoundationRepoName)\packages\' -File '*Microsoft.WindowsAppSDK*'
+      Copy-Item -Force $srcWinAppSDKNupkgPath.FullName '$(Build.SourcesDirectory)\WindowsAppSDK\packages\'
+      $destWinAppSDKNupkgPath = Get-Childitem -Path '$(Build.SourcesDirectory)\WindowsAppSDK\packages\' -File '*Microsoft.WindowsAppSDK*'
       $winAppSDKZip = $destWinAppSDKNupkgPath.FullName -replace '.nupkg','.zip'
       Rename-Item -Path $destWinAppSDKNupkgPath.FullName -NewName $winAppSDKZip
       Expand-Archive $winAppSDKZip -DestinationPath ($destWinAppSDKNupkgPath.Directory.FullName + '\' + $destWinAppSDKNupkgPath.BaseName)
-      Copy-Item -Force ($destWinAppSDKNupkgPath.Directory.FullName + '\' + $destWinAppSDKNupkgPath.BaseName + "\include\WindowsAppSDK-VersionInfo.h") '$(Build.SourcesDirectory)\$(FoundationRepoName)\installer\dev\'
+      Copy-Item -Force ($destWinAppSDKNupkgPath.Directory.FullName + '\' + $destWinAppSDKNupkgPath.BaseName + "\include\WindowsAppSDK-VersionInfo.h") '$(Build.SourcesDirectory)\WindowsAppSDK\installer\dev\'
 
 - task: WinUndockNativeCompiler@1
   displayName: 'Setup native compiler version override'
@@ -201,12 +201,12 @@ steps:
     microsoftDropReadPat: $(System.AccessToken)
     compilerPackageName: $(compilerOverridePackageName)
     compilerPackageVersion: $(compilerOverridePackageVersion)
-    slnDirectory: $(Build.SourcesDirectory)\$(FoundationRepoName)\installer\dev
+    slnDirectory: $(Build.SourcesDirectory)\WindowsAppSDK\installer\dev
 
 - task: VSBuild@1
   displayName: 'Build Windows App Runtime Install'
   inputs:
-    solution: $(FoundationRepoName)\installer\dev\WindowsAppRuntimeInstall.vcxproj
+    solution: WindowsAppSDK\installer\dev\WindowsAppRuntimeInstall.vcxproj
     platform: '$(buildPlatform)'
     configuration: '$(buildConfiguration)'
     ${{ if eq( parameters.runStaticAnalysis, 'True') }}:
@@ -235,14 +235,14 @@ steps:
 - ${{ if eq(parameters.IsOneBranch, 'true') }}:
   - template: ${{variables['System.DefaultWorkingDirectory']}}\build\AzurePipelinesTemplates\WindowsAppSDK-PublishSymbol-Steps.yml
     parameters:
-      SearchPattern: '$(FoundationRepoName)\BuildOutput\$(buildConfiguration)\$(buildPlatform)\WindowsAppRuntimeInstall\*.pdb'
+      SearchPattern: 'WindowsAppSDK\BuildOutput\$(buildConfiguration)\$(buildPlatform)\WindowsAppRuntimeInstall\*.pdb'
       IsOfficial: ${{ parameters.IsOfficial }}
-      PublishPublicSymbolsPowershellPath: '$(Build.SourcesDirectory)\$(FoundationRepoName)\eng\common\Scripts\PublishPublicSymbols.ps1'
+      PublishPublicSymbolsPowershellPath: '$(Build.SourcesDirectory)\WindowsAppSDK\eng\common\Scripts\PublishPublicSymbols.ps1'
 
 - ${{ if eq(parameters.SignOutput, 'true') }}:
   - template: ${{variables['System.DefaultWorkingDirectory']}}\AzurePipelinesTemplates/WindowsAppSDK-EsrpCodeSigning-Steps.yml@WindowsAppSDKConfig
     parameters:
-      FolderPath: $(FoundationRepoName)\BuildOutput\$(buildConfiguration)\$(buildPlatform)\WindowsAppRuntimeInstall'
+      FolderPath: WindowsAppSDK\BuildOutput\$(buildConfiguration)\$(buildPlatform)\WindowsAppRuntimeInstall'
       Pattern: WindowsAppRuntimeInstall*.exe
       UseMinimatch: true
       KeyCode: 'CP-230012'
@@ -250,14 +250,14 @@ steps:
 - task: CopyFiles@2
   displayName: 'Publish Installer'
   inputs:
-    SourceFolder: '$(FoundationRepoName)\BuildOutput'
+    SourceFolder: 'WindowsAppSDK\BuildOutput'
     TargetFolder: '$(ob_outputDirectory)\Installer'
 
 - task: powershell@2
   displayName: 'Remove test certificate for MSIX test packages (DevCheck)'
   inputs:
     targetType: filePath
-    filePath: $(FoundationRepoName)\eng\common\DevCheck.ps1
+    filePath: WindowsAppSDK\eng\common\DevCheck.ps1
     arguments: -NoInteractive -Offline -Verbose -RemoveTestCert -RemoveTestPfx
     workingDirectory: '$(Build.SourcesDirectory)'
 

--- a/build/AzurePipelinesTemplates/WindowsAppSDK-BuildInstaller-Steps.yml
+++ b/build/AzurePipelinesTemplates/WindowsAppSDK-BuildInstaller-Steps.yml
@@ -238,7 +238,7 @@ steps:
       PublishPublicSymbolsPowershellPath: '$(Build.SourcesDirectory)\eng\common\Scripts\PublishPublicSymbols.ps1'
 
 - ${{ if eq(parameters.SignOutput, 'true') }}:
-  - template: AzurePipelinesTemplates/WindowsAppSDK-EsrpCodeSigning-Steps.yml@WindowsAppSDKConfig
+  - template: ${{variables['System.DefaultWorkingDirectory']}}\AzurePipelinesTemplates/WindowsAppSDK-EsrpCodeSigning-Steps.yml@WindowsAppSDKConfig
     parameters:
       FolderPath: $(Build.SourcesDirectory)\BuildOutput\$(buildConfiguration)\$(buildPlatform)\WindowsAppRuntimeInstall'
       Pattern: WindowsAppRuntimeInstall*.exe

--- a/build/AzurePipelinesTemplates/WindowsAppSDK-BuildInstaller-Steps.yml
+++ b/build/AzurePipelinesTemplates/WindowsAppSDK-BuildInstaller-Steps.yml
@@ -8,21 +8,34 @@ parameters:
 - name: IsOneBranch
   type: boolean
   default: False
+- name: runStaticAnalysis
+  type: boolean
+  default: False
+- name: UseCurrentBuild
+  type: boolean
+  default: False 
 
 steps:
-###
-# This step downloads the WindowsAppSDK NuGet package from last successful build of the Aggregator's Nightly build
-# for use in building the installers
-- task: DownloadPipelineArtifact@2
-  displayName: 'Download WindowsAppSDK'
-  inputs:
-    artifactName: 'WindowsAppSDK_Nuget_And_MSIX'
-    targetPath: '$(System.ArtifactsDirectory)'
-    source: 'specific'
-    project: $(System.TeamProjectId)
-    pipeline: 118002         
-    runVersion: 'latestFromBranch'
-    runBranch: "refs/heads/main"
+- ${{ if eq(parameters.UseCurrentBuild, 'True') }}:
+  - task: DownloadPipelineArtifact@2
+    displayName: 'Download WindowsAppSDK'
+    inputs:
+      artifactName: 'WindowsAppSDK_Nuget_And_MSIX'
+      targetPath: '$(System.ArtifactsDirectory)'
+- ${{ else }}:
+  ###
+  # This step downloads the WindowsAppSDK NuGet package from last successful build of the Aggregator's Nightly build
+  # for use in building the installers
+  - task: DownloadPipelineArtifact@2
+    displayName: 'Download WindowsAppSDK'
+    inputs:
+      artifactName: 'WindowsAppSDK_Nuget_And_MSIX'
+      targetPath: '$(System.ArtifactsDirectory)'
+      source: 'specific'
+      project: $(System.TeamProjectId)
+      pipeline: 118002         
+      runVersion: 'latestFromBranch'
+      runBranch: "refs/heads/main"
 
 ###
 # Install the internal licensing support for release-signed packages. This can always be present in
@@ -196,6 +209,20 @@ steps:
     solution: installer\dev\WindowsAppRuntimeInstall.vcxproj
     platform: '$(buildPlatform)'
     configuration: '$(buildConfiguration)'
+
+- ${{ if eq(parameters.runStaticAnalysis, 'True') }}:
+  - task: SDLNativeRules@3
+    condition: and(succeeded(), eq(variables['buildConfiguration'], 'Release'), eq(variables['buildPlatform'], 'x64'))
+    displayName: Run the PREfast SDL Native Rules
+    inputs:
+      userProvideBuildInfo: auto
+      toolVersion: Latest
+      # Generally speaking, we leave it to the external repos to scan the bits in their packages.
+      excludedPaths: |
+        $(Build.SourcesDirectory)\packages
+    continueOnError: true
+    env:
+      SYSTEM_ACCESSTOKEN: $(System.AccessToken)
 
 - task: ms.vss-governance-buildtask.governance-build-task-component-detection.ComponentGovernanceComponentDetection@0
   displayName: 'Component Governance Detection'

--- a/build/AzurePipelinesTemplates/WindowsAppSDK-BuildInstaller-Steps.yml
+++ b/build/AzurePipelinesTemplates/WindowsAppSDK-BuildInstaller-Steps.yml
@@ -47,22 +47,22 @@ steps:
   name: ConvertVersionDetailsToPackageConfig
   displayName: "Convert VersionDetails To PackageConfig"
   inputs:
-    filePath: '$(Build.SourcesDirectory)\$(FoundationRepoPath)build\Scripts\ConvertVersionDetailsToPackageConfig.ps1'
-    arguments: -versionDetailsPath '$(Build.SourcesDirectory)\$(FoundationRepoPath)eng\Version.Details.xml' -packageConfigPath '$(Build.SourcesDirectory)\$(FoundationRepoPath)build\packages.config'
+    filePath: '$(Build.SourcesDirectory)\$(foundationRepoPath)build\Scripts\ConvertVersionDetailsToPackageConfig.ps1'
+    arguments: -versionDetailsPath '$(Build.SourcesDirectory)\$(foundationRepoPath)eng\Version.Details.xml' -packageConfigPath '$(Build.SourcesDirectory)\$(foundationRepoPath)build\packages.config'
 
 - task: 333b11bd-d341-40d9-afcf-b32d5ce6f23b@2
   displayName: RestoreNuGetPackages
   inputs:
-    restoreSolution: $(FoundationRepoPath)build/packages.config
+    restoreSolution: $(foundationRepoPath)build/packages.config
     feedsToUse: config
-    nugetConfigPath: $(FoundationRepoPath)nuget.config
+    nugetConfigPath: $(foundationRepoPath)nuget.config
     restoreDirectory: packages
 
 - task: powershell@2
   displayName: 'Create test pfx to sign MSIX test packages (DevCheck)'
   inputs:
     targetType: filePath
-    filePath: $(FoundationRepoPath)eng\common\DevCheck.ps1
+    filePath: $(foundationRepoPath)eng\common\DevCheck.ps1
     arguments: -NoInteractive -Offline -Verbose -CertPassword 'BuildPipeline' -CheckTestPfx -Clean
     workingDirectory: '$(Build.SourcesDirectory)'
 
@@ -70,7 +70,7 @@ steps:
   displayName: 'Install test certificate for MSIX test packages (DevCheck)'
   inputs:
     targetType: filePath
-    filePath: $(FoundationRepoPath)eng\common\DevCheck.ps1
+    filePath: $(foundationRepoPath)eng\common\DevCheck.ps1
     arguments: -NoInteractive -Offline -Verbose -CheckTestCert
     workingDirectory: '$(Build.SourcesDirectory)'
 
@@ -81,7 +81,7 @@ steps:
 - task: CopyFiles@2
   displayName: 'Copy licenses to target folder'
   inputs:
-    SourceFolder: '$(Build.SourcesDirectory)\$(FoundationRepoPath)build\packages\$(AppLicensingInternalPackageName).$(AppLicensingInternalPackageVersion)\licenses'
+    SourceFolder: '$(Build.SourcesDirectory)\$(foundationRepoPath)build\packages\$(AppLicensingInternalPackageName).$(AppLicensingInternalPackageVersion)\licenses'
     Contents: |
       *.xml
     TargetFolder: '$(Build.SourcesDirectory)\InstallerInput'
@@ -91,10 +91,10 @@ steps:
 - task: CopyFiles@2
   displayName: 'Extract files needed for Nuget package'
   inputs:
-    SourceFolder: '$(Build.SourcesDirectory)\$(FoundationRepoPath)build\packages\$(AppLicensingInternalPackageName).$(AppLicensingInternalPackageVersion)\src'
+    SourceFolder: '$(Build.SourcesDirectory)\$(foundationRepoPath)build\packages\$(AppLicensingInternalPackageName).$(AppLicensingInternalPackageVersion)\src'
     Contents: |
       *.h
-    TargetFolder: '$(Build.SourcesDirectory)\$(FoundationRepoPath)installer\dev'
+    TargetFolder: '$(Build.SourcesDirectory)\$(foundationRepoPath)installer\dev'
     flattenFolders: false
     overWrite: true
 
@@ -105,7 +105,7 @@ steps:
 - task: PowerShell@2
   displayName: ExtractMSIXPackagesFromNuget
   inputs:
-    filePath: '$(Build.SourcesDirectory)\$(FoundationRepoPath)build\Scripts\ExtractMSIXFromNuget.ps1'
+    filePath: '$(Build.SourcesDirectory)\$(foundationRepoPath)build\Scripts\ExtractMSIXFromNuget.ps1'
     arguments: >
       -Source '$(System.ArtifactsDirectory)'
       -Dest '$(Build.SourcesDirectory)\InstallerInput'
@@ -113,7 +113,7 @@ steps:
 - task: PowerShell@2
   displayName: CreateInstallerOverrideHeader
   inputs:
-    filePath: '$(Build.SourcesDirectory)\$(FoundationRepoPath)build\Scripts\CreateInstallerOverrideHeader.ps1'
+    filePath: '$(Build.SourcesDirectory)\$(foundationRepoPath)build\Scripts\CreateInstallerOverrideHeader.ps1'
     arguments: >
       -SourceFolder '$(Build.SourcesDirectory)\InstallerInput'
       -DestinationFolder '$(Build.SourcesDirectory)\InstallerInput'
@@ -123,9 +123,9 @@ steps:
   displayName: 'Restore Windows App Runtime Install Nuget'
   inputs:
     command: 'restore'
-    restoreSolution: $(FoundationRepoPath)installer\WindowsAppRuntimeInstall.sln
+    restoreSolution: $(foundationRepoPath)installer\WindowsAppRuntimeInstall.sln
     feedsToUse: config
-    nugetConfigPath: $(Build.SourcesDirectory)\$(FoundationRepoPath)nuget.config
+    nugetConfigPath: $(Build.SourcesDirectory)\$(foundationRepoPath)nuget.config
 
 - task: CopyFiles@2
   displayName: 'Copy installer override header'
@@ -133,7 +133,7 @@ steps:
     SourceFolder: '$(Build.SourcesDirectory)\InstallerInput'
     Contents: |
       windowsappruntime_definitions_override.h
-    TargetFolder: $(FoundationRepoPath)installer\dev
+    TargetFolder: $(foundationRepoPath)installer\dev
     flattenFolders: false
 
 - task: NuGetAuthenticate@1
@@ -147,7 +147,7 @@ steps:
   inputs:
     command: "custom"
     arguments:
-        'restore $(Build.SourcesDirectory)\$(FoundationRepoPath)installer\dev\telemetry\packages.config -ConfigFile $(Build.SourcesDirectory)\$(FoundationRepoPath)nuget.config -PackagesDirectory $(Build.SourcesDirectory)\$(FoundationRepoPath)packages'
+        'restore $(Build.SourcesDirectory)\$(foundationRepoPath)installer\dev\telemetry\packages.config -ConfigFile $(Build.SourcesDirectory)\$(foundationRepoPath)nuget.config -PackagesDirectory $(Build.SourcesDirectory)\$(foundationRepoPath)packages'
 
 # Overwrite wil\Traceloggingconfig.h content in public nuget with that of MicrosoftTelemetry.h from internal nuget
 # This step enables telemetry in the Installer
@@ -156,10 +156,10 @@ steps:
   inputs:
     targetType: "inline"
     script: |
-        $srcPath = Get-Childitem -Path '$(Build.SourcesDirectory)\$(FoundationRepoPath)packages\' -File 'MicrosoftTelemetry.h' -Recurse
+        $srcPath = Get-Childitem -Path '$(Build.SourcesDirectory)\$(foundationRepoPath)packages\' -File 'MicrosoftTelemetry.h' -Recurse
         if ($srcPath -ne $null)
         {
-          $destinationPaths = Get-Childitem -Path '$(Build.SourcesDirectory)\$(FoundationRepoPath)packages\' -File 'Traceloggingconfig.h' -Recurse
+          $destinationPaths = Get-Childitem -Path '$(Build.SourcesDirectory)\$(foundationRepoPath)packages\' -File 'Traceloggingconfig.h' -Recurse
           if ($destinationPaths -ne $null)
           {
             foreach ($destPath in $destinationPaths)
@@ -169,14 +169,14 @@ steps:
           }
           else
           {
-            Write-Host Did not find the destination wil/traceloggingconfig.h under $(Build.SourcesDirectory)\$(FoundationRepoPath)packages\
-            Get-Childitem -Path '$(Build.SourcesDirectory)\$(FoundationRepoPath)packages\' -Recurse
+            Write-Host Did not find the destination wil/traceloggingconfig.h under $(Build.SourcesDirectory)\$(foundationRepoPath)packages\
+            Get-Childitem -Path '$(Build.SourcesDirectory)\$(foundationRepoPath)packages\' -Recurse
           }
         }
         else
         {
-          Write-Host Did not find the source MicrosoftTelemetry.h under $(Build.SourcesDirectory)\$(FoundationRepoPath)packages\
-          Get-Childitem -Path '$(Build.SourcesDirectory)\$(FoundationRepoPath)packages\' -Recurse
+          Write-Host Did not find the source MicrosoftTelemetry.h under $(Build.SourcesDirectory)\$(foundationRepoPath)packages\
+          Get-Childitem -Path '$(Build.SourcesDirectory)\$(foundationRepoPath)packages\' -Recurse
         }
 
 # Extract Microsoft.WindowsAppSDK Nuget package artifact published by BuildWindowsAppSDKPackages job of Aggregate stage,
@@ -188,12 +188,12 @@ steps:
     targetType: "inline"
     script: |
       $srcWinAppSDKNupkgPath = Get-Childitem -Path '$(System.ArtifactsDirectory)\NugetPackages' -File '*Microsoft.WindowsAppSDK*'
-      Copy-Item -Force $srcWinAppSDKNupkgPath.FullName '$(Build.SourcesDirectory)\$(FoundationRepoPath)packages\'
-      $destWinAppSDKNupkgPath = Get-Childitem -Path '$(Build.SourcesDirectory)\$(FoundationRepoPath)packages\' -File '*Microsoft.WindowsAppSDK*'
+      Copy-Item -Force $srcWinAppSDKNupkgPath.FullName '$(Build.SourcesDirectory)\$(foundationRepoPath)packages\'
+      $destWinAppSDKNupkgPath = Get-Childitem -Path '$(Build.SourcesDirectory)\$(foundationRepoPath)packages\' -File '*Microsoft.WindowsAppSDK*'
       $winAppSDKZip = $destWinAppSDKNupkgPath.FullName -replace '.nupkg','.zip'
       Rename-Item -Path $destWinAppSDKNupkgPath.FullName -NewName $winAppSDKZip
       Expand-Archive $winAppSDKZip -DestinationPath ($destWinAppSDKNupkgPath.Directory.FullName + '\' + $destWinAppSDKNupkgPath.BaseName)
-      Copy-Item -Force ($destWinAppSDKNupkgPath.Directory.FullName + '\' + $destWinAppSDKNupkgPath.BaseName + "\include\WindowsAppSDK-VersionInfo.h") '$(Build.SourcesDirectory)\$(FoundationRepoPath)installer\dev\'
+      Copy-Item -Force ($destWinAppSDKNupkgPath.Directory.FullName + '\' + $destWinAppSDKNupkgPath.BaseName + "\include\WindowsAppSDK-VersionInfo.h") '$(Build.SourcesDirectory)\$(foundationRepoPath)installer\dev\'
 
 - task: WinUndockNativeCompiler@1
   displayName: 'Setup native compiler version override'
@@ -201,12 +201,12 @@ steps:
     microsoftDropReadPat: $(System.AccessToken)
     compilerPackageName: $(compilerOverridePackageName)
     compilerPackageVersion: $(compilerOverridePackageVersion)
-    slnDirectory: $(Build.SourcesDirectory)\$(FoundationRepoPath)installer\dev
+    slnDirectory: $(Build.SourcesDirectory)\$(foundationRepoPath)installer\dev
 
 - task: VSBuild@1
   displayName: 'Build Windows App Runtime Install'
   inputs:
-    solution: $(FoundationRepoPath)installer\dev\WindowsAppRuntimeInstall.vcxproj
+    solution: $(foundationRepoPath)installer\dev\WindowsAppRuntimeInstall.vcxproj
     platform: '$(buildPlatform)'
     configuration: '$(buildConfiguration)'
     ${{ if eq( parameters.runStaticAnalysis, 'True') }}:
@@ -235,14 +235,14 @@ steps:
 - ${{ if eq(parameters.IsOneBranch, 'true') }}:
   - template: ${{variables['System.DefaultWorkingDirectory']}}\build\AzurePipelinesTemplates\WindowsAppSDK-PublishSymbol-Steps.yml
     parameters:
-      SearchPattern: '$(FoundationRepoPath)BuildOutput\$(buildConfiguration)\$(buildPlatform)\WindowsAppRuntimeInstall\*.pdb'
+      SearchPattern: '$(foundationRepoPath)BuildOutput\$(buildConfiguration)\$(buildPlatform)\WindowsAppRuntimeInstall\*.pdb'
       IsOfficial: ${{ parameters.IsOfficial }}
-      PublishPublicSymbolsPowershellPath: '$(Build.SourcesDirectory)\$(FoundationRepoPath)eng\common\Scripts\PublishPublicSymbols.ps1'
+      PublishPublicSymbolsPowershellPath: '$(Build.SourcesDirectory)\$(foundationRepoPath)eng\common\Scripts\PublishPublicSymbols.ps1'
 
 - ${{ if eq(parameters.SignOutput, 'true') }}:
   - template: ${{variables['System.DefaultWorkingDirectory']}}\AzurePipelinesTemplates/WindowsAppSDK-EsrpCodeSigning-Steps.yml@WindowsAppSDKConfig
     parameters:
-      FolderPath: $(FoundationRepoPath)BuildOutput\$(buildConfiguration)\$(buildPlatform)\WindowsAppRuntimeInstall'
+      FolderPath: $(foundationRepoPath)BuildOutput\$(buildConfiguration)\$(buildPlatform)\WindowsAppRuntimeInstall'
       Pattern: WindowsAppRuntimeInstall*.exe
       UseMinimatch: true
       KeyCode: 'CP-230012'
@@ -250,14 +250,14 @@ steps:
 - task: CopyFiles@2
   displayName: 'Publish Installer'
   inputs:
-    SourceFolder: '$(FoundationRepoPath)BuildOutput'
+    SourceFolder: '$(foundationRepoPath)BuildOutput'
     TargetFolder: '$(ob_outputDirectory)\Installer'
 
 - task: powershell@2
   displayName: 'Remove test certificate for MSIX test packages (DevCheck)'
   inputs:
     targetType: filePath
-    filePath: $(FoundationRepoPath)eng\common\DevCheck.ps1
+    filePath: $(foundationRepoPath)eng\common\DevCheck.ps1
     arguments: -NoInteractive -Offline -Verbose -RemoveTestCert -RemoveTestPfx
     workingDirectory: '$(Build.SourcesDirectory)'
 

--- a/build/AzurePipelinesTemplates/WindowsAppSDK-BuildInstaller-Steps.yml
+++ b/build/AzurePipelinesTemplates/WindowsAppSDK-BuildInstaller-Steps.yml
@@ -234,14 +234,14 @@ steps:
     failOnAlert: true
 
 - ${{ if eq(parameters.IsOneBranch, 'true') }}:
-  - template: ${{variables['System.DefaultWorkingDirectory']}}\build\AzurePipelinesTemplates\WindowsAppSDK-PublishSymbol-Steps.yml
+  - template: ${{variables['System.DefaultWorkingDirectory']}}${{ parameters.CheckoutPath }}\build\AzurePipelinesTemplates\WindowsAppSDK-PublishSymbol-Steps.yml
     parameters:
       SearchPattern: '$(Build.SourcesDirectory)${{ parameters.CheckoutPath }}\BuildOutput\$(buildConfiguration)\$(buildPlatform)\WindowsAppRuntimeInstall\*.pdb'
       IsOfficial: ${{ parameters.IsOfficial }}
       PublishPublicSymbolsPowershellPath: '$(Build.SourcesDirectory)${{ parameters.CheckoutPath }}\eng\common\Scripts\PublishPublicSymbols.ps1'
 
 - ${{ if eq(parameters.SignOutput, 'true') }}:
-  - template: ${{variables['System.DefaultWorkingDirectory']}}\AzurePipelinesTemplates/WindowsAppSDK-EsrpCodeSigning-Steps.yml@WindowsAppSDKConfig
+  - template: ${{variables['System.DefaultWorkingDirectory']}}${{ parameters.CheckoutPath }}\AzurePipelinesTemplates/WindowsAppSDK-EsrpCodeSigning-Steps.yml@WindowsAppSDKConfig
     parameters:
       FolderPath: $(Build.SourcesDirectory)${{ parameters.CheckoutPath }}\BuildOutput\$(buildConfiguration)\$(buildPlatform)\WindowsAppRuntimeInstall'
       Pattern: WindowsAppRuntimeInstall*.exe

--- a/build/AzurePipelinesTemplates/WindowsAppSDK-BuildInstaller-Steps.yml
+++ b/build/AzurePipelinesTemplates/WindowsAppSDK-BuildInstaller-Steps.yml
@@ -14,7 +14,10 @@ parameters:
 - name: UseCurrentBuild
   type: boolean
   default: False 
-
+- name: CheckoutPath
+  type: string
+  default: "" 
+  
 steps:
 - ${{ if eq(parameters.UseCurrentBuild, 'True') }}:
   - task: DownloadPipelineArtifact@2
@@ -47,22 +50,22 @@ steps:
   name: ConvertVersionDetailsToPackageConfig
   displayName: "Convert VersionDetails To PackageConfig"
   inputs:
-    filePath: '$(Build.SourcesDirectory)\build\Scripts\ConvertVersionDetailsToPackageConfig.ps1'
-    arguments: -versionDetailsPath '$(Build.SourcesDirectory)\eng\Version.Details.xml' -packageConfigPath '$(Build.SourcesDirectory)\build\packages.config'
+    filePath: '$(Build.SourcesDirectory)${{ parameters.CheckoutPath }}\build\Scripts\ConvertVersionDetailsToPackageConfig.ps1'
+    arguments: -versionDetailsPath '$(Build.SourcesDirectory)${{ parameters.CheckoutPath }}\eng\Version.Details.xml' -packageConfigPath '$(Build.SourcesDirectory)${{ parameters.CheckoutPath }}\build\packages.config'
 
 - task: 333b11bd-d341-40d9-afcf-b32d5ce6f23b@2
   displayName: RestoreNuGetPackages
   inputs:
-    restoreSolution: $(Build.SourcesDirectory)/build/packages.config
+    restoreSolution: $(Build.SourcesDirectory)${{ parameters.CheckoutPath }}/build/packages.config
     feedsToUse: config
-    nugetConfigPath: $(Build.SourcesDirectory)/nuget.config
+    nugetConfigPath: $(Build.SourcesDirectory)${{ parameters.CheckoutPath }}/nuget.config
     restoreDirectory: packages
 
 - task: powershell@2
   displayName: 'Create test pfx to sign MSIX test packages (DevCheck)'
   inputs:
     targetType: filePath
-    filePath: eng\common\DevCheck.ps1
+    filePath: ${{ parameters.CheckoutPath }}eng\common\DevCheck.ps1
     arguments: -NoInteractive -Offline -Verbose -CertPassword 'BuildPipeline' -CheckTestPfx -Clean
     workingDirectory: '$(Build.SourcesDirectory)'
 
@@ -70,7 +73,7 @@ steps:
   displayName: 'Install test certificate for MSIX test packages (DevCheck)'
   inputs:
     targetType: filePath
-    filePath: eng\common\DevCheck.ps1
+    filePath: ${{ parameters.CheckoutPath }}eng\common\DevCheck.ps1
     arguments: -NoInteractive -Offline -Verbose -CheckTestCert
     workingDirectory: '$(Build.SourcesDirectory)'
 
@@ -81,20 +84,20 @@ steps:
 - task: CopyFiles@2
   displayName: 'Copy licenses to target folder'
   inputs:
-    SourceFolder: '$(Build.SourcesDirectory)\build\packages\$(AppLicensingInternalPackageName).$(AppLicensingInternalPackageVersion)\licenses'
+    SourceFolder: '$(Build.SourcesDirectory)${{ parameters.CheckoutPath }}\build\packages\$(AppLicensingInternalPackageName).$(AppLicensingInternalPackageVersion)\licenses'
     Contents: |
       *.xml
-    TargetFolder: '$(Build.SourcesDirectory)\InstallerInput'
+    TargetFolder: '$(Build.SourcesDirectory)${{ parameters.CheckoutPath }}\InstallerInput'
     flattenFolders: false
 
 # Copy license installation header into the correct installer source location.
 - task: CopyFiles@2
   displayName: 'Extract files needed for Nuget package'
   inputs:
-    SourceFolder: '$(Build.SourcesDirectory)\build\packages\$(AppLicensingInternalPackageName).$(AppLicensingInternalPackageVersion)\src'
+    SourceFolder: '$(Build.SourcesDirectory)${{ parameters.CheckoutPath }}\build\packages\$(AppLicensingInternalPackageName).$(AppLicensingInternalPackageVersion)\src'
     Contents: |
       *.h
-    TargetFolder: '$(Build.SourcesDirectory)\installer\dev'
+    TargetFolder: '$(Build.SourcesDirectory)${{ parameters.CheckoutPath }}\installer\dev'
     flattenFolders: false
     overWrite: true
 
@@ -105,7 +108,7 @@ steps:
 - task: PowerShell@2
   displayName: ExtractMSIXPackagesFromNuget
   inputs:
-    filePath: '$(Build.SourcesDirectory)\build\scripts\ExtractMSIXFromNuget.ps1'
+    filePath: '$(Build.SourcesDirectory)${{ parameters.CheckoutPath }}\build\scripts\ExtractMSIXFromNuget.ps1'
     arguments: >
       -Source '$(System.ArtifactsDirectory)'
       -Dest '$(Build.SourcesDirectory)\InstallerInput'
@@ -113,7 +116,7 @@ steps:
 - task: PowerShell@2
   displayName: CreateInstallerOverrideHeader
   inputs:
-    filePath: '$(Build.SourcesDirectory)\build\Scripts\CreateInstallerOverrideHeader.ps1'
+    filePath: '$(Build.SourcesDirectory)${{ parameters.CheckoutPath }}\build\Scripts\CreateInstallerOverrideHeader.ps1'
     arguments: >
       -SourceFolder '$(Build.SourcesDirectory)\InstallerInput'
       -DestinationFolder '$(Build.SourcesDirectory)\InstallerInput'
@@ -123,9 +126,9 @@ steps:
   displayName: 'Restore Windows App Runtime Install Nuget'
   inputs:
     command: 'restore'
-    restoreSolution: installer\WindowsAppRuntimeInstall.sln
+    restoreSolution: ${{ parameters.CheckoutPath }}installer\WindowsAppRuntimeInstall.sln
     feedsToUse: config
-    nugetConfigPath: $(Build.SourcesDirectory)\nuget.config
+    nugetConfigPath: $(Build.SourcesDirectory)${{ parameters.CheckoutPath }}\nuget.config
 
 - task: CopyFiles@2
   displayName: 'Copy installer override header'
@@ -147,7 +150,7 @@ steps:
   inputs:
     command: "custom"
     arguments:
-        'restore $(Build.SourcesDirectory)\installer\dev\telemetry\packages.config -ConfigFile $(Build.SourcesDirectory)\nuget.config -PackagesDirectory $(Build.SourcesDirectory)\packages'
+        'restore $(Build.SourcesDirectory)${{ parameters.CheckoutPath }}\installer\dev\telemetry\packages.config -ConfigFile $(Build.SourcesDirectory)${{ parameters.CheckoutPath }}\nuget.config -PackagesDirectory $(Build.SourcesDirectory)\packages'
 
 # Overwrite wil\Traceloggingconfig.h content in public nuget with that of MicrosoftTelemetry.h from internal nuget
 # This step enables telemetry in the Installer
@@ -201,12 +204,12 @@ steps:
     microsoftDropReadPat: $(System.AccessToken)
     compilerPackageName: $(compilerOverridePackageName)
     compilerPackageVersion: $(compilerOverridePackageVersion)
-    slnDirectory: $(Build.SourcesDirectory)\installer\dev
+    slnDirectory: $(Build.SourcesDirectory)${{ parameters.CheckoutPath }}\installer\dev
 
 - task: VSBuild@1
   displayName: 'Build Windows App Runtime Install'
   inputs:
-    solution: installer\dev\WindowsAppRuntimeInstall.vcxproj
+    solution: ${{ parameters.CheckoutPath }}installer\dev\WindowsAppRuntimeInstall.vcxproj
     platform: '$(buildPlatform)'
     configuration: '$(buildConfiguration)'
 
@@ -231,16 +234,16 @@ steps:
     failOnAlert: true
 
 - ${{ if eq(parameters.IsOneBranch, 'true') }}:
-  - template: ${{variables['System.DefaultWorkingDirectory']}}\build\AzurePipelinesTemplates\WindowsAppSDK-PublishSymbol-Steps.yml
+  - template: ${{variables['System.DefaultWorkingDirectory']}}${{ parameters.CheckoutPath }}\build\AzurePipelinesTemplates\WindowsAppSDK-PublishSymbol-Steps.yml
     parameters:
-      SearchPattern: '$(Build.SourcesDirectory)\BuildOutput\$(buildConfiguration)\$(buildPlatform)\WindowsAppRuntimeInstall\*.pdb'
+      SearchPattern: '$(Build.SourcesDirectory)${{ parameters.CheckoutPath }}\BuildOutput\$(buildConfiguration)\$(buildPlatform)\WindowsAppRuntimeInstall\*.pdb'
       IsOfficial: ${{ parameters.IsOfficial }}
-      PublishPublicSymbolsPowershellPath: '$(Build.SourcesDirectory)\eng\common\Scripts\PublishPublicSymbols.ps1'
+      PublishPublicSymbolsPowershellPath: '$(Build.SourcesDirectory)${{ parameters.CheckoutPath }}\eng\common\Scripts\PublishPublicSymbols.ps1'
 
 - ${{ if eq(parameters.SignOutput, 'true') }}:
-  - template: ${{variables['System.DefaultWorkingDirectory']}}\AzurePipelinesTemplates/WindowsAppSDK-EsrpCodeSigning-Steps.yml@WindowsAppSDKConfig
+  - template: ${{variables['System.DefaultWorkingDirectory']}}${{ parameters.CheckoutPath }}\AzurePipelinesTemplates/WindowsAppSDK-EsrpCodeSigning-Steps.yml@WindowsAppSDKConfig
     parameters:
-      FolderPath: $(Build.SourcesDirectory)\BuildOutput\$(buildConfiguration)\$(buildPlatform)\WindowsAppRuntimeInstall'
+      FolderPath: $(Build.SourcesDirectory)${{ parameters.CheckoutPath }}\BuildOutput\$(buildConfiguration)\$(buildPlatform)\WindowsAppRuntimeInstall'
       Pattern: WindowsAppRuntimeInstall*.exe
       UseMinimatch: true
       KeyCode: 'CP-230012'
@@ -255,7 +258,7 @@ steps:
   displayName: 'Remove test certificate for MSIX test packages (DevCheck)'
   inputs:
     targetType: filePath
-    filePath: eng\common\DevCheck.ps1
+    filePath: ${{ parameters.CheckoutPath }}eng\common\DevCheck.ps1
     arguments: -NoInteractive -Offline -Verbose -RemoveTestCert -RemoveTestPfx
     workingDirectory: '$(Build.SourcesDirectory)'
 

--- a/build/AzurePipelinesTemplates/WindowsAppSDK-BuildInstaller-Steps.yml
+++ b/build/AzurePipelinesTemplates/WindowsAppSDK-BuildInstaller-Steps.yml
@@ -234,14 +234,14 @@ steps:
     failOnAlert: true
 
 - ${{ if eq(parameters.IsOneBranch, 'true') }}:
-  - template: ${{variables['System.DefaultWorkingDirectory']}}${{ parameters.CheckoutPath }}\build\AzurePipelinesTemplates\WindowsAppSDK-PublishSymbol-Steps.yml
+  - template: ${{variables['System.DefaultWorkingDirectory']}}\build\AzurePipelinesTemplates\WindowsAppSDK-PublishSymbol-Steps.yml
     parameters:
       SearchPattern: '$(Build.SourcesDirectory)${{ parameters.CheckoutPath }}\BuildOutput\$(buildConfiguration)\$(buildPlatform)\WindowsAppRuntimeInstall\*.pdb'
       IsOfficial: ${{ parameters.IsOfficial }}
       PublishPublicSymbolsPowershellPath: '$(Build.SourcesDirectory)${{ parameters.CheckoutPath }}\eng\common\Scripts\PublishPublicSymbols.ps1'
 
 - ${{ if eq(parameters.SignOutput, 'true') }}:
-  - template: ${{variables['System.DefaultWorkingDirectory']}}${{ parameters.CheckoutPath }}\AzurePipelinesTemplates/WindowsAppSDK-EsrpCodeSigning-Steps.yml@WindowsAppSDKConfig
+  - template: ${{variables['System.DefaultWorkingDirectory']}}\AzurePipelinesTemplates/WindowsAppSDK-EsrpCodeSigning-Steps.yml@WindowsAppSDKConfig
     parameters:
       FolderPath: $(Build.SourcesDirectory)${{ parameters.CheckoutPath }}\BuildOutput\$(buildConfiguration)\$(buildPlatform)\WindowsAppRuntimeInstall'
       Pattern: WindowsAppRuntimeInstall*.exe

--- a/build/AzurePipelinesTemplates/WindowsAppSDK-BuildInstaller-Steps.yml
+++ b/build/AzurePipelinesTemplates/WindowsAppSDK-BuildInstaller-Steps.yml
@@ -47,7 +47,7 @@ steps:
   name: ConvertVersionDetailsToPackageConfig
   displayName: "Convert VersionDetails To PackageConfig"
   inputs:
-    filePath: '$(Build.SourcesDirectory)\WindowsAppSDK\build\Scripts\ConvertVersionDetailsToPackageConfig.ps1'
+    filePath: '$(Build.SourcesDirectory)\build\Scripts\ConvertVersionDetailsToPackageConfig.ps1'
     arguments: -versionDetailsPath '$(Build.SourcesDirectory)\WindowsAppSDK\eng\Version.Details.xml' -packageConfigPath '$(Build.SourcesDirectory)\WindowsAppSDK\build\packages.config'
 
 - task: 333b11bd-d341-40d9-afcf-b32d5ce6f23b@2

--- a/build/AzurePipelinesTemplates/WindowsAppSDK-BuildInstaller-Steps.yml
+++ b/build/AzurePipelinesTemplates/WindowsAppSDK-BuildInstaller-Steps.yml
@@ -1,3 +1,14 @@
+parameters:
+- name: SignOutput
+  type: boolean
+  default: False
+- name: IsOfficial
+  type: boolean
+  default: False 
+- name: IsOneBranch
+  type: boolean
+  default: False
+
 steps:
 ###
 # This step downloads the WindowsAppSDK NuGet package from last successful build of the Aggregator's Nightly build
@@ -192,10 +203,25 @@ steps:
     scanType: 'Register'
     failOnAlert: true
 
+- ${{ if eq(parameters.IsOneBranch, 'true') }}:
+  - template: ${{variables['System.DefaultWorkingDirectory']}}\build\AzurePipelinesTemplates\WindowsAppSDK-PublishSymbol-Steps.yml
+    parameters:
+      SearchPattern: '$(Build.SourcesDirectory)\BuildOutput\$(buildConfiguration)\$(buildPlatform)\WindowsAppRuntimeInstall\*.pdb'
+      IsOfficial: ${{ parameters.IsOfficial }}
+      PublishPublicSymbolsPowershellPath: '$(Build.SourcesDirectory)\eng\common\Scripts\PublishPublicSymbols.ps1'
+
+- ${{ if eq(parameters.SignOutput, 'true') }}:
+  - template: AzurePipelinesTemplates/WindowsAppSDK-EsrpCodeSigning-Steps.yml@WindowsAppSDKConfig
+    parameters:
+      FolderPath: $(Build.SourcesDirectory)\BuildOutput\$(buildConfiguration)\$(buildPlatform)\WindowsAppRuntimeInstall'
+      Pattern: WindowsAppRuntimeInstall*.exe
+      UseMinimatch: true
+      KeyCode: 'CP-230012'
+
 - task: CopyFiles@2
   displayName: 'Publish Installer'
   inputs:
-    SourceFolder: 'BuildOutput'
+    SourceFolder: '$(Build.SourcesDirectory)\BuildOutput'
     TargetFolder: '$(ob_outputDirectory)\Installer'
 
 - task: powershell@2
@@ -206,7 +232,8 @@ steps:
     arguments: -NoInteractive -Offline -Verbose -RemoveTestCert -RemoveTestPfx
     workingDirectory: '$(Build.SourcesDirectory)'
 
-- task: PublishBuildArtifacts@1
-  inputs:
-    PathtoPublish: '$(ob_outputDirectory)'
-    artifactName: '$(ob_artifactBaseName)'
+- ${{ if ne(parameters.IsOneBranch, 'true') }}:
+  - task: PublishBuildArtifacts@1
+    inputs:
+      PathtoPublish: '$(ob_outputDirectory)'
+      artifactName: '$(ob_artifactBaseName)'

--- a/build/AzurePipelinesTemplates/WindowsAppSDK-BuildInstaller-Steps.yml
+++ b/build/AzurePipelinesTemplates/WindowsAppSDK-BuildInstaller-Steps.yml
@@ -14,10 +14,7 @@ parameters:
 - name: UseCurrentBuild
   type: boolean
   default: False 
-- name: CheckoutPath
-  type: string
-  default: "" 
-  
+
 steps:
 - ${{ if eq(parameters.UseCurrentBuild, 'True') }}:
   - task: DownloadPipelineArtifact@2
@@ -50,22 +47,22 @@ steps:
   name: ConvertVersionDetailsToPackageConfig
   displayName: "Convert VersionDetails To PackageConfig"
   inputs:
-    filePath: '$(Build.SourcesDirectory)${{ parameters.CheckoutPath }}\build\Scripts\ConvertVersionDetailsToPackageConfig.ps1'
-    arguments: -versionDetailsPath '$(Build.SourcesDirectory)${{ parameters.CheckoutPath }}\eng\Version.Details.xml' -packageConfigPath '$(Build.SourcesDirectory)${{ parameters.CheckoutPath }}\build\packages.config'
+    filePath: '$(Build.SourcesDirectory)\build\Scripts\ConvertVersionDetailsToPackageConfig.ps1'
+    arguments: -versionDetailsPath '$(Build.SourcesDirectory)\eng\Version.Details.xml' -packageConfigPath '$(Build.SourcesDirectory)\build\packages.config'
 
 - task: 333b11bd-d341-40d9-afcf-b32d5ce6f23b@2
   displayName: RestoreNuGetPackages
   inputs:
-    restoreSolution: $(Build.SourcesDirectory)${{ parameters.CheckoutPath }}/build/packages.config
+    restoreSolution: $(Build.SourcesDirectory)/build/packages.config
     feedsToUse: config
-    nugetConfigPath: $(Build.SourcesDirectory)${{ parameters.CheckoutPath }}/nuget.config
+    nugetConfigPath: $(Build.SourcesDirectory)/nuget.config
     restoreDirectory: packages
 
 - task: powershell@2
   displayName: 'Create test pfx to sign MSIX test packages (DevCheck)'
   inputs:
     targetType: filePath
-    filePath: ${{ parameters.CheckoutPath }}eng\common\DevCheck.ps1
+    filePath: eng\common\DevCheck.ps1
     arguments: -NoInteractive -Offline -Verbose -CertPassword 'BuildPipeline' -CheckTestPfx -Clean
     workingDirectory: '$(Build.SourcesDirectory)'
 
@@ -73,7 +70,7 @@ steps:
   displayName: 'Install test certificate for MSIX test packages (DevCheck)'
   inputs:
     targetType: filePath
-    filePath: ${{ parameters.CheckoutPath }}eng\common\DevCheck.ps1
+    filePath: eng\common\DevCheck.ps1
     arguments: -NoInteractive -Offline -Verbose -CheckTestCert
     workingDirectory: '$(Build.SourcesDirectory)'
 
@@ -84,20 +81,20 @@ steps:
 - task: CopyFiles@2
   displayName: 'Copy licenses to target folder'
   inputs:
-    SourceFolder: '$(Build.SourcesDirectory)${{ parameters.CheckoutPath }}\build\packages\$(AppLicensingInternalPackageName).$(AppLicensingInternalPackageVersion)\licenses'
+    SourceFolder: '$(Build.SourcesDirectory)\build\packages\$(AppLicensingInternalPackageName).$(AppLicensingInternalPackageVersion)\licenses'
     Contents: |
       *.xml
-    TargetFolder: '$(Build.SourcesDirectory)${{ parameters.CheckoutPath }}\InstallerInput'
+    TargetFolder: '$(Build.SourcesDirectory)\InstallerInput'
     flattenFolders: false
 
 # Copy license installation header into the correct installer source location.
 - task: CopyFiles@2
   displayName: 'Extract files needed for Nuget package'
   inputs:
-    SourceFolder: '$(Build.SourcesDirectory)${{ parameters.CheckoutPath }}\build\packages\$(AppLicensingInternalPackageName).$(AppLicensingInternalPackageVersion)\src'
+    SourceFolder: '$(Build.SourcesDirectory)\build\packages\$(AppLicensingInternalPackageName).$(AppLicensingInternalPackageVersion)\src'
     Contents: |
       *.h
-    TargetFolder: '$(Build.SourcesDirectory)${{ parameters.CheckoutPath }}\installer\dev'
+    TargetFolder: '$(Build.SourcesDirectory)\installer\dev'
     flattenFolders: false
     overWrite: true
 
@@ -108,7 +105,7 @@ steps:
 - task: PowerShell@2
   displayName: ExtractMSIXPackagesFromNuget
   inputs:
-    filePath: '$(Build.SourcesDirectory)${{ parameters.CheckoutPath }}\build\scripts\ExtractMSIXFromNuget.ps1'
+    filePath: '$(Build.SourcesDirectory)\build\scripts\ExtractMSIXFromNuget.ps1'
     arguments: >
       -Source '$(System.ArtifactsDirectory)'
       -Dest '$(Build.SourcesDirectory)\InstallerInput'
@@ -116,7 +113,7 @@ steps:
 - task: PowerShell@2
   displayName: CreateInstallerOverrideHeader
   inputs:
-    filePath: '$(Build.SourcesDirectory)${{ parameters.CheckoutPath }}\build\Scripts\CreateInstallerOverrideHeader.ps1'
+    filePath: '$(Build.SourcesDirectory)\build\Scripts\CreateInstallerOverrideHeader.ps1'
     arguments: >
       -SourceFolder '$(Build.SourcesDirectory)\InstallerInput'
       -DestinationFolder '$(Build.SourcesDirectory)\InstallerInput'
@@ -126,9 +123,9 @@ steps:
   displayName: 'Restore Windows App Runtime Install Nuget'
   inputs:
     command: 'restore'
-    restoreSolution: ${{ parameters.CheckoutPath }}installer\WindowsAppRuntimeInstall.sln
+    restoreSolution: installer\WindowsAppRuntimeInstall.sln
     feedsToUse: config
-    nugetConfigPath: $(Build.SourcesDirectory)${{ parameters.CheckoutPath }}\nuget.config
+    nugetConfigPath: $(Build.SourcesDirectory)\nuget.config
 
 - task: CopyFiles@2
   displayName: 'Copy installer override header'
@@ -150,7 +147,7 @@ steps:
   inputs:
     command: "custom"
     arguments:
-        'restore $(Build.SourcesDirectory)${{ parameters.CheckoutPath }}\installer\dev\telemetry\packages.config -ConfigFile $(Build.SourcesDirectory)${{ parameters.CheckoutPath }}\nuget.config -PackagesDirectory $(Build.SourcesDirectory)\packages'
+        'restore $(Build.SourcesDirectory)\installer\dev\telemetry\packages.config -ConfigFile $(Build.SourcesDirectory)\nuget.config -PackagesDirectory $(Build.SourcesDirectory)\packages'
 
 # Overwrite wil\Traceloggingconfig.h content in public nuget with that of MicrosoftTelemetry.h from internal nuget
 # This step enables telemetry in the Installer
@@ -204,12 +201,12 @@ steps:
     microsoftDropReadPat: $(System.AccessToken)
     compilerPackageName: $(compilerOverridePackageName)
     compilerPackageVersion: $(compilerOverridePackageVersion)
-    slnDirectory: $(Build.SourcesDirectory)${{ parameters.CheckoutPath }}\installer\dev
+    slnDirectory: $(Build.SourcesDirectory)\installer\dev
 
 - task: VSBuild@1
   displayName: 'Build Windows App Runtime Install'
   inputs:
-    solution: ${{ parameters.CheckoutPath }}installer\dev\WindowsAppRuntimeInstall.vcxproj
+    solution: installer\dev\WindowsAppRuntimeInstall.vcxproj
     platform: '$(buildPlatform)'
     configuration: '$(buildConfiguration)'
 
@@ -234,16 +231,16 @@ steps:
     failOnAlert: true
 
 - ${{ if eq(parameters.IsOneBranch, 'true') }}:
-  - template: ${{variables['System.DefaultWorkingDirectory']}}${{ parameters.CheckoutPath }}\build\AzurePipelinesTemplates\WindowsAppSDK-PublishSymbol-Steps.yml
+  - template: ${{variables['System.DefaultWorkingDirectory']}}\build\AzurePipelinesTemplates\WindowsAppSDK-PublishSymbol-Steps.yml
     parameters:
-      SearchPattern: '$(Build.SourcesDirectory)${{ parameters.CheckoutPath }}\BuildOutput\$(buildConfiguration)\$(buildPlatform)\WindowsAppRuntimeInstall\*.pdb'
+      SearchPattern: '$(Build.SourcesDirectory)\BuildOutput\$(buildConfiguration)\$(buildPlatform)\WindowsAppRuntimeInstall\*.pdb'
       IsOfficial: ${{ parameters.IsOfficial }}
-      PublishPublicSymbolsPowershellPath: '$(Build.SourcesDirectory)${{ parameters.CheckoutPath }}\eng\common\Scripts\PublishPublicSymbols.ps1'
+      PublishPublicSymbolsPowershellPath: '$(Build.SourcesDirectory)\eng\common\Scripts\PublishPublicSymbols.ps1'
 
 - ${{ if eq(parameters.SignOutput, 'true') }}:
-  - template: ${{variables['System.DefaultWorkingDirectory']}}${{ parameters.CheckoutPath }}\AzurePipelinesTemplates/WindowsAppSDK-EsrpCodeSigning-Steps.yml@WindowsAppSDKConfig
+  - template: ${{variables['System.DefaultWorkingDirectory']}}\AzurePipelinesTemplates/WindowsAppSDK-EsrpCodeSigning-Steps.yml@WindowsAppSDKConfig
     parameters:
-      FolderPath: $(Build.SourcesDirectory)${{ parameters.CheckoutPath }}\BuildOutput\$(buildConfiguration)\$(buildPlatform)\WindowsAppRuntimeInstall'
+      FolderPath: $(Build.SourcesDirectory)\BuildOutput\$(buildConfiguration)\$(buildPlatform)\WindowsAppRuntimeInstall'
       Pattern: WindowsAppRuntimeInstall*.exe
       UseMinimatch: true
       KeyCode: 'CP-230012'
@@ -258,7 +255,7 @@ steps:
   displayName: 'Remove test certificate for MSIX test packages (DevCheck)'
   inputs:
     targetType: filePath
-    filePath: ${{ parameters.CheckoutPath }}eng\common\DevCheck.ps1
+    filePath: eng\common\DevCheck.ps1
     arguments: -NoInteractive -Offline -Verbose -RemoveTestCert -RemoveTestPfx
     workingDirectory: '$(Build.SourcesDirectory)'
 

--- a/build/AzurePipelinesTemplates/WindowsAppSDK-BuildInstaller-Steps.yml
+++ b/build/AzurePipelinesTemplates/WindowsAppSDK-BuildInstaller-Steps.yml
@@ -47,22 +47,22 @@ steps:
   name: ConvertVersionDetailsToPackageConfig
   displayName: "Convert VersionDetails To PackageConfig"
   inputs:
-    filePath: '$(Build.SourcesDirectory)\build\Scripts\ConvertVersionDetailsToPackageConfig.ps1'
-    arguments: -versionDetailsPath '$(Build.SourcesDirectory)\eng\Version.Details.xml' -packageConfigPath '$(Build.SourcesDirectory)\build\packages.config'
+    filePath: '$(Build.SourcesDirectory)\$(FoundationRepoName)\build\Scripts\ConvertVersionDetailsToPackageConfig.ps1'
+    arguments: -versionDetailsPath '$(Build.SourcesDirectory)\$(FoundationRepoName)\eng\Version.Details.xml' -packageConfigPath '$(Build.SourcesDirectory)\$(FoundationRepoName)\build\packages.config'
 
 - task: 333b11bd-d341-40d9-afcf-b32d5ce6f23b@2
   displayName: RestoreNuGetPackages
   inputs:
-    restoreSolution: $(Build.SourcesDirectory)/build/packages.config
+    restoreSolution: $(FoundationRepoName)/build/packages.config
     feedsToUse: config
-    nugetConfigPath: $(Build.SourcesDirectory)/nuget.config
+    nugetConfigPath: $(FoundationRepoName)/build/nuget.config
     restoreDirectory: packages
 
 - task: powershell@2
   displayName: 'Create test pfx to sign MSIX test packages (DevCheck)'
   inputs:
     targetType: filePath
-    filePath: eng\common\DevCheck.ps1
+    filePath: $(FoundationRepoName)\eng\common\DevCheck.ps1
     arguments: -NoInteractive -Offline -Verbose -CertPassword 'BuildPipeline' -CheckTestPfx -Clean
     workingDirectory: '$(Build.SourcesDirectory)'
 
@@ -70,7 +70,7 @@ steps:
   displayName: 'Install test certificate for MSIX test packages (DevCheck)'
   inputs:
     targetType: filePath
-    filePath: eng\common\DevCheck.ps1
+    filePath: $(FoundationRepoName)\eng\common\DevCheck.ps1
     arguments: -NoInteractive -Offline -Verbose -CheckTestCert
     workingDirectory: '$(Build.SourcesDirectory)'
 
@@ -81,7 +81,7 @@ steps:
 - task: CopyFiles@2
   displayName: 'Copy licenses to target folder'
   inputs:
-    SourceFolder: '$(Build.SourcesDirectory)\build\packages\$(AppLicensingInternalPackageName).$(AppLicensingInternalPackageVersion)\licenses'
+    SourceFolder: '$(Build.SourcesDirectory)\$(FoundationRepoName)\build\packages\$(AppLicensingInternalPackageName).$(AppLicensingInternalPackageVersion)\licenses'
     Contents: |
       *.xml
     TargetFolder: '$(Build.SourcesDirectory)\InstallerInput'
@@ -91,10 +91,10 @@ steps:
 - task: CopyFiles@2
   displayName: 'Extract files needed for Nuget package'
   inputs:
-    SourceFolder: '$(Build.SourcesDirectory)\build\packages\$(AppLicensingInternalPackageName).$(AppLicensingInternalPackageVersion)\src'
+    SourceFolder: '$(Build.SourcesDirectory)\$(FoundationRepoName)\build\packages\$(AppLicensingInternalPackageName).$(AppLicensingInternalPackageVersion)\src'
     Contents: |
       *.h
-    TargetFolder: '$(Build.SourcesDirectory)\installer\dev'
+    TargetFolder: '$(Build.SourcesDirectory)\$(FoundationRepoName)\installer\dev'
     flattenFolders: false
     overWrite: true
 
@@ -105,7 +105,7 @@ steps:
 - task: PowerShell@2
   displayName: ExtractMSIXPackagesFromNuget
   inputs:
-    filePath: '$(Build.SourcesDirectory)\build\scripts\ExtractMSIXFromNuget.ps1'
+    filePath: '$(Build.SourcesDirectory)\$(FoundationRepoName)\build\Scripts\ExtractMSIXFromNuget.ps1'
     arguments: >
       -Source '$(System.ArtifactsDirectory)'
       -Dest '$(Build.SourcesDirectory)\InstallerInput'
@@ -113,7 +113,7 @@ steps:
 - task: PowerShell@2
   displayName: CreateInstallerOverrideHeader
   inputs:
-    filePath: '$(Build.SourcesDirectory)\build\Scripts\CreateInstallerOverrideHeader.ps1'
+    filePath: '$(Build.SourcesDirectory)\$(FoundationRepoName)\build\Scripts\CreateInstallerOverrideHeader.ps1'
     arguments: >
       -SourceFolder '$(Build.SourcesDirectory)\InstallerInput'
       -DestinationFolder '$(Build.SourcesDirectory)\InstallerInput'
@@ -123,9 +123,9 @@ steps:
   displayName: 'Restore Windows App Runtime Install Nuget'
   inputs:
     command: 'restore'
-    restoreSolution: installer\WindowsAppRuntimeInstall.sln
+    restoreSolution: $(FoundationRepoName)\installer\WindowsAppRuntimeInstall.sln
     feedsToUse: config
-    nugetConfigPath: $(Build.SourcesDirectory)\nuget.config
+    nugetConfigPath: $(Build.SourcesDirectory)\$(FoundationRepoName)\nuget.config
 
 - task: CopyFiles@2
   displayName: 'Copy installer override header'
@@ -133,7 +133,7 @@ steps:
     SourceFolder: '$(Build.SourcesDirectory)\InstallerInput'
     Contents: |
       windowsappruntime_definitions_override.h
-    TargetFolder: installer\dev
+    TargetFolder: $(FoundationRepoName)\installer\dev
     flattenFolders: false
 
 - task: NuGetAuthenticate@1
@@ -147,7 +147,7 @@ steps:
   inputs:
     command: "custom"
     arguments:
-        'restore $(Build.SourcesDirectory)\installer\dev\telemetry\packages.config -ConfigFile $(Build.SourcesDirectory)\nuget.config -PackagesDirectory $(Build.SourcesDirectory)\packages'
+        'restore $(Build.SourcesDirectory)\$(FoundationRepoName)\installer\dev\telemetry\packages.config -ConfigFile $(Build.SourcesDirectory)\$(FoundationRepoName)\nuget.config -PackagesDirectory $(Build.SourcesDirectory)\$(FoundationRepoName)\packages'
 
 # Overwrite wil\Traceloggingconfig.h content in public nuget with that of MicrosoftTelemetry.h from internal nuget
 # This step enables telemetry in the Installer
@@ -156,10 +156,10 @@ steps:
   inputs:
     targetType: "inline"
     script: |
-        $srcPath = Get-Childitem -Path '$(Build.SourcesDirectory)\packages\' -File 'MicrosoftTelemetry.h' -Recurse
+        $srcPath = Get-Childitem -Path '$(Build.SourcesDirectory)\$(FoundationRepoName)\packages\' -File 'MicrosoftTelemetry.h' -Recurse
         if ($srcPath -ne $null)
         {
-          $destinationPaths = Get-Childitem -Path '$(Build.SourcesDirectory)\packages\' -File 'Traceloggingconfig.h' -Recurse
+          $destinationPaths = Get-Childitem -Path '$(Build.SourcesDirectory)\$(FoundationRepoName)\packages\' -File 'Traceloggingconfig.h' -Recurse
           if ($destinationPaths -ne $null)
           {
             foreach ($destPath in $destinationPaths)
@@ -169,14 +169,14 @@ steps:
           }
           else
           {
-            Write-Host Did not find the destination wil/traceloggingconfig.h under $(Build.SourcesDirectory)\packages\
-            Get-Childitem -Path '$(Build.SourcesDirectory)\packages\' -Recurse
+            Write-Host Did not find the destination wil/traceloggingconfig.h under $(Build.SourcesDirectory)\$(FoundationRepoName)\packages\
+            Get-Childitem -Path '$(Build.SourcesDirectory)\$(FoundationRepoName)\packages\' -Recurse
           }
         }
         else
         {
-          Write-Host Did not find the source MicrosoftTelemetry.h under $(Build.SourcesDirectory)\packages\
-          Get-Childitem -Path '$(Build.SourcesDirectory)\packages\' -Recurse
+          Write-Host Did not find the source MicrosoftTelemetry.h under $(Build.SourcesDirectory)\$(FoundationRepoName)\packages\
+          Get-Childitem -Path '$(Build.SourcesDirectory)\$(FoundationRepoName)\packages\' -Recurse
         }
 
 # Extract Microsoft.WindowsAppSDK Nuget package artifact published by BuildWindowsAppSDKPackages job of Aggregate stage,
@@ -188,12 +188,12 @@ steps:
     targetType: "inline"
     script: |
       $srcWinAppSDKNupkgPath = Get-Childitem -Path '$(System.ArtifactsDirectory)\NugetPackages' -File '*Microsoft.WindowsAppSDK*'
-      Copy-Item -Force $srcWinAppSDKNupkgPath.FullName '$(Build.SourcesDirectory)\packages\'
-      $destWinAppSDKNupkgPath = Get-Childitem -Path '$(Build.SourcesDirectory)\packages\' -File '*Microsoft.WindowsAppSDK*'
+      Copy-Item -Force $srcWinAppSDKNupkgPath.FullName '$(Build.SourcesDirectory)\$(FoundationRepoName)\packages\'
+      $destWinAppSDKNupkgPath = Get-Childitem -Path '$(Build.SourcesDirectory)\$(FoundationRepoName)\packages\' -File '*Microsoft.WindowsAppSDK*'
       $winAppSDKZip = $destWinAppSDKNupkgPath.FullName -replace '.nupkg','.zip'
       Rename-Item -Path $destWinAppSDKNupkgPath.FullName -NewName $winAppSDKZip
       Expand-Archive $winAppSDKZip -DestinationPath ($destWinAppSDKNupkgPath.Directory.FullName + '\' + $destWinAppSDKNupkgPath.BaseName)
-      Copy-Item -Force ($destWinAppSDKNupkgPath.Directory.FullName + '\' + $destWinAppSDKNupkgPath.BaseName + "\include\WindowsAppSDK-VersionInfo.h") '$(Build.SourcesDirectory)\installer\dev\'
+      Copy-Item -Force ($destWinAppSDKNupkgPath.Directory.FullName + '\' + $destWinAppSDKNupkgPath.BaseName + "\include\WindowsAppSDK-VersionInfo.h") '$(Build.SourcesDirectory)\$(FoundationRepoName)\installer\dev\'
 
 - task: WinUndockNativeCompiler@1
   displayName: 'Setup native compiler version override'
@@ -201,14 +201,16 @@ steps:
     microsoftDropReadPat: $(System.AccessToken)
     compilerPackageName: $(compilerOverridePackageName)
     compilerPackageVersion: $(compilerOverridePackageVersion)
-    slnDirectory: $(Build.SourcesDirectory)\installer\dev
+    slnDirectory: $(Build.SourcesDirectory)\$(FoundationRepoName)\installer\dev
 
 - task: VSBuild@1
   displayName: 'Build Windows App Runtime Install'
   inputs:
-    solution: installer\dev\WindowsAppRuntimeInstall.vcxproj
+    solution: $(FoundationRepoName)\installer\dev\WindowsAppRuntimeInstall.vcxproj
     platform: '$(buildPlatform)'
     configuration: '$(buildConfiguration)'
+    ${{ if eq( parameters.runStaticAnalysis, 'True') }}:
+      createLogFile: true
 
 - ${{ if eq(parameters.runStaticAnalysis, 'True') }}:
   - task: SDLNativeRules@3
@@ -233,14 +235,14 @@ steps:
 - ${{ if eq(parameters.IsOneBranch, 'true') }}:
   - template: ${{variables['System.DefaultWorkingDirectory']}}\build\AzurePipelinesTemplates\WindowsAppSDK-PublishSymbol-Steps.yml
     parameters:
-      SearchPattern: '$(Build.SourcesDirectory)\BuildOutput\$(buildConfiguration)\$(buildPlatform)\WindowsAppRuntimeInstall\*.pdb'
+      SearchPattern: '$(FoundationRepoName)\BuildOutput\$(buildConfiguration)\$(buildPlatform)\WindowsAppRuntimeInstall\*.pdb'
       IsOfficial: ${{ parameters.IsOfficial }}
-      PublishPublicSymbolsPowershellPath: '$(Build.SourcesDirectory)\eng\common\Scripts\PublishPublicSymbols.ps1'
+      PublishPublicSymbolsPowershellPath: '$(Build.SourcesDirectory)\$(FoundationRepoName)\eng\common\Scripts\PublishPublicSymbols.ps1'
 
 - ${{ if eq(parameters.SignOutput, 'true') }}:
   - template: ${{variables['System.DefaultWorkingDirectory']}}\AzurePipelinesTemplates/WindowsAppSDK-EsrpCodeSigning-Steps.yml@WindowsAppSDKConfig
     parameters:
-      FolderPath: $(Build.SourcesDirectory)\BuildOutput\$(buildConfiguration)\$(buildPlatform)\WindowsAppRuntimeInstall'
+      FolderPath: $(FoundationRepoName)\BuildOutput\$(buildConfiguration)\$(buildPlatform)\WindowsAppRuntimeInstall'
       Pattern: WindowsAppRuntimeInstall*.exe
       UseMinimatch: true
       KeyCode: 'CP-230012'
@@ -248,14 +250,14 @@ steps:
 - task: CopyFiles@2
   displayName: 'Publish Installer'
   inputs:
-    SourceFolder: '$(Build.SourcesDirectory)\BuildOutput'
+    SourceFolder: '$(FoundationRepoName)\BuildOutput'
     TargetFolder: '$(ob_outputDirectory)\Installer'
 
 - task: powershell@2
   displayName: 'Remove test certificate for MSIX test packages (DevCheck)'
   inputs:
     targetType: filePath
-    filePath: eng\common\DevCheck.ps1
+    filePath: $(FoundationRepoName)\eng\common\DevCheck.ps1
     arguments: -NoInteractive -Offline -Verbose -RemoveTestCert -RemoveTestPfx
     workingDirectory: '$(Build.SourcesDirectory)'
 

--- a/build/AzurePipelinesTemplates/WindowsAppSDK-BuildInstaller-Steps.yml
+++ b/build/AzurePipelinesTemplates/WindowsAppSDK-BuildInstaller-Steps.yml
@@ -47,22 +47,22 @@ steps:
   name: ConvertVersionDetailsToPackageConfig
   displayName: "Convert VersionDetails To PackageConfig"
   inputs:
-    filePath: '$(Build.SourcesDirectory)\build\Scripts\ConvertVersionDetailsToPackageConfig.ps1'
-    arguments: -versionDetailsPath '$(Build.SourcesDirectory)\WindowsAppSDK\eng\Version.Details.xml' -packageConfigPath '$(Build.SourcesDirectory)\WindowsAppSDK\build\packages.config'
+    filePath: '$(Build.SourcesDirectory)\$(FoundationRepoPath)build\Scripts\ConvertVersionDetailsToPackageConfig.ps1'
+    arguments: -versionDetailsPath '$(Build.SourcesDirectory)\$(FoundationRepoPath)eng\Version.Details.xml' -packageConfigPath '$(Build.SourcesDirectory)\$(FoundationRepoPath)build\packages.config'
 
 - task: 333b11bd-d341-40d9-afcf-b32d5ce6f23b@2
   displayName: RestoreNuGetPackages
   inputs:
-    restoreSolution: WindowsAppSDK/build/packages.config
+    restoreSolution: $(FoundationRepoPath)build/packages.config
     feedsToUse: config
-    nugetConfigPath: WindowsAppSDK/nuget.config
+    nugetConfigPath: $(FoundationRepoPath)nuget.config
     restoreDirectory: packages
 
 - task: powershell@2
   displayName: 'Create test pfx to sign MSIX test packages (DevCheck)'
   inputs:
     targetType: filePath
-    filePath: WindowsAppSDK\eng\common\DevCheck.ps1
+    filePath: $(FoundationRepoPath)eng\common\DevCheck.ps1
     arguments: -NoInteractive -Offline -Verbose -CertPassword 'BuildPipeline' -CheckTestPfx -Clean
     workingDirectory: '$(Build.SourcesDirectory)'
 
@@ -70,7 +70,7 @@ steps:
   displayName: 'Install test certificate for MSIX test packages (DevCheck)'
   inputs:
     targetType: filePath
-    filePath: WindowsAppSDK\eng\common\DevCheck.ps1
+    filePath: $(FoundationRepoPath)eng\common\DevCheck.ps1
     arguments: -NoInteractive -Offline -Verbose -CheckTestCert
     workingDirectory: '$(Build.SourcesDirectory)'
 
@@ -81,7 +81,7 @@ steps:
 - task: CopyFiles@2
   displayName: 'Copy licenses to target folder'
   inputs:
-    SourceFolder: '$(Build.SourcesDirectory)\WindowsAppSDK\build\packages\$(AppLicensingInternalPackageName).$(AppLicensingInternalPackageVersion)\licenses'
+    SourceFolder: '$(Build.SourcesDirectory)\$(FoundationRepoPath)build\packages\$(AppLicensingInternalPackageName).$(AppLicensingInternalPackageVersion)\licenses'
     Contents: |
       *.xml
     TargetFolder: '$(Build.SourcesDirectory)\InstallerInput'
@@ -91,10 +91,10 @@ steps:
 - task: CopyFiles@2
   displayName: 'Extract files needed for Nuget package'
   inputs:
-    SourceFolder: '$(Build.SourcesDirectory)\WindowsAppSDK\build\packages\$(AppLicensingInternalPackageName).$(AppLicensingInternalPackageVersion)\src'
+    SourceFolder: '$(Build.SourcesDirectory)\$(FoundationRepoPath)build\packages\$(AppLicensingInternalPackageName).$(AppLicensingInternalPackageVersion)\src'
     Contents: |
       *.h
-    TargetFolder: '$(Build.SourcesDirectory)\WindowsAppSDK\installer\dev'
+    TargetFolder: '$(Build.SourcesDirectory)\$(FoundationRepoPath)installer\dev'
     flattenFolders: false
     overWrite: true
 
@@ -105,7 +105,7 @@ steps:
 - task: PowerShell@2
   displayName: ExtractMSIXPackagesFromNuget
   inputs:
-    filePath: '$(Build.SourcesDirectory)\WindowsAppSDK\build\Scripts\ExtractMSIXFromNuget.ps1'
+    filePath: '$(Build.SourcesDirectory)\$(FoundationRepoPath)build\Scripts\ExtractMSIXFromNuget.ps1'
     arguments: >
       -Source '$(System.ArtifactsDirectory)'
       -Dest '$(Build.SourcesDirectory)\InstallerInput'
@@ -113,7 +113,7 @@ steps:
 - task: PowerShell@2
   displayName: CreateInstallerOverrideHeader
   inputs:
-    filePath: '$(Build.SourcesDirectory)\WindowsAppSDK\build\Scripts\CreateInstallerOverrideHeader.ps1'
+    filePath: '$(Build.SourcesDirectory)\$(FoundationRepoPath)build\Scripts\CreateInstallerOverrideHeader.ps1'
     arguments: >
       -SourceFolder '$(Build.SourcesDirectory)\InstallerInput'
       -DestinationFolder '$(Build.SourcesDirectory)\InstallerInput'
@@ -123,9 +123,9 @@ steps:
   displayName: 'Restore Windows App Runtime Install Nuget'
   inputs:
     command: 'restore'
-    restoreSolution: WindowsAppSDK\installer\WindowsAppRuntimeInstall.sln
+    restoreSolution: $(FoundationRepoPath)installer\WindowsAppRuntimeInstall.sln
     feedsToUse: config
-    nugetConfigPath: $(Build.SourcesDirectory)\WindowsAppSDK\nuget.config
+    nugetConfigPath: $(Build.SourcesDirectory)\$(FoundationRepoPath)nuget.config
 
 - task: CopyFiles@2
   displayName: 'Copy installer override header'
@@ -133,7 +133,7 @@ steps:
     SourceFolder: '$(Build.SourcesDirectory)\InstallerInput'
     Contents: |
       windowsappruntime_definitions_override.h
-    TargetFolder: WindowsAppSDK\installer\dev
+    TargetFolder: $(FoundationRepoPath)installer\dev
     flattenFolders: false
 
 - task: NuGetAuthenticate@1
@@ -147,7 +147,7 @@ steps:
   inputs:
     command: "custom"
     arguments:
-        'restore $(Build.SourcesDirectory)\WindowsAppSDK\installer\dev\telemetry\packages.config -ConfigFile $(Build.SourcesDirectory)\WindowsAppSDK\nuget.config -PackagesDirectory $(Build.SourcesDirectory)\WindowsAppSDK\packages'
+        'restore $(Build.SourcesDirectory)\$(FoundationRepoPath)installer\dev\telemetry\packages.config -ConfigFile $(Build.SourcesDirectory)\$(FoundationRepoPath)nuget.config -PackagesDirectory $(Build.SourcesDirectory)\$(FoundationRepoPath)packages'
 
 # Overwrite wil\Traceloggingconfig.h content in public nuget with that of MicrosoftTelemetry.h from internal nuget
 # This step enables telemetry in the Installer
@@ -156,10 +156,10 @@ steps:
   inputs:
     targetType: "inline"
     script: |
-        $srcPath = Get-Childitem -Path '$(Build.SourcesDirectory)\WindowsAppSDK\packages\' -File 'MicrosoftTelemetry.h' -Recurse
+        $srcPath = Get-Childitem -Path '$(Build.SourcesDirectory)\$(FoundationRepoPath)packages\' -File 'MicrosoftTelemetry.h' -Recurse
         if ($srcPath -ne $null)
         {
-          $destinationPaths = Get-Childitem -Path '$(Build.SourcesDirectory)\WindowsAppSDK\packages\' -File 'Traceloggingconfig.h' -Recurse
+          $destinationPaths = Get-Childitem -Path '$(Build.SourcesDirectory)\$(FoundationRepoPath)packages\' -File 'Traceloggingconfig.h' -Recurse
           if ($destinationPaths -ne $null)
           {
             foreach ($destPath in $destinationPaths)
@@ -169,14 +169,14 @@ steps:
           }
           else
           {
-            Write-Host Did not find the destination wil/traceloggingconfig.h under $(Build.SourcesDirectory)\WindowsAppSDK\packages\
-            Get-Childitem -Path '$(Build.SourcesDirectory)\WindowsAppSDK\packages\' -Recurse
+            Write-Host Did not find the destination wil/traceloggingconfig.h under $(Build.SourcesDirectory)\$(FoundationRepoPath)packages\
+            Get-Childitem -Path '$(Build.SourcesDirectory)\$(FoundationRepoPath)packages\' -Recurse
           }
         }
         else
         {
-          Write-Host Did not find the source MicrosoftTelemetry.h under $(Build.SourcesDirectory)\WindowsAppSDK\packages\
-          Get-Childitem -Path '$(Build.SourcesDirectory)\WindowsAppSDK\packages\' -Recurse
+          Write-Host Did not find the source MicrosoftTelemetry.h under $(Build.SourcesDirectory)\$(FoundationRepoPath)packages\
+          Get-Childitem -Path '$(Build.SourcesDirectory)\$(FoundationRepoPath)packages\' -Recurse
         }
 
 # Extract Microsoft.WindowsAppSDK Nuget package artifact published by BuildWindowsAppSDKPackages job of Aggregate stage,
@@ -188,12 +188,12 @@ steps:
     targetType: "inline"
     script: |
       $srcWinAppSDKNupkgPath = Get-Childitem -Path '$(System.ArtifactsDirectory)\NugetPackages' -File '*Microsoft.WindowsAppSDK*'
-      Copy-Item -Force $srcWinAppSDKNupkgPath.FullName '$(Build.SourcesDirectory)\WindowsAppSDK\packages\'
-      $destWinAppSDKNupkgPath = Get-Childitem -Path '$(Build.SourcesDirectory)\WindowsAppSDK\packages\' -File '*Microsoft.WindowsAppSDK*'
+      Copy-Item -Force $srcWinAppSDKNupkgPath.FullName '$(Build.SourcesDirectory)\$(FoundationRepoPath)packages\'
+      $destWinAppSDKNupkgPath = Get-Childitem -Path '$(Build.SourcesDirectory)\$(FoundationRepoPath)packages\' -File '*Microsoft.WindowsAppSDK*'
       $winAppSDKZip = $destWinAppSDKNupkgPath.FullName -replace '.nupkg','.zip'
       Rename-Item -Path $destWinAppSDKNupkgPath.FullName -NewName $winAppSDKZip
       Expand-Archive $winAppSDKZip -DestinationPath ($destWinAppSDKNupkgPath.Directory.FullName + '\' + $destWinAppSDKNupkgPath.BaseName)
-      Copy-Item -Force ($destWinAppSDKNupkgPath.Directory.FullName + '\' + $destWinAppSDKNupkgPath.BaseName + "\include\WindowsAppSDK-VersionInfo.h") '$(Build.SourcesDirectory)\WindowsAppSDK\installer\dev\'
+      Copy-Item -Force ($destWinAppSDKNupkgPath.Directory.FullName + '\' + $destWinAppSDKNupkgPath.BaseName + "\include\WindowsAppSDK-VersionInfo.h") '$(Build.SourcesDirectory)\$(FoundationRepoPath)installer\dev\'
 
 - task: WinUndockNativeCompiler@1
   displayName: 'Setup native compiler version override'
@@ -201,12 +201,12 @@ steps:
     microsoftDropReadPat: $(System.AccessToken)
     compilerPackageName: $(compilerOverridePackageName)
     compilerPackageVersion: $(compilerOverridePackageVersion)
-    slnDirectory: $(Build.SourcesDirectory)\WindowsAppSDK\installer\dev
+    slnDirectory: $(Build.SourcesDirectory)\$(FoundationRepoPath)installer\dev
 
 - task: VSBuild@1
   displayName: 'Build Windows App Runtime Install'
   inputs:
-    solution: WindowsAppSDK\installer\dev\WindowsAppRuntimeInstall.vcxproj
+    solution: $(FoundationRepoPath)installer\dev\WindowsAppRuntimeInstall.vcxproj
     platform: '$(buildPlatform)'
     configuration: '$(buildConfiguration)'
     ${{ if eq( parameters.runStaticAnalysis, 'True') }}:
@@ -235,14 +235,14 @@ steps:
 - ${{ if eq(parameters.IsOneBranch, 'true') }}:
   - template: ${{variables['System.DefaultWorkingDirectory']}}\build\AzurePipelinesTemplates\WindowsAppSDK-PublishSymbol-Steps.yml
     parameters:
-      SearchPattern: 'WindowsAppSDK\BuildOutput\$(buildConfiguration)\$(buildPlatform)\WindowsAppRuntimeInstall\*.pdb'
+      SearchPattern: '$(FoundationRepoPath)BuildOutput\$(buildConfiguration)\$(buildPlatform)\WindowsAppRuntimeInstall\*.pdb'
       IsOfficial: ${{ parameters.IsOfficial }}
-      PublishPublicSymbolsPowershellPath: '$(Build.SourcesDirectory)\WindowsAppSDK\eng\common\Scripts\PublishPublicSymbols.ps1'
+      PublishPublicSymbolsPowershellPath: '$(Build.SourcesDirectory)\$(FoundationRepoPath)eng\common\Scripts\PublishPublicSymbols.ps1'
 
 - ${{ if eq(parameters.SignOutput, 'true') }}:
   - template: ${{variables['System.DefaultWorkingDirectory']}}\AzurePipelinesTemplates/WindowsAppSDK-EsrpCodeSigning-Steps.yml@WindowsAppSDKConfig
     parameters:
-      FolderPath: WindowsAppSDK\BuildOutput\$(buildConfiguration)\$(buildPlatform)\WindowsAppRuntimeInstall'
+      FolderPath: $(FoundationRepoPath)BuildOutput\$(buildConfiguration)\$(buildPlatform)\WindowsAppRuntimeInstall'
       Pattern: WindowsAppRuntimeInstall*.exe
       UseMinimatch: true
       KeyCode: 'CP-230012'
@@ -250,14 +250,14 @@ steps:
 - task: CopyFiles@2
   displayName: 'Publish Installer'
   inputs:
-    SourceFolder: 'WindowsAppSDK\BuildOutput'
+    SourceFolder: '$(FoundationRepoPath)BuildOutput'
     TargetFolder: '$(ob_outputDirectory)\Installer'
 
 - task: powershell@2
   displayName: 'Remove test certificate for MSIX test packages (DevCheck)'
   inputs:
     targetType: filePath
-    filePath: WindowsAppSDK\eng\common\DevCheck.ps1
+    filePath: $(FoundationRepoPath)eng\common\DevCheck.ps1
     arguments: -NoInteractive -Offline -Verbose -RemoveTestCert -RemoveTestPfx
     workingDirectory: '$(Build.SourcesDirectory)'
 

--- a/build/AzurePipelinesTemplates/WindowsAppSDK-PackTransportPackage-Stage.yml
+++ b/build/AzurePipelinesTemplates/WindowsAppSDK-PackTransportPackage-Stage.yml
@@ -128,38 +128,11 @@ stages:
           **\*.pdb
         targetFolder: $(Build.ArtifactStagingDirectory)\symbols
 
-    - task: PublishSymbols@2
-      displayName: 'Publish private symbols to internal server (without source indexing)'
-      inputs:
-        searchPattern: '$(Build.ArtifactStagingDirectory)\symbols\**\*.pdb'
-        symbolServerType: 'TeamServices'
-      # This ADO task does not support indexing of github sources currently :-(
-        indexSources: false
-        detailedLog: true
-        SymbolsArtifactName: $(symbolsArtifactName)
-      # There is a bug which causes this task to fail if LIB includes an inaccessible path (even though it does not depend on it).
-      # To work around this issue, we just force LIB to be any dir that we know exists.
-      env:
-        LIB: $(Build.SourcesDirectory)
-
-    # Publishing symbols publicly requires making an API call to the service and is handled by PublishPublicSymbols.ps1
-    # in eng/common
-    # See this page for more info:
-    # https://www.osgwiki.com/wiki/Symbols_Publishing_Pipeline_to_SymWeb_and_MSDL
-    - ${{ if eq(parameters.IsOfficial, 'true') }}:
-      - pwsh: |
-          Install-Module -Name Az.Accounts -Scope AllUsers -AllowClobber -Force
-        displayName: Install Az.Accounts PowerShell module
-
-      # WinAppSDK-AZSC service connection must be used because the service principal created by this connection has been granted read and publish access
-      - task: AzurePowerShell@5
-        displayName: Publish symbols to SymWeb and MSDL
-        inputs:
-          azureSubscription: 'WinAppSDK-AZSC'
-          ScriptType: 'InlineScript'
-          Inline: $(Build.SourcesDirectory)\eng\common\Scripts\PublishPublicSymbols.ps1 -RequestName "$(symbolsArtifactName)"
-          azurePowerShellVersion: 'LatestVersion'
-          pwsh: true
+    - template: ${{variables['System.DefaultWorkingDirectory']}}\build\AzurePipelinesTemplates\WindowsAppSDK-PublishSymbol-Steps.yml
+      parameters:
+        SearchPattern: '$(Build.ArtifactStagingDirectory)\symbols\**\*.pdb'
+        IsOfficial: ${{ parameters.IsOfficial }}
+        PublishPublicSymbolsPowershellPath: '$(Build.SourcesDirectory)\eng\common\Scripts\PublishPublicSymbols.ps1'
 
     - task: PowerShell@2
       name: SetVersion

--- a/build/AzurePipelinesTemplates/WindowsAppSDK-PublishSymbol-Steps.yml
+++ b/build/AzurePipelinesTemplates/WindowsAppSDK-PublishSymbol-Steps.yml
@@ -1,0 +1,41 @@
+parameters:
+- name: "SearchPattern"
+  type: string
+  default: ""
+- name: "IsOfficial"
+  type: boolean
+  default: False
+- name: "PublishPublicSymbolsPowershellPath"
+  type: string
+  default: "$(Build.SourcesDirectory)/eng/common/Scripts/PublishPublicSymbols.ps1"
+
+steps:
+- task: PublishSymbols@2
+  displayName: 'Publish private symbols to internal server'
+  inputs:
+    searchPattern: ${{ parameters.searchPattern }}
+    symbolServerType: 'TeamServices'
+    indexSources: true
+    detailedLog: true
+    SymbolsArtifactName: $(symbolsArtifactName)
+  env:
+    LIB: $(Build.SourcesDirectory)
+
+# Publishing symbols publicly requires making an API call to the service and is handled by PublishPublicSymbols.ps1
+# in eng/common
+# See this page for more info:
+# https://www.osgwiki.com/wiki/Symbols_Publishing_Pipeline_to_SymWeb_and_MSDL
+- ${{ if eq(parameters.IsOfficial, 'true') }}:
+  - pwsh: |
+      Install-Module -Name Az.Accounts -Scope AllUsers -AllowClobber -Force
+    displayName: Install Az.Accounts PowerShell module
+
+  # WinAppSDK-AZSC service connection must be used because the service principal created by this connection has been granted read and publish access
+  - task: AzurePowerShell@5
+    displayName: Publish symbols to SymWeb and MSDL
+    inputs:
+      azureSubscription: 'WinAppSDK-AZSC'
+      ScriptType: 'InlineScript'
+      Inline: ${{ parameters.PublishPublicSymbolsPowershellPath }} -RequestName "$(symbolsArtifactName)"
+      azurePowerShellVersion: 'LatestVersion'
+      pwsh: true


### PR DESCRIPTION
Update BuildInstaller Template to allowed to be used from a OneBranch pipeline

Also added 
- ESRPCodeSigning step
- PublishSymbols step
- SDL Analysis step

Refactored the PublishSymbols step from other templates into
build/AzurePipelinesTemplates/WindowsAppSDK-PublishSymbol-Steps.yml 