### PR TITLE
53812687 - Disable auto bug filing via TSA for the 1.6-Stable branch on the Foundation repo

### DIFF
--- a/build/WindowsAppSDK-Foundation-Nightly.yml
+++ b/build/WindowsAppSDK-Foundation-Nightly.yml
@@ -63,7 +63,10 @@ extends:
 
     globalSdl: # Refer the wiki for more options in this parameter: https://aka.ms/obpipelines/sdl
       tsa:
-        enabled: $(TsaEnabled) # onebranch publish all sdl results to TSA. If TSA is disabled all SDL tools will forced into 'break' build mode.  Please provide TSAOptions.json.
+        # We focus on enabling TSA on the Main branch, not on servicing branches, to avoid getting
+        # duplicates of bugs that are against the Main branch. To re-enable TSA, do this instead:
+        # enabled:  $(TsaEnabled) # onebranch publish all sdl results to TSA. If TSA is disabled all SDL tools will forced into 'break' build mode.
+        enabled:  false
       isNativeCode: false #TODO turn back on when bug in CheckCFlags2.exe is fixed
       asyncSdl: # https://aka.ms/obpipelines/asyncsdl
         enabled: false

--- a/build/WindowsAppSDK-Foundation-Official.yml
+++ b/build/WindowsAppSDK-Foundation-Official.yml
@@ -63,7 +63,10 @@ extends:
 
     globalSdl: # Refer the wiki for more options in this parameter: https://aka.ms/obpipelines/sdl
       tsa:
-        enabled: $(TsaEnabled) # onebranch publish all sdl results to TSA. If TSA is disabled all SDL tools will forced into 'break' build mode.  Please provide TSAOptions.json.
+        # We focus on enabling TSA on the Main branch, not on servicing branches, to avoid getting
+        # duplicates of bugs that are against the Main branch. To re-enable TSA, do this instead:
+        # enabled:  $(TsaEnabled) # onebranch publish all sdl results to TSA. If TSA is disabled all SDL tools will forced into 'break' build mode.
+        enabled:  false        
       isNativeCode: false #TODO turn back on when bug in CheckCFlags2.exe is fixed
       asyncSdl: # https://aka.ms/obpipelines/asyncsdl
         enabled: false

--- a/build/WindowsAppSDK-Foundation-PR.yml
+++ b/build/WindowsAppSDK-Foundation-PR.yml
@@ -54,7 +54,10 @@ extends:
 
     globalSdl: # Refer the wiki for more options in this parameter: https://aka.ms/obpipelines/sdl
       tsa:
-        enabled: $(TsaEnabled) # onebranch publish all sdl results to TSA. If TSA is disabled all SDL tools will forced into 'break' build mode.  Please provide TSAOptions.json.
+        # We focus on enabling TSA on the Main branch, not on servicing branches, to avoid getting
+        # duplicates of bugs that are against the Main branch. To re-enable TSA, do this instead:
+        # enabled:  $(TsaEnabled) # onebranch publish all sdl results to TSA. If TSA is disabled all SDL tools will forced into 'break' build mode.
+        enabled:  false
       isNativeCode: false #TODO turn back on when bug in CheckCFlags2.exe is fixed
       psscriptanalyzer:
         enable: true


### PR DESCRIPTION
Disable auto bug filing via TSA for the 1.6-Stable branch on the Foundation repo, as we focus on enabling TSA for the main branch.
Once this PR has been merged, I will attempt to CP it to 1.5.
----

A microsoft employee must use /azp run to validate using the pipelines below.

WARNING:
Comments made by azure-pipelines bot maybe inaccurate.
Please see pipeline link to verify that the build is being ran.

For status checks on the main branch, please use TransportPackage-Foundation-PR
(https://microsoft.visualstudio.com/ProjectReunion/_build?definitionId=81063&_a=summary)
and run the build against your PR branch with the default parameters.
