### PR TITLE
1.6-stable: cherry-pick Fix IsPackageDeploymentFeatureSupported (#4598)

### DIFF
--- a/dev/MRTCore/mrt/Microsoft.Windows.ApplicationModel.Resources/src/packages.config
+++ b/dev/MRTCore/mrt/Microsoft.Windows.ApplicationModel.Resources/src/packages.config
@@ -4,5 +4,5 @@
   <package id="Microsoft.SourceLink.Common" version="1.1.1" targetFramework="native" developmentDependency="true" />
   <package id="Microsoft.SourceLink.GitHub" version="1.1.1" targetFramework="native" developmentDependency="true" />
   <package id="Microsoft.Windows.CppWinRT" version="2.0.230706.1" targetFramework="native" />
-  <package id="Microsoft.Windows.ImplementationLibrary" version="1.0.220914.1" targetFramework="native" />
+  <package id="Microsoft.Windows.ImplementationLibrary" version="1.0.231216.1" targetFramework="native" />
 </packages>

--- a/dev/PackageManager/API/M.W.M.D.PackageDeploymentManager.cpp
+++ b/dev/PackageManager/API/M.W.M.D.PackageDeploymentManager.cpp
@@ -125,9 +125,14 @@ namespace winrt::Microsoft::Windows::Management::Deployment::implementation
             }
             case winrt::Microsoft::Windows::Management::Deployment::PackageDeploymentFeature::IsPackageReadyOrNewerAvailable:
             {
-                //TODO Feature lookup
-                // Relies on PackageManagement_IsFeatureSupported(L"IsPackageReadyOrNewerAvailable") exist in Microsoft.FrameworkUdk and enabled
-                return false;
+                BOOL isSupported{};
+                const HRESULT hr{ PackageManagement_IsFeatureSupported(L"IsPackageReadyOrNewerAvailable", &isSupported) };
+                if (hr == E_NOTIMPL)
+                {
+                    return false;
+                }
+                THROW_IF_FAILED_MSG(hr, "IsPackageReadyOrNewerAvailable");
+                return !!isSupported;
             }
             case winrt::Microsoft::Windows::Management::Deployment::PackageDeploymentFeature::RemovePackageByUri:
             {
@@ -137,11 +142,15 @@ namespace winrt::Microsoft::Windows::Management::Deployment::implementation
             }
             case winrt::Microsoft::Windows::Management::Deployment::PackageDeploymentFeature::ResetPackage:
             {
-                return ::WindowsVersion::IsExportPresent(L"appxdeploymentclient.dll", "MsixResetPackageAsync");
+                //TODO Awaiting Windows update
+                //return ::WindowsVersion::IsExportPresent(L"appxdeploymentclient.dll", "MsixResetPackageAsync");
+                return false;
             }
             case winrt::Microsoft::Windows::Management::Deployment::PackageDeploymentFeature::RepairPackage:
             {
-                return ::WindowsVersion::IsExportPresent(L"appxdeploymentclient.dll", "MsixRepairPackageAsync");
+                //TODO Awaiting Windows update
+                //return ::WindowsVersion::IsExportPresent(L"appxdeploymentclient.dll", "MsixRepairPackageAsync");
+                return false;
             }
             case winrt::Microsoft::Windows::Management::Deployment::PackageDeploymentFeature::ProvisionPackage_Framework:
             {

--- a/dev/WindowsAppRuntime_DLL/packages.config
+++ b/dev/WindowsAppRuntime_DLL/packages.config
@@ -5,5 +5,5 @@
   <package id="Microsoft.SourceLink.GitHub" version="1.1.1" targetFramework="native" developmentDependency="true" />
   <package id="Microsoft.Windows.CppWinRT" version="2.0.230706.1" targetFramework="native" />
   <package id="Microsoft.Windows.ImplementationLibrary" version="1.0.231216.1" targetFramework="native" />
-  <package id="Microsoft.FrameworkUdk" version="1.7.0-CI-26107.1701.240510-1748.0" targetFramework="native" />
+  <package id="Microsoft.FrameworkUdk" version="1.6.4-CI-26107.1006.240719-1146.0" targetFramework="native" />
 </packages>

--- a/test/ApplicationData/packages.config
+++ b/test/ApplicationData/packages.config
@@ -3,7 +3,7 @@
   <package id="Microsoft.Build.Tasks.Git" version="1.1.1" targetFramework="native" developmentDependency="true" />
   <package id="Microsoft.SourceLink.Common" version="1.1.1" targetFramework="native" developmentDependency="true" />
   <package id="Microsoft.SourceLink.GitHub" version="1.1.1" targetFramework="native" developmentDependency="true" />
-  <package id="Microsoft.Taef" version="10.82.230714001" targetFramework="native" />
+  <package id="Microsoft.Taef" version="10.92.240405002" targetFramework="native" />
   <package id="Microsoft.Windows.CppWinRT" version="2.0.230706.1" targetFramework="native" />
   <package id="Microsoft.Windows.ImplementationLibrary" version="1.0.231216.1" targetFramework="native" />
 </packages>

--- a/test/PackageManager/API/packages.config
+++ b/test/PackageManager/API/packages.config
@@ -6,5 +6,5 @@
   <package id="Microsoft.Taef" version="10.92.240405002" targetFramework="native" />
   <package id="Microsoft.Windows.CppWinRT" version="2.0.230706.1" targetFramework="native" />
   <package id="Microsoft.Windows.ImplementationLibrary" version="1.0.231216.1" targetFramework="native" />
-  <package id="Microsoft.FrameworkUdk" version="1.7.0-CI-26107.1701.240510-1748.0" targetFramework="native" />
+  <package id="Microsoft.FrameworkUdk" version="1.6.4-CI-26107.1006.240719-1146.0" targetFramework="native" />
 </packages>

--- a/test/PackageManager/data/PackageManager.Test.M.Black.msix/packages.config
+++ b/test/PackageManager/data/PackageManager.Test.M.Black.msix/packages.config
@@ -3,5 +3,5 @@
   <package id="Microsoft.Build.Tasks.Git" version="1.1.1" targetFramework="native" developmentDependency="true" />
   <package id="Microsoft.SourceLink.Common" version="1.1.1" targetFramework="native" developmentDependency="true" />
   <package id="Microsoft.SourceLink.GitHub" version="1.1.1" targetFramework="native" developmentDependency="true" />
-  <package id="Microsoft.Windows.ImplementationLibrary" version="1.0.220914.1" targetFramework="native" />
+  <package id="Microsoft.Windows.ImplementationLibrary" version="1.0.231216.1" targetFramework="native" />
 </packages>

--- a/test/PackageManager/data/PackageManager.Test.M.Blacker.msix/packages.config
+++ b/test/PackageManager/data/PackageManager.Test.M.Blacker.msix/packages.config
@@ -3,5 +3,5 @@
   <package id="Microsoft.Build.Tasks.Git" version="1.1.1" targetFramework="native" developmentDependency="true" />
   <package id="Microsoft.SourceLink.Common" version="1.1.1" targetFramework="native" developmentDependency="true" />
   <package id="Microsoft.SourceLink.GitHub" version="1.1.1" targetFramework="native" developmentDependency="true" />
-  <package id="Microsoft.Windows.ImplementationLibrary" version="1.0.220914.1" targetFramework="native" />
+  <package id="Microsoft.Windows.ImplementationLibrary" version="1.0.231216.1" targetFramework="native" />
 </packages>

--- a/test/PackageManager/data/PackageManager.Test.M.White.msix/packages.config
+++ b/test/PackageManager/data/PackageManager.Test.M.White.msix/packages.config
@@ -3,5 +3,5 @@
   <package id="Microsoft.Build.Tasks.Git" version="1.1.1" targetFramework="native" developmentDependency="true" />
   <package id="Microsoft.SourceLink.Common" version="1.1.1" targetFramework="native" developmentDependency="true" />
   <package id="Microsoft.SourceLink.GitHub" version="1.1.1" targetFramework="native" developmentDependency="true" />
-  <package id="Microsoft.Windows.ImplementationLibrary" version="1.0.220914.1" targetFramework="native" />
+  <package id="Microsoft.Windows.ImplementationLibrary" version="1.0.231216.1" targetFramework="native" />
 </packages>

--- a/test/PackageManager/data/PackageManager.Test.M.Whiter.msix/packages.config
+++ b/test/PackageManager/data/PackageManager.Test.M.Whiter.msix/packages.config
@@ -3,5 +3,5 @@
   <package id="Microsoft.Build.Tasks.Git" version="1.1.1" targetFramework="native" developmentDependency="true" />
   <package id="Microsoft.SourceLink.Common" version="1.1.1" targetFramework="native" developmentDependency="true" />
   <package id="Microsoft.SourceLink.GitHub" version="1.1.1" targetFramework="native" developmentDependency="true" />
-  <package id="Microsoft.Windows.ImplementationLibrary" version="1.0.220914.1" targetFramework="native" />
+  <package id="Microsoft.Windows.ImplementationLibrary" version="1.0.231216.1" targetFramework="native" />
 </packages>


### PR DESCRIPTION
cherry-pick 1cd3034c41f33fd1cb0775967e429765b3ebe5f4 from main
[Fix IsPackageDeploymentFeatureSupported (#4598)](https://github.com/microsoft/WindowsAppSDK/pull/4598)

ALSO: DevCheck -SyncDependencies to update stale dependency references reported by DevCheck -CheckDependencies