### PR TITLE
Reenable Installer Validation using Latest Official WindowsAppSDK builds

### DIFF
--- a/build/AzurePipelinesTemplates/WindowsAppSDK-BuildInstaller-Steps.yml
+++ b/build/AzurePipelinesTemplates/WindowsAppSDK-BuildInstaller-Steps.yml
@@ -33,8 +33,8 @@ steps:
       targetPath: '$(System.ArtifactsDirectory)'
       source: 'specific'
       project: $(System.TeamProjectId)
-      pipeline: $(OfficialPipelineID) 
-      pipelineId: $(LatestOfficialBuildID) 
+      pipeline: 104083
+      pipelineId: 102534029
       runVersion: 'latestFromBranch'
       runBranch: "refs/heads/main"
 

--- a/build/AzurePipelinesTemplates/WindowsAppSDK-BuildInstaller-Steps.yml
+++ b/build/AzurePipelinesTemplates/WindowsAppSDK-BuildInstaller-Steps.yml
@@ -33,9 +33,8 @@ steps:
       targetPath: '$(System.ArtifactsDirectory)'
       source: 'specific'
       project: $(System.TeamProjectId)
-      allowPartiallySucceededBuilds: True
-      allowFailedBuilds: True
-      pipeline: 118002         
+      pipeline: $(OfficialPipelineID) 
+      pipelineId: $(LatestOfficialBuildID) 
       runVersion: 'latestFromBranch'
       runBranch: "refs/heads/main"
 

--- a/build/AzurePipelinesTemplates/WindowsAppSDK-BuildInstaller-Steps.yml
+++ b/build/AzurePipelinesTemplates/WindowsAppSDK-BuildInstaller-Steps.yml
@@ -24,8 +24,9 @@ steps:
       targetPath: '$(System.ArtifactsDirectory)'
 - ${{ else }}:
   ###
-  # This step downloads the WindowsAppSDK NuGet package from last successful or failed build of the Aggregator's Nightly build
-  # for use in building the installers
+  # This step downloads the WindowsAppSDK NuGet package from a pipeline
+  # variables: OfficialPipelineID LatestOfficialBuildID
+  # for use in building the Installers
   - task: DownloadPipelineArtifact@2
     displayName: 'Download WindowsAppSDK From Latest Nightly'
     inputs:

--- a/build/AzurePipelinesTemplates/WindowsAppSDK-BuildInstaller-Steps.yml
+++ b/build/AzurePipelinesTemplates/WindowsAppSDK-BuildInstaller-Steps.yml
@@ -33,10 +33,8 @@ steps:
       targetPath: '$(System.ArtifactsDirectory)'
       source: 'specific'
       project: $(System.TeamProjectId)
-      pipeline: 104083
-      pipelineId: 102534029
-      runVersion: 'latestFromBranch'
-      runBranch: "refs/heads/main"
+      pipeline: $(OfficialPipelineID) 
+      pipelineId: $(LatestOfficialBuildID) 
 
 ###
 # Install the internal licensing support for release-signed packages. This can always be present in

--- a/build/ProjectReunion-BuildFoundation.yml
+++ b/build/ProjectReunion-BuildFoundation.yml
@@ -16,7 +16,6 @@ variables:
 - template: ..\eng\common\AzurePipelinesTemplates\WindowsAppSDK-GlobalVariables.yml
 
 stages:
-# Disabling this because it is sensitive to failures on the Aggregator Nightly Build
 - template: AzurePipelinesTemplates\WindowsAppSDK-BuildInstaller-Stage.yml@self
 
 - template: AzurePipelinesTemplates\WindowsAppSDK-Build-Stage.yml@self

--- a/build/ProjectReunion-BuildFoundation.yml
+++ b/build/ProjectReunion-BuildFoundation.yml
@@ -17,7 +17,7 @@ variables:
 
 stages:
 # Disabling this because it is sensitive to failures on the Aggregator Nightly Build
-# - template: AzurePipelinesTemplates\WindowsAppSDK-BuildInstaller-Stage.yml@self
+- template: AzurePipelinesTemplates\WindowsAppSDK-BuildInstaller-Stage.yml@self
 
 - template: AzurePipelinesTemplates\WindowsAppSDK-Build-Stage.yml@self
   parameters:


### PR DESCRIPTION
Reenable Installer Validation where instead of downloading from the latest main branch, we download from the latest official build which is controlled by two pipeline variables.

This should give us more stability in the validation. 