### PR TITLE
b#48614111:  Add "break on error" setting to the top of powershell scripts in WASDK

### DIFF
--- a/BuildAll.ps1
+++ b/BuildAll.ps1
@@ -27,6 +27,9 @@ Param(
     [switch]$Clean = $false
 )
 
+Set-StrictMode -Version 3.0
+$ErrorActionPreference = 'Stop'
+
 $env:Build_SourcesDirectory = (Split-Path $MyInvocation.MyCommand.Path)
 $buildOverridePath = "build\override"
 $BasePath = "BuildOutput/FullNuget"

--- a/BuildAll.ps1
+++ b/BuildAll.ps1
@@ -291,7 +291,10 @@ Try {
         {
             foreach($platformToRun in $platform.Split(","))
             {
+                # TODO: $windowsAppSdkBinariesPath may not be defined. Remove the temp downgrade to 1.0 once this issue has been fixed (b#52130179). 
+                Set-StrictMode -Version 1.0
                 .\build\CopyFilesToStagingDir.ps1 -BuildOutputDir 'BuildOutput' -OverrideDir "$buildOverridePath" -PublishDir "$windowsAppSdkBinariesPath" -NugetDir "$BasePath" -Platform $PlatformToRun -Configuration $ConfigurationToRun
+                Set-StrictMode -Version 3.0
                 if ($lastexitcode -ne 0)
                 {
                     write-host "ERROR: msCopyFilesToStagingDir.ps1 FAILED."

--- a/TestAll.ps1
+++ b/TestAll.ps1
@@ -72,6 +72,7 @@ param(
 $StartTime = Get-Date
 $lastexitcode = 0
 Set-StrictMode -Version 3.0
+$ErrorActionPreference = 'Stop'
 
 function Get-Tests
 {

--- a/build/CopyFilesToStagingDir.ps1
+++ b/build/CopyFilesToStagingDir.ps1
@@ -13,11 +13,7 @@ Set-StrictMode -Version 3.0
 $ErrorActionPreference = 'Stop'
 
 $FullBuildOutput = "$($BuildOutputDir)\$($Configuration)\$($Platform)"
-
-# TODO: BuildAll.ps1 maynot specify PublishDir. Remove the temp downgrade to 1.0 once this has been fixed.
-Set-StrictMode -Version 1.0
 $FullPublishDir = "$($PublishDir)\$($Configuration)\$($Platform)"
-Set-StrictMode -Version 3.0
 
 if (!(Test-Path $FullPublishDir)) { mkdir $FullPublishDir }
 

--- a/build/CopyFilesToStagingDir.ps1
+++ b/build/CopyFilesToStagingDir.ps1
@@ -13,7 +13,11 @@ Set-StrictMode -Version 3.0
 $ErrorActionPreference = 'Stop'
 
 $FullBuildOutput = "$($BuildOutputDir)\$($Configuration)\$($Platform)"
+
+# TODO: BuildAll.ps1 maynot specify PublishDir. Remove the temp downgrade to 1.0 once this has been fixed.
+Set-StrictMode -Version 1.0
 $FullPublishDir = "$($PublishDir)\$($Configuration)\$($Platform)"
+Set-StrictMode -Version 3.0
 
 if (!(Test-Path $FullPublishDir)) { mkdir $FullPublishDir }
 

--- a/build/CopyFilesToStagingDir.ps1
+++ b/build/CopyFilesToStagingDir.ps1
@@ -9,6 +9,9 @@ Param(
     [switch]$PublishAppxFiles=$false
 )
 
+Set-StrictMode -Version 3.0
+$ErrorActionPreference = 'Stop'
+
 $FullBuildOutput = "$($BuildOutputDir)\$($Configuration)\$($Platform)"
 $FullPublishDir = "$($PublishDir)\$($Configuration)\$($Platform)"
 

--- a/build/NuSpecs/build-nupkg.ps1
+++ b/build/NuSpecs/build-nupkg.ps1
@@ -16,6 +16,9 @@ Param(
 # Version is read from the VERSION file.
 #
 
+Set-StrictMode -Version 3.0
+$ErrorActionPreference = 'Stop'
+
 $scriptDirectory = $script:MyInvocation.MyCommand.Path | Split-Path -Parent
 
 pushd $scriptDirectory

--- a/build/ShouldSkipPRBuild.ps1
+++ b/build/ShouldSkipPRBuild.ps1
@@ -24,6 +24,9 @@ function AllChangedFilesAreSkippable
     return $allFilesAreSkippable
 }
 
+Set-StrictMode -Version 3.0
+$ErrorActionPreference = 'Stop'
+
 $shouldSkipBuild = $false
 
 if($env:BUILD_REASON -eq "PullRequest")

--- a/build/StripSymbols.ps1
+++ b/build/StripSymbols.ps1
@@ -3,6 +3,7 @@
     [parameter(mandatory)][string] $OutputDirectory
 )
 
+Set-StrictMode -Version 3.0
 $ErrorActionPreference = "Stop"
 function Get-Is64Bit
 {

--- a/build/scripts/ConvertVersionDetailsToPackageConfig.ps1
+++ b/build/scripts/ConvertVersionDetailsToPackageConfig.ps1
@@ -5,6 +5,9 @@ Param(
     [string]$packageConfigPath = ""
 )
 
+Set-StrictMode -Version 3.0
+$ErrorActionPreference = 'Stop'
+
 [xml]$buildConfig = Get-Content -Path $versionDetailsPath
 
 $packagesText =

--- a/build/scripts/Install-WindowsSdkISO.ps1
+++ b/build/scripts/Install-WindowsSdkISO.ps1
@@ -2,6 +2,8 @@
 param([Parameter(Mandatory=$true, Position=0)]
       [string]$buildNumber)
 
+Set-StrictMode -Version 3.0
+
 # Ensure the error action preference is set to the default for PowerShell3, 'Stop'
 $ErrorActionPreference = 'Stop'
 

--- a/build/scripts/windows-sdk.ps1
+++ b/build/scripts/windows-sdk.ps1
@@ -7,9 +7,8 @@ param(
     [string]$SdkVersion = $null
 )
 
+Set-StrictMode -Version 3.0
 $ErrorActionPreference = "Stop"
-
-
 
 function Install-EXE
 {

--- a/dev/MRTCore/build/DownloadDotNetCoreSdk.ps1
+++ b/dev/MRTCore/build/DownloadDotNetCoreSdk.ps1
@@ -4,6 +4,9 @@ param(
     [switch]$skipLKG
 )
 
+Set-StrictMode -Version 3.0
+$ErrorActionPreference = 'Stop'
+
 $dotnetInstallScript = "$env:TEMP\dotnet-install.ps1"
 
 $repoInstallDir  = [System.IO.Path]::GetFullPath("$PSScriptRoot\..\.dotnet")

--- a/dev/MRTCore/build/Initialize-InstallMSBuild.ps1
+++ b/dev/MRTCore/build/Initialize-InstallMSBuild.ps1
@@ -6,6 +6,9 @@ param(
 
 Import-Module -Name $PSScriptRoot\MSBuildFunctions.psm1 -DisableNameChecking
 
+Set-StrictMode -Version 3.0
+$ErrorActionPreference = 'Stop'
+
 # Check if the VS cmd prompt is a valid one
 $msbuildUpToDate = Test-MSBuild (Join-Path $env:VSINSTALLDIR "MSBuild\Current\Bin\msbuild.exe")
 if (-not $msbuildUpToDate)

--- a/eng/common/Scripts/ConvertVersionDetailsToPackageConfig.ps1
+++ b/eng/common/Scripts/ConvertVersionDetailsToPackageConfig.ps1
@@ -5,6 +5,9 @@ Param(
     [string]$packageConfigPath = ""
 )
 
+Set-StrictMode -Version 3.0
+$ErrorActionPreference = 'Stop'
+
 [xml]$buildConfig = Get-Content -Path $versionDetailsPath
 
 $packagesText =

--- a/eng/common/Scripts/GetLKGCompilerPackageInfoIfNeeded.ps1
+++ b/eng/common/Scripts/GetLKGCompilerPackageInfoIfNeeded.ps1
@@ -3,6 +3,7 @@ param
     [String] $SourceDirectory
 )
 
+Set-StrictMode -Version 3.0
 $ErrorActionPreference = "Stop"
 
 # If $env:LkgVcToolsName and $env:LkgVcToolsVersion are not fully specified, try to retrieve the defaults from WindowsAppSDK-GlobalVariables.yml.

--- a/eng/common/Scripts/MaestroGetRequest.ps1
+++ b/eng/common/Scripts/MaestroGetRequest.ps1
@@ -6,6 +6,9 @@ Param(
     [string]$queryParameters
 )
 
+Set-StrictMode -Version 3.0
+$ErrorActionPreference = 'Stop'
+
 $headers = @{
     Authorization="Bearer $token"
 }

--- a/eng/common/Scripts/MaestroHelpers.ps1
+++ b/eng/common/Scripts/MaestroHelpers.ps1
@@ -79,3 +79,6 @@ function IsMaestroFriendlyAzureDevOpUri([string]$buildRepositoryUri)
     }
     return $false
 }
+
+Set-StrictMode -Version 3.0
+$ErrorActionPreference = 'Stop'

--- a/eng/common/Scripts/MaestroPostRequest.ps1
+++ b/eng/common/Scripts/MaestroPostRequest.ps1
@@ -7,6 +7,9 @@ Param(
     [string]$queryParameters = ''
 )
 
+Set-StrictMode -Version 3.0
+$ErrorActionPreference = 'Stop'
+
 $headers = @{
     Authorization="Bearer $token"
 }

--- a/eng/common/Scripts/PublishPublicSymbols.ps1
+++ b/eng/common/Scripts/PublishPublicSymbols.ps1
@@ -5,6 +5,9 @@ Param(
     [switch] $preProductionEnviroment
 )
 
+Set-StrictMode -Version 3.0
+$ErrorActionPreference = 'Stop'
+
 $ProjectName = 'WindowsAppSDK'
 
 $endPoint = "https://symbolrequestprod.trafficmanager.net/projects/$ProjectName/requests"

--- a/eng/common/Scripts/StripSymbols.ps1
+++ b/eng/common/Scripts/StripSymbols.ps1
@@ -3,6 +3,7 @@ param(
     [parameter(mandatory)][string] $OutputDirectory
 )
 
+Set-StrictMode -Version 3.0
 $ErrorActionPreference = "Stop"
 function Get-IsAmd64Bit
 {

--- a/eng/common/Scripts/UpdateVersionDetailsConfig.ps1
+++ b/eng/common/Scripts/UpdateVersionDetailsConfig.ps1
@@ -4,6 +4,9 @@ Param(
     [string]$dependencyVersion
 )
 
+Set-StrictMode -Version 3.0
+$ErrorActionPreference = 'Stop'
+
 Write-Host $dependencyName
 Write-Host $dependencyVersion
 

--- a/eng/common/VersionInfo/GenerateVersionInfo.ps1
+++ b/eng/common/VersionInfo/GenerateVersionInfo.ps1
@@ -21,6 +21,9 @@ Param(
     [int]$ProductMinor
 )
 
+Set-StrictMode -Version 3.0
+$ErrorActionPreference = 'Stop'
+
 # Don't output file with Bom
 $utf8NoBomEncoding = New-Object System.Text.UTF8Encoding $False
 

--- a/tools/GenerateDynamicDependencyOverrides.ps1
+++ b/tools/GenerateDynamicDependencyOverrides.ps1
@@ -28,6 +28,9 @@ function Convert-Guid
     return $guid
 }
 
+Set-StrictMode -Version 3.0
+$ErrorActionPreference = 'Stop'
+
 if (-not(Test-Path -Path $Path -PathType Container))
 {
     Write-Host "Creating $Path..."

--- a/tools/GeneratePushNotificationsOverrides.ps1
+++ b/tools/GeneratePushNotificationsOverrides.ps1
@@ -28,6 +28,9 @@ function Convert-Guid
     return $guid
 }
 
+Set-StrictMode -Version 3.0
+$ErrorActionPreference = 'Stop'
+
 if (-not(Test-Path -Path $Path -PathType Container))
 {
     Write-Host "Creating $Path..."

--- a/tools/TerminalVelocity/Generate-TerminalVelocityFeatures.ps1
+++ b/tools/TerminalVelocity/Generate-TerminalVelocityFeatures.ps1
@@ -46,8 +46,7 @@ Param(
     [string]$Namespace
 )
 
-#Set-StrictMode -Version 3.0
-Set-StrictMode -Version 1.0
+Set-StrictMode -Version 3.0
 
 # Make sure Channel has the exact spelling even if the parameter had different case
 foreach ($c in "Experimental", "Preview", "Stable", "WindowsInbox")
@@ -96,7 +95,11 @@ Class Feature
     {
         $this.Name = $entry.name
         $this.State = ConvertTo-FeatureState $entry.state
+
+        # TODO: Remove the temp workaround of downgrading to StrictModel 1.0 once b#52128443 is fixed. 
+        Set-StrictMode -Version 1.0
         $this.Id = $entry.id
+
         $this.ChannelTokenStates = [System.Collections.Generic.Dictionary[string, State]]::new()
         $this.DisabledReleaseToken = $Null -Ne $entry.alwaysDisabledReleaseTokens
 
@@ -110,6 +113,7 @@ Class Feature
         {
             $this.ChannelTokenStates[$b] = [State]::AlwaysEnabled
         }
+        Set-StrictMode -Version 3.0
     }
 
     [string] PreprocessorName([string]$namespace)

--- a/tools/TerminalVelocity/Generate-TerminalVelocityFeatures.ps1
+++ b/tools/TerminalVelocity/Generate-TerminalVelocityFeatures.ps1
@@ -99,7 +99,6 @@ Class Feature
         # TODO: Remove the temp workaround of downgrading to StrictModel 1.0 once b#52128443 is fixed. 
         Set-StrictMode -Version 1.0
         $this.Id = $entry.id
-
         $this.ChannelTokenStates = [System.Collections.Generic.Dictionary[string, State]]::new()
         $this.DisabledReleaseToken = $Null -Ne $entry.alwaysDisabledReleaseTokens
 
@@ -174,7 +173,6 @@ Function Resolve-FinalFeatureState
 
     $Feature.State
 }
-
 
 $ErrorActionPreference = "Stop"
 $xml = [xml](Get-Content $Path -EA:Stop)

--- a/tools/TerminalVelocity/Generate-TerminalVelocityFeatures.ps1
+++ b/tools/TerminalVelocity/Generate-TerminalVelocityFeatures.ps1
@@ -46,7 +46,8 @@ Param(
     [string]$Namespace
 )
 
-Set-StrictMode -Version 3.0
+#Set-StrictMode -Version 3.0
+Set-StrictMode -Version 1.0
 
 # Make sure Channel has the exact spelling even if the parameter had different case
 foreach ($c in "Experimental", "Preview", "Stable", "WindowsInbox")
@@ -169,6 +170,7 @@ Function Resolve-FinalFeatureState
 
     $Feature.State
 }
+
 
 $ErrorActionPreference = "Stop"
 $xml = [xml](Get-Content $Path -EA:Stop)

--- a/tools/TerminalVelocity/Generate-TerminalVelocityFeatures.ps1
+++ b/tools/TerminalVelocity/Generate-TerminalVelocityFeatures.ps1
@@ -46,6 +46,8 @@ Param(
     [string]$Namespace
 )
 
+Set-StrictMode -Version 3.0
+
 # Make sure Channel has the exact spelling even if the parameter had different case
 foreach ($c in "Experimental", "Preview", "Stable", "WindowsInbox")
 {

--- a/tools/VerifyCopyrightHeaders.ps1
+++ b/tools/VerifyCopyrightHeaders.ps1
@@ -13,6 +13,9 @@ Param(
     [switch]$Fix = $false
 )
 
+Set-StrictMode -Version 3.0
+$ErrorActionPreference = 'Stop'
+
 $copyrightHeaderText = (
     "Copyright (c) Microsoft Corporation and Contributors.",
     "Licensed under the MIT License."


### PR DESCRIPTION
b#48614111:  Add "break on error" setting to the top of powershell scripts in WASDK
With this PR, "break on error" is enabled everywhere except for 2 small blocks in 2 ps1 files, which are being tracked by 2 separate bugs.

//////////

A microsoft employee must use /azp run to validate using the pipelines below.

WARNING:
Comments made by azure-pipelines bot maybe inaccurate.
Please see pipeline link to verify that the build is being ran.

For status checks on the main branch, please use TransportPackage-Foundation-PR
(https://microsoft.visualstudio.com/ProjectReunion/_build?definitionId=81063&_a=summary)
and run the build against your PR branch with the default parameters.
