### PR TITLE
Allow Installer validation stage to download from a build that has failed

### DIFF
--- a/build/AzurePipelinesTemplates/WindowsAppSDK-BuildInstaller-Steps.yml
+++ b/build/AzurePipelinesTemplates/WindowsAppSDK-BuildInstaller-Steps.yml
@@ -18,7 +18,7 @@ parameters:
 steps:
 - ${{ if eq(parameters.UseCurrentBuild, 'True') }}:
   - task: DownloadPipelineArtifact@2
-    displayName: 'Download WindowsAppSDK'
+    displayName: 'Download WindowsAppSDK From Current Build'
     inputs:
       artifactName: 'WindowsAppSDK_Nuget_And_MSIX'
       targetPath: '$(System.ArtifactsDirectory)'
@@ -27,7 +27,7 @@ steps:
   # This step downloads the WindowsAppSDK NuGet package from last successful build of the Aggregator's Nightly build
   # for use in building the installers
   - task: DownloadPipelineArtifact@2
-    displayName: 'Download WindowsAppSDK'
+    displayName: 'Download WindowsAppSDK From Latest Nightly'
     inputs:
       artifactName: 'WindowsAppSDK_Nuget_And_MSIX'
       targetPath: '$(System.ArtifactsDirectory)'

--- a/build/AzurePipelinesTemplates/WindowsAppSDK-BuildInstaller-Steps.yml
+++ b/build/AzurePipelinesTemplates/WindowsAppSDK-BuildInstaller-Steps.yml
@@ -33,6 +33,8 @@ steps:
       targetPath: '$(System.ArtifactsDirectory)'
       source: 'specific'
       project: $(System.TeamProjectId)
+      allowPartiallySucceededBuilds: True
+      allowFailedBuilds: True
       pipeline: 118002         
       runVersion: 'latestFromBranch'
       runBranch: "refs/heads/main"

--- a/build/AzurePipelinesTemplates/WindowsAppSDK-BuildInstaller-Steps.yml
+++ b/build/AzurePipelinesTemplates/WindowsAppSDK-BuildInstaller-Steps.yml
@@ -24,7 +24,7 @@ steps:
       targetPath: '$(System.ArtifactsDirectory)'
 - ${{ else }}:
   ###
-  # This step downloads the WindowsAppSDK NuGet package from last successful build of the Aggregator's Nightly build
+  # This step downloads the WindowsAppSDK NuGet package from last successful or failed build of the Aggregator's Nightly build
   # for use in building the installers
   - task: DownloadPipelineArtifact@2
     displayName: 'Download WindowsAppSDK From Latest Nightly'


### PR DESCRIPTION
A nightly could fail in the test stages but succeeds in the Aggregator stage. 

This change allows it so the Foundation build can still download the WindowsAppSDK Nuget package even if the build partially fail. 