### PR TITLE
Update template to follow best practices in namespace use (Issue #1823)

### DIFF
--- a/dev/VSIX/ProjectTemplates/Desktop/CppWinRT/PackagedApp/BlankApp/App.cpp
+++ b/dev/VSIX/ProjectTemplates/Desktop/CppWinRT/PackagedApp/BlankApp/App.cpp
@@ -2,8 +2,10 @@
 #include "App.xaml.h"
 #include "MainWindow.xaml.h"
 
-using namespace winrt;
-using namespace Microsoft::UI::Xaml;
+namespace winrt
+{
+    using namespace Microsoft::UI::Xaml;
+}
 
 // To learn more about WinUI, the WinUI project structure,
 // and more about our project templates, see: http://aka.ms/winui-project-info.
@@ -20,7 +22,7 @@ namespace winrt::$safeprojectname$::implementation
         // See https://github.com/microsoft/cppwinrt/tree/master/nuget#initializecomponent
 
 #if defined _DEBUG && !defined DISABLE_XAML_GENERATED_BREAK_ON_UNHANDLED_EXCEPTION
-        UnhandledException([](IInspectable const&, UnhandledExceptionEventArgs const& e)
+        UnhandledException([](winrt::IInspectable const&, winrt::UnhandledExceptionEventArgs const& e)
         {
             if (IsDebuggerPresent())
             {
@@ -35,9 +37,9 @@ namespace winrt::$safeprojectname$::implementation
     /// Invoked when the application is launched.
     /// </summary>
     /// <param name="e">Details about the launch request and process.</param>
-    void App::OnLaunched([[maybe_unused]] LaunchActivatedEventArgs const& e)
+    void App::OnLaunched([[maybe_unused]] winrt::LaunchActivatedEventArgs const& e)
     {
-        window = make<MainWindow>();
+        window = winrt::make<MainWindow>();
         window.Activate();
     }
 }

--- a/dev/VSIX/ProjectTemplates/Desktop/CppWinRT/PackagedApp/BlankApp/MainWindow.cpp
+++ b/dev/VSIX/ProjectTemplates/Desktop/CppWinRT/PackagedApp/BlankApp/MainWindow.cpp
@@ -4,8 +4,10 @@
 #include "MainWindow.g.cpp"
 #endif
 
-using namespace winrt;
-using namespace Microsoft::UI::Xaml;
+namespace winrt
+{
+    using namespace Microsoft::UI::Xaml;
+}
 
 // To learn more about WinUI, the WinUI project structure,
 // and more about our project templates, see: http://aka.ms/winui-project-info.

--- a/dev/VSIX/ProjectTemplates/Desktop/CppWinRT/SingleProjectPackagedApp/App.cpp
+++ b/dev/VSIX/ProjectTemplates/Desktop/CppWinRT/SingleProjectPackagedApp/App.cpp
@@ -2,8 +2,10 @@
 #include "App.xaml.h"
 #include "MainWindow.xaml.h"
 
-using namespace winrt;
-using namespace Microsoft::UI::Xaml;
+namespace winrt
+{
+    using namespace Microsoft::UI::Xaml;
+}
 
 // To learn more about WinUI, the WinUI project structure,
 // and more about our project templates, see: http://aka.ms/winui-project-info.
@@ -20,7 +22,7 @@ namespace winrt::$safeprojectname$::implementation
         // See https://github.com/microsoft/cppwinrt/tree/master/nuget#initializecomponent
 
 #if defined _DEBUG && !defined DISABLE_XAML_GENERATED_BREAK_ON_UNHANDLED_EXCEPTION
-        UnhandledException([](IInspectable const&, UnhandledExceptionEventArgs const& e)
+        UnhandledException([](winrt::IInspectable const&, winrt::UnhandledExceptionEventArgs const& e)
         {
             if (IsDebuggerPresent())
             {
@@ -35,9 +37,9 @@ namespace winrt::$safeprojectname$::implementation
     /// Invoked when the application is launched.
     /// </summary>
     /// <param name="e">Details about the launch request and process.</param>
-    void App::OnLaunched([[maybe_unused]] LaunchActivatedEventArgs const& e)
+    void App::OnLaunched([[maybe_unused]] winrt::LaunchActivatedEventArgs const& e)
     {
-        window = make<MainWindow>();
+        window = winrt::make<MainWindow>();
         window.Activate();
     }
 }

--- a/dev/VSIX/ProjectTemplates/Desktop/CppWinRT/SingleProjectPackagedApp/MainWindow.cpp
+++ b/dev/VSIX/ProjectTemplates/Desktop/CppWinRT/SingleProjectPackagedApp/MainWindow.cpp
@@ -4,8 +4,10 @@
 #include "MainWindow.g.cpp"
 #endif
 
-using namespace winrt;
-using namespace Microsoft::UI::Xaml;
+namespace winrt
+{
+    using namespace Microsoft::UI::Xaml;
+}
 
 // To learn more about WinUI, the WinUI project structure,
 // and more about our project templates, see: http://aka.ms/winui-project-info.


### PR DESCRIPTION
Addressing issue #1823 and update the template on the namespace, in order to address compiling error when projects that uses C++/WinRT along with C++/CX and/or WRL

A microsoft employee must use /azp run to validate using the pipelines below.

WARNING:
Comments made by azure-pipelines bot maybe inaccurate.
Please see pipeline link to verify that the build is being ran.

For status checks on the main branch, please use TransportPackage-Foundation-PR
(https://microsoft.visualstudio.com/ProjectReunion/_build?definitionId=81063&_a=summary)
and run the build against your PR branch with the default parameters.
