### PR TITLE
Update C# templates to introduce file scoped namespaces

### DIFF
--- a/dev/VSIX/Extension/Cs/Dev17/VSPackage.cs
+++ b/dev/VSIX/Extension/Cs/Dev17/VSPackage.cs
@@ -7,52 +7,51 @@ using System.Runtime.InteropServices;
 using System.Threading;
 using Task = System.Threading.Tasks.Task;
 
-namespace WindowsAppSDK.Cs.Extension
+namespace WindowsAppSDK.Cs.Extension;
+
+/// <summary>
+/// This is the class that implements the package exposed by this assembly.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The minimum requirement for a class to be considered a valid package for Visual Studio
+/// is to implement the IVsPackage interface and register itself with the shell.
+/// This package uses the helper classes defined inside the Managed Package Framework (MPF)
+/// to do it: it derives from the Package class that provides the implementation of the
+/// IVsPackage interface and uses the registration attributes defined in the framework to
+/// register itself and its components with the shell. These attributes tell the pkgdef creation
+/// utility what data to put into .pkgdef file.
+/// </para>
+/// <para>
+/// To get loaded into VS, the package must be referred by &lt;Asset Type="Microsoft.VisualStudio.VsPackage" ...&gt; in .vsixmanifest file.
+/// </para>
+/// </remarks>
+[PackageRegistration(UseManagedResourcesOnly = true, AllowsBackgroundLoading = true)]
+[Guid(VSPackage.PackageGuidString)]
+public sealed class VSPackage : AsyncPackage
 {
     /// <summary>
-    /// This is the class that implements the package exposed by this assembly.
+    /// VSPackage GUID string.
+    /// 
+    /// NOTE: This MUST match the MSBuild property 'PackageGuidString' defined in the .csproj
     /// </summary>
-    /// <remarks>
-    /// <para>
-    /// The minimum requirement for a class to be considered a valid package for Visual Studio
-    /// is to implement the IVsPackage interface and register itself with the shell.
-    /// This package uses the helper classes defined inside the Managed Package Framework (MPF)
-    /// to do it: it derives from the Package class that provides the implementation of the
-    /// IVsPackage interface and uses the registration attributes defined in the framework to
-    /// register itself and its components with the shell. These attributes tell the pkgdef creation
-    /// utility what data to put into .pkgdef file.
-    /// </para>
-    /// <para>
-    /// To get loaded into VS, the package must be referred by &lt;Asset Type="Microsoft.VisualStudio.VsPackage" ...&gt; in .vsixmanifest file.
-    /// </para>
-    /// </remarks>
-    [PackageRegistration(UseManagedResourcesOnly = true, AllowsBackgroundLoading = true)]
-    [Guid(VSPackage.PackageGuidString)]
-    public sealed class VSPackage : AsyncPackage
+    public const string PackageGuidString = "B0F1BA01-DE66-4EF9-9C8B-DBB99FB4DA4B";
+
+    #region Package Members
+
+    /// <summary>
+    /// Initialization of the package; this method is called right after the package is sited, so this is the place
+    /// where you can put all the initialization code that rely on services provided by VisualStudio.
+    /// </summary>
+    /// <param name="cancellationToken">A cancellation token to monitor for initialization cancellation, which can occur when VS is shutting down.</param>
+    /// <param name="progress">A provider for progress updates.</param>
+    /// <returns>A task representing the async work of package initialization, or an already completed task if there is none. Do not return null from this method.</returns>
+    protected override async Task InitializeAsync(CancellationToken cancellationToken, IProgress<ServiceProgressData> progress)
     {
-        /// <summary>
-        /// VSPackage GUID string.
-        /// 
-        /// NOTE: This MUST match the MSBuild property 'PackageGuidString' defined in the .csproj
-        /// </summary>
-        public const string PackageGuidString = "B0F1BA01-DE66-4EF9-9C8B-DBB99FB4DA4B";
-
-        #region Package Members
-
-        /// <summary>
-        /// Initialization of the package; this method is called right after the package is sited, so this is the place
-        /// where you can put all the initialization code that rely on services provided by VisualStudio.
-        /// </summary>
-        /// <param name="cancellationToken">A cancellation token to monitor for initialization cancellation, which can occur when VS is shutting down.</param>
-        /// <param name="progress">A provider for progress updates.</param>
-        /// <returns>A task representing the async work of package initialization, or an already completed task if there is none. Do not return null from this method.</returns>
-        protected override async Task InitializeAsync(CancellationToken cancellationToken, IProgress<ServiceProgressData> progress)
-        {
-            // When initialized asynchronously, the current thread may be a background thread at this point.
-            // Do any initialization that requires the UI thread after switching to the UI thread.
-            await JoinableTaskFactory.SwitchToMainThreadAsync(cancellationToken);
-        }
-
-        #endregion
+        // When initialized asynchronously, the current thread may be a background thread at this point.
+        // Do any initialization that requires the UI thread after switching to the UI thread.
+        await JoinableTaskFactory.SwitchToMainThreadAsync(cancellationToken);
     }
+
+    #endregion
 }

--- a/dev/VSIX/Extension/Cs/Dev17/VSPackage.cs
+++ b/dev/VSIX/Extension/Cs/Dev17/VSPackage.cs
@@ -28,7 +28,7 @@ namespace WindowsAppSDK.Cs.Extension;
 /// </remarks>
 [PackageRegistration(UseManagedResourcesOnly = true, AllowsBackgroundLoading = true)]
 [Guid(VSPackage.PackageGuidString)]
-public sealed class VSPackage : AsyncPackage
+public sealed partial class VSPackage : AsyncPackage
 {
     /// <summary>
     /// VSPackage GUID string.

--- a/dev/VSIX/Extension/Cs/Dev17/VSPackage.cs
+++ b/dev/VSIX/Extension/Cs/Dev17/VSPackage.cs
@@ -7,51 +7,52 @@ using System.Runtime.InteropServices;
 using System.Threading;
 using Task = System.Threading.Tasks.Task;
 
-namespace WindowsAppSDK.Cs.Extension;
-
-/// <summary>
-/// This is the class that implements the package exposed by this assembly.
-/// </summary>
-/// <remarks>
-/// <para>
-/// The minimum requirement for a class to be considered a valid package for Visual Studio
-/// is to implement the IVsPackage interface and register itself with the shell.
-/// This package uses the helper classes defined inside the Managed Package Framework (MPF)
-/// to do it: it derives from the Package class that provides the implementation of the
-/// IVsPackage interface and uses the registration attributes defined in the framework to
-/// register itself and its components with the shell. These attributes tell the pkgdef creation
-/// utility what data to put into .pkgdef file.
-/// </para>
-/// <para>
-/// To get loaded into VS, the package must be referred by &lt;Asset Type="Microsoft.VisualStudio.VsPackage" ...&gt; in .vsixmanifest file.
-/// </para>
-/// </remarks>
-[PackageRegistration(UseManagedResourcesOnly = true, AllowsBackgroundLoading = true)]
-[Guid(VSPackage.PackageGuidString)]
-public sealed partial class VSPackage : AsyncPackage
+namespace WindowsAppSDK.Cs.Extension
 {
     /// <summary>
-    /// VSPackage GUID string.
-    /// 
-    /// NOTE: This MUST match the MSBuild property 'PackageGuidString' defined in the .csproj
+    /// This is the class that implements the package exposed by this assembly.
     /// </summary>
-    public const string PackageGuidString = "B0F1BA01-DE66-4EF9-9C8B-DBB99FB4DA4B";
-
-    #region Package Members
-
-    /// <summary>
-    /// Initialization of the package; this method is called right after the package is sited, so this is the place
-    /// where you can put all the initialization code that rely on services provided by VisualStudio.
-    /// </summary>
-    /// <param name="cancellationToken">A cancellation token to monitor for initialization cancellation, which can occur when VS is shutting down.</param>
-    /// <param name="progress">A provider for progress updates.</param>
-    /// <returns>A task representing the async work of package initialization, or an already completed task if there is none. Do not return null from this method.</returns>
-    protected override async Task InitializeAsync(CancellationToken cancellationToken, IProgress<ServiceProgressData> progress)
+    /// <remarks>
+    /// <para>
+    /// The minimum requirement for a class to be considered a valid package for Visual Studio
+    /// is to implement the IVsPackage interface and register itself with the shell.
+    /// This package uses the helper classes defined inside the Managed Package Framework (MPF)
+    /// to do it: it derives from the Package class that provides the implementation of the
+    /// IVsPackage interface and uses the registration attributes defined in the framework to
+    /// register itself and its components with the shell. These attributes tell the pkgdef creation
+    /// utility what data to put into .pkgdef file.
+    /// </para>
+    /// <para>
+    /// To get loaded into VS, the package must be referred by &lt;Asset Type="Microsoft.VisualStudio.VsPackage" ...&gt; in .vsixmanifest file.
+    /// </para>
+    /// </remarks>
+    [PackageRegistration(UseManagedResourcesOnly = true, AllowsBackgroundLoading = true)]
+    [Guid(VSPackage.PackageGuidString)]
+    public sealed partial class VSPackage : AsyncPackage
     {
-        // When initialized asynchronously, the current thread may be a background thread at this point.
-        // Do any initialization that requires the UI thread after switching to the UI thread.
-        await JoinableTaskFactory.SwitchToMainThreadAsync(cancellationToken);
-    }
+        /// <summary>
+        /// VSPackage GUID string.
+        /// 
+        /// NOTE: This MUST match the MSBuild property 'PackageGuidString' defined in the .csproj
+        /// </summary>
+        public const string PackageGuidString = "B0F1BA01-DE66-4EF9-9C8B-DBB99FB4DA4B";
 
-    #endregion
+        #region Package Members
+
+        /// <summary>
+        /// Initialization of the package; this method is called right after the package is sited, so this is the place
+        /// where you can put all the initialization code that rely on services provided by VisualStudio.
+        /// </summary>
+        /// <param name="cancellationToken">A cancellation token to monitor for initialization cancellation, which can occur when VS is shutting down.</param>
+        /// <param name="progress">A provider for progress updates.</param>
+        /// <returns>A task representing the async work of package initialization, or an already completed task if there is none. Do not return null from this method.</returns>
+        protected override async Task InitializeAsync(CancellationToken cancellationToken, IProgress<ServiceProgressData> progress)
+        {
+            // When initialized asynchronously, the current thread may be a background thread at this point.
+            // Do any initialization that requires the UI thread after switching to the UI thread.
+            await JoinableTaskFactory.SwitchToMainThreadAsync(cancellationToken);
+        }
+
+        #endregion
+    }
 }

