### PR TITLE
[1.6] Update Taef, WIL, AzureKeyVault task versions. Sync FrameworkUdk versions.

### DIFF
--- a/dev/DeploymentAgent/packages.config
+++ b/dev/DeploymentAgent/packages.config
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Microsoft.Windows.CppWinRT" version="2.0.230706.1" targetFramework="native" />
-  <package id="Microsoft.Windows.ImplementationLibrary" version="1.0.231216.1" targetFramework="native" />
+  <package id="Microsoft.Windows.ImplementationLibrary" version="1.0.240803.1" targetFramework="native" />
 </packages>

--- a/dev/MRTCore/mrt/Core/src/packages.config
+++ b/dev/MRTCore/mrt/Core/src/packages.config
@@ -3,5 +3,5 @@
   <package id="Microsoft.Build.Tasks.Git" version="1.1.1" targetFramework="native" developmentDependency="true" />
   <package id="Microsoft.SourceLink.Common" version="1.1.1" targetFramework="native" developmentDependency="true" />
   <package id="Microsoft.SourceLink.GitHub" version="1.1.1" targetFramework="native" developmentDependency="true" />
-  <package id="Microsoft.Windows.ImplementationLibrary" version="1.0.231216.1" targetFramework="native" />
+  <package id="Microsoft.Windows.ImplementationLibrary" version="1.0.240803.1" targetFramework="native" />
 </packages>

--- a/dev/MRTCore/mrt/Core/unittests/packages.config
+++ b/dev/MRTCore/mrt/Core/unittests/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.Taef" version="10.92.240405002" targetFramework="native" />
+  <package id="Microsoft.Taef" version="10.94.240624002" targetFramework="native" />
 </packages>

--- a/dev/MRTCore/mrt/Microsoft.Windows.ApplicationModel.Resources/UnpackagedTests/packages.config
+++ b/dev/MRTCore/mrt/Microsoft.Windows.ApplicationModel.Resources/UnpackagedTests/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.Taef" version="10.92.240405002" targetFramework="net45" />
+  <package id="Microsoft.Taef" version="10.94.240624002" targetFramework="net45" />
 </packages>

--- a/dev/MRTCore/mrt/Microsoft.Windows.ApplicationModel.Resources/src/packages.config
+++ b/dev/MRTCore/mrt/Microsoft.Windows.ApplicationModel.Resources/src/packages.config
@@ -4,5 +4,5 @@
   <package id="Microsoft.SourceLink.Common" version="1.1.1" targetFramework="native" developmentDependency="true" />
   <package id="Microsoft.SourceLink.GitHub" version="1.1.1" targetFramework="native" developmentDependency="true" />
   <package id="Microsoft.Windows.CppWinRT" version="2.0.230706.1" targetFramework="native" />
-  <package id="Microsoft.Windows.ImplementationLibrary" version="1.0.231216.1" targetFramework="native" />
+  <package id="Microsoft.Windows.ImplementationLibrary" version="1.0.240803.1" targetFramework="native" />
 </packages>

--- a/dev/MRTCore/mrt/mrm/UnitTests/packages.config
+++ b/dev/MRTCore/mrt/mrm/UnitTests/packages.config
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.Windows.ImplementationLibrary" version="1.0.231216.1" targetFramework="native" />
-  <package id="Microsoft.Taef" version="10.92.240405002" targetFramework="native" />
+  <package id="Microsoft.Windows.ImplementationLibrary" version="1.0.240803.1" targetFramework="native" />
+  <package id="Microsoft.Taef" version="10.94.240624002" targetFramework="native" />
 </packages>

--- a/dev/MRTCore/mrt/mrm/mrmex/packages.config
+++ b/dev/MRTCore/mrt/mrm/mrmex/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.Windows.ImplementationLibrary" version="1.0.231216.1" targetFramework="native" />
+  <package id="Microsoft.Windows.ImplementationLibrary" version="1.0.240803.1" targetFramework="native" />
 </packages>

--- a/dev/MRTCore/mrt/mrm/mrmmin/packages.config
+++ b/dev/MRTCore/mrt/mrm/mrmmin/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.Windows.ImplementationLibrary" version="1.0.231216.1" targetFramework="native" />
+  <package id="Microsoft.Windows.ImplementationLibrary" version="1.0.240803.1" targetFramework="native" />
 </packages>

--- a/dev/PushNotifications/PushNotificationsLongRunningTask.StartupTask/packages.config
+++ b/dev/PushNotifications/PushNotificationsLongRunningTask.StartupTask/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.Windows.ImplementationLibrary" version="1.0.231216.1" targetFramework="native" />
+  <package id="Microsoft.Windows.ImplementationLibrary" version="1.0.240803.1" targetFramework="native" />
   <package id="Microsoft.Build.Tasks.Git" version="1.1.1" targetFramework="native" developmentDependency="true" />
   <package id="Microsoft.SourceLink.GitHub" version="1.1.1" targetFramework="native" developmentDependency="true" />
   <package id="Microsoft.SourceLink.Common" version="1.1.1" targetFramework="native" developmentDependency="true" />

