### PR TITLE
Update TouchdownBuildTask to Version 4 

### DIFF
--- a/build/AzurePipelinesTemplates/WindowsAppSDK-CallTouchDownBuild-Steps.yml
+++ b/build/AzurePipelinesTemplates/WindowsAppSDK-CallTouchDownBuild-Steps.yml
@@ -21,13 +21,12 @@ steps:
     git config --global user.email "DoNotEmailThis@dev.null.microsoft.com"
     git config --global user.name "TDBuild"
 
-- task: TouchdownBuildTask@1
+- task: TouchdownBuildTask@4
   inputs:
     environment: 'PRODEXT'
     teamId: ${{ parameters.TeamID }}
-    authType: 'OAuth'
-    authId: $(TdBuildAuthID)
-    authKey: $(TdBuildToken)
+    authType: 'FederatedIdentity'
+    FederatedIdentityServiceConnection: "WindowsAppSDKSigningConnection"
     localizationTarget: true
     isPreview: false
     resourceFilePath: ${{ parameters.ResourceFilePath }}


### PR DESCRIPTION
Update TouchdownBuildTask to Version 4 which eliminates the use of secrets by moving to using federated credentails

Switched our TDBuild registration to use an existing ProjectReunion App registration that already has a federated credentials setup

Migration guide:
https://eng.ms/docs/cloud-ai-platform/devdiv/one-engineering-system-1es/1es-docs/touchdown-build/apis-and-integration/touchdown-build-azure-devops-task/touchdown-build-azure-devops-task-migration