### PR TITLE
[Cherry-pick][WinAppSDK 1.6] [MRTCore] Sync between WGA.PrimaryLanguageOverride and MWGA.PrimaryLanguageOverride

### DIFF
--- a/dev/MRTCore/mrt/Microsoft.Windows.ApplicationModel.Resources/src/ResourceContext.cpp
+++ b/dev/MRTCore/mrt/Microsoft.Windows.ApplicationModel.Resources/src/ResourceContext.cpp
@@ -6,6 +6,8 @@
 #include "ResourceContext.g.cpp"
 #include "winrt/Windows.Globalization.h"
 
+#include <AppModel.Identity.h>
+
 const wchar_t c_languageQualifierName[] = L"Language";
 
 #include "ApplicationLanguages.h"
@@ -99,6 +101,16 @@ void ResourceContext::Apply()
         if (!eachValue.Value().empty())
         {
             winrt::check_hresult(MrmSetQualifier(m_resourceContext, eachValue.Key().c_str(), eachValue.Value().c_str()));
+        }
+    }
+
+    // sync with Windows::Globalization::ApplicationLanguages::PrimaryLanguageOverride if it has been updated more recently
+    if (AppModel::Identity::IsPackagedProcess())
+    {
+        auto language = winrt::Windows::Globalization::ApplicationLanguages::PrimaryLanguageOverride();
+        if (language != ApplicationLanguages::PrimaryLanguageOverride())
+        {
+            ApplicationLanguages::PrimaryLanguageOverride(language);
         }
     }
     if (!ApplicationLanguages::PrimaryLanguageOverride().empty())


### PR DESCRIPTION
Sync between old and new API. If old one (Windows.Globalization.ApplicationLanguages.PrimaryLanguageOverride) was set more recently than the new one (Microsoft.Windows.Globalization.ApplicationLanguages.PrimaryLanguageOverride), also update the new one to the latest value.

Only do this for packaged apps, as Windows.Globalization.ApplicationLanguages.PrimaryLanguageOverride is not supported for unpackaged apps.

(cherry picked from commit aaa39d5e70937d39f76bab8e585e485e0ea7cb15)

Co-authored-by: Stefan Markovic <stefan@janeasystems.com>
(cherry picked from commit 68ffb095b3de98fb6fd11c3898dea7bec4fff978)

A microsoft employee must use /azp run to validate using the pipelines below.

WARNING:
Comments made by azure-pipelines bot maybe inaccurate.
Please see pipeline link to verify that the build is being ran.

For status checks on the main branch, please use TransportPackage-Foundation-PR
(https://microsoft.visualstudio.com/ProjectReunion/_build?definitionId=81063&_a=summary)
and run the build against your PR branch with the default parameters.
