### PR TITLE
Reintroduce Runtime Identifier in Pubxml to Resolve Platform Mismatch

### DIFF
--- a/dev/VSIX/ProjectTemplates/Desktop/CSharp/ClassLibrary/ProjectTemplate.csproj
+++ b/dev/VSIX/ProjectTemplates/Desktop/CSharp/ClassLibrary/ProjectTemplate.csproj
@@ -3,8 +3,7 @@
     <TargetFramework>$DotNetVersion$-windows10.0.19041.0</TargetFramework>
     <TargetPlatformMinVersion>10.0.17763.0</TargetPlatformMinVersion>
     <RootNamespace>$safeprojectname$</RootNamespace>
-    <RuntimeIdentifiers Condition="$([MSBuild]::GetTargetFrameworkVersion('$(TargetFramework)')) >= 8">win-x86;win-x64;win-arm64</RuntimeIdentifiers>
-    <RuntimeIdentifiers Condition="$([MSBuild]::GetTargetFrameworkVersion('$(TargetFramework)')) &lt; 8">win10-x86;win10-x64;win10-arm64</RuntimeIdentifiers>
+    <RuntimeIdentifiers>win-x86;win-x64;win-arm64</RuntimeIdentifiers>
     <UseWinUI>true</UseWinUI>
   </PropertyGroup>
   

--- a/dev/VSIX/ProjectTemplates/Desktop/CSharp/PackagedApp/BlankApp/ProjectTemplate.csproj
+++ b/dev/VSIX/ProjectTemplates/Desktop/CSharp/PackagedApp/BlankApp/ProjectTemplate.csproj
@@ -6,8 +6,7 @@
     <RootNamespace>$safeprojectname$</RootNamespace>
     <ApplicationManifest>app.manifest</ApplicationManifest>
     <Platforms>x86;x64;ARM64</Platforms>
-    <RuntimeIdentifiers Condition="$([MSBuild]::GetTargetFrameworkVersion('$(TargetFramework)')) >= 8">win-x86;win-x64;win-arm64</RuntimeIdentifiers>
-    <RuntimeIdentifiers Condition="$([MSBuild]::GetTargetFrameworkVersion('$(TargetFramework)')) &lt; 8">win10-x86;win10-x64;win10-arm64</RuntimeIdentifiers>
+    <RuntimeIdentifiers>win-x86;win-x64;win-arm64</RuntimeIdentifiers>
     <UseWinUI>true</UseWinUI>
     <Nullable>enable</Nullable>
   </PropertyGroup>

--- a/dev/VSIX/ProjectTemplates/Desktop/CSharp/PackagedApp/BlankApp/Properties/PublishProfiles/win-arm64.pubxml
+++ b/dev/VSIX/ProjectTemplates/Desktop/CSharp/PackagedApp/BlankApp/Properties/PublishProfiles/win-arm64.pubxml
@@ -6,6 +6,7 @@ https://go.microsoft.com/fwlink/?LinkID=208121.
   <PropertyGroup>
     <PublishProtocol>FileSystem</PublishProtocol>
     <Platform>ARM64</Platform>
+    <RuntimeIdentifier>win-arm64</RuntimeIdentifier>
     <PublishDir>bin\$(Configuration)\$(TargetFramework)\$(RuntimeIdentifier)\publish\</PublishDir>
     <SelfContained>true</SelfContained>
     <PublishSingleFile>False</PublishSingleFile>

--- a/dev/VSIX/ProjectTemplates/Desktop/CSharp/PackagedApp/BlankApp/Properties/PublishProfiles/win-x64.pubxml
+++ b/dev/VSIX/ProjectTemplates/Desktop/CSharp/PackagedApp/BlankApp/Properties/PublishProfiles/win-x64.pubxml
@@ -6,6 +6,7 @@ https://go.microsoft.com/fwlink/?LinkID=208121.
   <PropertyGroup>
     <PublishProtocol>FileSystem</PublishProtocol>
     <Platform>x64</Platform>
+    <RuntimeIdentifier>win-x64</RuntimeIdentifier>
     <PublishDir>bin\$(Configuration)\$(TargetFramework)\$(RuntimeIdentifier)\publish\</PublishDir>
     <SelfContained>true</SelfContained>
     <PublishSingleFile>False</PublishSingleFile>