--- a/dev/VSIX/ItemTemplates/Desktop/CSharp/BlankWindow/BlankWindow.xaml
+++ b/dev/VSIX/ItemTemplates/Desktop/CSharp/BlankWindow/BlankWindow.xaml
@@ -9,6 +9,10 @@
     mc:Ignorable="d"
     Title="$itemname$">
 
+    <Window.SystemBackdrop>
+        <MicaBackdrop />
+    </Window.SystemBackdrop>
+
     <Grid>
 
     </Grid>

--- a/dev/VSIX/ItemTemplates/Desktop/CSharp/BlankWindow/BlankWindow.xaml.cs
+++ b/dev/VSIX/ItemTemplates/Desktop/CSharp/BlankWindow/BlankWindow.xaml.cs
@@ -16,16 +16,15 @@ using Microsoft.UI.Xaml.Navigation;
 // To learn more about WinUI, the WinUI project structure,
 // and more about our project templates, see: http://aka.ms/winui-project-info.
 
-namespace $rootnamespace$
+namespace $rootnamespace$;
+
+/// <summary>
+/// An empty window that can be used on its own or navigated to within a Frame.
+/// </summary>
+public sealed partial class $safeitemname$ : Window
 {
-    /// <summary>
-    /// An empty window that can be used on its own or navigated to within a Frame.
-    /// </summary>
-    public sealed partial class $safeitemname$ : Window
+    public $safeitemname$()
     {
-        public $safeitemname$()
-        {
-            this.InitializeComponent();
-        }
+        this.InitializeComponent();
     }
 }

--- a/dev/VSIX/ItemTemplates/Desktop/CSharp/BlankWindow/BlankWindow.xaml.cs
+++ b/dev/VSIX/ItemTemplates/Desktop/CSharp/BlankWindow/BlankWindow.xaml.cs
@@ -25,6 +25,6 @@ public sealed partial class $safeitemname$ : Window
 {
     public $safeitemname$()
     {
-        this.InitializeComponent();
+        InitializeComponent();
     }
 }

--- a/dev/VSIX/ItemTemplates/Desktop/CppWinRT/BlankWindow/BlankWindow.cpp
+++ b/dev/VSIX/ItemTemplates/Desktop/CppWinRT/BlankWindow/BlankWindow.cpp
@@ -21,9 +21,4 @@ namespace winrt::$rootnamespace$::implementation
     {
         throw hresult_not_implemented();
     }
-
-    void $safeitemname$::myButton_Click(IInspectable const&, RoutedEventArgs const&)
-    {
-        myButton().Content(box_value(L"Clicked"));
-    }
 }

--- a/dev/VSIX/ItemTemplates/Desktop/CppWinRT/BlankWindow/BlankWindow.h
+++ b/dev/VSIX/ItemTemplates/Desktop/CppWinRT/BlankWindow/BlankWindow.h
@@ -14,8 +14,6 @@ namespace winrt::$rootnamespace$::implementation
 
         int32_t MyProperty();
         void MyProperty(int32_t value);
-
-        void myButton_Click(IInspectable const& sender, Microsoft::UI::Xaml::RoutedEventArgs const& args);
     };
 }
 

--- a/dev/VSIX/ItemTemplates/Desktop/CppWinRT/BlankWindow/BlankWindow.xaml
+++ b/dev/VSIX/ItemTemplates/Desktop/CppWinRT/BlankWindow/BlankWindow.xaml
@@ -9,7 +9,7 @@
     mc:Ignorable="d"
     Title="$itemname$">
 
-    <StackPanel Orientation="Horizontal" HorizontalAlignment="Center" VerticalAlignment="Center">
-        <Button x:Name="myButton" Click="myButton_Click">Click Me</Button>
-    </StackPanel>
+    <Grid>
+
+    </Grid>
 </Window>

--- a/dev/VSIX/ItemTemplates/Neutral/CSharp/BlankPage/BlankPage.xaml
+++ b/dev/VSIX/ItemTemplates/Neutral/CSharp/BlankPage/BlankPage.xaml
@@ -9,10 +9,6 @@
     mc:Ignorable="d"
     Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
 
-    <Window.SystemBackdrop>
-        <MicaBackdrop />
-    </Window.SystemBackdrop>
-
     <Grid>
 
     </Grid>

--- a/dev/VSIX/ItemTemplates/Neutral/CSharp/BlankPage/BlankPage.xaml
+++ b/dev/VSIX/ItemTemplates/Neutral/CSharp/BlankPage/BlankPage.xaml
@@ -6,8 +6,7 @@
     xmlns:local="using:$rootnamespace$"
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-    mc:Ignorable="d"
-    Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
+    mc:Ignorable="d">
 
     <Grid>
 

--- a/dev/VSIX/ItemTemplates/Neutral/CSharp/BlankPage/BlankPage.xaml
+++ b/dev/VSIX/ItemTemplates/Neutral/CSharp/BlankPage/BlankPage.xaml
@@ -9,6 +9,10 @@
     mc:Ignorable="d"
     Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
 
+    <Window.SystemBackdrop>
+        <MicaBackdrop />
+    </Window.SystemBackdrop>
+
     <Grid>
 
     </Grid>

--- a/dev/VSIX/ItemTemplates/Neutral/CSharp/BlankPage/BlankPage.xaml.cs
+++ b/dev/VSIX/ItemTemplates/Neutral/CSharp/BlankPage/BlankPage.xaml.cs
@@ -16,16 +16,15 @@ using Microsoft.UI.Xaml.Navigation;
 // To learn more about WinUI, the WinUI project structure,
 // and more about our project templates, see: http://aka.ms/winui-project-info.
 
-namespace $rootnamespace$
+namespace $rootnamespace$;
+
+/// <summary>
+/// An empty page that can be used on its own or navigated to within a Frame.
+/// </summary>
+public sealed partial class $safeitemname$ : Page
 {
-    /// <summary>
-    /// An empty page that can be used on its own or navigated to within a Frame.
-    /// </summary>
-    public sealed partial class $safeitemname$ : Page
+    public $safeitemname$()
     {
-        public $safeitemname$()
-        {
-            this.InitializeComponent();
-        }
+        this.InitializeComponent();
     }
 }

--- a/dev/VSIX/ItemTemplates/Neutral/CSharp/BlankPage/BlankPage.xaml.cs
+++ b/dev/VSIX/ItemTemplates/Neutral/CSharp/BlankPage/BlankPage.xaml.cs
@@ -25,6 +25,6 @@ public sealed partial class $safeitemname$ : Page
 {
     public $safeitemname$()
     {
-        this.InitializeComponent();
+        InitializeComponent();
     }
 }

--- a/dev/VSIX/ItemTemplates/Neutral/CSharp/TemplatedControl/CustomControl.cs
+++ b/dev/VSIX/ItemTemplates/Neutral/CSharp/TemplatedControl/CustomControl.cs
@@ -18,6 +18,6 @@ public sealed partial class $safeitemname$ : Control
 {
     public $safeitemname$()
     {
-        this.DefaultStyleKey = typeof($safeitemname$);
+        DefaultStyleKey = typeof($safeitemname$);
     }
 }

--- a/dev/VSIX/ItemTemplates/Neutral/CSharp/TemplatedControl/CustomControl.cs
+++ b/dev/VSIX/ItemTemplates/Neutral/CSharp/TemplatedControl/CustomControl.cs
@@ -12,13 +12,12 @@ using Microsoft.UI.Xaml.Media;
 // To learn more about WinUI, the WinUI project structure,
 // and more about our project templates, see: http://aka.ms/winui-project-info.
 
-namespace $rootnamespace$
+namespace $rootnamespace$;
+
+public sealed class $safeitemname$ : Control
 {
-    public sealed class $safeitemname$ : Control
+    public $safeitemname$()
     {
-        public $safeitemname$()
-        {
-            this.DefaultStyleKey = typeof($safeitemname$);
-        }
+        this.DefaultStyleKey = typeof($safeitemname$);
     }
 }

--- a/dev/VSIX/ItemTemplates/Neutral/CSharp/TemplatedControl/CustomControl.cs
+++ b/dev/VSIX/ItemTemplates/Neutral/CSharp/TemplatedControl/CustomControl.cs
@@ -14,7 +14,7 @@ using Microsoft.UI.Xaml.Media;
 
 namespace $rootnamespace$;
 
