### PR TITLE
Automatically generate password to avoid using Convert-To-SecureString (Cherry Pick)

### DIFF
--- a/build/AzurePipelinesTemplates/WindowsAppSDK-BuildInstaller-Steps.yml
+++ b/build/AzurePipelinesTemplates/WindowsAppSDK-BuildInstaller-Steps.yml
@@ -63,7 +63,7 @@ steps:
   inputs:
     targetType: filePath
     filePath: $(foundationRepoPath)tools\DevCheck\DevCheck.ps1
-    arguments: -NoInteractive -Offline -Verbose -CertPassword 'BuildPipeline' -CheckTestPfx -Clean
+    arguments: -NoInteractive -Offline -Verbose -CheckTestPfx -Clean
     workingDirectory: '$(Build.SourcesDirectory)'
 
 - task: powershell@2

--- a/build/AzurePipelinesTemplates/WindowsAppSDK-RunTests-Steps.yml
+++ b/build/AzurePipelinesTemplates/WindowsAppSDK-RunTests-Steps.yml
@@ -11,7 +11,7 @@ steps:
     inputs:
       targetType: filePath
       filePath: tools\DevCheck\DevCheck.ps1
-      arguments: -NoInteractive -Offline -Verbose -CertPassword 'BuildPipeline' -CheckTestPfx -Clean -CheckDependencies -ShowSystemInfo
+      arguments: -NoInteractive -Offline -Verbose -CheckTestPfx -Clean -CheckDependencies -ShowSystemInfo
       workingDirectory: '$(Build.SourcesDirectory)'
 
   - task: DownloadPipelineArtifact@2

--- a/build/AzurePipelinesTemplates/WindowsAppSDK-SetupBuildEnvironment-Steps.yml
+++ b/build/AzurePipelinesTemplates/WindowsAppSDK-SetupBuildEnvironment-Steps.yml
@@ -72,7 +72,7 @@ steps:
   inputs:
     targetType: filePath
     filePath: tools\DevCheck\DevCheck.ps1
-    arguments: -NoInteractive -Offline -Verbose -CertPassword 'BuildPipeline' -CheckTestPfx -Clean -CheckDependencies -ShowSystemInfo
+    arguments: -NoInteractive -Offline -Verbose -CheckTestPfx -Clean -CheckDependencies -ShowSystemInfo
     workingDirectory: '$(Build.SourcesDirectory)'
 
 - task: PowerShell@2

--- a/tools/DevCheck/DevCheck.ps1
+++ b/tools/DevCheck/DevCheck.ps1
@@ -99,7 +99,7 @@
 #>
 
 Param(
-    [String]$CertPassword=$null,
+    [SecureString]$CertPassword=$null,
 
     [String]$CertPasswordFile=$null,
 
@@ -771,10 +771,9 @@ function Repair-DevTestPfx
 
     # -CertPassword <password> is a required parameter for this work
     $password = ''
-    $password_plaintext = $null
     if (-not [string]::IsNullOrEmpty($CertPassword))
     {
-        $password_plaintext = $CertPassword
+        $password = $CertPassword
     }
     elseif (-not [string]::IsNullOrEmpty($CertPasswordFile))
     {
@@ -790,18 +789,29 @@ function Repair-DevTestPfx
     {
         $password = Get-Content -Path $pwd_file -Encoding utf8
     }
-    if ([string]::IsNullOrEmpty($password_plaintext) -And ($NoInteractive -eq $false))
+    elseif ([string]::IsNullOrEmpty($password) -And ($NoInteractive -eq $false))
     {
-        $password_plaintext = Read-Host -Prompt 'Creating test certificate. Please enter a password'
+        $password = Read-Host -Prompt 'Creating test certificate. Please enter a password' -AsSecureString
     }
-    if ([string]::IsNullOrEmpty($password_plaintext))
+    else
     {
-        Write-Host "Test certificate .pfx...password parameter (-CertPassword | -CertPasswordFile | -CertPasswordUser) or prompting required"
-        $global:issues++
-        return $false
+        $charSet = 'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789!@#$%)'
+        $passwordLength = 20
+        $password = New-Object -TypeName System.Security.SecureString
+        # Generate random characters and append to SecureString
+        for ($i = 0; $i -lt $passwordLength; $i++) 
+        {
+            $randomChar = $charSet[(Get-Random -Maximum $charSet.Length)]
+            $password.AppendChar($randomChar)
+        }
     }
-    $password = ConvertTo-SecureString -String $password_plaintext -Force -AsPlainText
-    Set-Content -Path $pwd_file -Value $password_plaintext -Force
+
+    # Convert back to plaintext. This is not secure but this cert is only use for development purposes.
+    # Do not use for production purposes.
+    $BSTR = [System.Runtime.InteropServices.Marshal]::SecureStringToBSTR($password)
+    $passwordPlainText = [System.Runtime.InteropServices.Marshal]::PtrToStringAuto($BSTR)
+    [Runtime.InteropServices.Marshal]::ZeroFreeBSTR($BSTR)
+    Set-Content -Path $pwd_file -Value $passwordPlainText -Force
 
     # Prepare to record the pfx for the certificate
     $user = Get-UserPath


### PR DESCRIPTION
…g (#4855)

A microsoft employee must use /azp run to validate using the pipelines below.

WARNING:
Comments made by azure-pipelines bot maybe inaccurate.
Please see pipeline link to verify that the build is being ran.

For status checks on the main branch, please use TransportPackage-Foundation-PR
(https://microsoft.visualstudio.com/ProjectReunion/_build?definitionId=81063&_a=summary)
and run the build against your PR branch with the default parameters.