--- a/dev/VSIX/ProjectTemplates/Desktop/CSharp/PackagedApp/BlankApp/Properties/PublishProfiles/win-x86.pubxml
+++ b/dev/VSIX/ProjectTemplates/Desktop/CSharp/PackagedApp/BlankApp/Properties/PublishProfiles/win-x86.pubxml
@@ -6,6 +6,7 @@ https://go.microsoft.com/fwlink/?LinkID=208121.
   <PropertyGroup>
     <PublishProtocol>FileSystem</PublishProtocol>
     <Platform>x86</Platform>
+    <RuntimeIdentifier>win-x86</RuntimeIdentifier>
     <PublishDir>bin\$(Configuration)\$(TargetFramework)\$(RuntimeIdentifier)\publish\</PublishDir>
     <SelfContained>true</SelfContained>
     <PublishSingleFile>False</PublishSingleFile>

--- a/dev/VSIX/ProjectTemplates/Desktop/CSharp/SingleProjectPackagedApp/ProjectTemplate.csproj
+++ b/dev/VSIX/ProjectTemplates/Desktop/CSharp/SingleProjectPackagedApp/ProjectTemplate.csproj
@@ -6,8 +6,7 @@
     <RootNamespace>$safeprojectname$</RootNamespace>
     <ApplicationManifest>app.manifest</ApplicationManifest>
     <Platforms>x86;x64;ARM64</Platforms>
-    <RuntimeIdentifiers Condition="$([MSBuild]::GetTargetFrameworkVersion('$(TargetFramework)')) >= 8">win-x86;win-x64;win-arm64</RuntimeIdentifiers>
-    <RuntimeIdentifiers Condition="$([MSBuild]::GetTargetFrameworkVersion('$(TargetFramework)')) &lt; 8">win10-x86;win10-x64;win10-arm64</RuntimeIdentifiers>
+    <RuntimeIdentifiers>win-x86;win-x64;win-arm64</RuntimeIdentifiers>
     <PublishProfile>win-$(Platform).pubxml</PublishProfile>
     <UseWinUI>true</UseWinUI>
     <EnableMsixTooling>true</EnableMsixTooling>

--- a/dev/VSIX/ProjectTemplates/Desktop/CSharp/SingleProjectPackagedApp/Properties/PublishProfiles/win-arm64.pubxml
+++ b/dev/VSIX/ProjectTemplates/Desktop/CSharp/SingleProjectPackagedApp/Properties/PublishProfiles/win-arm64.pubxml
@@ -6,6 +6,7 @@ https://go.microsoft.com/fwlink/?LinkID=208121.
   <PropertyGroup>
     <PublishProtocol>FileSystem</PublishProtocol>
     <Platform>ARM64</Platform>
+    <RuntimeIdentifier>win-arm64</RuntimeIdentifier>
     <PublishDir>bin\$(Configuration)\$(TargetFramework)\$(RuntimeIdentifier)\publish\</PublishDir>
     <SelfContained>true</SelfContained>
     <PublishSingleFile>False</PublishSingleFile>

--- a/dev/VSIX/ProjectTemplates/Desktop/CSharp/SingleProjectPackagedApp/Properties/PublishProfiles/win-x64.pubxml
+++ b/dev/VSIX/ProjectTemplates/Desktop/CSharp/SingleProjectPackagedApp/Properties/PublishProfiles/win-x64.pubxml
@@ -6,6 +6,7 @@ https://go.microsoft.com/fwlink/?LinkID=208121.
   <PropertyGroup>
     <PublishProtocol>FileSystem</PublishProtocol>
     <Platform>x64</Platform>
+    <RuntimeIdentifier>win-x64</RuntimeIdentifier>
     <PublishDir>bin\$(Configuration)\$(TargetFramework)\$(RuntimeIdentifier)\publish\</PublishDir>
     <SelfContained>true</SelfContained>
     <PublishSingleFile>False</PublishSingleFile>

--- a/dev/VSIX/ProjectTemplates/Desktop/CSharp/SingleProjectPackagedApp/Properties/PublishProfiles/win-x86.pubxml
+++ b/dev/VSIX/ProjectTemplates/Desktop/CSharp/SingleProjectPackagedApp/Properties/PublishProfiles/win-x86.pubxml
@@ -6,6 +6,7 @@ https://go.microsoft.com/fwlink/?LinkID=208121.
   <PropertyGroup>
     <PublishProtocol>FileSystem</PublishProtocol>
     <Platform>x86</Platform>
+    <RuntimeIdentifier>win-x86</RuntimeIdentifier>
     <PublishDir>bin\$(Configuration)\$(TargetFramework)\$(RuntimeIdentifier)\publish\</PublishDir>
     <SelfContained>true</SelfContained>
     <PublishSingleFile>False</PublishSingleFile>