-public sealed class $safeitemname$ : Control
+public sealed partial class $safeitemname$ : Control
 {
     public $safeitemname$()
     {

--- a/dev/VSIX/ItemTemplates/Neutral/CSharp/UserControl/UserControl.xaml
+++ b/dev/VSIX/ItemTemplates/Neutral/CSharp/UserControl/UserControl.xaml
@@ -8,6 +8,10 @@
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     mc:Ignorable="d">
 
+    <Window.SystemBackdrop>
+        <MicaBackdrop />
+    </Window.SystemBackdrop>
+
     <Grid>
 
     </Grid>

--- a/dev/VSIX/ItemTemplates/Neutral/CSharp/UserControl/UserControl.xaml
+++ b/dev/VSIX/ItemTemplates/Neutral/CSharp/UserControl/UserControl.xaml
@@ -8,10 +8,6 @@
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     mc:Ignorable="d">
 
-    <Window.SystemBackdrop>
-        <MicaBackdrop />
-    </Window.SystemBackdrop>
-
     <Grid>
 
     </Grid>

--- a/dev/VSIX/ItemTemplates/Neutral/CSharp/UserControl/UserControl.xaml.cs
+++ b/dev/VSIX/ItemTemplates/Neutral/CSharp/UserControl/UserControl.xaml.cs
@@ -22,6 +22,6 @@ public sealed partial class $safeitemname$ : UserControl
 {
     public $safeitemname$()
     {
-        this.InitializeComponent();
+        InitializeComponent();
     }
 }

--- a/dev/VSIX/ItemTemplates/Neutral/CSharp/UserControl/UserControl.xaml.cs
+++ b/dev/VSIX/ItemTemplates/Neutral/CSharp/UserControl/UserControl.xaml.cs
@@ -16,13 +16,12 @@ using Microsoft.UI.Xaml.Navigation;
 // To learn more about WinUI, the WinUI project structure,
 // and more about our project templates, see: http://aka.ms/winui-project-info.
 
-namespace $rootnamespace$
+namespace $rootnamespace$;
+
+public sealed partial class $safeitemname$ : UserControl
 {
-    public sealed partial class $safeitemname$ : UserControl
+    public $safeitemname$()
     {
-        public $safeitemname$()
-        {
-            this.InitializeComponent();
-        }
+        this.InitializeComponent();
     }
 }

--- a/dev/VSIX/ItemTemplates/Neutral/CppWinRT/BlankPage/BlankPage.cpp
+++ b/dev/VSIX/ItemTemplates/Neutral/CppWinRT/BlankPage/BlankPage.cpp
@@ -21,9 +21,4 @@ namespace winrt::$rootnamespace$::implementation
     {
         throw hresult_not_implemented();
     }
-
-    void $safeitemname$::myButton_Click(IInspectable const&, RoutedEventArgs const&)
-    {
-        myButton().Content(box_value(L"Clicked"));
-    }
 }

--- a/dev/VSIX/ItemTemplates/Neutral/CppWinRT/BlankPage/BlankPage.h
+++ b/dev/VSIX/ItemTemplates/Neutral/CppWinRT/BlankPage/BlankPage.h
@@ -14,8 +14,6 @@ namespace winrt::$rootnamespace$::implementation
 
         int32_t MyProperty();
         void MyProperty(int32_t value);
-
-        void myButton_Click(IInspectable const& sender, Microsoft::UI::Xaml::RoutedEventArgs const& args);
     };
 }
 

--- a/dev/VSIX/ItemTemplates/Neutral/CppWinRT/BlankPage/BlankPage.xaml
+++ b/dev/VSIX/ItemTemplates/Neutral/CppWinRT/BlankPage/BlankPage.xaml
@@ -8,7 +8,7 @@
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     mc:Ignorable="d">
 
-    <StackPanel Orientation="Horizontal" HorizontalAlignment="Center" VerticalAlignment="Center">
-        <Button x:Name="myButton" Click="myButton_Click">Click Me</Button>
-    </StackPanel>
+    <Grid>
+
+    </Grid>
 </Page>

--- a/dev/VSIX/ItemTemplates/Neutral/CppWinRT/UserControl/UserControl.cpp
+++ b/dev/VSIX/ItemTemplates/Neutral/CppWinRT/UserControl/UserControl.cpp
@@ -21,9 +21,4 @@ namespace winrt::$rootnamespace$::implementation
     {
         throw hresult_not_implemented();
     }
-
-    void $safeitemname$::myButton_Click(IInspectable const&, RoutedEventArgs const&)
-    {
-        myButton().Content(box_value(L"Clicked"));
-    }
 }

--- a/dev/VSIX/ItemTemplates/Neutral/CppWinRT/UserControl/UserControl.h
+++ b/dev/VSIX/ItemTemplates/Neutral/CppWinRT/UserControl/UserControl.h
@@ -14,8 +14,6 @@ namespace winrt::$rootnamespace$::implementation
 
         int32_t MyProperty();
         void MyProperty(int32_t value);
-
-        void myButton_Click(IInspectable const& sender, Microsoft::UI::Xaml::RoutedEventArgs const& args);
     };
 }
 

--- a/dev/VSIX/ItemTemplates/Neutral/CppWinRT/UserControl/UserControl.xaml
+++ b/dev/VSIX/ItemTemplates/Neutral/CppWinRT/UserControl/UserControl.xaml
@@ -8,7 +8,7 @@
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     mc:Ignorable="d">
 
-    <StackPanel Orientation="Horizontal" HorizontalAlignment="Center" VerticalAlignment="Center">
-        <Button x:Name="myButton" Click="myButton_Click">Click Me</Button>
-    </StackPanel>
+    <Grid>
+
+    </Grid>
 </UserControl>

--- a/dev/VSIX/ProjectTemplates/Desktop/CSharp/ClassLibrary/Class1.cs
+++ b/dev/VSIX/ProjectTemplates/Desktop/CSharp/ClassLibrary/Class1.cs
@@ -7,9 +7,8 @@ using System.Threading.Tasks;
 // To learn more about WinUI, the WinUI project structure,
 // and more about our project templates, see: http://aka.ms/winui-project-info.
 
-namespace $safeprojectname$
+namespace $safeprojectname$;
+
+public class Class1
 {
-    public class Class1
-    {
-    }
 }

--- a/dev/VSIX/ProjectTemplates/Desktop/CSharp/ClassLibrary/Class1.cs
+++ b/dev/VSIX/ProjectTemplates/Desktop/CSharp/ClassLibrary/Class1.cs
@@ -9,6 +9,6 @@ using System.Threading.Tasks;
 
 namespace $safeprojectname$;
 
-public class Class1
+public partial class Class1
 {
 }

--- a/dev/VSIX/ProjectTemplates/Desktop/CSharp/PackagedApp/BlankApp/App.xaml.cs
+++ b/dev/VSIX/ProjectTemplates/Desktop/CSharp/PackagedApp/BlankApp/App.xaml.cs
@@ -19,32 +19,31 @@ using Microsoft.UI.Xaml.Shapes;
 // To learn more about WinUI, the WinUI project structure,
 // and more about our project templates, see: http://aka.ms/winui-project-info.
 
-namespace $safeprojectname$
+namespace $safeprojectname$;
+
+/// <summary>
+/// Provides application-specific behavior to supplement the default Application class.
+/// </summary>
+public partial class App : Application
 {
     /// <summary>
-    /// Provides application-specific behavior to supplement the default Application class.
+    /// Initializes the singleton application object.  This is the first line of authored code
+    /// executed, and as such is the logical equivalent of main() or WinMain().
     /// </summary>
-    public partial class App : Application
+    public App()
     {
-        /// <summary>
-        /// Initializes the singleton application object.  This is the first line of authored code
-        /// executed, and as such is the logical equivalent of main() or WinMain().
-        /// </summary>
-        public App()
-        {
-            this.InitializeComponent();
-        }
-
-        /// <summary>
-        /// Invoked when the application is launched.
-        /// </summary>
-        /// <param name="args">Details about the launch request and process.</param>
-        protected override void OnLaunched(Microsoft.UI.Xaml.LaunchActivatedEventArgs args)
-        {
-            m_window = new MainWindow();
-            m_window.Activate();
-        }
-
-        private Window? m_window;
+        this.InitializeComponent();
     }
+
+    /// <summary>
+    /// Invoked when the application is launched.
+    /// </summary>
+    /// <param name="args">Details about the launch request and process.</param>
+    protected override void OnLaunched(Microsoft.UI.Xaml.LaunchActivatedEventArgs args)
+    {
+        m_window = new MainWindow();
+        m_window.Activate();
+    }
+
+    private Window? m_window;
 }

--- a/dev/VSIX/ProjectTemplates/Desktop/CSharp/PackagedApp/BlankApp/App.xaml.cs
+++ b/dev/VSIX/ProjectTemplates/Desktop/CSharp/PackagedApp/BlankApp/App.xaml.cs
@@ -26,13 +26,15 @@ namespace $safeprojectname$;
 /// </summary>
 public partial class App : Application
 {
+    private Window? _window;
+    
     /// <summary>
     /// Initializes the singleton application object.  This is the first line of authored code
     /// executed, and as such is the logical equivalent of main() or WinMain().
     /// </summary>
     public App()
     {
-        this.InitializeComponent();
+        InitializeComponent();
     }
 
     /// <summary>
@@ -41,9 +43,7 @@ public partial class App : Application
     /// <param name="args">Details about the launch request and process.</param>
     protected override void OnLaunched(Microsoft.UI.Xaml.LaunchActivatedEventArgs args)
     {
-        m_window = new MainWindow();
-        m_window.Activate();
+        _window = new MainWindow();
+        _window.Activate();
     }
-
-    private Window? m_window;
 }

