### PR TITLE
Bug Fix for Cannot install version 1.3: DDLM package not found

### DIFF
--- a/installer/dev/install.cpp
+++ b/installer/dev/install.cpp
@@ -315,7 +315,8 @@ namespace WindowsAppRuntimeInstaller
         {
             if (isPackageInstalledAndIsPackageStatusOK)
             {
-                // If currently installed Package (either same or higher version than the version from the installer) is in good state, do nothing and return.
+                // If currently installed Package (either same or higher version than the version from the installer) is in good state, clear the package higher version and return.
+                installActivityContext.SetExistingPackageIfHigherVersion(L"");  
                 return;
             }
         }
@@ -353,6 +354,9 @@ namespace WindowsAppRuntimeInstaller
 
             // Re-register higher version of the package that is already installed.
            hrDeploymentResult = RegisterPackage(installActivityContext, installActivityContext.GetExistingPackageIfHigherVersion().c_str(), forceDeployment);
+
+           // Clear the package higher version after it has been re-registered 
+           installActivityContext.SetExistingPackageIfHigherVersion(L"");
         }
         else
         {


### PR DESCRIPTION
**Issue Description:** 
There is an issue with the installation of DDLM packages, specifically when a newer installer version (e.g., 1.6.1) is run before an older version (e.g., 1.5.7). This sequence causes the DDLM packages to not install for the older version, resulting in a "package not found" error during provisioning. 

**Root Cause:** 
Processing the DDLM package enters a conditional statement due to the stale value for GetExistingPackageIfHigherVersion (set because the singleton packages have already been processed). Consequently, the singleton package is merely re-registered, and the DDLM package is not added when older versions are executed.

**Fix:** 
Once the higher version package has been re-registered or its status is confirmed to be okay, the value for m_existingPackageIfHigherVersion should be cleared.
	
**Testing:** 
Built both a new and an older version of the installer with the fix. First ran the new version, followed by the older one, ensuring that only a single Singleton package was present. Verified that the DDLM packages, main package, and frameworks installed corresponded to each installer version.



************************************************************************************************************************
A microsoft employee must use /azp run to validate using the pipelines below.

WARNING:
Comments made by azure-pipelines bot maybe inaccurate.
Please see pipeline link to verify that the build is being ran.

For status checks on the main branch, please use TransportPackage-Foundation-PR
(https://microsoft.visualstudio.com/ProjectReunion/_build?definitionId=81063&_a=summary)
and run the build against your PR branch with the default parameters.
