### PR TITLE
Enable nullable reference types on new projects (.NET guidance) and fix warning

### DIFF
--- a/dev/VSIX/ProjectTemplates/Desktop/CSharp/PackagedApp/BlankApp/App.xaml.cs
+++ b/dev/VSIX/ProjectTemplates/Desktop/CSharp/PackagedApp/BlankApp/App.xaml.cs
@@ -45,6 +45,6 @@ namespace $safeprojectname$
             m_window.Activate();
         }
 
-        private Window m_window;
+        private Window? m_window;
     }
 }

--- a/dev/VSIX/ProjectTemplates/Desktop/CSharp/PackagedApp/BlankApp/ProjectTemplate.csproj
+++ b/dev/VSIX/ProjectTemplates/Desktop/CSharp/PackagedApp/BlankApp/ProjectTemplate.csproj
@@ -9,6 +9,7 @@
     <RuntimeIdentifiers Condition="$([MSBuild]::GetTargetFrameworkVersion('$(TargetFramework)')) >= 8">win-x86;win-x64;win-arm64</RuntimeIdentifiers>
     <RuntimeIdentifiers Condition="$([MSBuild]::GetTargetFrameworkVersion('$(TargetFramework)')) &lt; 8">win10-x86;win10-x64;win10-arm64</RuntimeIdentifiers>
     <UseWinUI>true</UseWinUI>
+    <Nullable>enable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>

--- a/dev/VSIX/ProjectTemplates/Desktop/CSharp/SingleProjectPackagedApp/App.xaml.cs
+++ b/dev/VSIX/ProjectTemplates/Desktop/CSharp/SingleProjectPackagedApp/App.xaml.cs
@@ -45,6 +45,6 @@ namespace $safeprojectname$
             m_window.Activate();
         }
 
-        private Window m_window;
+        private Window? m_window;
     }
 }

--- a/dev/VSIX/ProjectTemplates/Desktop/CSharp/SingleProjectPackagedApp/ProjectTemplate.csproj
+++ b/dev/VSIX/ProjectTemplates/Desktop/CSharp/SingleProjectPackagedApp/ProjectTemplate.csproj
@@ -11,6 +11,7 @@
     <PublishProfile>win-$(Platform).pubxml</PublishProfile>
     <UseWinUI>true</UseWinUI>
     <EnableMsixTooling>true</EnableMsixTooling>
+    <Nullable>enable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>

--- a/dev/VSIX/ProjectTemplates/Desktop/CSharp/UnitTestApp/ProjectTemplate.csproj
+++ b/dev/VSIX/ProjectTemplates/Desktop/CSharp/UnitTestApp/ProjectTemplate.csproj
@@ -11,6 +11,7 @@
     <PublishProfile>win-$(Platform).pubxml</PublishProfile>
     <UseWinUI>true</UseWinUI>
     <EnableMsixTooling>true</EnableMsixTooling>
+    <Nullable>enable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>

--- a/dev/VSIX/ProjectTemplates/Desktop/CSharp/UnitTestApp/UnitTestApp.xaml.cs
+++ b/dev/VSIX/ProjectTemplates/Desktop/CSharp/UnitTestApp/UnitTestApp.xaml.cs
@@ -52,6 +52,6 @@ namespace $safeprojectname$
             Microsoft.VisualStudio.TestPlatform.TestExecutor.UnitTestClient.Run(Environment.CommandLine);
         }
 
-        private Window m_window;
+        private Window? m_window;
     }
 }


### PR DESCRIPTION
[Nullable reference types](https://learn.microsoft.com/en-us/dotnet/csharp/nullable-references) states:
"Beginning with .NET 6, new projects include the <Nullable>enable</Nullable> element in all project templates."

Following suit with WinAppSDK C# templates, and addressing warning on m_window.