### PR TITLE
New PackageDeploymentManager methods not tagged with new v2 contract

### DIFF
--- a/dev/PackageManager/API/PackageManager.idl
+++ b/dev/PackageManager/API/PackageManager.idl
@@ -471,11 +471,13 @@ namespace Microsoft.Windows.Management.Deployment
         //-------------------------------------------------------------
         // IsRegistrationPending
 
-        [contract(PackageDeploymentContract, 2)]
-        Boolean IsPackageRegistrationPending(String packageFullName);
+        /// @warning The parameter is should be "packageFullName" but can't due to http://task.ms/53280356.
+        ///          Consider the current (wrong) parameter name deprecated until vFuture (2.0) when we can change to the new (right) parameter name.
+        Boolean IsPackageRegistrationPending(String packageFamilyName);
 
-        [contract(PackageDeploymentContract, 2)]
-        Boolean IsPackageRegistrationPendingForUser(String userSecurityId, String packageFullName);
+        /// @warning The parameter is should be "packageFullName" but can't due to http://task.ms/53280356.
+        ///          Consider the current (wrong) parameter name deprecated until vFuture (2.0) when we can change to the new (right) parameter name.
+        Boolean IsPackageRegistrationPendingForUser(String userSecurityId, String packageFamilyName);
     }
 
     [contract(PackageDeploymentContract, 1)]

--- a/dev/PackageManager/API/PackageManager.idl
+++ b/dev/PackageManager/API/PackageManager.idl
@@ -294,6 +294,7 @@ namespace Microsoft.Windows.Management.Deployment
         //-------------------------------------------------------------
         // IsPackageDeploymentFeatureSupported
 
+        [contract(PackageDeploymentContract, 2)]
         static Boolean IsPackageDeploymentFeatureSupported(PackageDeploymentFeature feature);
 
         //-------------------------------------------------------------
@@ -470,8 +471,10 @@ namespace Microsoft.Windows.Management.Deployment
         //-------------------------------------------------------------
         // IsRegistrationPending
 
+        [contract(PackageDeploymentContract, 2)]
         Boolean IsPackageRegistrationPending(String packageFullName);
 
+        [contract(PackageDeploymentContract, 2)]
         Boolean IsPackageRegistrationPendingForUser(String userSecurityId, String packageFullName);
     }
 


### PR DESCRIPTION
https://task.ms/53375777

```
static Boolean IsPackageDeploymentFeatureSupported(PackageDeploymentFeature feature);
Boolean IsPackageRegistrationPending(String packageFullName);
Boolean IsPackageRegistrationPendingForUser(String userSecurityId, String packageFullName);
```

Should be prefixed with [contract(PackageDeploymentContract, 2)]

NOTE: Also backporting to 1.6