### PR TITLE
Unpackaged App CTA compliance code changes

### DIFF
--- a/dev/PushNotifications/PushNotificationsLongRunningTask/NotificationListener.cpp
+++ b/dev/PushNotifications/PushNotificationsLongRunningTask/NotificationListener.cpp
@@ -84,7 +84,7 @@ CATCH_RETURN()
 STDMETHODIMP_(HRESULT __stdcall) NotificationListener::GetAppProcessName(
     _Out_ HSTRING* appProcessName) noexcept try
 {
-    *appProcessName = ((m_processName.c_str() == nullptr || wcslen(m_processName.c_str()) == 0) ?
+    *appProcessName = (m_processName.empty() ?
         wil::unique_hstring() :
         wil::make_unique_string<wil::unique_hstring>(m_processName.c_str())).release();
     

--- a/dev/PushNotifications/PushNotificationsLongRunningTask/NotificationListener.cpp
+++ b/dev/PushNotifications/PushNotificationsLongRunningTask/NotificationListener.cpp
@@ -84,7 +84,6 @@ CATCH_RETURN()
 STDMETHODIMP_(HRESULT __stdcall) NotificationListener::GetAppProcessName(
     _Out_ HSTRING* appProcessName) noexcept try
 {
-    auto lock{ m_lock.lock_shared() };
     *appProcessName = ((m_processName.c_str() == nullptr || wcslen(m_processName.c_str()) == 0) ?
         wil::unique_hstring() :
         wil::make_unique_string<wil::unique_hstring>(m_processName.c_str())).release();

--- a/dev/PushNotifications/PushNotificationsLongRunningTask/NotificationListener.cpp
+++ b/dev/PushNotifications/PushNotificationsLongRunningTask/NotificationListener.cpp
@@ -80,3 +80,15 @@ STDMETHODIMP_(HRESULT __stdcall) NotificationListener::OnToastNotificationReceiv
     return S_OK;
 }
 CATCH_RETURN()
+
+STDMETHODIMP_(HRESULT __stdcall) NotificationListener::GetAppProcessName(
+    _Out_ HSTRING* appProcessName) noexcept try
+{
+    auto lock{ m_lock.lock_shared() };
+    *appProcessName = ((m_processName.c_str() == nullptr || wcslen(m_processName.c_str()) == 0) ?
+        wil::unique_hstring() :
+        wil::make_unique_string<wil::unique_hstring>(m_processName.c_str())).release();
+    
+    return S_OK;
+}
+CATCH_RETURN()

--- a/dev/PushNotifications/PushNotificationsLongRunningTask/NotificationListener.h
+++ b/dev/PushNotifications/PushNotificationsLongRunningTask/NotificationListener.h
@@ -8,7 +8,8 @@
 #include "ToastRegistrationManager.h"
 
 class NotificationListener : public Microsoft::WRL::RuntimeClass<::ABI::Microsoft::Internal::PushNotifications::INotificationListener,
-                                                                    ::ABI::Microsoft::Internal::PushNotifications::INotificationListener2>
+                                                                    ::ABI::Microsoft::Internal::PushNotifications::INotificationListener2,
+                                                                    ::ABI::Microsoft::Internal::PushNotifications::INotificationListener3>
 {
 public:
     HRESULT RuntimeClassInitialize(
@@ -21,6 +22,8 @@ public:
     STDMETHOD(OnRawNotificationReceived)(unsigned int payloadLength, _In_ byte* payload, _In_ HSTRING correlationVector) noexcept;
     STDMETHOD(OnToastNotificationReceived)(ABI::Microsoft::Internal::ToastNotifications::INotificationProperties* notificationProperties,
         ABI::Microsoft::Internal::ToastNotifications::INotificationTransientProperties*) noexcept;
+    STDMETHOD(GetAppProcessName)(_Out_ HSTRING* appProcessName) noexcept;
+
 private:
     std::shared_ptr<ForegroundSinkManager> m_foregroundSinkManager;
     std::shared_ptr<ToastRegistrationManager> m_toastRegistrationManager;


### PR DESCRIPTION
These changes are done to support CTA compliance for unpackaged apps using notifications. For CTA we need to attribute data used by unpackaged apps for notifications in SRUM DB. Since unpackaged app does not have an identity (e.g - AppUserModuleId). SRUM uses ProcessName to attribute data to unpackaged apps

A microsoft employee must use /azp run to validate using the pipelines below.

WARNING:
Comments made by azure-pipelines bot maybe inaccurate.
Please see pipeline link to verify that the build is being ran.

For status checks on the main branch, please use TransportPackage-Foundation-PR
(https://microsoft.visualstudio.com/ProjectReunion/_build?definitionId=81063&_a=summary)
and run the build against your PR branch with the default parameters.
