### PR TITLE
Update Runtime Identifier Paths for Compatibility with .NET 8

### DIFF
--- a/build/CopyFilesToStagingDir.ps1
+++ b/build/CopyFilesToStagingDir.ps1
@@ -174,9 +174,8 @@ PublishFile $FullBuildOutput\DynamicDependencyLifetimeManager.ProxyStub\DynamicD
 PublishFile $FullBuildOutput\DynamicDependencyLifetimeManager.ProxyStub\DynamicDependencyLifetimeManager.ProxyStub.pdb $NugetDir\runtimes\win10-$Platform\native
 #
 # Native (not managed, AppLocal / no MSIX)
-PublishFile $FullBuildOutput\WindowsAppRuntime_BootstrapDLL\Microsoft.WindowsAppRuntime.Bootstrap.dll $NugetDir\runtimes\win10-$Platform\native
 PublishFile $FullBuildOutput\WindowsAppRuntime_BootstrapDLL\Microsoft.WindowsAppRuntime.Bootstrap.dll $NugetDir\runtimes\win-$Platform\native
-PublishFile $FullBuildOutput\WindowsAppRuntime_BootstrapDLL\Microsoft.WindowsAppRuntime.Bootstrap.pdb $NugetDir\runtimes\win10-$Platform\native
+PublishFile $FullBuildOutput\WindowsAppRuntime_BootstrapDLL\Microsoft.WindowsAppRuntime.Bootstrap.pdb $NugetDir\runtimes\win-$Platform\native
 #
 # WinMD for UWP apps
 PublishFile $FullBuildOutput\WindowsAppRuntime_DLL\StrippedWinMD\Microsoft.Windows.ApplicationModel.DynamicDependency.winmd $NugetDir\lib\uap10.0


### PR DESCRIPTION
This PR addresses a warning that occurs when targeting .NET 8 in projects using the `Microsoft.WindowsAppSDK`. The warning, identified as NETSDK1206, is triggered due to the use of version-specific or distribution-specific runtime identifiers (RIDs) like `win10-arm64`, `win10-x64`, and `win10-x86`. In .NET 8 and higher, these RIDs are not recognized by default, leading to potential issues in locating necessary assets. The runtime identifier paths have been modified from `win10-$Platform` to `win-$Platform` to align with the new RID scheme in .NET 8.