--- a/dev/VSIX/ProjectTemplates/Desktop/CSharp/PackagedApp/BlankApp/MainWindow.xaml
+++ b/dev/VSIX/ProjectTemplates/Desktop/CSharp/PackagedApp/BlankApp/MainWindow.xaml
@@ -9,6 +9,10 @@
     mc:Ignorable="d"
     Title="$projectname$">
 
+    <Window.SystemBackdrop>
+        <MicaBackdrop />
+    </Window.SystemBackdrop>
+
     <Grid>
 
     </Grid>

--- a/dev/VSIX/ProjectTemplates/Desktop/CSharp/PackagedApp/BlankApp/MainWindow.xaml
+++ b/dev/VSIX/ProjectTemplates/Desktop/CSharp/PackagedApp/BlankApp/MainWindow.xaml
@@ -9,7 +9,7 @@
     mc:Ignorable="d"
     Title="$projectname$">
 
-    <StackPanel Orientation="Horizontal" HorizontalAlignment="Center" VerticalAlignment="Center">
-        <Button x:Name="myButton" Click="myButton_Click">Click Me</Button>
-    </StackPanel>
+    <Grid>
+
+    </Grid>
 </Window>

--- a/dev/VSIX/ProjectTemplates/Desktop/CSharp/PackagedApp/BlankApp/MainWindow.xaml.cs
+++ b/dev/VSIX/ProjectTemplates/Desktop/CSharp/PackagedApp/BlankApp/MainWindow.xaml.cs
@@ -27,9 +27,4 @@ public sealed partial class MainWindow : Window
     {
         this.InitializeComponent();
     }
-
-    private void myButton_Click(object sender, RoutedEventArgs e)
-    {
-        myButton.Content = "Clicked";
-    }
 }

--- a/dev/VSIX/ProjectTemplates/Desktop/CSharp/PackagedApp/BlankApp/MainWindow.xaml.cs
+++ b/dev/VSIX/ProjectTemplates/Desktop/CSharp/PackagedApp/BlankApp/MainWindow.xaml.cs
@@ -25,6 +25,6 @@ public sealed partial class MainWindow : Window
 {
     public MainWindow()
     {
-        this.InitializeComponent();
+        InitializeComponent();
     }
 }

--- a/dev/VSIX/ProjectTemplates/Desktop/CSharp/PackagedApp/BlankApp/MainWindow.xaml.cs
+++ b/dev/VSIX/ProjectTemplates/Desktop/CSharp/PackagedApp/BlankApp/MainWindow.xaml.cs
@@ -16,21 +16,20 @@ using Microsoft.UI.Xaml.Navigation;
 // To learn more about WinUI, the WinUI project structure,
 // and more about our project templates, see: http://aka.ms/winui-project-info.
 
