### PR TITLE
Fix ExtractWindowsAppSDKVersion deleting the NuGet Package

### DIFF
--- a/build/AzurePipelinesTemplates/WindowsAppSDK-BuildVSIX-Steps.yml
+++ b/build/AzurePipelinesTemplates/WindowsAppSDK-BuildVSIX-Steps.yml
@@ -51,7 +51,9 @@ steps:
   inputs:
     targetType: 'inline'
     script: |
-      $files = Get-ChildItem $(System.ArtifactsDirectory)
+      Copy-Item -Path "$(System.ArtifactsDirectory)" -Destination "$(Build.SourcesDirectory)\temp" -Recurse
+
+      $files = Get-ChildItem $(Build.SourcesDirectory)\temp
       foreach ($file in $files) # Iterate through each package we restored in the directory
       {
         Write-Host "file:" $file.FullName


### PR DESCRIPTION
Fix ExtractWindowsAppSDKVersion deleting the NuGet Package that the VSIX build needs by copying it to a temporary location and extracting it from there