### PR TITLE
Update TeminalVelocity changes for OAuth2Manager Experimental API

### DIFF
--- a/build/AzurePipelinesTemplates/WindowsAppSDK-SetupBuildEnvironment-Steps.yml
+++ b/build/AzurePipelinesTemplates/WindowsAppSDK-SetupBuildEnvironment-Steps.yml
@@ -188,6 +188,14 @@ steps:
     workingDirectory: '$(Build.SourcesDirectory)'
 
 - task: powershell@2
+  displayName: 'Create OAuth2Manager TerminalVelocity features'
+  inputs:
+    targetType: filePath
+    filePath: tools\TerminalVelocity\Generate-TerminalVelocityFeatures.ps1
+    arguments: -Path $(Build.SourcesDirectory)\dev\common\TerminalVelocityFeatures-OAuth.xml -Channel $(channel) -Language C++ -Namespace Microsoft.Security.Authentication.OAuth -Output $(Build.SourcesDirectory)\dev\common\TerminalVelocityFeatures-OAuth.h
+    workingDirectory: '$(Build.SourcesDirectory)'
+
+- task: powershell@2
   name: UpdateTraceloggingConfig
   inputs:
     targetType: 'inline'

--- a/dev/Common/TerminalVelocityFeatures-OAuth.xml
+++ b/dev/Common/TerminalVelocityFeatures-OAuth.xml
@@ -12,5 +12,9 @@
         <name>Feature_OAuth</name>
         <description>OAuth for the WindowsAppRuntime</description>
         <state>AlwaysEnabled</state>
+        <alwaysDisabledChannelTokens>
+          <channelToken>Preview</channelToken>
+          <channelToken>Stable</channelToken>
+        </alwaysDisabledChannelTokens>
     </feature>
 </features>


### PR DESCRIPTION
This PR introduces a TerminalVelocity check to control the availability of an experimental feature in the Windows App SDK. The feature is enabled in the Experimental channel, while it remains NOOP'd in the Preview and Stable channels, following the TerminalVelocity guidelines for efficient code stripping.

For more information:
https://github.com/microsoft/WindowsAppSDK/blob/main/docs/Coding-Guidelines/Experimental.md
https://github.com/microsoft/WindowsAppSDK/blob/main/docs/Coding-Guidelines/TerminalVelocity.md

A microsoft employee must use /azp run to validate using the pipelines below.

WARNING:
Comments made by azure-pipelines bot maybe inaccurate.
Please see pipeline link to verify that the build is being ran.

For status checks on the main branch, please use TransportPackage-Foundation-PR
(https://microsoft.visualstudio.com/ProjectReunion/_build?definitionId=81063&_a=summary)
and run the build against your PR branch with the default parameters.