--- a/dev/PushNotifications/PushNotificationsLongRunningTask/packages.config
+++ b/dev/PushNotifications/PushNotificationsLongRunningTask/packages.config
@@ -4,5 +4,5 @@
   <package id="Microsoft.SourceLink.Common" version="1.1.1" targetFramework="native" developmentDependency="true" />
   <package id="Microsoft.SourceLink.GitHub" version="1.1.1" targetFramework="native" developmentDependency="true" />
   <package id="Microsoft.Windows.CppWinRT" version="2.0.230706.1" targetFramework="native" />
-  <package id="Microsoft.Windows.ImplementationLibrary" version="1.0.231216.1" targetFramework="native" />
+  <package id="Microsoft.Windows.ImplementationLibrary" version="1.0.240803.1" targetFramework="native" />
 </packages>

--- a/dev/RestartAgent/packages.config
+++ b/dev/RestartAgent/packages.config
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Microsoft.Windows.CppWinRT" version="2.0.230706.1" targetFramework="native" />
-  <package id="Microsoft.Windows.ImplementationLibrary" version="1.0.231216.1" targetFramework="native" />
+  <package id="Microsoft.Windows.ImplementationLibrary" version="1.0.240803.1" targetFramework="native" />
 </packages>

--- a/dev/WindowsAppRuntime_BootstrapDLL/packages.config
+++ b/dev/WindowsAppRuntime_BootstrapDLL/packages.config
@@ -3,5 +3,5 @@
   <package id="Microsoft.Build.Tasks.Git" version="1.1.1" targetFramework="native" developmentDependency="true" />
   <package id="Microsoft.SourceLink.Common" version="1.1.1" targetFramework="native" developmentDependency="true" />
   <package id="Microsoft.SourceLink.GitHub" version="1.1.1" targetFramework="native" developmentDependency="true" />
-  <package id="Microsoft.Windows.ImplementationLibrary" version="1.0.231216.1" targetFramework="native" />
+  <package id="Microsoft.Windows.ImplementationLibrary" version="1.0.240803.1" targetFramework="native" />
 </packages>

--- a/dev/WindowsAppRuntime_DLL/packages.config
+++ b/dev/WindowsAppRuntime_DLL/packages.config
@@ -5,5 +5,5 @@
   <package id="Microsoft.SourceLink.GitHub" version="1.1.1" targetFramework="native" developmentDependency="true" />
   <package id="Microsoft.Windows.CppWinRT" version="2.0.230706.1" targetFramework="native" />
   <package id="Microsoft.Windows.ImplementationLibrary" version="1.0.240803.1" targetFramework="native" />
-  <package id="Microsoft.FrameworkUdk" version="1.6.4-CI-26107.1006.240719-1146.0" targetFramework="native" />
+  <package id="Microsoft.FrameworkUdk" version="1.6.4-CI-26107.1008.240814-1149.0" targetFramework="native" />
 </packages>

--- a/dev/WindowsAppRuntime_DLL/packages.config
+++ b/dev/WindowsAppRuntime_DLL/packages.config
@@ -4,6 +4,6 @@
   <package id="Microsoft.SourceLink.Common" version="1.1.1" targetFramework="native" developmentDependency="true" />
   <package id="Microsoft.SourceLink.GitHub" version="1.1.1" targetFramework="native" developmentDependency="true" />
   <package id="Microsoft.Windows.CppWinRT" version="2.0.230706.1" targetFramework="native" />
-  <package id="Microsoft.Windows.ImplementationLibrary" version="1.0.231216.1" targetFramework="native" />
+  <package id="Microsoft.Windows.ImplementationLibrary" version="1.0.240803.1" targetFramework="native" />
   <package id="Microsoft.FrameworkUdk" version="1.6.4-CI-26107.1006.240719-1146.0" targetFramework="native" />
 </packages>

--- a/eng/Version.Dependencies.xml
+++ b/eng/Version.Dependencies.xml
@@ -29,9 +29,9 @@
   <Dependency Name="Microsoft.Build.Tasks.Git"                Version="1.1.1"/>
   <Dependency Name="Microsoft.SourceLink.Common"              Version="1.1.1"/>
   <Dependency Name="Microsoft.SourceLink.GitHub"              Version="1.1.1"/>
-  <Dependency Name="Microsoft.Taef"                           Version="10.92.240405002"/>
+  <Dependency Name="Microsoft.Taef"                           Version="10.94.240624002"/>
   <Dependency Name="Microsoft.Telemetry.Inbox.Native"         Version="10.0.19041.1-191206-1406.vb-release.x86fre" />
   <Dependency Name="Microsoft.Windows.CppWinRT"               Version="2.0.230706.1"/>
-  <Dependency Name="Microsoft.Windows.ImplementationLibrary"  Version="1.0.231216.1"/>
+  <Dependency Name="Microsoft.Windows.ImplementationLibrary"  Version="1.0.240803.1"/>
   <Dependency Name="Microsoft.WindowsAppSDK.Protobuf"         Version="3.21.12"/>
 </Dependencies>

--- a/eng/common/AzurePipelinesTemplates/WindowsAppSDK-BuildSetup-Steps.yml
+++ b/eng/common/AzurePipelinesTemplates/WindowsAppSDK-BuildSetup-Steps.yml
@@ -24,7 +24,7 @@ parameters:
 steps:
   - checkout: git://ProjectReunion/WindowsAppSDKAggregator
 