-namespace $safeprojectname$
-{
-    /// <summary>
-    /// An empty window that can be used on its own or navigated to within a Frame.
-    /// </summary>
-    public sealed partial class MainWindow : Window
-    {
-        public MainWindow()
-        {
-            this.InitializeComponent();
-        }
+namespace $safeprojectname$;
 
-        private void myButton_Click(object sender, RoutedEventArgs e)
-        {
-            myButton.Content = "Clicked";
-        }
+/// <summary>
+/// An empty window that can be used on its own or navigated to within a Frame.
+/// </summary>
+public sealed partial class MainWindow : Window
+{
+    public MainWindow()
+    {
+        this.InitializeComponent();
+    }
+
+    private void myButton_Click(object sender, RoutedEventArgs e)
+    {
+        myButton.Content = "Clicked";
     }
 }

--- a/dev/VSIX/ProjectTemplates/Desktop/CSharp/SingleProjectPackagedApp/App.xaml.cs
+++ b/dev/VSIX/ProjectTemplates/Desktop/CSharp/SingleProjectPackagedApp/App.xaml.cs
@@ -19,32 +19,31 @@ using Microsoft.UI.Xaml.Shapes;
 // To learn more about WinUI, the WinUI project structure,
 // and more about our project templates, see: http://aka.ms/winui-project-info.
 
-namespace $safeprojectname$
+namespace $safeprojectname$;
+
+/// <summary>
+/// Provides application-specific behavior to supplement the default Application class.
+/// </summary>
+public partial class App : Application
 {
     /// <summary>
-    /// Provides application-specific behavior to supplement the default Application class.
+    /// Initializes the singleton application object.  This is the first line of authored code
+    /// executed, and as such is the logical equivalent of main() or WinMain().
     /// </summary>
-    public partial class App : Application
+    public App()
     {
-        /// <summary>
-        /// Initializes the singleton application object.  This is the first line of authored code
-        /// executed, and as such is the logical equivalent of main() or WinMain().
-        /// </summary>
-        public App()
-        {
-            this.InitializeComponent();
-        }
-
-        /// <summary>
-        /// Invoked when the application is launched.
-        /// </summary>
-        /// <param name="args">Details about the launch request and process.</param>
-        protected override void OnLaunched(Microsoft.UI.Xaml.LaunchActivatedEventArgs args)
-        {
-            m_window = new MainWindow();
-            m_window.Activate();
-        }
-
-        private Window? m_window;
+        this.InitializeComponent();
     }
+
+    /// <summary>
+    /// Invoked when the application is launched.
+    /// </summary>
+    /// <param name="args">Details about the launch request and process.</param>
+    protected override void OnLaunched(Microsoft.UI.Xaml.LaunchActivatedEventArgs args)
+    {
+        m_window = new MainWindow();
+        m_window.Activate();
+    }
+
+    private Window? m_window;
 }

--- a/dev/VSIX/ProjectTemplates/Desktop/CSharp/SingleProjectPackagedApp/App.xaml.cs
+++ b/dev/VSIX/ProjectTemplates/Desktop/CSharp/SingleProjectPackagedApp/App.xaml.cs
@@ -26,13 +26,15 @@ namespace $safeprojectname$;
 /// </summary>
 public partial class App : Application
 {
+    private Window? _window;
+    
     /// <summary>
     /// Initializes the singleton application object.  This is the first line of authored code
     /// executed, and as such is the logical equivalent of main() or WinMain().
     /// </summary>
     public App()
     {
-        this.InitializeComponent();
+        InitializeComponent();
     }
 
     /// <summary>
@@ -41,9 +43,7 @@ public partial class App : Application
     /// <param name="args">Details about the launch request and process.</param>
     protected override void OnLaunched(Microsoft.UI.Xaml.LaunchActivatedEventArgs args)
     {
-        m_window = new MainWindow();
-        m_window.Activate();
+        _window = new MainWindow();
+        _window.Activate();
     }
-
-    private Window? m_window;
 }

--- a/dev/VSIX/ProjectTemplates/Desktop/CSharp/SingleProjectPackagedApp/MainWindow.xaml
+++ b/dev/VSIX/ProjectTemplates/Desktop/CSharp/SingleProjectPackagedApp/MainWindow.xaml
@@ -9,6 +9,10 @@
     mc:Ignorable="d"
     Title="$projectname$">
 
+    <Window.SystemBackdrop>
+        <MicaBackdrop />
+    </Window.SystemBackdrop>
+
     <Grid>
 
     </Grid>

--- a/dev/VSIX/ProjectTemplates/Desktop/CSharp/SingleProjectPackagedApp/MainWindow.xaml
+++ b/dev/VSIX/ProjectTemplates/Desktop/CSharp/SingleProjectPackagedApp/MainWindow.xaml
@@ -9,7 +9,7 @@
     mc:Ignorable="d"
     Title="$projectname$">
 
-    <StackPanel Orientation="Horizontal" HorizontalAlignment="Center" VerticalAlignment="Center">
-        <Button x:Name="myButton" Click="myButton_Click">Click Me</Button>
-    </StackPanel>
+    <Grid>
+
+    </Grid>
 </Window>

--- a/dev/VSIX/ProjectTemplates/Desktop/CSharp/SingleProjectPackagedApp/MainWindow.xaml.cs
+++ b/dev/VSIX/ProjectTemplates/Desktop/CSharp/SingleProjectPackagedApp/MainWindow.xaml.cs
@@ -27,9 +27,4 @@ public sealed partial class MainWindow : Window
     {
         this.InitializeComponent();
     }
-
-    private void myButton_Click(object sender, RoutedEventArgs e)
-    {
-        myButton.Content = "Clicked";
-    }
 }

--- a/dev/VSIX/ProjectTemplates/Desktop/CSharp/SingleProjectPackagedApp/MainWindow.xaml.cs
+++ b/dev/VSIX/ProjectTemplates/Desktop/CSharp/SingleProjectPackagedApp/MainWindow.xaml.cs
@@ -25,6 +25,6 @@ public sealed partial class MainWindow : Window
 {
     public MainWindow()
     {
-        this.InitializeComponent();
+        InitializeComponent();
     }
 }

--- a/dev/VSIX/ProjectTemplates/Desktop/CSharp/SingleProjectPackagedApp/MainWindow.xaml.cs
+++ b/dev/VSIX/ProjectTemplates/Desktop/CSharp/SingleProjectPackagedApp/MainWindow.xaml.cs
@@ -16,21 +16,20 @@ using Microsoft.UI.Xaml.Navigation;
 // To learn more about WinUI, the WinUI project structure,
 // and more about our project templates, see: http://aka.ms/winui-project-info.
 
-namespace $safeprojectname$
-{
-    /// <summary>
-    /// An empty window that can be used on its own or navigated to within a Frame.
-    /// </summary>
-    public sealed partial class MainWindow : Window
-    {
-        public MainWindow()
-        {
-            this.InitializeComponent();
-        }
+namespace $safeprojectname$;
 
-        private void myButton_Click(object sender, RoutedEventArgs e)
-        {
-            myButton.Content = "Clicked";
-        }
+/// <summary>
+/// An empty window that can be used on its own or navigated to within a Frame.
+/// </summary>
+public sealed partial class MainWindow : Window
+{
+    public MainWindow()
+    {
+        this.InitializeComponent();
+    }
+
+    private void myButton_Click(object sender, RoutedEventArgs e)
+    {
+        myButton.Content = "Clicked";
     }
 }

--- a/dev/VSIX/ProjectTemplates/Desktop/CSharp/UnitTestApp/UnitTestApp.xaml.cs
+++ b/dev/VSIX/ProjectTemplates/Desktop/CSharp/UnitTestApp/UnitTestApp.xaml.cs
@@ -27,13 +27,15 @@ namespace $safeprojectname$;
 /// </summary>
 public partial class UnitTestApp : Application
 {
+    private Window? _window;
+    
     /// <summary>
     /// Initializes the singleton application object.  This is the first line of authored code
     /// executed, and as such is the logical equivalent of main() or WinMain().
     /// </summary>
     public UnitTestApp()
     {
-        this.InitializeComponent();
+        InitializeComponent();
     }
 
     /// <summary>
@@ -44,13 +46,11 @@ public partial class UnitTestApp : Application
     {
         Microsoft.VisualStudio.TestPlatform.TestExecutor.UnitTestClient.CreateDefaultUI();
 
-        m_window = new UnitTestAppWindow();
-        m_window.Activate();
+        _window = new UnitTestAppWindow();
+        _window.Activate();
 
-        UITestMethodAttribute.DispatcherQueue = m_window.DispatcherQueue;
+        UITestMethodAttribute.DispatcherQueue = _window.DispatcherQueue;
 
         Microsoft.VisualStudio.TestPlatform.TestExecutor.UnitTestClient.Run(Environment.CommandLine);
     }
-
-    private Window? m_window;
 }

--- a/dev/VSIX/ProjectTemplates/Desktop/CSharp/UnitTestApp/UnitTestApp.xaml.cs
+++ b/dev/VSIX/ProjectTemplates/Desktop/CSharp/UnitTestApp/UnitTestApp.xaml.cs
@@ -20,38 +20,37 @@ using Microsoft.VisualStudio.TestTools.UnitTesting.AppContainer;
 // To learn more about WinUI, the WinUI project structure,
 // and more about our project templates, see: http://aka.ms/winui-project-info.
 
-namespace $safeprojectname$
+namespace $safeprojectname$;
+
+/// <summary>
+/// Provides application-specific behavior to supplement the default Application class.
+/// </summary>
+public partial class UnitTestApp : Application
 {
     /// <summary>
-    /// Provides application-specific behavior to supplement the default Application class.
+    /// Initializes the singleton application object.  This is the first line of authored code
+    /// executed, and as such is the logical equivalent of main() or WinMain().
     /// </summary>
-    public partial class UnitTestApp : Application
+    public UnitTestApp()
     {
-        /// <summary>
-        /// Initializes the singleton application object.  This is the first line of authored code
-        /// executed, and as such is the logical equivalent of main() or WinMain().
-        /// </summary>
-        public UnitTestApp()
-        {
-            this.InitializeComponent();
-        }
-
-        /// <summary>
-        /// Invoked when the application is launched.
-        /// </summary>
-        /// <param name="args">Details about the launch request and process.</param>
-        protected override void OnLaunched(Microsoft.UI.Xaml.LaunchActivatedEventArgs args)
-        {
-            Microsoft.VisualStudio.TestPlatform.TestExecutor.UnitTestClient.CreateDefaultUI();
-
-            m_window = new UnitTestAppWindow();
-            m_window.Activate();
-
-            UITestMethodAttribute.DispatcherQueue = m_window.DispatcherQueue;
-
-            Microsoft.VisualStudio.TestPlatform.TestExecutor.UnitTestClient.Run(Environment.CommandLine);
-        }
-
-        private Window? m_window;
+        this.InitializeComponent();
     }
+
+    /// <summary>
+    /// Invoked when the application is launched.
+    /// </summary>
+    /// <param name="args">Details about the launch request and process.</param>
+    protected override void OnLaunched(Microsoft.UI.Xaml.LaunchActivatedEventArgs args)
+    {
+        Microsoft.VisualStudio.TestPlatform.TestExecutor.UnitTestClient.CreateDefaultUI();
+
+        m_window = new UnitTestAppWindow();
+        m_window.Activate();
+
+        UITestMethodAttribute.DispatcherQueue = m_window.DispatcherQueue;
+
+        Microsoft.VisualStudio.TestPlatform.TestExecutor.UnitTestClient.Run(Environment.CommandLine);
+    }
+
+    private Window? m_window;
 }

--- a/dev/VSIX/ProjectTemplates/Desktop/CSharp/UnitTestApp/UnitTestAppWindow.xaml
+++ b/dev/VSIX/ProjectTemplates/Desktop/CSharp/UnitTestApp/UnitTestAppWindow.xaml
@@ -9,6 +9,10 @@
     mc:Ignorable="d"
     Title="$projectname$">
 
+    <Window.SystemBackdrop>
+        <MicaBackdrop />
+    </Window.SystemBackdrop>
+
     <Grid>
 
     </Grid>

--- a/dev/VSIX/ProjectTemplates/Desktop/CSharp/UnitTestApp/UnitTestAppWindow.xaml.cs
+++ b/dev/VSIX/ProjectTemplates/Desktop/CSharp/UnitTestApp/UnitTestAppWindow.xaml.cs
@@ -16,13 +16,12 @@ using Microsoft.UI.Xaml.Navigation;
 // To learn more about WinUI, the WinUI project structure,
 // and more about our project templates, see: http://aka.ms/winui-project-info.
 
-namespace $safeprojectname$
+namespace $safeprojectname$;
+
+public sealed partial class UnitTestAppWindow : Window
 {
-    public sealed partial class UnitTestAppWindow : Window
+    public UnitTestAppWindow()
     {
-        public UnitTestAppWindow()
-        {
-            this.InitializeComponent();
-        }
+        this.InitializeComponent();
     }
 }

--- a/dev/VSIX/ProjectTemplates/Desktop/CSharp/UnitTestApp/UnitTestAppWindow.xaml.cs
+++ b/dev/VSIX/ProjectTemplates/Desktop/CSharp/UnitTestApp/UnitTestAppWindow.xaml.cs
@@ -22,6 +22,6 @@ public sealed partial class UnitTestAppWindow : Window
 {
     public UnitTestAppWindow()
     {
-        this.InitializeComponent();
+        InitializeComponent();
     }
 }

--- a/dev/VSIX/ProjectTemplates/Desktop/CSharp/UnitTestApp/UnitTests.cs
+++ b/dev/VSIX/ProjectTemplates/Desktop/CSharp/UnitTestApp/UnitTests.cs
@@ -8,7 +8,7 @@ using System.Linq;
 namespace $safeprojectname$;
 
 [TestClass]
-public class UnitTest1
+public partial class UnitTest1
 {
     [TestMethod]
     public void TestMethod1()

--- a/dev/VSIX/ProjectTemplates/Desktop/CSharp/UnitTestApp/UnitTests.cs
+++ b/dev/VSIX/ProjectTemplates/Desktop/CSharp/UnitTestApp/UnitTests.cs
@@ -5,23 +5,22 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 
-namespace $safeprojectname$
-{
-    [TestClass]
-    public class UnitTest1
-    {
-        [TestMethod]
-        public void TestMethod1()
-        {
-            Assert.AreEqual(0, 0);
-        }
+namespace $safeprojectname$;
 
-        // Use the UITestMethod attribute for tests that need to run on the UI thread.
-        [UITestMethod]
-        public void TestMethod2()
-        {
-            var grid = new Grid();
-            Assert.AreEqual(0, grid.MinWidth);
-        }
+[TestClass]
+public class UnitTest1
+{
+    [TestMethod]
+    public void TestMethod1()
+    {
+        Assert.AreEqual(0, 0);
+    }
+
+    // Use the UITestMethod attribute for tests that need to run on the UI thread.
+    [UITestMethod]
+    public void TestMethod2()
+    {
+        var grid = new Grid();
+        Assert.AreEqual(0, grid.MinWidth);
     }
 }

--- a/dev/VSIX/ProjectTemplates/Desktop/CppWinRT/PackagedApp/BlankApp/MainWindow.cpp
+++ b/dev/VSIX/ProjectTemplates/Desktop/CppWinRT/PackagedApp/BlankApp/MainWindow.cpp
@@ -21,9 +21,4 @@ namespace winrt::$safeprojectname$::implementation
     {
         throw hresult_not_implemented();
     }
-
-    void MainWindow::myButton_Click(IInspectable const&, RoutedEventArgs const&)
-    {
-        myButton().Content(box_value(L"Clicked"));
-    }
 }

--- a/dev/VSIX/ProjectTemplates/Desktop/CppWinRT/PackagedApp/BlankApp/MainWindow.h
+++ b/dev/VSIX/ProjectTemplates/Desktop/CppWinRT/PackagedApp/BlankApp/MainWindow.h
@@ -14,8 +14,6 @@ namespace winrt::$safeprojectname$::implementation
 
         int32_t MyProperty();
         void MyProperty(int32_t value);
-
-        void myButton_Click(IInspectable const& sender, Microsoft::UI::Xaml::RoutedEventArgs const& args);
     };
 }
 

--- a/dev/VSIX/ProjectTemplates/Desktop/CppWinRT/PackagedApp/BlankApp/MainWindow.xaml
+++ b/dev/VSIX/ProjectTemplates/Desktop/CppWinRT/PackagedApp/BlankApp/MainWindow.xaml
@@ -9,7 +9,7 @@
     mc:Ignorable="d"
     Title="$projectname$">
 
-    <StackPanel Orientation="Horizontal" HorizontalAlignment="Center" VerticalAlignment="Center">
-        <Button x:Name="myButton" Click="myButton_Click">Click Me</Button>
-    </StackPanel>
+    <Grid>
+
+    </Grid>
 </Window>

--- a/dev/VSIX/ProjectTemplates/Desktop/CppWinRT/SingleProjectPackagedApp/MainWindow.cpp
+++ b/dev/VSIX/ProjectTemplates/Desktop/CppWinRT/SingleProjectPackagedApp/MainWindow.cpp
@@ -21,9 +21,4 @@ namespace winrt::$safeprojectname$::implementation
     {
         throw hresult_not_implemented();
     }
-
-    void MainWindow::myButton_Click(IInspectable const&, RoutedEventArgs const&)
-    {
-        myButton().Content(box_value(L"Clicked"));
-    }
 }

--- a/dev/VSIX/ProjectTemplates/Desktop/CppWinRT/SingleProjectPackagedApp/MainWindow.h
+++ b/dev/VSIX/ProjectTemplates/Desktop/CppWinRT/SingleProjectPackagedApp/MainWindow.h
@@ -14,8 +14,6 @@ namespace winrt::$safeprojectname$::implementation
 
         int32_t MyProperty();
         void MyProperty(int32_t value);
-
-        void myButton_Click(IInspectable const& sender, Microsoft::UI::Xaml::RoutedEventArgs const& args);
     };
 }
 

