### PR TITLE
1.6 New PackageDeploymentManager methods not tagged with new v2 contract

### DIFF
--- a/dev/PackageManager/API/PackageManager.idl
+++ b/dev/PackageManager/API/PackageManager.idl
@@ -294,6 +294,7 @@ namespace Microsoft.Windows.Management.Deployment
         //-------------------------------------------------------------
         // IsPackageDeploymentFeatureSupported
 
+        [contract(PackageDeploymentContract, 2)]
         static Boolean IsPackageDeploymentFeatureSupported(PackageDeploymentFeature feature);
 
         //-------------------------------------------------------------
@@ -470,9 +471,13 @@ namespace Microsoft.Windows.Management.Deployment
         //-------------------------------------------------------------
         // IsRegistrationPending
 
-        Boolean IsPackageRegistrationPending(String packageFullName);
+        /// @warning The parameter is should be "packageFullName" but can't due to http://task.ms/53280356.
+        ///          Consider the current (wrong) parameter name deprecated until vFuture (2.0) when we can change to the new (right) parameter name.
+        Boolean IsPackageRegistrationPending(String packageFamilyName);
 
-        Boolean IsPackageRegistrationPendingForUser(String userSecurityId, String packageFullName);
+        /// @warning The parameter is should be "packageFullName" but can't due to http://task.ms/53280356.
+        ///          Consider the current (wrong) parameter name deprecated until vFuture (2.0) when we can change to the new (right) parameter name.
+        Boolean IsPackageRegistrationPendingForUser(String userSecurityId, String packageFamilyName);
     }
 
     [contract(PackageDeploymentContract, 1)]


### PR DESCRIPTION
cherry-pick New PackageDeploymentManager methods not tagged with new v2 contract #4663

https://github.com/microsoft/WindowsAppSDK/pull/4663