### PR TITLE
[CP to main] Fix centrally-versioned package references

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -2,10 +2,7 @@
     This is the project file used by CentralPackageVersions, and used to control all PackageReference's
     and make sure the version is only declared in a single place
 
-    In order to the CentralPackageVersions, add this to your SDK-Style .csproj file:
-    <Sdk Name="Microsoft.Build.CentralPackageVersions" Version="2.0.1" />
-
-    For more info: https://github.com/microsoft/MSBuildSdks/tree/master/src/CentralPackageVersions
+    https://learn.microsoft.com/en-us/nuget/consume-packages/Central-Package-Management
 -->
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup>

--- a/dev/VSIX/Directory.Build.props
+++ b/dev/VSIX/Directory.Build.props
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+    <!-- NOTE: This file does not import Directory.Build.props in parent dirs -->
 
     <!-- Provide default nuget feed (Windows App SDK internal) and package versions for developer builds -->
     <PropertyGroup>
@@ -11,6 +12,8 @@
         <Deployment Condition="'$(Deployment)' == '' ">Standalone</Deployment>
         <!-- Don't automatically deploy the extension to the test VS environment during the build -->
         <DeployExtension>false</DeployExtension>
+
+        <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
     </PropertyGroup>
 
     <!-- Useful folder paths -->
@@ -38,5 +41,4 @@
         <OutputPath>$(IntermediateOutputPath)</OutputPath>
         <OutDir>$(OutputPath)</OutDir>
     </PropertyGroup>
-
 </Project>


### PR DESCRIPTION
Cherry pick from https://github.com/microsoft/WindowsAppSDK/pull/4674

For the projects under the VSIX folder, the build stopped honoring the "Directory.Packages.props" file at the root of the repo. This causes us to pick up old versions of all these packages, and hilarity ensues.

I'm not sure at the moment what caused this change in behavior, but this fix looks safe as we continue to investigate.