--- a/dev/VSIX/ProjectTemplates/Desktop/CppWinRT/SingleProjectPackagedApp/MainWindow.xaml
+++ b/dev/VSIX/ProjectTemplates/Desktop/CppWinRT/SingleProjectPackagedApp/MainWindow.xaml
@@ -9,7 +9,7 @@
     mc:Ignorable="d"
     Title="$projectname$">
 
-    <StackPanel Orientation="Horizontal" HorizontalAlignment="Center" VerticalAlignment="Center">
-        <Button x:Name="myButton" Click="myButton_Click">Click Me</Button>
-    </StackPanel>
+    <Grid>
+
+    </Grid>
 </Window>

--- a/dev/VSIX/Shared/WizardImplementation.cs
+++ b/dev/VSIX/Shared/WizardImplementation.cs
@@ -43,6 +43,7 @@ public partial class NuGetPackageInstaller : IWizard
             _nuGetPackages = packages.Split(';').Where(p => !string.IsNullOrEmpty(p));
         }
     }        
+
     public void ProjectFinishedGenerating(Project project)
     {
         ThreadHelper.ThrowIfNotOnUIThread();
@@ -61,6 +62,7 @@ public partial class NuGetPackageInstaller : IWizard
             }
         }
     }
+
     private async Task InstallNuGetPackagesAsync()
     {
         await ThreadHelper.JoinableTaskFactory.RunAsync(async () =>
@@ -116,13 +118,16 @@ public partial class NuGetPackageInstaller : IWizard
     public void BeforeOpeningFile(ProjectItem _)
     {
     }        
+
     public void ProjectItemFinishedGenerating(ProjectItem _)
     {
     }        
+
     public void RunFinished()
     {
 
     }
+
     private void SaveAllProjects()
     {
         ThreadHelper.ThrowIfNotOnUIThread("SaveAllProjects must be called on the UI thread.");
@@ -139,6 +144,7 @@ public partial class NuGetPackageInstaller : IWizard
             }
         }
     }
+
     private void OnSolutionRestoreFinished(IReadOnlyList<string> projects)
     {
         // Debouncing prevents multiple rapid executions of 'InstallNuGetPackageAsync'
@@ -151,6 +157,7 @@ public partial class NuGetPackageInstaller : IWizard
         var joinableTaskFactory = new JoinableTaskFactory(ThreadHelper.JoinableTaskContext);
         _ = joinableTaskFactory.RunAsync(InstallNuGetPackagesAsync);
     }
+
     private void LogError(string message)
     {
         ThreadHelper.ThrowIfNotOnUIThread();
@@ -164,6 +171,7 @@ public partial class NuGetPackageInstaller : IWizard
             }
         });
     }
