### PR TITLE
Remove publish of packages dir

### DIFF
--- a/build/AzurePipelinesTemplates/WindowsAppSDK-BuildBinaries-Steps.yml
+++ b/build/AzurePipelinesTemplates/WindowsAppSDK-BuildBinaries-Steps.yml
@@ -134,12 +134,6 @@ steps:
     SourceFolder: '$(build.SourcesDirectory)\BuildOutput'
     TargetFolder: '$(ob_outputDirectory)'
 
-- task: CopyFiles@2
-  displayName: MoveToOutputDirectory
-  inputs:
-    SourceFolder: '$(build.SourcesDirectory)\packages'
-    TargetFolder: '$(ob_outputDirectory)\packages'
-
 - ${{ if not( parameters.IsOneBranch ) }}:
   - task: PublishBuildArtifacts@1
     inputs:


### PR DESCRIPTION
Can't think of a good reason to publish the entire nuget cache, which adds 4GB and significant time

A microsoft employee must use /azp run to validate using the pipelines below.

WARNING:
Comments made by azure-pipelines bot maybe inaccurate.
Please see pipeline link to verify that the build is being ran.

For status checks on the main branch, please use TransportPackage-Foundation-PR
(https://microsoft.visualstudio.com/ProjectReunion/_build?definitionId=81063&_a=summary)
and run the build against your PR branch with the default parameters.