-  - task: AzureKeyVault@1
+  - task: AzureKeyVault@2
     inputs:
       azureSubscription: ${{ parameters.AzureSubscriptionServiceConnection }}
       KeyVaultName: 'ProjectReunionCerts'

--- a/installer/dev/packages.config
+++ b/installer/dev/packages.config
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Microsoft.Windows.CppWinRT" version="2.0.230706.1" targetFramework="native" />
-  <package id="Microsoft.Windows.ImplementationLibrary" version="1.0.231216.1" targetFramework="native" />
+  <package id="Microsoft.Windows.ImplementationLibrary" version="1.0.240803.1" targetFramework="native" />
 </packages>

--- a/installer/test/InstallerFunctionalTests/packages.config
+++ b/installer/test/InstallerFunctionalTests/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.Taef" version="10.92.240405002" targetFramework="native" />
+  <package id="Microsoft.Taef" version="10.94.240624002" targetFramework="native" />
   <package id="Microsoft.Windows.CppWinRT" version="2.0.230706.1" targetFramework="native" />
-  <package id="Microsoft.Windows.ImplementationLibrary" version="1.0.231216.1" targetFramework="native" />
+  <package id="Microsoft.Windows.ImplementationLibrary" version="1.0.240803.1" targetFramework="native" />
 </packages>

--- a/test/AccessControlTests/packages.config
+++ b/test/AccessControlTests/packages.config
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.Taef" version="10.92.240405002" targetFramework="native" />
+  <package id="Microsoft.Taef" version="10.94.240624002" targetFramework="native" />
   <package id="Microsoft.Windows.CppWinRT" version="2.0.230706.1" targetFramework="native" />
 </packages>

--- a/test/AppLifecycle/packages.config
+++ b/test/AppLifecycle/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.Taef" version="10.92.240405002" targetFramework="native" />
+  <package id="Microsoft.Taef" version="10.94.240624002" targetFramework="native" />
   <package id="Microsoft.Windows.CppWinRT" version="2.0.230706.1" targetFramework="native" />
-  <package id="Microsoft.Windows.ImplementationLibrary" version="1.0.231216.1" targetFramework="native" />
+  <package id="Microsoft.Windows.ImplementationLibrary" version="1.0.240803.1" targetFramework="native" />
 </packages>

--- a/test/AppNotificationBuilderTests/packages.config
+++ b/test/AppNotificationBuilderTests/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.Taef" version="10.92.240405002" targetFramework="native" />
+  <package id="Microsoft.Taef" version="10.94.240624002" targetFramework="native" />
   <package id="Microsoft.Windows.CppWinRT" version="2.0.230706.1" targetFramework="native" />
-  <package id="Microsoft.Windows.ImplementationLibrary" version="1.0.231216.1" targetFramework="native" />
+  <package id="Microsoft.Windows.ImplementationLibrary" version="1.0.240803.1" targetFramework="native" />
 </packages>

--- a/test/AppNotificationTests/packages.config
+++ b/test/AppNotificationTests/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.Taef" version="10.92.240405002" targetFramework="native" />
+  <package id="Microsoft.Taef" version="10.94.240624002" targetFramework="native" />
   <package id="Microsoft.Windows.CppWinRT" version="2.0.230706.1" targetFramework="native" />
-  <package id="Microsoft.Windows.ImplementationLibrary" version="1.0.231216.1" targetFramework="native" />
+  <package id="Microsoft.Windows.ImplementationLibrary" version="1.0.240803.1" targetFramework="native" />
 </packages>

--- a/test/ApplicationData/packages.config
+++ b/test/ApplicationData/packages.config
@@ -3,7 +3,7 @@
   <package id="Microsoft.Build.Tasks.Git" version="1.1.1" targetFramework="native" developmentDependency="true" />
   <package id="Microsoft.SourceLink.Common" version="1.1.1" targetFramework="native" developmentDependency="true" />
   <package id="Microsoft.SourceLink.GitHub" version="1.1.1" targetFramework="native" developmentDependency="true" />
-  <package id="Microsoft.Taef" version="10.92.240405002" targetFramework="native" />
+  <package id="Microsoft.Taef" version="10.94.240624002" targetFramework="native" />
   <package id="Microsoft.Windows.CppWinRT" version="2.0.230706.1" targetFramework="native" />
-  <package id="Microsoft.Windows.ImplementationLibrary" version="1.0.231216.1" targetFramework="native" />
+  <package id="Microsoft.Windows.ImplementationLibrary" version="1.0.240803.1" targetFramework="native" />
 </packages>

--- a/test/Common/packages.config
+++ b/test/Common/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.Taef" version="10.92.240405002" targetFramework="native" />
+  <package id="Microsoft.Taef" version="10.94.240624002" targetFramework="native" />
   <package id="Microsoft.Windows.CppWinRT" version="2.0.230706.1" targetFramework="native" />
-  <package id="Microsoft.Windows.ImplementationLibrary" version="1.0.231216.1" targetFramework="native" />
+  <package id="Microsoft.Windows.ImplementationLibrary" version="1.0.240803.1" targetFramework="native" />
 </packages>

