### PR TITLE
[1.6-stable] Add AppData Terminal Velocity call to yml

### DIFF
--- a/build/AzurePipelinesTemplates/WindowsAppSDK-SetupBuildEnvironment-Steps.yml
+++ b/build/AzurePipelinesTemplates/WindowsAppSDK-SetupBuildEnvironment-Steps.yml
@@ -124,6 +124,14 @@ steps:
     workingDirectory: '$(Build.SourcesDirectory)'
 
 - task: powershell@2
+  displayName: 'Create ApplicationData TerminalVelocity features'
+  inputs:
+    targetType: filePath
+    filePath: tools\TerminalVelocity\Generate-TerminalVelocityFeatures.ps1
+    arguments: -Path $(Build.SourcesDirectory)\dev\common\TerminalVelocityFeatures-ApplicationData.xml -Channel $(channel) -Language C++ -Namespace Microsoft.Windows.ApplicationData -Output $(Build.SourcesDirectory)\dev\common\TerminalVelocityFeatures-ApplicationData.h
+    workingDirectory: '$(Build.SourcesDirectory)'
+
+- task: powershell@2
   displayName: 'Create AppNotifications TerminalVelocity features'
   inputs:
     targetType: filePath

--- a/build/AzurePipelinesTemplates/WindowsAppSDK-SetupBuildEnvironment-Steps.yml
+++ b/build/AzurePipelinesTemplates/WindowsAppSDK-SetupBuildEnvironment-Steps.yml
@@ -128,7 +128,7 @@ steps:
   inputs:
     targetType: filePath
     filePath: tools\TerminalVelocity\Generate-TerminalVelocityFeatures.ps1
-    arguments: -Path $(Build.SourcesDirectory)\dev\common\TerminalVelocityFeatures-ApplicationData.xml -Channel $(channel) -Language C++ -Namespace Microsoft.Windows.ApplicationData -Output $(Build.SourcesDirectory)\dev\common\TerminalVelocityFeatures-ApplicationData.h
+    arguments: -Path $(Build.SourcesDirectory)\dev\common\TerminalVelocityFeatures-ApplicationData.xml -Channel $(channel) -Language C++ -Namespace Microsoft.Windows.Storage.ApplicationData -Output $(Build.SourcesDirectory)\dev\common\TerminalVelocityFeatures-ApplicationData.h
     workingDirectory: '$(Build.SourcesDirectory)'
 
 - task: powershell@2


### PR DESCRIPTION
We need to call TerminalVelocity to properly remove experimental APIs from stable builds.

For status checks on the main branch, please use TransportPackage-Foundation-PR
(https://microsoft.visualstudio.com/ProjectReunion/_build?definitionId=81063&_a=summary)
and run the build against your PR branch with the default parameters.
