### PR TITLE
[1.6 servicing] RegisterPackageSetAsync() requires URI when it should be optional to register by PackageFamilyName

### DIFF
--- a/dev/PackageManager/API/M.W.M.D.PackageDeploymentManager.cpp
+++ b/dev/PackageManager/API/M.W.M.D.PackageDeploymentManager.cpp
@@ -819,7 +819,7 @@ namespace winrt::Microsoft::Windows::Management::Deployment::implementation
         progress(packageDeploymentProgress);
 
         // Check parameter(s)
-        Validate_PackageUriIsRequired(packageSet);
+        Validate_PackageUriIsOptional(packageSet);
 
         packageDeploymentProgress.Status = PackageDeploymentProgressStatus::InProgress;
         const double c_progressPercentageStartOfInstalls{ 0.10 };
@@ -834,12 +834,22 @@ namespace winrt::Microsoft::Windows::Management::Deployment::implementation
         for (const winrt::Microsoft::Windows::Management::Deployment::PackageSetItem& packageSetItem : packageSetItems)
         {
             const auto packageUri{ GetEffectivePackageUri(packageSet, packageSetItem) };
+            const auto packageFamilyName{ packageSetItem.PackageFamilyName() };
             try
             {
                 const auto progressBeforePackage{ packageDeploymentProgress.Progress };
-                error = LOG_IF_FAILED_MSG(RegisterPackage(packageUri, options, packageDeploymentProgress, progress, progressIncrementPerPackageSetItem, extendedError, errorText, activityId),
-                                          "ExtendedError:0x%08X PackageFamilyName:%ls PackageUri:%ls",
-                                          extendedError, packageSetItem.PackageFamilyName().c_str(), packageUri.ToString().c_str());
+                if (packageUri)
+                {
+                    error = LOG_IF_FAILED_MSG(RegisterPackage(packageUri, options, packageDeploymentProgress, progress, progressIncrementPerPackageSetItem, extendedError, errorText, activityId),
+                                              "ExtendedError:0x%08X PackageFamilyName:%ls PackageUri:%ls",
+                                              extendedError, packageFamilyName.c_str(), packageUri.ToString().c_str());
+                }
+                else
+                {
+                    error = LOG_IF_FAILED_MSG(RegisterPackageByPackageFamilyName(packageFamilyName, options, packageDeploymentProgress, progress, progressIncrementPerPackageSetItem, extendedError, errorText, activityId),
+                                              "ExtendedError:0x%08X PackageFamilyName:%ls",
+                                              extendedError, packageFamilyName.c_str());
+                }
                 const auto progressAfterPackage{ progressBeforePackage + progressIncrementPerPackageSetItem };
                 if (packageDeploymentProgress.Progress < progressAfterPackage)
                 {
@@ -850,7 +860,7 @@ namespace winrt::Microsoft::Windows::Management::Deployment::implementation
             catch (...)
             {
                 const auto exception{ hresult_error(to_hresult(), take_ownership_from_abi) };
-                error = LOG_HR_MSG(exception.code(), "ExtendedError:0x%08X PackageFamilyName:%ls PackageUri:%ls", extendedError, packageSetItem.PackageFamilyName().c_str(), packageUri.ToString().c_str());
+                error = LOG_HR_MSG(exception.code(), "ExtendedError:0x%08X PackageFamilyName:%ls PackageUri:%ls", extendedError, packageFamilyName.c_str(), (packageUri ? packageUri.ToString().c_str() : L"<null>"));
             }
             if (FAILED(error))
             {
@@ -1212,7 +1222,7 @@ namespace winrt::Microsoft::Windows::Management::Deployment::implementation
             catch (...)
             {
                 const auto exception{ hresult_error(to_hresult(), take_ownership_from_abi) };
-                error = LOG_HR_MSG(exception.code(), "ExtendedError:0x%08X PackageUri:%ls PackageFamilyName:%ls PackageUri:%ls",
+                error = LOG_HR_MSG(exception.code(), "ExtendedError:0x%08X PackageFamilyName:%ls PackageUri:%ls",
                                    extendedError, packageFullName, packageUriAsString.c_str());
             }
             if (FAILED(error))
@@ -1382,7 +1392,7 @@ namespace winrt::Microsoft::Windows::Management::Deployment::implementation
             catch (...)
             {
                 const auto exception{ hresult_error(to_hresult(), take_ownership_from_abi) };
-                error = LOG_HR_MSG(exception.code(), "ExtendedError:0x%08X PackageUri:%ls PackageFamilyName:%ls PackageUri:%ls",
+                error = LOG_HR_MSG(exception.code(), "ExtendedError:0x%08X PackageFamilyName:%ls PackageUri:%ls",
                                    extendedError, packageFullName, packageUriAsString.c_str());
             }
             if (FAILED(error))
@@ -1622,13 +1632,14 @@ namespace winrt::Microsoft::Windows::Management::Deployment::implementation
                 PackageDeploymentProgressStatus::Queued, 0} };
         progress(packageDeploymentProgress);
 
+        const double progressMaxPerPackageFamily{ 1.0 };
         HRESULT error{};
         HRESULT extendedError{};
         winrt::hstring errorText;
         winrt::guid activityId{};
         try
         {
-            error = LOG_IF_FAILED_MSG(RegisterPackageByPackageFamilyName(packageFamilyName, options, packageDeploymentProgress, progress, extendedError, errorText, activityId),
+            error = LOG_IF_FAILED_MSG(RegisterPackageByPackageFamilyName(packageFamilyName, options, packageDeploymentProgress, progress, progressMaxPerPackageFamily, extendedError, errorText, activityId),
                                       "ExtendedError:0x%08X PackageFamilyName:%ls",
                                       extendedError, packageFamilyName.c_str());
         }
@@ -2225,6 +2236,7 @@ namespace winrt::Microsoft::Windows::Management::Deployment::implementation
         winrt::Microsoft::Windows::Management::Deployment::RegisterPackageOptions const& registerOptions,
         winrt::Microsoft::Windows::Management::Deployment::PackageDeploymentProgress& packageDeploymentProgress,
         wistd::function<void(winrt::Microsoft::Windows::Management::Deployment::PackageDeploymentProgress)> progress,
+        const double progressMaxPerPackage,
         HRESULT& extendedError,
         winrt::hstring& errorText,
         winrt::guid& activityId)
@@ -2233,6 +2245,7 @@ namespace winrt::Microsoft::Windows::Management::Deployment::implementation
         errorText.clear();
         activityId = winrt::guid{};
 
+        const auto progressBefore{ packageDeploymentProgress.Progress };
         const auto deploymentOptions{ ToDeploymentOptions(registerOptions) };
         auto deploymentOperation{ m_packageManager.RegisterPackageByFamilyNameAsync(packageFamilyName,
             registerOptions.DependencyPackageFamilyNames(), deploymentOptions,
@@ -2242,9 +2255,12 @@ namespace winrt::Microsoft::Windows::Management::Deployment::implementation
                                             winrt::Windows::Management::Deployment::DeploymentProgress> const& /*sender*/,
                                          winrt::Windows::Management::Deployment::DeploymentProgress const& progressInfo)
         {
-            const double progressMaxPerPackageFamily{ 1.0 };
-            packageDeploymentProgress.Progress = PercentageToProgress(progressInfo.percentage, progressMaxPerPackageFamily);
-            progress(packageDeploymentProgress);
+            const auto progressAfter{ progressBefore + PercentageToProgress(progressInfo.percentage, progressMaxPerPackage) };
+            if (packageDeploymentProgress.Progress < progressAfter)
+            {
+                packageDeploymentProgress.Progress = progressAfter;
+                progress(packageDeploymentProgress);
+            }
         });
         deploymentOperation.get();
         try

--- a/dev/PackageManager/API/M.W.M.D.PackageDeploymentManager.h
+++ b/dev/PackageManager/API/M.W.M.D.PackageDeploymentManager.h
@@ -155,6 +155,7 @@ namespace winrt::Microsoft::Windows::Management::Deployment::implementation
             winrt::Microsoft::Windows::Management::Deployment::RegisterPackageOptions const& registerOptions,
             winrt::Microsoft::Windows::Management::Deployment::PackageDeploymentProgress& packageDeploymentProgress,
             wistd::function<void(winrt::Microsoft::Windows::Management::Deployment::PackageDeploymentProgress)> progress,
+        const double progressMaxPerPackage,
             HRESULT& extendedError,
             winrt::hstring& errorText,
             winrt::guid& activityId);

--- a/specs/packagemanager/PackageManagement.md
+++ b/specs/packagemanager/PackageManagement.md
@@ -311,18 +311,18 @@ return new PackageDeploymentResult(PackageDeploymentStatus.CompletedSuccess);
 
 |Verb                    | MinVersion |     PackageFamilyName     | PackageUri | ProcessorArchitectureFilter |
 |------------------------|:----------:|:-------------------------:|:----------:|:---------------------------:|
-|IsReady                 |  Used      |          Required         |     N/A    |           Optional          |
-|IsReadyOrNewerAvailable |  Used      |          Required         |     N/A    |           Optional          |
-|EnsureReady             |  Used      |          Required         |  Used  |           Optional          |
-|Add                     |    N/A     |             N/A           |  Used  |              N/A            |
-|Stage                   |    N/A     |             N/A           |  USed  |              N/A            |
-|Register                |    N/A     |             N/A           |  Used  |              N/A            |
-|Remove                  |    N/A     | Used-if-no-PackageUri |  Optional  |              N/A            |
-|Repair                  |    N/A     | Used-if-no-PackageUri |  Optional  |              N/A            |
-|Reset                   |    N/A     | Used-if-no-PackageUri |  Optional  |              N/A            |
-|IsProvisioned           |    N/A     |          Used         |  Optional  |              N/A            |
-|Provision               |    N/A     | Used-if-no-PackageUri |  Optional  |              N/A            |
-|Deprovision             |    N/A     | Used-if-no-PackageUri |  Optional  |              N/A            |
+|IsReady                 |    Used    |          Required         |    N/A     |           Optional          |
+|IsReadyOrNewerAvailable |    Used    |          Required         |    N/A     |           Optional          |
+|EnsureReady             |    Used    |          Required         |    Used    |           Optional          |
+|Add                     |    N/A     |            N/A            |    Used    |             N/A             |
+|Stage                   |    N/A     |            N/A            |    Used    |             N/A             |
+|Register                |    N/A     |   Used-if-no-PackageUri   |  Optional  |             N/A             |
+|Remove                  |    N/A     |   Used-if-no-PackageUri   |  Optional  |             N/A             |
+|Repair                  |    N/A     |   Used-if-no-PackageUri   |  Optional  |             N/A             |
+|Reset                   |    N/A     |   Used-if-no-PackageUri   |  Optional  |             N/A             |
+|IsProvisioned           |    N/A     |            Used           |  Optional  |             N/A             |
+|Provision               |    N/A     |   Used-if-no-PackageUri   |  Optional  |             N/A             |
+|Deprovision             |    N/A     |   Used-if-no-PackageUri   |  Optional  |             N/A             |
 
 **Legend:**
 
@@ -330,7 +330,6 @@ return new PackageDeploymentResult(PackageDeploymentStatus.CompletedSuccess);
 * **Optional** = This property is used, if specified.
 * **Required** = This property is required.
 * **Used** = This property is used; if not specified, the default value is used.
-
 
 ## 3.9. PackageRuntimeManager
 

--- a/test/PackageManager/API/PackageDeploymentManagerTests_Register.cpp
+++ b/test/PackageManager/API/PackageDeploymentManagerTests_Register.cpp
@@ -437,6 +437,58 @@ namespace Test::PackageManager::Tests
             VERIFY_IS_TRUE(packageDeploymentManager.IsPackageSetReady(packageSet));
         }
 
+        TEST_METHOD(RegisterPackageSetAsync_Framework_1_Staged_PackageFamilyName_Success)
+        {
+            BEGIN_TEST_METHOD_PROPERTIES()
+                TEST_CLASS_PROPERTY(L"RunAs", L"ElevatedUser")
+            END_TEST_METHOD_PROPERTIES()
+
+            RETURN_IF_SKIP_ON_WIN10_DUE_TO_0x80073D2B_IN_TEST();
+
+            StagePackage_Red();
+
+            auto packageDeploymentManager{ winrt::Microsoft::Windows::Management::Deployment::PackageDeploymentManager::GetDefault() };
+
+            winrt::Microsoft::Windows::Management::Deployment::PackageSet packageSet;
+            PCWSTR c_packageSetId{ L"RGB" };
+            packageSet.Id(c_packageSetId);
+            winrt::Microsoft::Windows::Management::Deployment::PackageSetItem red{ Make_PackageSetItem_NoPackageUri(::TPF::Red::GetPackageFullName()) };
+            packageSet.Items().Append(red);
+
+            winrt::Microsoft::Windows::Management::Deployment::RegisterPackageOptions options;
+            auto deploymentOperation{ packageDeploymentManager.RegisterPackageSetAsync(packageSet, options) };
+            auto deploymentResult{ WaitForDeploymentOperation(deploymentOperation) };
+            TPMT::VerifyDeploymentSucceeded(deploymentResult, __FILE__, __LINE__, __FUNCTION__);
+
+            VERIFY_IS_TRUE(packageDeploymentManager.IsPackageSetReady(packageSet));
+        }
+
+        TEST_METHOD(RegisterPackageSetAsync_Main_1_Staged_PackageFamilyName_Success)
+        {
+            BEGIN_TEST_METHOD_PROPERTIES()
+                TEST_CLASS_PROPERTY(L"RunAs", L"ElevatedUser")
+            END_TEST_METHOD_PROPERTIES()
+
+            RETURN_IF_SKIP_ON_WIN10_DUE_TO_0x80073D2B_IN_TEST();
+
+            StagePackage_Black();
+
+            auto packageDeploymentManager{ winrt::Microsoft::Windows::Management::Deployment::PackageDeploymentManager::GetDefault() };
+
+            winrt::Microsoft::Windows::Management::Deployment::PackageSet packageSet;
+            PCWSTR c_packageSetId{ L"RGB" };
+            packageSet.Id(c_packageSetId);
+            winrt::Microsoft::Windows::Management::Deployment::PackageSetItem black{ Make_PackageSetItem_NoPackageUri(::TPM::Black::GetPackageFullName()) };
+            packageSet.Items().Append(black);
+
+            winrt::Microsoft::Windows::Management::Deployment::RegisterPackageOptions options;
+            auto deploymentOperation{ packageDeploymentManager.RegisterPackageSetAsync(packageSet, options) };
+            auto deploymentResult{ WaitForDeploymentOperation(deploymentOperation) };
+            TPMT::VerifyDeploymentSucceeded(deploymentResult, __FILE__, __LINE__, __FUNCTION__);
+
+            VERIFY_IS_TRUE(packageDeploymentManager.IsPackageSetReady(packageSet));
+        }
+
         TEST_METHOD(RegisterPackageSetAsync_Framework_1_Registered_Success)
         {
             RETURN_IF_SKIP_ON_WIN10_DUE_TO_0x80073D2B_IN_TEST();
@@ -471,6 +523,50 @@ namespace Test::PackageManager::Tests
             PCWSTR c_packageSetId{ L"BW" };
             packageSet.Id(c_packageSetId);
             winrt::Microsoft::Windows::Management::Deployment::PackageSetItem black{ Make_PackageSetItem_ForRegister(::TPM::Black::GetPackageFullName()) };
+            packageSet.Items().Append(black);
+
+            winrt::Microsoft::Windows::Management::Deployment::RegisterPackageOptions options;
+            auto deploymentOperation{ packageDeploymentManager.RegisterPackageSetAsync(packageSet, options) };
+            auto deploymentResult{ WaitForDeploymentOperation(deploymentOperation) };
+            TPMT::VerifyDeploymentSucceeded(deploymentResult, __FILE__, __LINE__, __FUNCTION__);
+
+            VERIFY_IS_TRUE(packageDeploymentManager.IsPackageSetReady(packageSet));
+        }
+
+        TEST_METHOD(RegisterPackageSetAsync_Framework_1_Registered_PackageFamilyName_Success)
+        {
+            RETURN_IF_SKIP_ON_WIN10_DUE_TO_0x80073D2B_IN_TEST();
+
+            AddPackage_Red();
+
+            auto packageDeploymentManager{ winrt::Microsoft::Windows::Management::Deployment::PackageDeploymentManager::GetDefault() };
+
+            winrt::Microsoft::Windows::Management::Deployment::PackageSet packageSet;
+            PCWSTR c_packageSetId{ L"RGB" };
+            packageSet.Id(c_packageSetId);
+            winrt::Microsoft::Windows::Management::Deployment::PackageSetItem red{ Make_PackageSetItem_NoPackageUri(::TPF::Red::GetPackageFullName()) };
+            packageSet.Items().Append(red);
+
+            winrt::Microsoft::Windows::Management::Deployment::RegisterPackageOptions options;
+            auto deploymentOperation{ packageDeploymentManager.RegisterPackageSetAsync(packageSet, options) };
+            auto deploymentResult{ WaitForDeploymentOperation(deploymentOperation) };
+            TPMT::VerifyDeploymentSucceeded(deploymentResult, __FILE__, __LINE__, __FUNCTION__);
+
+            VERIFY_IS_TRUE(packageDeploymentManager.IsPackageSetReady(packageSet));
+        }
+
+        TEST_METHOD(RegisterPackageSetAsync_Main_1_Registered_PackageFamilyName_Success)
+        {
+            RETURN_IF_SKIP_ON_WIN10_DUE_TO_0x80073D2B_IN_TEST();
+
+            AddPackage_Black();
+
+            auto packageDeploymentManager{ winrt::Microsoft::Windows::Management::Deployment::PackageDeploymentManager::GetDefault() };
+
+            winrt::Microsoft::Windows::Management::Deployment::PackageSet packageSet;
+            PCWSTR c_packageSetId{ L"BW" };
+            packageSet.Id(c_packageSetId);
+            winrt::Microsoft::Windows::Management::Deployment::PackageSetItem black{ Make_PackageSetItem_NoPackageUri(::TPM::Black::GetPackageFullName()) };
             packageSet.Items().Append(black);
 
             winrt::Microsoft::Windows::Management::Deployment::RegisterPackageOptions options;
@@ -537,6 +633,62 @@ namespace Test::PackageManager::Tests
             RemovePackage_Blacker();
         }
 
+        TEST_METHOD(RegisterPackageSetAsync_Framework_1_OlderRegistered_PackageFamilyName_Success)
+        {
+            RETURN_IF_SKIP_ON_WIN10_DUE_TO_0x80073D2B_IN_TEST();
+
+            AddPackage_Red();
+            StagePackage_Redder();
+
+            auto packageDeploymentManager{ winrt::Microsoft::Windows::Management::Deployment::PackageDeploymentManager::GetDefault() };
+
+            winrt::Microsoft::Windows::Management::Deployment::PackageSet packageSet;
+            PCWSTR c_packageSetId{ L"RGB" };
+            packageSet.Id(c_packageSetId);
+            winrt::Microsoft::Windows::Management::Deployment::PackageSetItem redder{ Make_PackageSetItem_NoPackageUri(::TPF::Redder::GetPackageFullName()) };
+            packageSet.Items().Append(redder);
+
+            winrt::Microsoft::Windows::Management::Deployment::RegisterPackageOptions options;
+            auto deploymentOperation{ packageDeploymentManager.RegisterPackageSetAsync(packageSet, options) };
+            auto deploymentResult{ WaitForDeploymentOperation(deploymentOperation) };
+            TPMT::VerifyDeploymentSucceeded(deploymentResult, __FILE__, __LINE__, __FUNCTION__);
+
+            VERIFY_IS_TRUE(packageDeploymentManager.IsPackageSetReady(packageSet));
+
+            VERIFY_IS_FALSE(IsPackageRegistered_Red());
+            VERIFY_IS_TRUE(IsPackageRegistered_Redder());
+
+            RemovePackage_Redder();
+        }
+
+        TEST_METHOD(RegisterPackageSetAsync_Main_1_OlderRegistered_PackageFamilyName_Success)
+        {
+            RETURN_IF_SKIP_ON_WIN10_DUE_TO_0x80073D2B_IN_TEST();
+
+            AddPackage_Black();
+            StagePackage_Blacker();
+
+            auto packageDeploymentManager{ winrt::Microsoft::Windows::Management::Deployment::PackageDeploymentManager::GetDefault() };
+
+            winrt::Microsoft::Windows::Management::Deployment::PackageSet packageSet;
+            PCWSTR c_packageSetId{ L"RGB" };
+            packageSet.Id(c_packageSetId);
+            winrt::Microsoft::Windows::Management::Deployment::PackageSetItem redder{ Make_PackageSetItem_NoPackageUri(::TPM::Blacker::GetPackageFullName()) };
+            packageSet.Items().Append(redder);
+
+            winrt::Microsoft::Windows::Management::Deployment::RegisterPackageOptions options;
+            auto deploymentOperation{ packageDeploymentManager.RegisterPackageSetAsync(packageSet, options) };
+            auto deploymentResult{ WaitForDeploymentOperation(deploymentOperation) };
+            TPMT::VerifyDeploymentSucceeded(deploymentResult, __FILE__, __LINE__, __FUNCTION__);
+
+            VERIFY_IS_TRUE(packageDeploymentManager.IsPackageSetReady(packageSet));
+
+            VERIFY_IS_FALSE(IsPackageRegistered_Black());
+            VERIFY_IS_TRUE(IsPackageRegistered_Blacker());
+
+            RemovePackage_Blacker();
+        }
+
         TEST_METHOD(RegisterPackageSetAsync_Framework_N_Registered_Success)
         {
             RETURN_IF_SKIP_ON_WIN10_DUE_TO_0x80073D2B_IN_TEST();
@@ -580,6 +732,59 @@ namespace Test::PackageManager::Tests
             winrt::Microsoft::Windows::Management::Deployment::PackageSetItem black{ Make_PackageSetItem_ForRegister(::TPM::Black::GetPackageFullName()) };
             packageSet.Items().Append(black);
             winrt::Microsoft::Windows::Management::Deployment::PackageSetItem white{ Make_PackageSetItem_ForRegister(::TPM::White::GetPackageFullName()) };
+            packageSet.Items().Append(white);
+
+            winrt::Microsoft::Windows::Management::Deployment::RegisterPackageOptions options;
+            auto deploymentOperation{ packageDeploymentManager.RegisterPackageSetAsync(packageSet, options) };
+            auto deploymentResult{ WaitForDeploymentOperation(deploymentOperation) };
+            TPMT::VerifyDeploymentSucceeded(deploymentResult, __FILE__, __LINE__, __FUNCTION__);
+
+            VERIFY_IS_TRUE(packageDeploymentManager.IsPackageSetReady(packageSet));
+        }
+
+        TEST_METHOD(RegisterPackageSetAsync_Framework_N_Registered_PackageFamilyName_Success)
+        {
+            RETURN_IF_SKIP_ON_WIN10_DUE_TO_0x80073D2B_IN_TEST();
+
+            AddPackage_Red();
+            AddPackage_Green();
+            AddPackage_Blue();
+
+            auto packageDeploymentManager{ winrt::Microsoft::Windows::Management::Deployment::PackageDeploymentManager::GetDefault() };
+
+            winrt::Microsoft::Windows::Management::Deployment::PackageSet packageSet;
+            PCWSTR c_packageSetId{ L"RGB" };
+            packageSet.Id(c_packageSetId);
+            winrt::Microsoft::Windows::Management::Deployment::PackageSetItem red{ Make_PackageSetItem_NoPackageUri(::TPF::Red::GetPackageFullName()) };
+            packageSet.Items().Append(red);
+            winrt::Microsoft::Windows::Management::Deployment::PackageSetItem green{ Make_PackageSetItem_NoPackageUri(::TPF::Green::GetPackageFullName()) };
+            packageSet.Items().Append(green);
+            winrt::Microsoft::Windows::Management::Deployment::PackageSetItem blue{ Make_PackageSetItem_NoPackageUri(::TPF::Blue::GetPackageFullName()) };
+            packageSet.Items().Append(blue);
+
+            winrt::Microsoft::Windows::Management::Deployment::RegisterPackageOptions options;
+            auto deploymentOperation{ packageDeploymentManager.RegisterPackageSetAsync(packageSet, options) };
+            auto deploymentResult{ WaitForDeploymentOperation(deploymentOperation) };
+            TPMT::VerifyDeploymentSucceeded(deploymentResult, __FILE__, __LINE__, __FUNCTION__);
+
+            VERIFY_IS_TRUE(packageDeploymentManager.IsPackageSetReady(packageSet));
+        }
+
+        TEST_METHOD(RegisterPackageSetAsync_Main_N_Registered_PackageFamilyName_Success)
+        {
+            RETURN_IF_SKIP_ON_WIN10_DUE_TO_0x80073D2B_IN_TEST();
+
+            AddPackage_Black();
+            AddPackage_White();
+
+            auto packageDeploymentManager{ winrt::Microsoft::Windows::Management::Deployment::PackageDeploymentManager::GetDefault() };
+
+            winrt::Microsoft::Windows::Management::Deployment::PackageSet packageSet;
+            PCWSTR c_packageSetId{ L"BW" };
+            packageSet.Id(c_packageSetId);
+            winrt::Microsoft::Windows::Management::Deployment::PackageSetItem black{ Make_PackageSetItem_NoPackageUri(::TPM::Black::GetPackageFullName()) };
+            packageSet.Items().Append(black);
+            winrt::Microsoft::Windows::Management::Deployment::PackageSetItem white{ Make_PackageSetItem_NoPackageUri(::TPM::White::GetPackageFullName()) };
             packageSet.Items().Append(white);
 
             winrt::Microsoft::Windows::Management::Deployment::RegisterPackageOptions options;
@@ -651,6 +856,67 @@ namespace Test::PackageManager::Tests
             RemovePackage_Blacker();
         }
 
+        TEST_METHOD(RegisterPackageSetAsync_Framework_N_OlderRegistered_PackageFamilyName_Success)
+        {
+            RETURN_IF_SKIP_ON_WIN10_DUE_TO_0x80073D2B_IN_TEST();
+
+            AddPackage_Red();
+            StagePackage_Redder();
+            AddPackage_Green();
+            AddPackage_Blue();
+
+            auto packageDeploymentManager{ winrt::Microsoft::Windows::Management::Deployment::PackageDeploymentManager::GetDefault() };
+
+            winrt::Microsoft::Windows::Management::Deployment::PackageSet packageSet;
+            PCWSTR c_packageSetId{ L"RGB" };
+            packageSet.Id(c_packageSetId);
+            winrt::Microsoft::Windows::Management::Deployment::PackageSetItem redder{ Make_PackageSetItem_NoPackageUri(::TPF::Redder::GetPackageFullName()) };
+            packageSet.Items().Append(redder);
+            winrt::Microsoft::Windows::Management::Deployment::PackageSetItem green{ Make_PackageSetItem_NoPackageUri(::TPF::Green::GetPackageFullName()) };
+            packageSet.Items().Append(green);
+            winrt::Microsoft::Windows::Management::Deployment::PackageSetItem blue{ Make_PackageSetItem_NoPackageUri(::TPF::Blue::GetPackageFullName()) };
+            packageSet.Items().Append(blue);
+
+            winrt::Microsoft::Windows::Management::Deployment::RegisterPackageOptions options;
+            auto deploymentOperation{ packageDeploymentManager.RegisterPackageSetAsync(packageSet, options) };
+            auto deploymentResult{ WaitForDeploymentOperation(deploymentOperation) };
+            TPMT::VerifyDeploymentSucceeded(deploymentResult, __FILE__, __LINE__, __FUNCTION__);
+
+            VERIFY_IS_TRUE(packageDeploymentManager.IsPackageSetReady(packageSet));
+
+            VERIFY_IS_FALSE(IsPackageRegistered_Red());
+            VERIFY_IS_TRUE(IsPackageRegistered_Redder());
+            RemovePackage_Redder();
+        }
+
+        TEST_METHOD(RegisterPackageSetAsync_Main_N_OlderRegistered_PackageFamilyName_Success)
+        {
+            AddPackage_Black();
+            StagePackage_Blacker();
+            AddPackage_White();
+
+            auto packageDeploymentManager{ winrt::Microsoft::Windows::Management::Deployment::PackageDeploymentManager::GetDefault() };
+
+            winrt::Microsoft::Windows::Management::Deployment::PackageSet packageSet;
+            PCWSTR c_packageSetId{ L"RGB" };
+            packageSet.Id(c_packageSetId);
+            winrt::Microsoft::Windows::Management::Deployment::PackageSetItem blacker{ Make_PackageSetItem_NoPackageUri(::TPM::Blacker::GetPackageFullName()) };
+            packageSet.Items().Append(blacker);
+            winrt::Microsoft::Windows::Management::Deployment::PackageSetItem white{ Make_PackageSetItem_NoPackageUri(::TPM::White::GetPackageFullName()) };
+            packageSet.Items().Append(white);
+
+            winrt::Microsoft::Windows::Management::Deployment::RegisterPackageOptions options;
+            auto deploymentOperation{ packageDeploymentManager.RegisterPackageSetAsync(packageSet, options) };
+            auto deploymentResult{ WaitForDeploymentOperation(deploymentOperation) };
+            TPMT::VerifyDeploymentSucceeded(deploymentResult, __FILE__, __LINE__, __FUNCTION__);
+
+            VERIFY_IS_TRUE(packageDeploymentManager.IsPackageSetReady(packageSet));
+
+            VERIFY_IS_FALSE(IsPackageRegistered_Black());
+            VERIFY_IS_TRUE(IsPackageRegistered_Blacker());
+            RemovePackage_Blacker();
+        }
+
         TEST_METHOD(RegisterPackageSetAsync_Framework_N_RegisteredAndStaged_Success)
         {
             BEGIN_TEST_METHOD_PROPERTIES()
@@ -699,6 +965,64 @@ namespace Test::PackageManager::Tests
             winrt::Microsoft::Windows::Management::Deployment::PackageSetItem black{ Make_PackageSetItem_ForRegister(::TPM::Black::GetPackageFullName()) };
             packageSet.Items().Append(black);
             winrt::Microsoft::Windows::Management::Deployment::PackageSetItem white{ Make_PackageSetItem_ForRegister(::TPM::White::GetPackageFullName()) };
+            packageSet.Items().Append(white);
+
+            winrt::Microsoft::Windows::Management::Deployment::RegisterPackageOptions options;
+            auto deploymentOperation{ packageDeploymentManager.RegisterPackageSetAsync(packageSet, options) };
+            auto deploymentResult{ WaitForDeploymentOperation(deploymentOperation) };
+            TPMT::VerifyDeploymentSucceeded(deploymentResult, __FILE__, __LINE__, __FUNCTION__);
+
+            VERIFY_IS_TRUE(packageDeploymentManager.IsPackageSetReady(packageSet));
+        }
+
+        TEST_METHOD(RegisterPackageSetAsync_Framework_N_RegisteredAndStaged_PackageFamilyName_Success)
+        {
+            BEGIN_TEST_METHOD_PROPERTIES()
+                TEST_CLASS_PROPERTY(L"RunAs", L"ElevatedUser")
+            END_TEST_METHOD_PROPERTIES()
+
+            RETURN_IF_SKIP_ON_WIN10_DUE_TO_0x80073D2B_IN_TEST();
+
+            AddPackage_Red();
+            StagePackage_Blue();
+
+            auto packageDeploymentManager{ winrt::Microsoft::Windows::Management::Deployment::PackageDeploymentManager::GetDefault() };
+
+            winrt::Microsoft::Windows::Management::Deployment::PackageSet packageSet;
+            PCWSTR c_packageSetId{ L"RB" };
+            packageSet.Id(c_packageSetId);
+            winrt::Microsoft::Windows::Management::Deployment::PackageSetItem red{ Make_PackageSetItem_NoPackageUri(::TPF::Red::GetPackageFullName()) };
+            packageSet.Items().Append(red);
+            winrt::Microsoft::Windows::Management::Deployment::PackageSetItem blue{ Make_PackageSetItem_NoPackageUri(::TPF::Blue::GetPackageFullName()) };
+            packageSet.Items().Append(blue);
+
+            winrt::Microsoft::Windows::Management::Deployment::RegisterPackageOptions options;
+            auto deploymentOperation{ packageDeploymentManager.RegisterPackageSetAsync(packageSet, options) };
+            auto deploymentResult{ WaitForDeploymentOperation(deploymentOperation) };
+            TPMT::VerifyDeploymentSucceeded(deploymentResult, __FILE__, __LINE__, __FUNCTION__);
+
+            VERIFY_IS_TRUE(packageDeploymentManager.IsPackageSetReady(packageSet));
+        }
+
+        TEST_METHOD(RegisterPackageSetAsync_Main_N_RegisteredAndStaged_PackageFamilyName_Success)
+        {
+            BEGIN_TEST_METHOD_PROPERTIES()
+                TEST_CLASS_PROPERTY(L"RunAs", L"ElevatedUser")
+            END_TEST_METHOD_PROPERTIES()
+
+            RETURN_IF_SKIP_ON_WIN10_DUE_TO_0x80073D2B_IN_TEST();
+
+            AddPackage_Black();
+            StagePackage_White();
+
+            auto packageDeploymentManager{ winrt::Microsoft::Windows::Management::Deployment::PackageDeploymentManager::GetDefault() };
+
+            winrt::Microsoft::Windows::Management::Deployment::PackageSet packageSet;
+            PCWSTR c_packageSetId{ L"BW" };
+            packageSet.Id(c_packageSetId);
+            winrt::Microsoft::Windows::Management::Deployment::PackageSetItem black{ Make_PackageSetItem_NoPackageUri(::TPM::Black::GetPackageFullName()) };
+            packageSet.Items().Append(black);
+            winrt::Microsoft::Windows::Management::Deployment::PackageSetItem white{ Make_PackageSetItem_NoPackageUri(::TPM::White::GetPackageFullName()) };
             packageSet.Items().Append(white);
 
             winrt::Microsoft::Windows::Management::Deployment::RegisterPackageOptions options;

--- a/test/PackageManager/API/PackageManagerTests.Packages.h
+++ b/test/PackageManager/API/PackageManagerTests.Packages.h
@@ -200,14 +200,17 @@ namespace Test::PackageManager::Tests
 
     inline winrt::Microsoft::Windows::Management::Deployment::PackageSetItem _Make_PackageSetItem(
         PCWSTR packageFullName,
-        winrt::Windows::Foundation::Uri const& packageUri)
+        const winrt::Windows::Foundation::Uri* packageUri)
     {
-        WEX::Logging::Log::Comment(WEX::Common::String().Format(L"PackageSetItem: PackageFullName:%s Path:%s", packageFullName, packageUri.ToString().c_str()));
+        WEX::Logging::Log::Comment(WEX::Common::String().Format(L"PackageSetItem: PackageFullName:%s Path:%s", packageFullName, (packageUri ? packageUri->ToString().c_str() : L"<null>")));
         const auto [packageName, packageVersion, packageArchitecture, packageResourceId, packagePublisherId, packageFamilyName]{ ::AppModel::Package::ParsePackageFullName(packageFullName) };
 
         winrt::Microsoft::Windows::Management::Deployment::PackageSetItem psi;
         psi.PackageFamilyName(packageFamilyName);
-        psi.PackageUri(packageUri);
+        if (packageUri)
+        {
+            psi.PackageUri(*packageUri);
+        }
         const ::AppModel::Identity::PackageVersion version{ packageVersion };
         psi.MinVersion(version.ToWinrtPackageVersion());
         return psi;
@@ -218,14 +221,20 @@ namespace Test::PackageManager::Tests
         PCWSTR packageDirName)
     {
         const auto packageUri{ TP::GetMsixPackageUri(packageDirName) };
-        return _Make_PackageSetItem(packageFullName, packageUri);
+        return _Make_PackageSetItem(packageFullName, &packageUri);
     }
 
     inline winrt::Microsoft::Windows::Management::Deployment::PackageSetItem Make_PackageSetItem_ForRegister(
         PCWSTR packageFullName)
     {
         const auto appxManifestUri{ TP::GetAppxManifestPackageUri(packageFullName) };
-        return _Make_PackageSetItem(packageFullName, appxManifestUri);
+        return _Make_PackageSetItem(packageFullName, &appxManifestUri);
+    }
+
+    inline winrt::Microsoft::Windows::Management::Deployment::PackageSetItem Make_PackageSetItem_NoPackageUri(
+        PCWSTR packageFullName)
+    {
+        return _Make_PackageSetItem(packageFullName, nullptr);
     }
 
     inline bool IsPackageRegistered_Red()


### PR DESCRIPTION
RegisterPackageSetAsync() requires URI when it should be optional to register by PackageFamilyName (#4813)

Backport https://github.com/microsoft/WindowsAppSDK/pull/4813 to 1.6-stable

https://task.ms/54537341