### PR TITLE
[Build] Fixing pre-existing "array out of bound" bug exposed by enabling strict mode 3.0

### DIFF
--- a/eng/common/Scripts/MaestroHelpers.ps1
+++ b/eng/common/Scripts/MaestroHelpers.ps1
@@ -54,13 +54,16 @@ function ConvertToMaestroFriendlyAzureDevOpUri([string]$buildRepositoryUri)
 function IsGitHubRepo([string]$buildRepositoryUri)
 {
     $githubUrls = @("https://github.com", "https://wwww.github.com")
-    for ($i = 0; $i -le ($githubUrls.length); $i += 1)
+    if ($githubUrls.length -gt 0)
     {
-        if ($buildRepositoryUri.length -ge $githubUrls[$i].length)
+        for ($i = 0; $i -lt ($githubUrls.length); $i += 1)
         {
-            if($buildRepositoryUri.Substring(0, $githubUrls[$i].length) -eq $githubUrls[$i])
+            if ($buildRepositoryUri.length -ge $githubUrls[$i].length)
             {
-                return $true
+                if($buildRepositoryUri.Substring(0, $githubUrls[$i].length) -eq $githubUrls[$i])
+                {
+                    return $true
+                }
             }
         }
     }


### PR DESCRIPTION
Fixed pre-existing "array index out of bound" bug in a Powershell script, exposed by enabling strict mode 3.0.
PR validation passed.

///////////////////

A microsoft employee must use /azp run to validate using the pipelines below.

WARNING:
Comments made by azure-pipelines bot maybe inaccurate.
Please see pipeline link to verify that the build is being ran.

For status checks on the main branch, please use TransportPackage-Foundation-PR
(https://microsoft.visualstudio.com/ProjectReunion/_build?definitionId=81063&_a=summary)
and run the build against your PR branch with the default parameters.
