### PR TITLE
Removing UniversalBGTask Activation class entry from framework manifest

### DIFF
--- a/build/NuSpecs/AppxManifest.xml
+++ b/build/NuSpecs/AppxManifest.xml
@@ -27,12 +27,6 @@
     </Extension>
     <Extension Category="windows.activatableClass.inProcessServer">
       <InProcessServer>
-        <Path>Microsoft.Windows.ApplicationModel.Background.UniversalBGTask.dll</Path>
-        <ActivatableClass ActivatableClassId="Microsoft.Windows.ApplicationModel.Background.UniversalBGTask.Task" ThreadingModel="both" />
-      </InProcessServer>
-    </Extension>
-    <Extension Category="windows.activatableClass.inProcessServer">
-      <InProcessServer>
         <Path>Microsoft.WindowsAppRuntime.dll</Path>
         <!-- NOTE: Keep ActivationClass elements sorted by absolute ActivatableClassId (namespace.class) -->
 


### PR DESCRIPTION
UniversalBGTask activation class declaration needs to get added directly in the app package based on status of `WindowsAppSDKBackgroundTask` property, Hence removing it from framework package manifest