--- a/test/Deployment/API/packages.config
+++ b/test/Deployment/API/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.Taef" version="10.92.240405002" targetFramework="native" />
+  <package id="Microsoft.Taef" version="10.94.240624002" targetFramework="native" />
   <package id="Microsoft.Windows.CppWinRT" version="2.0.230706.1" targetFramework="native" />
-  <package id="Microsoft.Windows.ImplementationLibrary" version="1.0.231216.1" targetFramework="native" />
+  <package id="Microsoft.Windows.ImplementationLibrary" version="1.0.240803.1" targetFramework="native" />
 </packages>

--- a/test/Deployment/Test_DeploymentManagerAutoInitialize/CPP/Test_DeploymentManagerAutoInitialize_CPP_Default/packages.config
+++ b/test/Deployment/Test_DeploymentManagerAutoInitialize/CPP/Test_DeploymentManagerAutoInitialize_CPP_Default/packages.config
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Microsoft.Windows.CppWinRT" version="2.0.230706.1" targetFramework="native" />
-  <package id="Microsoft.Windows.ImplementationLibrary" version="1.0.231216.1" targetFramework="native" />
+  <package id="Microsoft.Windows.ImplementationLibrary" version="1.0.240803.1" targetFramework="native" />
 </packages>

--- a/test/Deployment/Test_DeploymentManagerAutoInitialize/CPP/Test_DeploymentManagerAutoInitialize_CPP_Options_Default/packages.config
+++ b/test/Deployment/Test_DeploymentManagerAutoInitialize/CPP/Test_DeploymentManagerAutoInitialize_CPP_Options_Default/packages.config
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Microsoft.Windows.CppWinRT" version="2.0.230706.1" targetFramework="native" />
-  <package id="Microsoft.Windows.ImplementationLibrary" version="1.0.231216.1" targetFramework="native" />
+  <package id="Microsoft.Windows.ImplementationLibrary" version="1.0.240803.1" targetFramework="native" />
 </packages>

--- a/test/Deployment/Test_DeploymentManagerAutoInitialize/CPP/Test_DeploymentManagerAutoInitialize_CPP_Options_Defined/packages.config
+++ b/test/Deployment/Test_DeploymentManagerAutoInitialize/CPP/Test_DeploymentManagerAutoInitialize_CPP_Options_Defined/packages.config
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Microsoft.Windows.CppWinRT" version="2.0.230706.1" targetFramework="native" />
-  <package id="Microsoft.Windows.ImplementationLibrary" version="1.0.231216.1" targetFramework="native" />
+  <package id="Microsoft.Windows.ImplementationLibrary" version="1.0.240803.1" targetFramework="native" />
 </packages>

--- a/test/Deployment/Test_DeploymentManagerAutoInitialize/CPP/Test_DeploymentManagerAutoInitialize_CPP_Options_None/packages.config
+++ b/test/Deployment/Test_DeploymentManagerAutoInitialize/CPP/Test_DeploymentManagerAutoInitialize_CPP_Options_None/packages.config
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Microsoft.Windows.CppWinRT" version="2.0.230706.1" targetFramework="native" />
-  <package id="Microsoft.Windows.ImplementationLibrary" version="1.0.231216.1" targetFramework="native" />
+  <package id="Microsoft.Windows.ImplementationLibrary" version="1.0.240803.1" targetFramework="native" />
 </packages>

--- a/test/DynamicDependency/Test_BootstrapAutoInitialize/CPP/Test_BootstrapAutoInitialize_CPP_Default/packages.config
+++ b/test/DynamicDependency/Test_BootstrapAutoInitialize/CPP/Test_BootstrapAutoInitialize_CPP_Default/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.Windows.ImplementationLibrary" version="1.0.231216.1" targetFramework="native" />
+  <package id="Microsoft.Windows.ImplementationLibrary" version="1.0.240803.1" targetFramework="native" />
 </packages>

--- a/test/DynamicDependency/Test_BootstrapAutoInitialize/CPP/Test_BootstrapAutoInitialize_CPP_Options_Default/packages.config
+++ b/test/DynamicDependency/Test_BootstrapAutoInitialize/CPP/Test_BootstrapAutoInitialize_CPP_Options_Default/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.Windows.ImplementationLibrary" version="1.0.231216.1" targetFramework="native" />
+  <package id="Microsoft.Windows.ImplementationLibrary" version="1.0.240803.1" targetFramework="native" />
 </packages>

--- a/test/DynamicDependency/Test_BootstrapAutoInitialize/CPP/Test_BootstrapAutoInitialize_CPP_Options_Defined/packages.config
+++ b/test/DynamicDependency/Test_BootstrapAutoInitialize/CPP/Test_BootstrapAutoInitialize_CPP_Options_Defined/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.Windows.ImplementationLibrary" version="1.0.231216.1" targetFramework="native" />
+  <package id="Microsoft.Windows.ImplementationLibrary" version="1.0.240803.1" targetFramework="native" />
 </packages>

--- a/test/DynamicDependency/Test_BootstrapAutoInitialize/CPP/Test_BootstrapAutoInitialize_CPP_Options_None/packages.config
+++ b/test/DynamicDependency/Test_BootstrapAutoInitialize/CPP/Test_BootstrapAutoInitialize_CPP_Options_None/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.Windows.ImplementationLibrary" version="1.0.231216.1" targetFramework="native" />
+  <package id="Microsoft.Windows.ImplementationLibrary" version="1.0.240803.1" targetFramework="native" />
 </packages>

