### PR TITLE
Fix BuildAll Error Stemming from StrictMode and Retarget Solution

### DIFF
--- a/BuildAll.ps1
+++ b/BuildAll.ps1
@@ -87,6 +87,7 @@ if(-not (test-path "$buildOverridePath"))
 
 Try {
     $WindowsAppSDKBuildPipeline = 0
+    $WindowsAppSDKVersionProperty = ""
 
     .\tools\GenerateDynamicDependencyOverrides.ps1 -Path "$buildOverridePath"
     .\tools\GeneratePushNotificationsOverrides.ps1 -Path "$buildOverridePath"

--- a/dev/MRTCore/mrt/Microsoft.Windows.ApplicationModel.Resources/src/Microsoft.Windows.ApplicationModel.Resources.vcxproj
+++ b/dev/MRTCore/mrt/Microsoft.Windows.ApplicationModel.Resources/src/Microsoft.Windows.ApplicationModel.Resources.vcxproj
@@ -17,7 +17,7 @@
     <DefaultLanguage>en-US</DefaultLanguage>
     <MinimumVisualStudioVersion>14.0</MinimumVisualStudioVersion>
     <Keyword>Win32Proj</Keyword>
-    <WindowsTargetPlatformVersion Condition=" '$(WindowsTargetPlatformVersion)' == '' ">10.0.20348.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion Condition=" '$(WindowsTargetPlatformVersion)' == '' ">10.0</WindowsTargetPlatformVersion>
     <WindowsTargetPlatformMinVersion>10.0.17134.0</WindowsTargetPlatformMinVersion>
     <!-- Need to add this otherwise the ADO build won't copy mrm.dll to output directory, and eventually the file will miss in ManagedTest.build.appxrecipe and make
          the tests fail to run in ADO pipeline -->

--- a/dev/MRTCore/mrt/Microsoft.Windows.ApplicationModel.Resources/src/Microsoft.Windows.ApplicationModel.Resources.vcxproj.filters
+++ b/dev/MRTCore/mrt/Microsoft.Windows.ApplicationModel.Resources/src/Microsoft.Windows.ApplicationModel.Resources.vcxproj.filters
@@ -84,4 +84,7 @@
   <ItemGroup>
     <ResourceCompile Include="Microsoft.Windows.ApplicationModel.Resources.rc" />
   </ItemGroup>
+  <ItemGroup>
+    <Natvis Include="$(MSBuildThisFileDirectory)..\..\natvis\wil.natvis" />
+  </ItemGroup>
 </Project>


### PR DESCRIPTION
Strictmode was causing the failure below
```
The variable '$WindowsAppSDKVersionProperty' cannot be retrieved because it has not been set.

at <ScriptBlock>, D:\WindowsAppSDK\BuildAll.ps1: line 162
```
The fix was to simply declare the variable outside of the scope. 
 