### PR TITLE
Fix IsPackageDeploymentFeatureSupported

### DIFF
--- a/dev/PackageManager/API/M.W.M.D.PackageDeploymentManager.cpp
+++ b/dev/PackageManager/API/M.W.M.D.PackageDeploymentManager.cpp
@@ -125,9 +125,9 @@ namespace winrt::Microsoft::Windows::Management::Deployment::implementation
             }
             case winrt::Microsoft::Windows::Management::Deployment::PackageDeploymentFeature::IsPackageReadyOrNewerAvailable:
             {
-                //TODO Feature lookup
-                // Relies on PackageManagement_IsFeatureSupported(L"IsPackageReadyOrNewerAvailable") exist in Microsoft.FrameworkUdk and enabled
-                return false;
+                BOOL isSupported{};
+                THROW_IF_FAILED(PackageManagement_IsFeatureSupported(L"IsPackageReadyOrNewerAvailable", &isSupported));
+                return !!isSupported;
             }
             case winrt::Microsoft::Windows::Management::Deployment::PackageDeploymentFeature::RemovePackageByUri:
             {
@@ -137,11 +137,15 @@ namespace winrt::Microsoft::Windows::Management::Deployment::implementation
             }
             case winrt::Microsoft::Windows::Management::Deployment::PackageDeploymentFeature::ResetPackage:
             {
-                return ::WindowsVersion::IsExportPresent(L"appxdeploymentclient.dll", "MsixResetPackageAsync");
+                //TODO Awaiting Windows update
+                //return ::WindowsVersion::IsExportPresent(L"appxdeploymentclient.dll", "MsixResetPackageAsync");
+                return false;
             }
             case winrt::Microsoft::Windows::Management::Deployment::PackageDeploymentFeature::RepairPackage:
             {
-                return ::WindowsVersion::IsExportPresent(L"appxdeploymentclient.dll", "MsixRepairPackageAsync");
+                //TODO Awaiting Windows update
+                //return ::WindowsVersion::IsExportPresent(L"appxdeploymentclient.dll", "MsixRepairPackageAsync");
+                return false;
             }
             case winrt::Microsoft::Windows::Management::Deployment::PackageDeploymentFeature::ProvisionPackage_Framework:
             {

--- a/dev/PackageManager/API/M.W.M.D.PackageDeploymentManager.cpp
+++ b/dev/PackageManager/API/M.W.M.D.PackageDeploymentManager.cpp
@@ -126,7 +126,12 @@ namespace winrt::Microsoft::Windows::Management::Deployment::implementation
             case winrt::Microsoft::Windows::Management::Deployment::PackageDeploymentFeature::IsPackageReadyOrNewerAvailable:
             {
                 BOOL isSupported{};
-                THROW_IF_FAILED(PackageManagement_IsFeatureSupported(L"IsPackageReadyOrNewerAvailable", &isSupported));
+                const HRESULT hr{ PackageManagement_IsFeatureSupported(L"IsPackageReadyOrNewerAvailable", &isSupported) };
+                if (hr == E_NOTIMPL)
+                {
+                    return false;
+                }
+                THROW_IF_FAILED_MSG(hr, "IsPackageReadyOrNewerAvailable");
                 return !!isSupported;
             }
             case winrt::Microsoft::Windows::Management::Deployment::PackageDeploymentFeature::RemovePackageByUri:


### PR DESCRIPTION
Corrected the `IsPackageDeploymentFeatureSupported()` checks for `IsPackageReadyOrNewerAvailable` (available on some platforms), `ResetPackage` (not available; vNext) and `RepairPackage` (not available; vNext)

Once in will be brought to shiproom for 1.6 approval

This corrects checks to address KNOWN ISSUES in [PackageDeploymentManager: IsReadyOrNewerAvailable(), FrameworkUdk update, Implement not-implemented functions, Tests!](https://github.com/microsoft/WindowsAppSDK/pull/4453)
#4453 

https://task.ms/52754253