### PR TITLE
[Build] Fix obsolete area path for filing TSA bugs on the Foundation repo

### DIFF
--- a/.config/tsaoptions.json
+++ b/.config/tsaoptions.json
@@ -1,8 +1,8 @@
 {
     "instanceUrl": "https://microsoft.visualstudio.com",
     "projectName": "os",
-    "areaPath": "OS\\Windows Client and Services\\ADEPT\\NEON\\TSABacklog",
-    "iterationPath": "OS\\2408",
+    "areaPath": "OS\\Windows Client and Services\\WinPD\\DEEP-Developer Experience, Ecosystem and Partnerships\\AmUse- App Metadata and User Setup Experience\\WinAppSDK\\WinAppSDK Engineering System",
+    "iterationPath": "OS\\2410",
     "notificationAliases": [ "WinAppSDK-Build@microsoft.com" ],
     "ignoreBranchName": true,
     "codebaseName": "WinAppSDK-Foundation"


### PR DESCRIPTION
The same changes as in [Pull Request 11512903](https://microsoft.visualstudio.com/ProjectReunion/_git/WindowsAppSDKAggregator/pullrequest/11512903?_a=files) but here for the Foundation repo instead.

--
A microsoft employee must use /azp run to validate using the pipelines below.

WARNING:
Comments made by azure-pipelines bot maybe inaccurate.
Please see pipeline link to verify that the build is being ran.

For status checks on the main branch, please use TransportPackage-Foundation-PR
(https://microsoft.visualstudio.com/ProjectReunion/_build?definitionId=81063&_a=summary)
and run the build against your PR branch with the default parameters.
