### PR TITLE
Updating CameraCaptureUI Spec Doc

### DIFF
--- a/specs/CameraCaptureUI/CameraCaptureUI.md
+++ b/specs/CameraCaptureUI/CameraCaptureUI.md
@@ -190,6 +190,11 @@ Provides settings for capturing photos with CameraCaptureUI.
 The settings include aspect ratio, image size, format, resolution, 
 and whether or not cropping is allowed by the user interface (UI).
 
+**Important Note**:  
+- Don't specify both size and aspect ratio in the `PhotoSettings`, doing so will cause an invalid argument exception.  
+- `PhotoSettings` can't have a ratio or size specified with cropping disabled.
+
+
 ## CameraCaptureUIPhotoCaptureSettings Properties
 
 | Name | Description | Value |
@@ -206,6 +211,11 @@ and whether or not cropping is allowed by the user interface (UI).
 ## CameraCaptureUIVideoCaptureSettings Class
 Provides settings for capturing videos. 
 The settings include format, maximum resolution, maximum duration, and whether or not to allow trimming.
+
+**Important Note**:  
+- `MaxDurationInSeconds` must be a valid value (i.e., the duration should be in the range of 0 to `UINT32_MAX`).
+- `MaxDurationInSeconds` cannot be set if `AllowTrimming` is false.
+
 
 ## CameraCaptureUIVideoCaptureSettings Properties
 | Name | Description | Value |
@@ -355,8 +365,6 @@ namespace Microsoft.Windows.Media.Capture
     }
  
     [contract(CameraCaptureUIContract, 1)]
-    [threading(sta),
-    marshaling_behavior(none)]
     runtimeclass CameraCaptureUI
     {
         CameraCaptureUI(Microsoft.UI.WindowId window);

--- a/specs/CameraCaptureUI/CameraCaptureUI.md
+++ b/specs/CameraCaptureUI/CameraCaptureUI.md
@@ -191,6 +191,7 @@ The settings include aspect ratio, image size, format, resolution,
 and whether or not cropping is allowed by the user interface (UI).
 
 **Important Note**:  
+- By default, `AllowCropping` is true.
 - Don't specify both size and aspect ratio in the `PhotoSettings`, doing so will cause an invalid argument exception.  
 - `PhotoSettings` can't have a ratio or size specified with cropping disabled. Attempting to do so will result in an invalid argument exception.
 
@@ -213,6 +214,7 @@ Provides settings for capturing videos.
 The settings include format, maximum resolution, maximum duration, and whether or not to allow trimming.
 
 **Important Note**:  
+- By default, `AllowTrimming` is true.
 - `MaxDurationInSeconds` must be a valid value (i.e., the duration should be in the range of 0 to `UINT32_MAX`). Specifying an invalid value will result in an invalid argument exception.
 - `MaxDurationInSeconds` cannot be set if `AllowTrimming` is false. Attempting to do so will result in an invalid argument exception.
 

--- a/specs/CameraCaptureUI/CameraCaptureUI.md
+++ b/specs/CameraCaptureUI/CameraCaptureUI.md
@@ -192,7 +192,7 @@ and whether or not cropping is allowed by the user interface (UI).
 
 **Important Note**:  
 - Don't specify both size and aspect ratio in the `PhotoSettings`, doing so will cause an invalid argument exception.  
-- `PhotoSettings` can't have a ratio or size specified with cropping disabled.
+- `PhotoSettings` can't have a ratio or size specified with cropping disabled. Attempting to do so will result in an invalid argument exception.
 
 
 ## CameraCaptureUIPhotoCaptureSettings Properties
@@ -213,8 +213,8 @@ Provides settings for capturing videos.
 The settings include format, maximum resolution, maximum duration, and whether or not to allow trimming.
 
 **Important Note**:  
-- `MaxDurationInSeconds` must be a valid value (i.e., the duration should be in the range of 0 to `UINT32_MAX`).
-- `MaxDurationInSeconds` cannot be set if `AllowTrimming` is false.
+- `MaxDurationInSeconds` must be a valid value (i.e., the duration should be in the range of 0 to `UINT32_MAX`). Specifying an invalid value will result in an invalid argument exception.
+- `MaxDurationInSeconds` cannot be set if `AllowTrimming` is false. Attempting to do so will result in an invalid argument exception.
 
 
 ## CameraCaptureUIVideoCaptureSettings Properties

--- a/specs/WinRT/WinRTAPIContracts.md
+++ b/specs/WinRT/WinRTAPIContracts.md
@@ -106,6 +106,7 @@ The list of all contracts defined across Windows App SDK
 | AppLifecycle       | windowsappsdk | AppLifecycleContract            | Microsoft.Windows.AppLifecycle                       |         |
 | AppNotifications   | windowsappsdk | AppNotificationsContract        | Microsoft.Windows.AppNotifications                   |         |
 | BackgroundTask     | windowsappsdk | BackgroundTaskContract          | Microsoft.Windows.ApplicationModel.Background        |         |
+| CameraCaptureUI    | windowsappsdk | CameraCaptureUIContract         | Microsoft.Windows.Media.Capture                      |         |
 | Deployment         | windowsappsdk | DeploymentManagerContract       | Microsoft.Windows.ApplicationModel.WindowsAppRuntime |         |
 | DynamicDependency  | windowsappsdk | DynamicDependencyContract       | Microsoft.Windows.ApplicationModel.DynamicDependency |         |
 | EnvironmentManager | windowsappsdk | EnvironmentManagerContract      | Microsoft.Windows.System                             |         |


### PR DESCRIPTION
This PR includes the following changes:
1) The change updates the CameraCaptureUI specifications doc to include important notes on usage for PhotoSettings and VideoSettings.
2) Added the CameraCaptureUIContract in the WinRT contracts as well.
3) A small update by removing the marshalling=none and threading=STA attributes. These settings were relevant to the UWP version of CameraCapture, but they are no longer applicable in the context of WinAppSDK. 