### PR TITLE
Bug 54198205: The Tags in nuspec file is wrong on Foundation repo

### DIFF
--- a/tools/DevCheck/nuspec/Microsoft.WindowsAppSDK.DevCheck.nuspec
+++ b/tools/DevCheck/nuspec/Microsoft.WindowsAppSDK.DevCheck.nuspec
@@ -12,6 +12,6 @@
     <iconUrl>https://raw.githubusercontent.com/microsoft/WindowsAppSDK/main/assets/WindowsAppSDK64.png</iconUrl>
     <description>DevCheck for WindowsAppSDK </description>
     <copyright>© Microsoft Corporation. All rights reserved.</copyright>
-    <tags>Windows,Windows App SDK,DevCheck</tags>
+    <tags>Windows "Windows App SDK" DevCheck</tags>
   </metadata>
 </package>


### PR DESCRIPTION
According to [this](https://learn.microsoft.com/en-us/nuget/reference/nuspec), the Tags element string is space-delimited, so ',' alone would not split a tag string.

How built:
- These changes will go through PR validation as usual.

How tested:
- The ultimate test is to visually verify that the Tags are shown correctly in the landing page of the related feed.

////
A microsoft employee must use /azp run to validate using the pipelines below.

WARNING:
Comments made by azure-pipelines bot maybe inaccurate.
Please see pipeline link to verify that the build is being ran.

For status checks on the main branch, please use TransportPackage-Foundation-PR
(https://microsoft.visualstudio.com/ProjectReunion/_build?definitionId=81063&_a=summary)
and run the build against your PR branch with the default parameters.