+    
     public bool ShouldAddProjectItem(string _)
     {
         return true;

--- a/dev/VSIX/Shared/WizardImplementation.cs
+++ b/dev/VSIX/Shared/WizardImplementation.cs
@@ -13,161 +13,159 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 
-namespace WindowsAppSDK.TemplateUtilities
+namespace WindowsAppSDK.TemplateUtilities;
+
+public class NuGetPackageInstaller : IWizard
 {
+    internal static Guid SolutionVCProjectGuid = new Guid("8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942");
+    private Project _project;
+    private IComponentModel _componentModel;
+    private IEnumerable<string> _nuGetPackages;
+    private IVsNuGetProjectUpdateEvents _nugetProjectUpdateEvents;
+    private IVsThreadedWaitDialog2 _waitDialog;
 
-    public class NuGetPackageInstaller : IWizard
+    public void RunStarted(object automationObject, Dictionary<string, string> replacementsDictionary, WizardRunKind runKind, object[] customParams)
     {
-        internal static Guid SolutionVCProjectGuid = new Guid("8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942");
-        private Project _project;
-        private IComponentModel _componentModel;
-        private IEnumerable<string> _nuGetPackages;
-        private IVsNuGetProjectUpdateEvents _nugetProjectUpdateEvents;
-        private IVsThreadedWaitDialog2 _waitDialog;
-
-        public void RunStarted(object automationObject, Dictionary<string, string> replacementsDictionary, WizardRunKind runKind, object[] customParams)
+        ThreadHelper.ThrowIfNotOnUIThread();
+        _componentModel = (IComponentModel)ServiceProvider.GlobalProvider.GetService(typeof(SComponentModel));
+        _waitDialog = ServiceProvider.GlobalProvider.GetService(typeof(SVsThreadedWaitDialog)) as IVsThreadedWaitDialog2;
+        if (_componentModel != null)
         {
-            ThreadHelper.ThrowIfNotOnUIThread();
-            _componentModel = (IComponentModel)ServiceProvider.GlobalProvider.GetService(typeof(SComponentModel));
-            _waitDialog = ServiceProvider.GlobalProvider.GetService(typeof(SVsThreadedWaitDialog)) as IVsThreadedWaitDialog2;
-            if (_componentModel != null)
+            _nugetProjectUpdateEvents = _componentModel.GetService<IVsNuGetProjectUpdateEvents>();
+            if (_nugetProjectUpdateEvents != null)
             {
-                _nugetProjectUpdateEvents = _componentModel.GetService<IVsNuGetProjectUpdateEvents>();
-                if (_nugetProjectUpdateEvents != null)
-                {
-                    _nugetProjectUpdateEvents.SolutionRestoreFinished += OnSolutionRestoreFinished;
-                }
-            }
-            // Assuming package list is passed via a custom parameter in the .vstemplate file
-            if (replacementsDictionary.TryGetValue("$NuGetPackages$", out string packages))
-            {
-                _nuGetPackages = packages.Split(';').Where(p => !string.IsNullOrEmpty(p));
-            }
-        }        
-        public void ProjectFinishedGenerating(Project project)
-        {
-            ThreadHelper.ThrowIfNotOnUIThread();
-            _project = project;
-            Guid _projectGuid;
-            if (project != null)
-            {
-                Guid.TryParse(project.Kind, out _projectGuid);
-
-                if (_projectGuid.Equals(SolutionVCProjectGuid))
-                {
-                    ThreadHelper.JoinableTaskFactory.Run(async () =>
-                    {
-                        await InstallNuGetPackagesAsync();
-                    });
-                }
+                _nugetProjectUpdateEvents.SolutionRestoreFinished += OnSolutionRestoreFinished;
             }
         }
-        private async Task InstallNuGetPackagesAsync()
+        // Assuming package list is passed via a custom parameter in the .vstemplate file
+        if (replacementsDictionary.TryGetValue("$NuGetPackages$", out string packages))
         {
-            await ThreadHelper.JoinableTaskFactory.RunAsync(async () =>
+            _nuGetPackages = packages.Split(';').Where(p => !string.IsNullOrEmpty(p));
+        }
+    }        
+    public void ProjectFinishedGenerating(Project project)
+    {
+        ThreadHelper.ThrowIfNotOnUIThread();
+        _project = project;
+        Guid _projectGuid;
+        if (project != null)
+        {
+            Guid.TryParse(project.Kind, out _projectGuid);
+
+            if (_projectGuid.Equals(SolutionVCProjectGuid))
+            {
+                ThreadHelper.JoinableTaskFactory.Run(async () =>
+                {
+                    await InstallNuGetPackagesAsync();
+                });
+            }
+        }
+    }
+    private async Task InstallNuGetPackagesAsync()
+    {
+        await ThreadHelper.JoinableTaskFactory.RunAsync(async () =>
+        {
+            await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
+            int canceled; // This variable will store the status after the dialog is closed
+
+            // Start the package installation task but do not await it here
+            var installationTask = StartInstallationAsync();
+
+            // Start the threaded wait dialog
+            _waitDialog.StartWaitDialog(null, "Installing NuGet packages into project...", null, null, "Operation in progress...", 0, false, true);
+
+            // Now await the installation task to complete
+            await installationTask;
+
+            // Once the installation is complete, end the wait dialog
+            _waitDialog.EndWaitDialog(out canceled);
+            // Check if the process was canceled before proceeding
+            if (canceled == 0) // If not canceled, finalize the process
             {
                 await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
-                int canceled; // This variable will store the status after the dialog is closed
+                SaveAllProjects();
+            }
+        });
+    }
 
-                // Start the package installation task but do not await it here
-                var installationTask = StartInstallationAsync();
-
-                // Start the threaded wait dialog
-                _waitDialog.StartWaitDialog(null, "Installing NuGet packages into project...", null, null, "Operation in progress...", 0, false, true);
-
-                // Now await the installation task to complete
-                await installationTask;
-
-                // Once the installation is complete, end the wait dialog
-                _waitDialog.EndWaitDialog(out canceled);
-                // Check if the process was canceled before proceeding
-                if (canceled == 0) // If not canceled, finalize the process
-                {
-                    await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
-                    SaveAllProjects();
-                }
-            });
+    private async Task StartInstallationAsync()
+    {
+        IVsPackageInstaller installer = _componentModel.GetService<IVsPackageInstaller>();
+        if (installer == null)
+        {
+            await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
+            LogError("Could not obtain IVsPackageInstaller service.");
+            return;
         }
 
-        private async Task StartInstallationAsync()
+        // Process each package installation
+        foreach (var packageId in _nuGetPackages)
         {
-            IVsPackageInstaller installer = _componentModel.GetService<IVsPackageInstaller>();
-            if (installer == null)
+            try
+            {
+                await Task.Run(() => installer.InstallPackage(null, _project, packageId, "", false));
+            }
+            catch (Exception ex)
             {
                 await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
-                LogError("Could not obtain IVsPackageInstaller service.");
-                return;
-            }
-
-            // Process each package installation
-            foreach (var packageId in _nuGetPackages)
-            {
-                try
-                {
-                    await Task.Run(() => installer.InstallPackage(null, _project, packageId, "", false));
-                }
-                catch (Exception ex)
-                {
-                    await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
-                    LogError($"Failed to install NuGet package: {packageId}. Error: {ex.Message}");
-                }
+                LogError($"Failed to install NuGet package: {packageId}. Error: {ex.Message}");
             }
         }
+    }
 
-        public void BeforeOpeningFile(ProjectItem _)
-        {
-        }        
-        public void ProjectItemFinishedGenerating(ProjectItem _)
-        {
-        }        
-        public void RunFinished()
-        {
+    public void BeforeOpeningFile(ProjectItem _)
+    {
+    }        
+    public void ProjectItemFinishedGenerating(ProjectItem _)
+    {
+    }        
+    public void RunFinished()
+    {
 
-        }
-        private void SaveAllProjects()
-        {
-            ThreadHelper.ThrowIfNotOnUIThread("SaveAllProjects must be called on the UI thread.");
+    }
+    private void SaveAllProjects()
+    {
+        ThreadHelper.ThrowIfNotOnUIThread("SaveAllProjects must be called on the UI thread.");
 
-            var dte = Package.GetGlobalService(typeof(DTE)) as DTE;
-            if (dte != null && dte.Solution != null && dte.Solution.Projects != null)
+        var dte = Package.GetGlobalService(typeof(DTE)) as DTE;
+        if (dte != null && dte.Solution != null && dte.Solution.Projects != null)
+        {
+            foreach (Project project in dte.Solution.Projects)
             {
-                foreach (Project project in dte.Solution.Projects)
+                if (project != null)
                 {
-                    if (project != null)
-                    {
-                        project.Save();
-                    }
+                    project.Save();
                 }
             }
         }
-        private void OnSolutionRestoreFinished(IReadOnlyList<string> projects)
+    }
+    private void OnSolutionRestoreFinished(IReadOnlyList<string> projects)
+    {
+        // Debouncing prevents multiple rapid executions of 'InstallNuGetPackageAsync'
+        // during solution restore.
+        if (_nugetProjectUpdateEvents == null)
         {
-            // Debouncing prevents multiple rapid executions of 'InstallNuGetPackageAsync'
-            // during solution restore.
-            if (_nugetProjectUpdateEvents == null)
+            return;
+        }
+        _nugetProjectUpdateEvents.SolutionRestoreFinished -= OnSolutionRestoreFinished;
+        var joinableTaskFactory = new JoinableTaskFactory(ThreadHelper.JoinableTaskContext);
+        _ = joinableTaskFactory.RunAsync(InstallNuGetPackagesAsync);
+    }
+    private void LogError(string message)
+    {
+        ThreadHelper.ThrowIfNotOnUIThread();
+        ThreadHelper.JoinableTaskFactory.Run(async delegate
+        {
+            await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
+            IVsActivityLog log = ServiceProvider.GlobalProvider.GetService(typeof(SVsActivityLog)) as IVsActivityLog;
+            if (log != null)
             {
-                return;
+                int hr = log.LogEntry((uint)__ACTIVITYLOG_ENTRYTYPE.ALE_ERROR, ToString(), message);
             }
-            _nugetProjectUpdateEvents.SolutionRestoreFinished -= OnSolutionRestoreFinished;
-            var joinableTaskFactory = new JoinableTaskFactory(ThreadHelper.JoinableTaskContext);
-            _ = joinableTaskFactory.RunAsync(InstallNuGetPackagesAsync);
-        }
-        private void LogError(string message)
-        {
-            ThreadHelper.ThrowIfNotOnUIThread();
-            ThreadHelper.JoinableTaskFactory.Run(async delegate
-            {
-                await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
-                IVsActivityLog log = ServiceProvider.GlobalProvider.GetService(typeof(SVsActivityLog)) as IVsActivityLog;
-                if (log != null)
-                {
-                    int hr = log.LogEntry((uint)__ACTIVITYLOG_ENTRYTYPE.ALE_ERROR, ToString(), message);
-                }
-            });
-        }
-        public bool ShouldAddProjectItem(string _)
-        {
-            return true;
-        }
+        });
+    }
+    public bool ShouldAddProjectItem(string _)
+    {
+        return true;
     }
 }

--- a/dev/VSIX/Shared/WizardImplementation.cs
+++ b/dev/VSIX/Shared/WizardImplementation.cs
@@ -13,167 +13,168 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 
-namespace WindowsAppSDK.TemplateUtilities;
-
-public partial class NuGetPackageInstaller : IWizard
+namespace WindowsAppSDK.TemplateUtilities
 {
-    internal static Guid SolutionVCProjectGuid = new Guid("8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942");
-    private Project _project;
-    private IComponentModel _componentModel;
-    private IEnumerable<string> _nuGetPackages;
-    private IVsNuGetProjectUpdateEvents _nugetProjectUpdateEvents;
-    private IVsThreadedWaitDialog2 _waitDialog;
-
-    public void RunStarted(object automationObject, Dictionary<string, string> replacementsDictionary, WizardRunKind runKind, object[] customParams)
+    public partial class NuGetPackageInstaller : IWizard
     {
-        ThreadHelper.ThrowIfNotOnUIThread();
-        _componentModel = (IComponentModel)ServiceProvider.GlobalProvider.GetService(typeof(SComponentModel));
-        _waitDialog = ServiceProvider.GlobalProvider.GetService(typeof(SVsThreadedWaitDialog)) as IVsThreadedWaitDialog2;
-        if (_componentModel != null)
-        {
-            _nugetProjectUpdateEvents = _componentModel.GetService<IVsNuGetProjectUpdateEvents>();
-            if (_nugetProjectUpdateEvents != null)
-            {
-                _nugetProjectUpdateEvents.SolutionRestoreFinished += OnSolutionRestoreFinished;
-            }
-        }
-        // Assuming package list is passed via a custom parameter in the .vstemplate file
-        if (replacementsDictionary.TryGetValue("$NuGetPackages$", out string packages))
-        {
-            _nuGetPackages = packages.Split(';').Where(p => !string.IsNullOrEmpty(p));
-        }
-    }        
+        internal static Guid SolutionVCProjectGuid = new Guid("8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942");
+        private Project _project;
+        private IComponentModel _componentModel;
+        private IEnumerable<string> _nuGetPackages;
+        private IVsNuGetProjectUpdateEvents _nugetProjectUpdateEvents;
+        private IVsThreadedWaitDialog2 _waitDialog;
 
-    public void ProjectFinishedGenerating(Project project)
-    {
-        ThreadHelper.ThrowIfNotOnUIThread();
-        _project = project;
-        Guid _projectGuid;
-        if (project != null)
+        public void RunStarted(object automationObject, Dictionary<string, string> replacementsDictionary, WizardRunKind runKind, object[] customParams)
         {
-            Guid.TryParse(project.Kind, out _projectGuid);
-
-            if (_projectGuid.Equals(SolutionVCProjectGuid))
+            ThreadHelper.ThrowIfNotOnUIThread();
+            _componentModel = (IComponentModel)ServiceProvider.GlobalProvider.GetService(typeof(SComponentModel));
+            _waitDialog = ServiceProvider.GlobalProvider.GetService(typeof(SVsThreadedWaitDialog)) as IVsThreadedWaitDialog2;
+            if (_componentModel != null)
             {
-                ThreadHelper.JoinableTaskFactory.Run(async () =>
+                _nugetProjectUpdateEvents = _componentModel.GetService<IVsNuGetProjectUpdateEvents>();
+                if (_nugetProjectUpdateEvents != null)
                 {
-                    await InstallNuGetPackagesAsync();
-                });
+                    _nugetProjectUpdateEvents.SolutionRestoreFinished += OnSolutionRestoreFinished;
+                }
             }
-        }
-    }
-
-    private async Task InstallNuGetPackagesAsync()
-    {
-        await ThreadHelper.JoinableTaskFactory.RunAsync(async () =>
-        {
-            await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
-            int canceled; // This variable will store the status after the dialog is closed
-
-            // Start the package installation task but do not await it here
-            var installationTask = StartInstallationAsync();
-
-            // Start the threaded wait dialog
-            _waitDialog.StartWaitDialog(null, "Installing NuGet packages into project...", null, null, "Operation in progress...", 0, false, true);
-
-            // Now await the installation task to complete
-            await installationTask;
-
-            // Once the installation is complete, end the wait dialog
-            _waitDialog.EndWaitDialog(out canceled);
-            // Check if the process was canceled before proceeding
-            if (canceled == 0) // If not canceled, finalize the process
+            // Assuming package list is passed via a custom parameter in the .vstemplate file
+            if (replacementsDictionary.TryGetValue("$NuGetPackages$", out string packages))
             {
-                await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
-                SaveAllProjects();
+                _nuGetPackages = packages.Split(';').Where(p => !string.IsNullOrEmpty(p));
             }
-        });
-    }
+        }        
 