--- a/test/DynamicDependency/Test_Win32/packages.config
+++ b/test/DynamicDependency/Test_Win32/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.Taef" version="10.92.240405002" targetFramework="native" />
+  <package id="Microsoft.Taef" version="10.94.240624002" targetFramework="native" />
 </packages>

--- a/test/DynamicDependency/Test_WinRT/packages.config
+++ b/test/DynamicDependency/Test_WinRT/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.Taef" version="10.92.240405002" targetFramework="native" />
+  <package id="Microsoft.Taef" version="10.94.240624002" targetFramework="native" />
 </packages>

--- a/test/DynamicDependency/data/Framework.Widgets/packages.config
+++ b/test/DynamicDependency/data/Framework.Widgets/packages.config
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Microsoft.Windows.CppWinRT" version="2.0.230706.1" targetFramework="native" />
-  <package id="Microsoft.Windows.ImplementationLibrary" version="1.0.231216.1" targetFramework="native" />
+  <package id="Microsoft.Windows.ImplementationLibrary" version="1.0.240803.1" targetFramework="native" />
 </packages>

--- a/test/EnvironmentManagerTests/packages.config
+++ b/test/EnvironmentManagerTests/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.Taef" version="10.92.240405002" targetFramework="native" />
+  <package id="Microsoft.Taef" version="10.94.240624002" targetFramework="native" />
   <package id="Microsoft.Windows.CppWinRT" version="2.0.230706.1" targetFramework="native" />
-  <package id="Microsoft.Windows.ImplementationLibrary" version="1.0.231216.1" targetFramework="native" />
+  <package id="Microsoft.Windows.ImplementationLibrary" version="1.0.240803.1" targetFramework="native" />
 </packages>

--- a/test/LRPTests/packages.config
+++ b/test/LRPTests/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.Taef" version="10.92.240405002" targetFramework="native" />
+  <package id="Microsoft.Taef" version="10.94.240624002" targetFramework="native" />
   <package id="Microsoft.Windows.CppWinRT" version="2.0.230706.1" targetFramework="native" />
-  <package id="Microsoft.Windows.ImplementationLibrary" version="1.0.231216.1" targetFramework="native" />
+  <package id="Microsoft.Windows.ImplementationLibrary" version="1.0.240803.1" targetFramework="native" />
 </packages>

--- a/test/PackageManager/API/packages.config
+++ b/test/PackageManager/API/packages.config
@@ -3,8 +3,8 @@
   <package id="Microsoft.Build.Tasks.Git" version="1.1.1" targetFramework="native" developmentDependency="true" />
   <package id="Microsoft.SourceLink.Common" version="1.1.1" targetFramework="native" developmentDependency="true" />
   <package id="Microsoft.SourceLink.GitHub" version="1.1.1" targetFramework="native" developmentDependency="true" />
-  <package id="Microsoft.Taef" version="10.92.240405002" targetFramework="native" />
+  <package id="Microsoft.Taef" version="10.94.240624002" targetFramework="native" />
   <package id="Microsoft.Windows.CppWinRT" version="2.0.230706.1" targetFramework="native" />
-  <package id="Microsoft.Windows.ImplementationLibrary" version="1.0.231216.1" targetFramework="native" />
+  <package id="Microsoft.Windows.ImplementationLibrary" version="1.0.240803.1" targetFramework="native" />
   <package id="Microsoft.FrameworkUdk" version="1.6.4-CI-26107.1006.240719-1146.0" targetFramework="native" />
 </packages>

--- a/test/PackageManager/API/packages.config
+++ b/test/PackageManager/API/packages.config
@@ -6,5 +6,5 @@
   <package id="Microsoft.Taef" version="10.94.240624002" targetFramework="native" />
   <package id="Microsoft.Windows.CppWinRT" version="2.0.230706.1" targetFramework="native" />
   <package id="Microsoft.Windows.ImplementationLibrary" version="1.0.240803.1" targetFramework="native" />
-  <package id="Microsoft.FrameworkUdk" version="1.6.4-CI-26107.1006.240719-1146.0" targetFramework="native" />
+  <package id="Microsoft.FrameworkUdk" version="1.6.4-CI-26107.1008.240814-1149.0" targetFramework="native" />
 </packages>

--- a/test/PackageManager/data/PackageManager.Test.M.Black.msix/packages.config
+++ b/test/PackageManager/data/PackageManager.Test.M.Black.msix/packages.config
@@ -3,5 +3,5 @@
   <package id="Microsoft.Build.Tasks.Git" version="1.1.1" targetFramework="native" developmentDependency="true" />
   <package id="Microsoft.SourceLink.Common" version="1.1.1" targetFramework="native" developmentDependency="true" />
   <package id="Microsoft.SourceLink.GitHub" version="1.1.1" targetFramework="native" developmentDependency="true" />
-  <package id="Microsoft.Windows.ImplementationLibrary" version="1.0.231216.1" targetFramework="native" />
+  <package id="Microsoft.Windows.ImplementationLibrary" version="1.0.240803.1" targetFramework="native" />
 </packages>

