### PR TITLE
Disabling Installer Validation Stage

### DIFF
--- a/build/ProjectReunion-BuildFoundation.yml
+++ b/build/ProjectReunion-BuildFoundation.yml
@@ -16,7 +16,8 @@ variables:
 - template: ..\eng\common\AzurePipelinesTemplates\WindowsAppSDK-GlobalVariables.yml
 
 stages:
-- template: AzurePipelinesTemplates\WindowsAppSDK-BuildInstaller-Stage.yml@self
+# Disabling this because it is sensitive to failures on the Aggregator Nightly Build
+# - template: AzurePipelinesTemplates\WindowsAppSDK-BuildInstaller-Stage.yml@self
 
 - template: AzurePipelinesTemplates\WindowsAppSDK-Build-Stage.yml@self
   parameters:


### PR DESCRIPTION
Disabling Installer Validation Stage.
A simple failure in the Aggregator stage will bring the PR validation down.
