### PR TITLE
Use $(Source.BuildBranch) parameter in SyncMirrors

### DIFF
--- a/build/WindowsAppSDK-SyncTrigger.yml
+++ b/build/WindowsAppSDK-SyncTrigger.yml
@@ -1,12 +1,4 @@
 name: $(BuildDefinitionName)_$(date:yyMM).$(date:dd)$(rev:rrr)
-parameters:
-- name: "SourceToTargetBranch"
-  type: object
-  default:
-    main: main
-    release/1.4-stable: release/1.4-stable
-    release/1.5-stable: release/1.5-stable
-    release/1.6-stable: release/1.6-stable
 
 resources:
   repositories:
@@ -17,12 +9,6 @@ resources:
 
 jobs:
 - job: SyncMirror
-  strategy:
-    matrix:
-      ${{ each branches in parameters.SourceToTargetBranch }}:
-        ${{ branches.key }}:
-          SourceBranch: ${{ branches.key }}
-          TargetBranch: ${{ branches.value }}
   dependsOn: []
   pool: 'ProjectReunionESPool-2022'
   steps:
@@ -33,19 +19,20 @@ jobs:
     inputs:
       targetType: 'inline'
       script: |
-        Write-Host "Sourcebranch " + "$(SourceBranch)"
-        Write-Host "TargetBranch " + "$(TargetBranch)"
+        $branch = "$(Build.SourceBranch)".Replace("refs/heads", "")
+        Write-Host "Sourcebranch " + $branch
+        Write-Host "TargetBranch " + $branch
 
         $repo = "https://github.com/microsoft/WindowsAppSDK.git"
         git remote add mirror $repo
         git remote
 
-        $target = "$(TargetBranch)"
+        $target = $branch
         git fetch origin $target
         git checkout $target
         git pull origin $target
 
-        $source = "$(SourceBranch)"
+        $source = $branch
         git fetch mirror $source
         git pull mirror $source
 


### PR DESCRIPTION
This didn't work in the previous PRs but I believe it should work now because refs/heads/ is being stripped