### PR TITLE
Bring back SourceToTargetBranch parameter

### DIFF
--- a/build/WindowsAppSDK-SyncTrigger.yml
+++ b/build/WindowsAppSDK-SyncTrigger.yml
@@ -1,4 +1,12 @@
 name: $(BuildDefinitionName)_$(date:yyMM).$(date:dd)$(rev:rrr)
+parameters:
+- name: "SourceToTargetBranch"
+  type: object
+  default:
+    main: main
+    release/1.4-stable: release/1.4-stable
+    release/1.5-stable: release/1.5-stable
+    release/1.6-stable: release/1.6-stable
 
 resources:
   repositories:
@@ -9,6 +17,12 @@ resources:
 
 jobs:
 - job: SyncMirror
+  strategy:
+    matrix:
+      ${{ each branches in parameters.SourceToTargetBranch }}:
+        ${{ branches.key }}:
+          SourceBranch: ${{ branches.key }}
+          TargetBranch: ${{ branches.value }}
   dependsOn: []
   pool: 'ProjectReunionESPool-2022'
   steps:
@@ -19,19 +33,19 @@ jobs:
     inputs:
       targetType: 'inline'
       script: |
-        Write-Host "Sourcebranch " + "$(Build.SourceBranch)"
-        Write-Host "TargetBranch " + "$(Build.SourceBranch)"
+        Write-Host "Sourcebranch " + "$(SourceBranch)"
+        Write-Host "TargetBranch " + "$(TargetBranch)"
 
         $repo = "https://github.com/microsoft/WindowsAppSDK.git"
         git remote add mirror $repo
         git remote
 
-        $target = "$(Build.SourceBranch)"
+        $target = "$(TargetBranch)"
         git fetch origin $target
         git checkout $target
         git pull origin $target
 
-        $source = "$(Build.SourceBranch)"
+        $source = "$(SourceBranch)"
         git fetch mirror $source
         git pull mirror $source
 


### PR DESCRIPTION
git push didn't seem to work and I suspect it might be the refs/branch/main from $(Source.BuildBranch)