### PR TITLE
Fix ApplicationData.MachineFolder path

### DIFF
--- a/dev/ApplicationData/M.W.S.ApplicationData.cpp
+++ b/dev/ApplicationData/M.W.S.ApplicationData.cpp
@@ -281,12 +281,12 @@ namespace winrt::Microsoft::Windows::Storage::implementation
     }
     std::filesystem::path ApplicationData::_MachinePath(hstring const& packageFamilyName)
     {
-        // Path = HKLM\...apprepository...\ApplicationData\...pkgfamilyname...\Machine
-        // This is typically %ProgramData%\Microsoft\Windows\AppRepository\ApplicationData\...pkgfamilyname...\Machine
+        // Path = HKLM\...apprepository...\Families\ApplicationData\...pkgfamilyname...\Machine
+        // This is typically %ProgramData%\Microsoft\Windows\AppRepository\Families\ApplicationData\...pkgfamilyname...\Machine
         PCWSTR c_path{ L"SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Appx" };
         PCWSTR c_valueName{ L"PackageRepositoryRoot" };
         std::filesystem::path appRepository{ wil::reg::get_value_string(HKEY_LOCAL_MACHINE, c_path, c_valueName) };
-        auto path{ appRepository / L"ApplicationData" };
+        auto path{ appRepository / L"Families\\ApplicationData" };
         path /= packageFamilyName.c_str();
         path /= "Machine";
 

--- a/specs/applicationdata/ApplicationData.md
+++ b/specs/applicationdata/ApplicationData.md
@@ -110,7 +110,7 @@ to grant more access than provided by default.
 
 ### 3.4.1. Machine Path/Folder
 
-The path for a package family's "Machine Folder" is located at `%ProgramData%\Microsoft\Windows\AppRepository\ApplicationData\...packagefamilyname...\Machine`.
+The path for a package family's "Machine Folder" is located at `%ProgramData%\Microsoft\Windows\AppRepository\Families\ApplicationData\...packagefamilyname...\Machine`.
 
 This directory is ACL'd similarly to a package's System Metadata directory (`%ProgramData%\Microsoft\Windows\AppRepository\Packages\...pkgfullname...`) e.g.
 

--- a/test/ApplicationData/ApplicationDataTests.cpp
+++ b/test/ApplicationData/ApplicationDataTests.cpp
@@ -90,14 +90,14 @@ namespace Test::PackageManager::Tests
 
     std::filesystem::path GetExpectedMachinePath(winrt::hstring const& packageFamilyName)
     {
-        // Expected Path = HKLM\...apprepository...\ApplicationData\...pkgfamilyname...\Machine
-        // This is typically %ProgramData%\Microsoft\Windows\AppRepository\ApplicationData\...pkgfamilyname...\Machine
+        // Expected Path = HKLM\...apprepository...\Families\ApplicationData\...pkgfamilyname...\Machine
+        // This is typically %ProgramData%\Microsoft\Windows\AppRepository\Families\ApplicationData\...pkgfamilyname...\Machine
         // and by 'typically' we mean 'all current Windows editions' so we'll assume it's true for ease of testing
         // and use this test as a canary to detect if/when this is ever not true on any supported platform.
         wil::unique_cotaskmem_string path;
         THROW_IF_FAILED(::SHGetKnownFolderPath(FOLDERID_ProgramData, 0, nullptr, wil::out_param(path)));
         const std::filesystem::path programData{ path.get() };
-        const auto packageRepositoryRoot{ programData / L"Microsoft\\Windows\\AppRepository\\ApplicationData" };
+        const auto packageRepositoryRoot{ programData / L"Microsoft\\Windows\\AppRepository\\Families\\ApplicationData" };
         const auto packageFamilyRoot{ packageRepositoryRoot / packageFamilyName.c_str() };
         const auto expectedMachinePath{ packageFamilyRoot / L"Machine" };
         return expectedMachinePath;


### PR DESCRIPTION
Per Chris Wall `MachineFolder` path should be `%ProgramData%\Microsoft\Windows\AppRepository\Families\ApplicationData\...pkgfamilyname...\Machine` (that ...\Families\... directory was missing)