### PR TITLE
DevCheck: Settings options, configuration dependency paths, Sync'd dependencies

### DIFF
--- a/dev/WindowsAppRuntime_DLL/packages.config
+++ b/dev/WindowsAppRuntime_DLL/packages.config
@@ -5,5 +5,5 @@
   <package id="Microsoft.SourceLink.GitHub" version="1.1.1" targetFramework="native" developmentDependency="true" />
   <package id="Microsoft.Windows.CppWinRT" version="2.0.230706.1" targetFramework="native" />
   <package id="Microsoft.Windows.ImplementationLibrary" version="1.0.240803.1" targetFramework="native" />
-  <package id="Microsoft.FrameworkUdk" version="1.7.0-CI-26107.1701.240510-1748.0" targetFramework="native" />
+  <package id="Microsoft.FrameworkUdk" version="1.7.0-CI-26107.1715.240815-1016.3" targetFramework="native" />
 </packages>

--- a/test/PackageManager/API/packages.config
+++ b/test/PackageManager/API/packages.config
@@ -6,5 +6,5 @@
   <package id="Microsoft.Taef" version="10.94.240624002" targetFramework="native" />
   <package id="Microsoft.Windows.CppWinRT" version="2.0.230706.1" targetFramework="native" />
   <package id="Microsoft.Windows.ImplementationLibrary" version="1.0.240803.1" targetFramework="native" />
-  <package id="Microsoft.FrameworkUdk" version="1.7.0-CI-26107.1701.240510-1748.0" targetFramework="native" />
+  <package id="Microsoft.FrameworkUdk" version="1.7.0-CI-26107.1715.240815-1016.3" targetFramework="native" />
 </packages>


### PR DESCRIPTION
New options
* -Settings => Load the settings file (if exists) to enable future customization (default=$True)
* -SettingsFile=file => Settings file to load (default = ...repo...\.user\DevCheck-Settings.ps1)
* -SaveSettingsFile=file => Save a default settings file (fail if exists; won't overwrite existing files)
* -UserSettings => Load the user settings file (if exists) to enable future customization (default=$True)
* -UserSettingsFile=file => User Settings file to load (default = ...repo...\.user\DevCheck-Settings.ps1)
* -SaveUserSettingsFile=file => Save a default user settings file (fail if exists; won't overwrite existing files)

Settings file is for a project to customize behavior. User Settings file is per user to mess with.

NOTE: A future update will change the default location for Settings file (pending a change to DevCheck.cmd @kythant is working on)

Change -CheckDependencies and -SyncDependencies to use a customization list of root directories. Use a settings file with custom values for `$global:dependency_paths` e.g.

```
$global:dependency_paths = ('fee', 'fie', 'foe\fum')
```

Also ran -SyncDependencies to correct a couple of stale entries (FrameworkUdk from May(!))