### PR TITLE
Fix incorrect cch param

### DIFF
--- a/dev/MRTCore/mrt/Core/src/MRM.cpp
+++ b/dev/MRTCore/mrt/Core/src/MRM.cpp
@@ -1023,7 +1023,7 @@ STDAPI MrmGetFilePathFromName(_In_opt_ PCWSTR filename, _Outptr_ PWSTR* filePath
         std::unique_ptr<wchar_t, decltype(&MrmFreeResource)> outputPath(rawOutputPath, MrmFreeResource);
         RETURN_IF_FAILED(PathCchCombineEx(
             outputPath.get(),
-            size,
+            length,
             path.get(),
             filenameToUse,
             PATHCCH_ALLOW_LONG_PATHS));


### PR DESCRIPTION
PathCchCombineEx's cchPathOut is a character count, not a byte count.  Result was an occasional crash when PathCchCombineEx would use what it thought was available storage as scratch space, causing a buffer overrun.
