### PR TITLE
Fix Typo refs/heads/ in SyncMirrors

### DIFF
--- a/build/WindowsAppSDK-SyncTrigger.yml
+++ b/build/WindowsAppSDK-SyncTrigger.yml
@@ -19,7 +19,7 @@ jobs:
     inputs:
       targetType: 'inline'
       script: |
-        $branch = "$(Build.SourceBranch)".Replace("refs/heads", "")
+        $branch = "$(Build.SourceBranch)".Replace("refs/heads/", "")
         Write-Host "Sourcebranch " + $branch
         Write-Host "TargetBranch " + $branch
 


### PR DESCRIPTION
refs/heads should be refs/heads/
Or else the $branch will be set to /main instead of main