### PR TITLE
[WinAppSDK 1.5] Roll back build image to VS 17.9

### DIFF
--- a/build/WindowsAppSDK-CommonVariables.yml
+++ b/build/WindowsAppSDK-CommonVariables.yml
@@ -11,7 +11,7 @@ variables:
   NUGET_XMLDOC_MODE: none
 
   # Docker image which is used to build the project https://aka.ms/obpipelines/containers
-  WindowsContainerImage: 'onebranch.azurecr.io/windows/ltsc2019/vse2022:latest'
+  WindowsContainerImage: 'onebranch.azurecr.io/windows/ltsc2019/vse2022@sha256:ac667f8d65f2c8b99daa6b7dc78c099a9caf1c6c527116df4527567d9af18647'
 
   Codeql.Enabled: true #  CodeQL runs every 3 days on the default branch for all languages its applicable to in that pipeline.
 


### PR DESCRIPTION
Our build image recently got updated to VS 17.10, which caused some changes and broke a few unit tests. This change rolls our image back to a previous version, that contains VS 17.9.

This is the "1.0.02629.40" image, described on this page:

https://eng.ms/docs/products/onebranch/infrastructureandimages/buildinfrastructureandimages/containerimages/windowsimages/windows2019vse2022/releasenotes 