### PR TITLE
DevCheck: Start the TAEFService if we install it

### DIFF
--- a/tools/DevCheck/DevCheck.ps1
+++ b/tools/DevCheck/DevCheck.ps1
@@ -799,7 +799,7 @@ function Repair-DevTestPfx
         $passwordLength = 20
         $password = New-Object -TypeName System.Security.SecureString
         # Generate random characters and append to SecureString
-        for ($i = 0; $i -lt $passwordLength; $i++) 
+        for ($i = 0; $i -lt $passwordLength; $i++)
         {
             $randomChar = $charSet[(Get-Random -Maximum $charSet.Length)]
             $password.AppendChar($randomChar)
@@ -1649,6 +1649,7 @@ if (($CheckAll -ne $false) -Or ($CheckTAEFService -ne $false))
     if ($test -eq 'NotFound')
     {
         $test = Install-TAEFService
+        $test = Start-TAEFService
     }
     elseif ($test -eq 'NotRunning-OlderVersion')
     {


### PR DESCRIPTION
If `DevCheck` found no TAEF service installed `DevCheck` installs it...but doesn't start it (unlike other cases where `DevCheck` installed the service is also started it).

Kudos to @wcheng-msft for spotting the problem