### PR TITLE
Find custom.props in parent dir

### DIFF
--- a/LkgToolset.props
+++ b/LkgToolset.props
@@ -15,7 +15,7 @@
     <Platform>Win32</Platform>
     <CustomProps>$([MSBuild]::GetPathOfFileAbove('custom.props', '$(MSBuildThisFileDirectory)'))</CustomProps>
   </PropertyGroup>
-  <Import Project="$(CustomProps)" Condition="Exists('$(CustomProps)') and '$(WorkaroundLkgWin32)'=='true'" />  <Import Project="custom.props" Condition="Exists('custom.props') and '$(WorkaroundLkgWin32)'=='true'" />
+  <Import Project="$(CustomProps)" Condition="Exists('$(CustomProps)') and '$(WorkaroundLkgWin32)'=='true'" />
   <PropertyGroup Condition="'$(WorkaroundLkgWin32)'=='true'">
     <Platform>x86</Platform>
   </PropertyGroup>

--- a/LkgToolset.props
+++ b/LkgToolset.props
@@ -13,8 +13,9 @@
   <PropertyGroup Condition="'$(Platform)'=='x86'">
     <WorkaroundLkgWin32>true</WorkaroundLkgWin32>
     <Platform>Win32</Platform>
+    <CustomProps>$([MSBuild]::GetPathOfFileAbove('custom.props', '$(MSBuildThisFileDirectory)'))</CustomProps>
   </PropertyGroup>
-  <Import Project="custom.props" Condition="Exists('custom.props') and '$(WorkaroundLkgWin32)'=='true'" />
+  <Import Project="$(CustomProps)" Condition="Exists('$(CustomProps)') and '$(WorkaroundLkgWin32)'=='true'" />  <Import Project="custom.props" Condition="Exists('custom.props') and '$(WorkaroundLkgWin32)'=='true'" />
   <PropertyGroup Condition="'$(WorkaroundLkgWin32)'=='true'">
     <Platform>x86</Platform>
   </PropertyGroup>


### PR DESCRIPTION
Fix build break - custom.props in parent directory

A microsoft employee must use /azp run to validate using the pipelines below.

WARNING:
Comments made by azure-pipelines bot maybe inaccurate.
Please see pipeline link to verify that the build is being ran.

For status checks on the main branch, please use TransportPackage-Foundation-PR
(https://microsoft.visualstudio.com/ProjectReunion/_build?definitionId=81063&_a=summary)
and run the build against your PR branch with the default parameters.
