### PR TITLE
Use separate folder for publishing redist files, not the nuget package cache

### DIFF
--- a/build/AzurePipelinesTemplates/WindowsAppSDK-BuildFoundation-Steps.yml
+++ b/build/AzurePipelinesTemplates/WindowsAppSDK-BuildFoundation-Steps.yml
@@ -138,13 +138,6 @@ steps:
     SourceFolder: '$(build.SourcesDirectory)\BuildOutput'
     TargetFolder: '$(ob_outputDirectory)'
 
-- task: CopyFiles@2
-  displayName: MoveToOutputDirectory
-  condition: always()
-  inputs:
-    SourceFolder: '$(build.SourcesDirectory)\packages'
-    TargetFolder: '$(ob_outputDirectory)\packages'
-
 - ${{ if not( parameters.IsOneBranch ) }}:
   - task: PublishBuildArtifacts@1
     condition: always()

--- a/build/AzurePipelinesTemplates/WindowsAppSDK-BuildFoundation-Steps.yml
+++ b/build/AzurePipelinesTemplates/WindowsAppSDK-BuildFoundation-Steps.yml
@@ -145,6 +145,14 @@ steps:
     SourceFolder: '$(build.SourcesDirectory)\redist'
     TargetFolder: '$(ob_outputDirectory)\redist'
 
+- task: CopyFiles@2
+  displayName: Stage TAEF files for publish
+  condition: always()
+  inputs:
+    SourceFolder: '$(build.SourcesDirectory)\packages'
+    Contents: Microsoft.Taef.*\**
+    TargetFolder: '$(ob_outputDirectory)\redist'
+
 - ${{ if not( parameters.IsOneBranch ) }}:
   - task: PublishBuildArtifacts@1
     condition: always()

--- a/build/AzurePipelinesTemplates/WindowsAppSDK-BuildFoundation-Steps.yml
+++ b/build/AzurePipelinesTemplates/WindowsAppSDK-BuildFoundation-Steps.yml
@@ -132,11 +132,18 @@ steps:
 # Artifacts are uploaded via ob_outputDirectory where the each vPack Push jobs downloads from
 # so the CopyFiles below are to move all the vPack files to the right locations
 - task: CopyFiles@2
-  displayName: MoveToOutputDirectory
+  displayName: Stage BuildOutput for publish
   condition: always()
   inputs:
     SourceFolder: '$(build.SourcesDirectory)\BuildOutput'
     TargetFolder: '$(ob_outputDirectory)'
+
+- task: CopyFiles@2
+  displayName: Stage redist files for publish
+  condition: always()
+  inputs:
+    SourceFolder: '$(build.SourcesDirectory)\redist'
+    TargetFolder: '$(ob_outputDirectory)\redist'
 
 - ${{ if not( parameters.IsOneBranch ) }}:
   - task: PublishBuildArtifacts@1

--- a/build/AzurePipelinesTemplates/WindowsAppSDK-RunTests-Steps.yml
+++ b/build/AzurePipelinesTemplates/WindowsAppSDK-RunTests-Steps.yml
@@ -73,14 +73,14 @@ steps:
     inputs:
       targetType: 'inline'
       script: |
-            $(Build.SourcesDirectory)\packages\dotnet-windowsdesktop-runtime-installer.exe /quiet /install /norestart
+            $(Build.SourcesDirectory)\redist\dotnet-windowsdesktop-runtime-installer.exe /quiet /install /norestart
 
   - task: powerShell@2
     displayName: 'Install VCLibs.Desktop'
     inputs:
       targetType: 'inline'
       script: |
-            $package = "$(Build.SourcesDirectory)\packages\Microsoft.VCLibs.${{ parameters.buildPlatform }}.14.00.Desktop.appx"
+            $package = "$(Build.SourcesDirectory)\redist\Microsoft.VCLibs.${{ parameters.buildPlatform }}.14.00.Desktop.appx"
             Add-AppxPackage $package -ErrorAction SilentlyContinue
 
   - task: powerShell@2