--- a/test/PackageManager/data/PackageManager.Test.M.Blacker.msix/packages.config
+++ b/test/PackageManager/data/PackageManager.Test.M.Blacker.msix/packages.config
@@ -3,5 +3,5 @@
   <package id="Microsoft.Build.Tasks.Git" version="1.1.1" targetFramework="native" developmentDependency="true" />
   <package id="Microsoft.SourceLink.Common" version="1.1.1" targetFramework="native" developmentDependency="true" />
   <package id="Microsoft.SourceLink.GitHub" version="1.1.1" targetFramework="native" developmentDependency="true" />
-  <package id="Microsoft.Windows.ImplementationLibrary" version="1.0.231216.1" targetFramework="native" />
+  <package id="Microsoft.Windows.ImplementationLibrary" version="1.0.240803.1" targetFramework="native" />
 </packages>

--- a/test/PackageManager/data/PackageManager.Test.M.White.msix/packages.config
+++ b/test/PackageManager/data/PackageManager.Test.M.White.msix/packages.config
@@ -3,5 +3,5 @@
   <package id="Microsoft.Build.Tasks.Git" version="1.1.1" targetFramework="native" developmentDependency="true" />
   <package id="Microsoft.SourceLink.Common" version="1.1.1" targetFramework="native" developmentDependency="true" />
   <package id="Microsoft.SourceLink.GitHub" version="1.1.1" targetFramework="native" developmentDependency="true" />
-  <package id="Microsoft.Windows.ImplementationLibrary" version="1.0.231216.1" targetFramework="native" />
+  <package id="Microsoft.Windows.ImplementationLibrary" version="1.0.240803.1" targetFramework="native" />
 </packages>

--- a/test/PackageManager/data/PackageManager.Test.M.Whiter.msix/packages.config
+++ b/test/PackageManager/data/PackageManager.Test.M.Whiter.msix/packages.config
@@ -3,5 +3,5 @@
   <package id="Microsoft.Build.Tasks.Git" version="1.1.1" targetFramework="native" developmentDependency="true" />
   <package id="Microsoft.SourceLink.Common" version="1.1.1" targetFramework="native" developmentDependency="true" />
   <package id="Microsoft.SourceLink.GitHub" version="1.1.1" targetFramework="native" developmentDependency="true" />
-  <package id="Microsoft.Windows.ImplementationLibrary" version="1.0.231216.1" targetFramework="native" />
+  <package id="Microsoft.Windows.ImplementationLibrary" version="1.0.240803.1" targetFramework="native" />
 </packages>

--- a/test/PowerNotifications/packages.config
+++ b/test/PowerNotifications/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.Taef" version="10.92.240405002" targetFramework="native" />
+  <package id="Microsoft.Taef" version="10.94.240624002" targetFramework="native" />
   <package id="Microsoft.Windows.CppWinRT" version="2.0.230706.1" targetFramework="native" />
-  <package id="Microsoft.Windows.ImplementationLibrary" version="1.0.231216.1" targetFramework="native" />
+  <package id="Microsoft.Windows.ImplementationLibrary" version="1.0.240803.1" targetFramework="native" />
 </packages>

--- a/test/PushNotificationTests/packages.config
+++ b/test/PushNotificationTests/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.Taef" version="10.92.240405002" targetFramework="native" />
+  <package id="Microsoft.Taef" version="10.94.240624002" targetFramework="native" />
   <package id="Microsoft.Windows.CppWinRT" version="2.0.230706.1" targetFramework="native" />
-  <package id="Microsoft.Windows.ImplementationLibrary" version="1.0.231216.1" targetFramework="native" />
+  <package id="Microsoft.Windows.ImplementationLibrary" version="1.0.240803.1" targetFramework="native" />
 </packages>

--- a/test/TestApps/AccessControlTestApp/packages.config
+++ b/test/TestApps/AccessControlTestApp/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.Taef" version="10.92.240405002" targetFramework="native" />
+  <package id="Microsoft.Taef" version="10.94.240624002" targetFramework="native" />
   <package id="Microsoft.Windows.CppWinRT" version="2.0.230706.1" targetFramework="native" />
-  <package id="Microsoft.Windows.ImplementationLibrary" version="1.0.231216.1" targetFramework="native" />
+  <package id="Microsoft.Windows.ImplementationLibrary" version="1.0.240803.1" targetFramework="native" />
 </packages>

--- a/test/TestApps/AppLifecycleTestApp/packages.config
+++ b/test/TestApps/AppLifecycleTestApp/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.Taef" version="10.92.240405002" targetFramework="native" />
+  <package id="Microsoft.Taef" version="10.94.240624002" targetFramework="native" />
   <package id="Microsoft.Windows.CppWinRT" version="2.0.230706.1" targetFramework="native" />
-  <package id="Microsoft.Windows.ImplementationLibrary" version="1.0.231216.1" targetFramework="native" />
+  <package id="Microsoft.Windows.ImplementationLibrary" version="1.0.240803.1" targetFramework="native" />
 </packages>

--- a/test/TestApps/ManualTestApp/packages.config
+++ b/test/TestApps/ManualTestApp/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.Taef" version="10.92.240405002" targetFramework="native" />
+  <package id="Microsoft.Taef" version="10.94.240624002" targetFramework="native" />
   <package id="Microsoft.Windows.CppWinRT" version="2.0.230706.1" targetFramework="native" />
