### PR TITLE
Adding reference for DynamicDependency winmd

### DIFF
--- a/build/NuSpecs/WindowsAppSDK-Nuget-Native.targets
+++ b/build/NuSpecs/WindowsAppSDK-Nuget-Native.targets
@@ -16,6 +16,12 @@
     </Reference>
   </ItemGroup>
 
+  <ItemGroup Condition="'$(AppxPackage)' == 'true'">
+    <Reference Include="$(MSBuildThisFileDirectory)..\..\lib\uap10.0\Microsoft.Windows.ApplicationModel.DynamicDependency.winmd">
+      <Private>false</Private>
+    </Reference>
+  </ItemGroup>
+
   <ItemGroup>
     <Reference Include="$(MSBuildThisFileDirectory)..\..\lib\uap10.0\Microsoft.Windows.ApplicationModel.WindowsAppRuntime.winmd">
       <Private>false</Private>


### PR DESCRIPTION
Currently the references for winmd that comes from WindowsAppSDK nuget package is getting affected by the references mentioned in targets file of WinUI. This change to de-couple the definition of references between both the packages.

Related Bug: https://task.ms/54538137