-    private async Task StartInstallationAsync()
-    {
-        IVsPackageInstaller installer = _componentModel.GetService<IVsPackageInstaller>();
-        if (installer == null)
+        public void ProjectFinishedGenerating(Project project)
         {
-            await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
-            LogError("Could not obtain IVsPackageInstaller service.");
-            return;
-        }
-
-        // Process each package installation
-        foreach (var packageId in _nuGetPackages)
-        {
-            try
+            ThreadHelper.ThrowIfNotOnUIThread();
+            _project = project;
+            Guid _projectGuid;
+            if (project != null)
             {
-                await Task.Run(() => installer.InstallPackage(null, _project, packageId, "", false));
-            }
-            catch (Exception ex)
-            {
-                await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
-                LogError($"Failed to install NuGet package: {packageId}. Error: {ex.Message}");
-            }
-        }
-    }
+                Guid.TryParse(project.Kind, out _projectGuid);
 
-    public void BeforeOpeningFile(ProjectItem _)
-    {
-    }        
-
-    public void ProjectItemFinishedGenerating(ProjectItem _)
-    {
-    }        
-
-    public void RunFinished()
-    {
-
-    }
-
-    private void SaveAllProjects()
-    {
-        ThreadHelper.ThrowIfNotOnUIThread("SaveAllProjects must be called on the UI thread.");
-
-        var dte = Package.GetGlobalService(typeof(DTE)) as DTE;
-        if (dte != null && dte.Solution != null && dte.Solution.Projects != null)
-        {
-            foreach (Project project in dte.Solution.Projects)
-            {
-                if (project != null)
+                if (_projectGuid.Equals(SolutionVCProjectGuid))
                 {
-                    project.Save();
+                    ThreadHelper.JoinableTaskFactory.Run(async () =>
+                    {
+                        await InstallNuGetPackagesAsync();
+                    });
                 }
             }
         }
-    }
 
-    private void OnSolutionRestoreFinished(IReadOnlyList<string> projects)
-    {
-        // Debouncing prevents multiple rapid executions of 'InstallNuGetPackageAsync'
-        // during solution restore.
-        if (_nugetProjectUpdateEvents == null)
+        private async Task InstallNuGetPackagesAsync()
         {
-            return;
-        }
-        _nugetProjectUpdateEvents.SolutionRestoreFinished -= OnSolutionRestoreFinished;
-        var joinableTaskFactory = new JoinableTaskFactory(ThreadHelper.JoinableTaskContext);
-        _ = joinableTaskFactory.RunAsync(InstallNuGetPackagesAsync);
-    }
-
-    private void LogError(string message)
-    {
-        ThreadHelper.ThrowIfNotOnUIThread();
-        ThreadHelper.JoinableTaskFactory.Run(async delegate
-        {
-            await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
-            IVsActivityLog log = ServiceProvider.GlobalProvider.GetService(typeof(SVsActivityLog)) as IVsActivityLog;
-            if (log != null)
+            await ThreadHelper.JoinableTaskFactory.RunAsync(async () =>
             {
-                int hr = log.LogEntry((uint)__ACTIVITYLOG_ENTRYTYPE.ALE_ERROR, ToString(), message);
+                await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
+                int canceled; // This variable will store the status after the dialog is closed
+
+                // Start the package installation task but do not await it here
+                var installationTask = StartInstallationAsync();
+
+                // Start the threaded wait dialog
+                _waitDialog.StartWaitDialog(null, "Installing NuGet packages into project...", null, null, "Operation in progress...", 0, false, true);
+
+                // Now await the installation task to complete
+                await installationTask;
+
+                // Once the installation is complete, end the wait dialog
+                _waitDialog.EndWaitDialog(out canceled);
+                // Check if the process was canceled before proceeding
+                if (canceled == 0) // If not canceled, finalize the process
+                {
+                    await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
+                    SaveAllProjects();
+                }
+            });
+        }
+
+        private async Task StartInstallationAsync()
+        {
+            IVsPackageInstaller installer = _componentModel.GetService<IVsPackageInstaller>();
+            if (installer == null)
+            {
+                await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
+                LogError("Could not obtain IVsPackageInstaller service.");
+                return;
             }
-        });
-    }
-    
-    public bool ShouldAddProjectItem(string _)
-    {
-        return true;
+
+            // Process each package installation
+            foreach (var packageId in _nuGetPackages)
+            {
+                try
+                {
+                    await Task.Run(() => installer.InstallPackage(null, _project, packageId, "", false));
+                }
+                catch (Exception ex)
+                {
+                    await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
+                    LogError($"Failed to install NuGet package: {packageId}. Error: {ex.Message}");
+                }
+            }
+        }
+
+        public void BeforeOpeningFile(ProjectItem _)
+        {
+        }        
+
+        public void ProjectItemFinishedGenerating(ProjectItem _)
+        {
+        }        
+
+        public void RunFinished()
+        {
+
+        }
+
+        private void SaveAllProjects()
+        {
+            ThreadHelper.ThrowIfNotOnUIThread("SaveAllProjects must be called on the UI thread.");
+
+            var dte = Package.GetGlobalService(typeof(DTE)) as DTE;
+            if (dte != null && dte.Solution != null && dte.Solution.Projects != null)
+            {
+                foreach (Project project in dte.Solution.Projects)
+                {
+                    if (project != null)
+                    {
+                        project.Save();
+                    }
+                }
+            }
+        }
+
+        private void OnSolutionRestoreFinished(IReadOnlyList<string> projects)
+        {
+            // Debouncing prevents multiple rapid executions of 'InstallNuGetPackageAsync'
+            // during solution restore.
+            if (_nugetProjectUpdateEvents == null)
+            {
+                return;
+            }
+            _nugetProjectUpdateEvents.SolutionRestoreFinished -= OnSolutionRestoreFinished;
+            var joinableTaskFactory = new JoinableTaskFactory(ThreadHelper.JoinableTaskContext);
+            _ = joinableTaskFactory.RunAsync(InstallNuGetPackagesAsync);
+        }
+
+        private void LogError(string message)
+        {
+            ThreadHelper.ThrowIfNotOnUIThread();
+            ThreadHelper.JoinableTaskFactory.Run(async delegate
+            {
+                await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
+                IVsActivityLog log = ServiceProvider.GlobalProvider.GetService(typeof(SVsActivityLog)) as IVsActivityLog;
+                if (log != null)
+                {
+                    int hr = log.LogEntry((uint)__ACTIVITYLOG_ENTRYTYPE.ALE_ERROR, ToString(), message);
+                }
+            });
+        }
+        
+        public bool ShouldAddProjectItem(string _)
+        {
+            return true;
+        }
     }
 }

--- a/dev/VSIX/Shared/WizardImplementation.cs
+++ b/dev/VSIX/Shared/WizardImplementation.cs
@@ -15,7 +15,7 @@ using System.Threading.Tasks;
 
 namespace WindowsAppSDK.TemplateUtilities;
 
-public class NuGetPackageInstaller : IWizard
+public partial class NuGetPackageInstaller : IWizard
 {
     internal static Guid SolutionVCProjectGuid = new Guid("8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942");
     private Project _project;


### PR DESCRIPTION
# Purpose
Regarding to https://github.com/microsoft/WindowsAppSDK/issues/3329, creating this PR to introduce file scoped namespaces.

# What have changed
For all .cs files inside `dev/VSIX/ItemTemplates` and `dev/VSIX/ProjectTemplates`, the template code format have been changed to file scoped namespaces:
```
namespace MyNamespace;

public sealed partial class MainWindow : Window
{
    public MainWindow()
    {
        ...
    }
}
```