-  <package id="Microsoft.Windows.ImplementationLibrary" version="1.0.231216.1" targetFramework="native" />
+  <package id="Microsoft.Windows.ImplementationLibrary" version="1.0.240803.1" targetFramework="native" />
 </packages>

--- a/test/TestApps/PushNotificationsDemoApp/packages.config
+++ b/test/TestApps/PushNotificationsDemoApp/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.Taef" version="10.92.240405002" targetFramework="native" />
+  <package id="Microsoft.Taef" version="10.94.240624002" targetFramework="native" />
   <package id="Microsoft.Windows.CppWinRT" version="2.0.230706.1" targetFramework="native" />
-  <package id="Microsoft.Windows.ImplementationLibrary" version="1.0.231216.1" targetFramework="native" />
+  <package id="Microsoft.Windows.ImplementationLibrary" version="1.0.240803.1" targetFramework="native" />
 </packages>

--- a/test/TestApps/PushNotificationsTestApp/packages.config
+++ b/test/TestApps/PushNotificationsTestApp/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.Taef" version="10.92.240405002" targetFramework="native" />
+  <package id="Microsoft.Taef" version="10.94.240624002" targetFramework="native" />
   <package id="Microsoft.Windows.CppWinRT" version="2.0.230706.1" targetFramework="native" />
-  <package id="Microsoft.Windows.ImplementationLibrary" version="1.0.231216.1" targetFramework="native" />
+  <package id="Microsoft.Windows.ImplementationLibrary" version="1.0.240803.1" targetFramework="native" />
 </packages>

--- a/test/TestApps/ToastNotificationsDemoApp/packages.config
+++ b/test/TestApps/ToastNotificationsDemoApp/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.Taef" version="10.92.240405002" targetFramework="native" />
+  <package id="Microsoft.Taef" version="10.94.240624002" targetFramework="native" />
   <package id="Microsoft.Windows.CppWinRT" version="2.0.230706.1" targetFramework="native" />
-  <package id="Microsoft.Windows.ImplementationLibrary" version="1.0.231216.1" targetFramework="native" />
+  <package id="Microsoft.Windows.ImplementationLibrary" version="1.0.240803.1" targetFramework="native" />
 </packages>

--- a/test/TestApps/ToastNotificationsTestApp/packages.config
+++ b/test/TestApps/ToastNotificationsTestApp/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.Taef" version="10.92.240405002" targetFramework="native" />
+  <package id="Microsoft.Taef" version="10.94.240624002" targetFramework="native" />
   <package id="Microsoft.Windows.CppWinRT" version="2.0.230706.1" targetFramework="native" />
-  <package id="Microsoft.Windows.ImplementationLibrary" version="1.0.231216.1" targetFramework="native" />
+  <package id="Microsoft.Windows.ImplementationLibrary" version="1.0.240803.1" targetFramework="native" />
 </packages>

--- a/test/VersionInfo/packages.config
+++ b/test/VersionInfo/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.Taef" version="10.92.240405002" targetFramework="native" />
+  <package id="Microsoft.Taef" version="10.94.240624002" targetFramework="native" />
   <package id="Microsoft.Windows.CppWinRT" version="2.0.230706.1" targetFramework="native" />
-  <package id="Microsoft.Windows.ImplementationLibrary" version="1.0.231216.1" targetFramework="native" />
+  <package id="Microsoft.Windows.ImplementationLibrary" version="1.0.240803.1" targetFramework="native" />
 </packages>

--- a/tools/ProjectTemplates/dev.cpp.dll.winrt-client-server/packages.config
+++ b/tools/ProjectTemplates/dev.cpp.dll.winrt-client-server/packages.config
@@ -4,5 +4,5 @@
   <package id="Microsoft.SourceLink.Common" version="1.1.1" targetFramework="native" developmentDependency="true" />
   <package id="Microsoft.SourceLink.GitHub" version="1.1.1" targetFramework="native" developmentDependency="true" />
   <package id="Microsoft.Windows.CppWinRT" version="2.0.230706.1" targetFramework="native" />
-  <package id="Microsoft.Windows.ImplementationLibrary" version="1.0.231216.1" targetFramework="native" />
+  <package id="Microsoft.Windows.ImplementationLibrary" version="1.0.240803.1" targetFramework="native" />
 </packages>

--- a/tools/ProjectTemplates/dev.cpp.dll.winrt-client/packages.config
+++ b/tools/ProjectTemplates/dev.cpp.dll.winrt-client/packages.config
@@ -4,5 +4,5 @@
   <package id="Microsoft.SourceLink.Common" version="1.1.1" targetFramework="native" developmentDependency="true" />
   <package id="Microsoft.SourceLink.GitHub" version="1.1.1" targetFramework="native" developmentDependency="true" />
   <package id="Microsoft.Windows.CppWinRT" version="2.0.230706.1" targetFramework="native" />
-  <package id="Microsoft.Windows.ImplementationLibrary" version="1.0.231216.1" targetFramework="native" />
+  <package id="Microsoft.Windows.ImplementationLibrary" version="1.0.240803.1" targetFramework="native" />
 </packages>

