### PR TITLE
Revert "[MRTCore] Sync between WGA.PrimaryLanguageOverride and MWGA.PrimaryLanguageOverride (#4608)"

### DIFF
--- a/dev/MRTCore/mrt/Microsoft.Windows.ApplicationModel.Resources/src/ResourceContext.cpp
+++ b/dev/MRTCore/mrt/Microsoft.Windows.ApplicationModel.Resources/src/ResourceContext.cpp
@@ -6,8 +6,6 @@
 #include "ResourceContext.g.cpp"
 #include "winrt/Windows.Globalization.h"
 
-#include <AppModel.Identity.h>
-
 const wchar_t c_languageQualifierName[] = L"Language";
 
 #include "ApplicationLanguages.h"
@@ -101,16 +99,6 @@ void ResourceContext::Apply()
         if (!eachValue.Value().empty())
         {
             winrt::check_hresult(MrmSetQualifier(m_resourceContext, eachValue.Key().c_str(), eachValue.Value().c_str()));
-        }
-    }
-
-    // sync with Windows::Globalization::ApplicationLanguages::PrimaryLanguageOverride if it has been updated more recently
-    if (AppModel::Identity::IsPackagedProcess())
-    {
-        auto language = winrt::Windows::Globalization::ApplicationLanguages::PrimaryLanguageOverride();
-        if (language != ApplicationLanguages::PrimaryLanguageOverride())
-        {
-            ApplicationLanguages::PrimaryLanguageOverride(language);
         }
     }
     if (!ApplicationLanguages::PrimaryLanguageOverride().empty())


### PR DESCRIPTION
Unfortunately, `Windows.Globalization.ApplicationLanguages.PrimaryLanguageOverride` relies on an internal API that throws an exception if no language override has been set. Even though this exception is expected and caught further up the stack, this can cause an incredible amount of noise in the debugger if it's configured to break on thrown exceptions. As a result, it is necessary to revert #4608 (which allows `Microsoft.Globalization.ApplicationLanguages.PrimaryLanguageOverride` to reflect the value of `Windows.Globalization.ApplicationLanguages.PrimaryLanguageOverride` if the latter API is used by the app) in order to suppress the noisy exception.

A microsoft employee must use /azp run to validate using the pipelines below.

WARNING:
Comments made by azure-pipelines bot maybe inaccurate.
Please see pipeline link to verify that the build is being ran.

For status checks on the main branch, please use TransportPackage-Foundation-PR
(https://microsoft.visualstudio.com/ProjectReunion/_build?definitionId=81063&_a=summary)
and run the build against your PR branch with the default parameters.