--- a/dev/VSIX/ProjectTemplates/Desktop/CSharp/UnitTestApp/ProjectTemplate.csproj
+++ b/dev/VSIX/ProjectTemplates/Desktop/CSharp/UnitTestApp/ProjectTemplate.csproj
@@ -6,8 +6,7 @@
     <RootNamespace>$safeprojectname$</RootNamespace>
     <ApplicationManifest>app.manifest</ApplicationManifest>
     <Platforms>x86;x64;ARM64</Platforms>
-    <RuntimeIdentifiers Condition="$([MSBuild]::GetTargetFrameworkVersion('$(TargetFramework)')) >= 8">win-x86;win-x64;win-arm64</RuntimeIdentifiers> 
-    <RuntimeIdentifiers Condition="$([MSBuild]::GetTargetFrameworkVersion('$(TargetFramework)')) &lt; 8">win10-x86;win10-x64;win10-arm64</RuntimeIdentifiers>
+    <RuntimeIdentifiers>win-x86;win-x64;win-arm64</RuntimeIdentifiers>
     <PublishProfile>win-$(Platform).pubxml</PublishProfile>
     <UseWinUI>true</UseWinUI>
     <EnableMsixTooling>true</EnableMsixTooling>

--- a/dev/VSIX/ProjectTemplates/Desktop/CSharp/UnitTestApp/Properties/PublishProfiles/win-arm64.pubxml
+++ b/dev/VSIX/ProjectTemplates/Desktop/CSharp/UnitTestApp/Properties/PublishProfiles/win-arm64.pubxml
@@ -6,6 +6,7 @@ https://go.microsoft.com/fwlink/?LinkID=208121.
   <PropertyGroup>
     <PublishProtocol>FileSystem</PublishProtocol>
     <Platform>ARM64</Platform>
+    <RuntimeIdentifier>win-arm64</RuntimeIdentifier>
     <PublishDir>bin\$(Configuration)\$(TargetFramework)\$(RuntimeIdentifier)\publish\</PublishDir>
     <SelfContained>true</SelfContained>
     <PublishSingleFile>False</PublishSingleFile>

--- a/dev/VSIX/ProjectTemplates/Desktop/CSharp/UnitTestApp/Properties/PublishProfiles/win-x64.pubxml
+++ b/dev/VSIX/ProjectTemplates/Desktop/CSharp/UnitTestApp/Properties/PublishProfiles/win-x64.pubxml
@@ -6,6 +6,7 @@ https://go.microsoft.com/fwlink/?LinkID=208121.
   <PropertyGroup>
     <PublishProtocol>FileSystem</PublishProtocol>
     <Platform>x64</Platform>
+    <RuntimeIdentifier>win-x64</RuntimeIdentifier>
     <PublishDir>bin\$(Configuration)\$(TargetFramework)\$(RuntimeIdentifier)\publish\</PublishDir>
     <SelfContained>true</SelfContained>
     <PublishSingleFile>False</PublishSingleFile>

--- a/dev/VSIX/ProjectTemplates/Desktop/CSharp/UnitTestApp/Properties/PublishProfiles/win-x86.pubxml
+++ b/dev/VSIX/ProjectTemplates/Desktop/CSharp/UnitTestApp/Properties/PublishProfiles/win-x86.pubxml
@@ -6,6 +6,7 @@ https://go.microsoft.com/fwlink/?LinkID=208121.
   <PropertyGroup>
     <PublishProtocol>FileSystem</PublishProtocol>
     <Platform>x86</Platform>
+    <RuntimeIdentifier>win-x86</RuntimeIdentifier>
     <PublishDir>bin\$(Configuration)\$(TargetFramework)\$(RuntimeIdentifier)\publish\</PublishDir>
     <SelfContained>true</SelfContained>
     <PublishSingleFile>False</PublishSingleFile>


### PR DESCRIPTION
This PR resolves the `NETSDK1032` error ("_The RuntimeIdentifier platform 'win-x64' and the PlatformTarget 'x86' must be compatible_") encountered when building and publishing WinUI 3 applications with multiple target architectures.

**Context:**
The error occurred on x64 and arm64 machines when selecting both x86 and x64 packages or when building C# WinUI 3 apps with .NET 9.0 set to x64 or x86 platforms.

**Fix:**
To resolve the issue, the RuntimeIdentifier (RID) has been reintroduced in the pubxml file, explicitly setting it to win-{arch} to ensure compatibility between the target platform and architecture. Conditional RIDs have also been removed across all project templates in favour of non-portable RIDs.