--- a/tools/ProjectTemplates/dev.cpp.exe+dll.com-oopserver/PurojekutoTenpuret/packages.config
+++ b/tools/ProjectTemplates/dev.cpp.exe+dll.com-oopserver/PurojekutoTenpuret/packages.config
@@ -4,5 +4,5 @@
   <package id="Microsoft.SourceLink.Common" version="1.1.1" targetFramework="native" developmentDependency="true" />
   <package id="Microsoft.SourceLink.GitHub" version="1.1.1" targetFramework="native" developmentDependency="true" />
   <package id="Microsoft.Windows.CppWinRT" version="2.0.230706.1" targetFramework="native" />
-  <package id="Microsoft.Windows.ImplementationLibrary" version="1.0.231216.1" targetFramework="native" />
+  <package id="Microsoft.Windows.ImplementationLibrary" version="1.0.240803.1" targetFramework="native" />
 </packages>

--- a/tools/ProjectTemplates/dev.cpp.exe.com-oopserver-main/packages.config
+++ b/tools/ProjectTemplates/dev.cpp.exe.com-oopserver-main/packages.config
@@ -4,5 +4,5 @@
   <package id="Microsoft.SourceLink.Common" version="1.1.1" targetFramework="native" developmentDependency="true" />
   <package id="Microsoft.SourceLink.GitHub" version="1.1.1" targetFramework="native" developmentDependency="true" />
   <package id="Microsoft.Windows.CppWinRT" version="2.0.230706.1" targetFramework="native" />
-  <package id="Microsoft.Windows.ImplementationLibrary" version="1.0.231216.1" targetFramework="native" />
+  <package id="Microsoft.Windows.ImplementationLibrary" version="1.0.240803.1" targetFramework="native" />
 </packages>

--- a/tools/ProjectTemplates/dev.cpp.exe.console-winrt-client/packages.config
+++ b/tools/ProjectTemplates/dev.cpp.exe.console-winrt-client/packages.config
@@ -4,5 +4,5 @@
   <package id="Microsoft.SourceLink.Common" version="1.1.1" targetFramework="native" developmentDependency="true" />
   <package id="Microsoft.SourceLink.GitHub" version="1.1.1" targetFramework="native" developmentDependency="true" />
   <package id="Microsoft.Windows.CppWinRT" version="2.0.230706.1" targetFramework="native" />
-  <package id="Microsoft.Windows.ImplementationLibrary" version="1.0.231216.1" targetFramework="native" />
+  <package id="Microsoft.Windows.ImplementationLibrary" version="1.0.240803.1" targetFramework="native" />
 </packages>

--- a/tools/ProjectTemplates/dev.cpp.exe.winmain-winrt-client/packages.config
+++ b/tools/ProjectTemplates/dev.cpp.exe.winmain-winrt-client/packages.config
@@ -4,5 +4,5 @@
   <package id="Microsoft.SourceLink.Common" version="1.1.1" targetFramework="native" developmentDependency="true" />
   <package id="Microsoft.SourceLink.GitHub" version="1.1.1" targetFramework="native" developmentDependency="true" />
   <package id="Microsoft.Windows.CppWinRT" version="2.0.230706.1" targetFramework="native" />
-  <package id="Microsoft.Windows.ImplementationLibrary" version="1.0.231216.1" targetFramework="native" />
+  <package id="Microsoft.Windows.ImplementationLibrary" version="1.0.240803.1" targetFramework="native" />
 </packages>

--- a/tools/ProjectTemplates/test.cpp.dll.taef/packages.config
+++ b/tools/ProjectTemplates/test.cpp.dll.taef/packages.config
@@ -3,7 +3,7 @@
   <package id="Microsoft.Build.Tasks.Git" version="1.1.1" targetFramework="native" developmentDependency="true" />
   <package id="Microsoft.SourceLink.Common" version="1.1.1" targetFramework="native" developmentDependency="true" />
   <package id="Microsoft.SourceLink.GitHub" version="1.1.1" targetFramework="native" developmentDependency="true" />
-  <package id="Microsoft.Taef" version="10.92.240405002" targetFramework="native" />
+  <package id="Microsoft.Taef" version="10.94.240624002" targetFramework="native" />
   <package id="Microsoft.Windows.CppWinRT" version="2.0.230706.1" targetFramework="native" />
-  <package id="Microsoft.Windows.ImplementationLibrary" version="1.0.231216.1" targetFramework="native" />
+  <package id="Microsoft.Windows.ImplementationLibrary" version="1.0.240803.1" targetFramework="native" />
 </packages>


### PR DESCRIPTION
[cp from main] update Taef to 10.94.240624002 (cae176ef207e18e0120ff389cba916966276e551)
[cp from main] update WIL to 1.0.240803.1 (cae176ef207e18e0120ff389cba916966276e551)
[cp from main] Update AzureKeyVault task version (9bf8deaff1ebb2c25e02c4d4dc4229edfab1165a)
sync FrameworkUdk versions in packages.config to match Versions.xml

WARNING:
Comments made by azure-pipelines bot maybe inaccurate.
Please see pipeline link to verify that the build is being ran.

For status checks on the main branch, please use TransportPackage-Foundation-PR
(https://microsoft.visualstudio.com/ProjectReunion/_build?definitionId=81063&_a=summary)
and run the build against your PR branch with the default parameters.
