### PR TITLE
Fix C6216 on PackageDeploymentManagerTests_IsPackageRegistrationPending.cpp

### DIFF
--- a/test/PackageManager/API/PackageDeploymentManagerTests_IsPackageRegistrationPending.cpp
+++ b/test/PackageManager/API/PackageDeploymentManagerTests_IsPackageRegistrationPending.cpp
@@ -99,7 +99,7 @@ namespace Test::PackageManager::Tests
             const winrt::hstring packageFullName{ ::TPM::Black::GetPackageFullName() };
             VERIFY_IS_TRUE(packageDeploymentManager.IsPackageRegistrationPending(packageFullName));
 
-            VERIFY_SUCCEEDED(LOG_IF_WIN32_BOOL_FALSE(::SetEvent(endOfTheLine.get())));
+            VERIFY_IS_TRUE(LOG_IF_WIN32_BOOL_FALSE(::SetEvent(endOfTheLine.get())));
         }
 
         TEST_METHOD(IsPackageRegistrationPendingForUser_NoSuchPackage)
@@ -157,7 +157,7 @@ namespace Test::PackageManager::Tests
             const winrt::hstring packageFullName{ ::TPM::Black::GetPackageFullName() };
             VERIFY_IS_TRUE(packageDeploymentManager.IsPackageRegistrationPendingForUser(winrt::hstring{}, packageFullName));
 
-            VERIFY_SUCCEEDED(LOG_IF_WIN32_BOOL_FALSE(::SetEvent(endOfTheLine.get())));
+            VERIFY_IS_TRUE(LOG_IF_WIN32_BOOL_FALSE(::SetEvent(endOfTheLine.get())));
         }
     };
 }


### PR DESCRIPTION
Nightly build is running into failures 
https://microsoft.visualstudio.com/ProjectReunion/_build/results?buildId=102381838&view=logs&j=1c272cb4-a7de-5c81-98c5-aeeff8319ee2&t=48f8fc41-e087-5792-5dca-ac677875ff2f

##[error]70. PREfast Error C6216 - File: file:///C:/__w/1/s/test/PackageManager/API/PackageDeploymentManagerTests_IsPackageRegistrationPending.cpp. Line: 160. Column 13. 

This PR resolves this prefast issue. 

Validation run here
https://microsoft.visualstudio.com/ProjectReunion/_build/results?buildId=102392887&view=results