@@ -88,7 +88,7 @@ steps:
     inputs:
       targetType: 'inline'
       script: |
-            $(Build.SourcesDirectory)\packages\vc_redist.${{ parameters.buildPlatform }}.exe /quiet /install /norestart
+            $(Build.SourcesDirectory)\redist\vc_redist.${{ parameters.buildPlatform }}.exe /quiet /install /norestart
 
   - task: powershell@2
     displayName: 'Run TE.Service'

--- a/build/AzurePipelinesTemplates/WindowsAppSDK-RunTests-Steps.yml
+++ b/build/AzurePipelinesTemplates/WindowsAppSDK-RunTests-Steps.yml
@@ -37,9 +37,10 @@ steps:
       targetPath: '$(Build.SourcesDirectory)\BuildOutput'
 
   - task: CopyFiles@2
+    displayName: Download published redist files
     inputs:
-      SourceFolder: '$(Build.SourcesDirectory)\BuildOutput\packages'
-      TargetFolder: '$(Build.SourcesDirectory)\packages'
+      SourceFolder: '$(Build.SourcesDirectory)\BuildOutput\redist'
+      TargetFolder: '$(Build.SourcesDirectory)\redist'
 
   - task: powerShell@2
     displayName: 'Enable developer mode'

--- a/build/AzurePipelinesTemplates/WindowsAppSDK-SetupBuildEnvironment-Steps.yml
+++ b/build/AzurePipelinesTemplates/WindowsAppSDK-SetupBuildEnvironment-Steps.yml
@@ -89,7 +89,7 @@ steps:
   inputs:
     targetType: filePath
     filePath: '$(Build.SourcesDirectory)\build\scripts\DownloadDotNetRuntimeInstaller.ps1'
-    arguments: -Platform "$(buildPlatform)" -OutputDirectory "$(build.SourcesDirectory)\packages"
+    arguments: -Platform "$(buildPlatform)" -OutputDirectory "$(build.SourcesDirectory)\redist"
 
 - task: PowerShell@2
   displayName: 'Download vcredist installer'
@@ -97,7 +97,7 @@ steps:
   inputs:
     targetType: filePath
     filePath: '$(Build.SourcesDirectory)\build\scripts\DownloadVCRedistInstaller.ps1'
-    arguments: -Platform "$(buildPlatform)" -OutputDirectory "$(build.SourcesDirectory)\packages"
+    arguments: -Platform "$(buildPlatform)" -OutputDirectory "$(build.SourcesDirectory)\redist"
 
 - task: PowerShell@2
   displayName: 'Download desktop bridge CRT'
@@ -105,7 +105,7 @@ steps:
   inputs:
     targetType: filePath
     filePath: '$(Build.SourcesDirectory)\build\scripts\DownloadVCLibsDesktop.ps1'
-    arguments: -Platform "$(buildPlatform)" -OutputDirectory "$(build.SourcesDirectory)\packages"
+    arguments: -Platform "$(buildPlatform)" -OutputDirectory "$(build.SourcesDirectory)\redist"
 
 - task: powershell@2
   displayName: 'Create DynamicDependencies TerminalVelocity features'

--- a/tools/DevCheck/DevCheck.ps1
+++ b/tools/DevCheck/DevCheck.ps1
@@ -1069,7 +1069,7 @@ function Install-TAEFService
     $cpu = Get-CpuArchitecture
     $taef_version = Get-TAEFPackageVersion
     $taef = "Microsoft.Taef.$($taef_version)"
-    $path = "$root\packages\$taef\build\Binaries\$cpu\Wex.Services.exe"
+    $path = "$root\redist\$taef\build\Binaries\$cpu\Wex.Services.exe"
     if (-not(Test-Path -Path $path -PathType Leaf))
     {
         Write-Host "Install TAEF service...Not Found ($path)"


### PR DESCRIPTION
The redist files (DotNet, VCRedist, VCLibs) were being dropped in the local nuget cache folder, packages, resulting in 4GB of unnecessary freight being published and downloaded.  