### PR TITLE
[Windows App SDK Installer] Functional Test Fixes

### DIFF
--- a/installer/dev/main.cpp
+++ b/installer/dev/main.cpp
@@ -82,7 +82,7 @@ int wmain(int argc, wchar_t *argv[])
         else if ((arg == L"-?") || (arg == L"--help"))
         {
             DisplayHelp();
-            return 1;
+            return 0;
         }
         else if ((arg == L"--info"))
         {

--- a/installer/test/InstallerFunctionalTests/constants.h
+++ b/installer/test/InstallerFunctionalTests/constants.h
@@ -19,10 +19,9 @@
     #define CONFIGURATION L"Release"
 #endif
 
-#define BUILDOUTPUT_DIR L"BuildOutput"
 #define INSTALLER_DIR L"WindowsAppRuntimeInstall"
-#define INSTALLER_FILENAME L"WindowsAppRuntimeInstall-" ARCH L"exe"
-#define INSTALLER_EXE_PATH BUILDOUTPUT_DIR L"\\" CONFIGURATION L"\\" ARCH L"\\" INSTALLER_DIR L"\\" INSTALLER_FILENAME
+#define INSTALLER_FILENAME L"WindowsAppRuntimeInstall-" ARCH L".exe"
+#define INSTALLER_EXE_PATH L"\\" INSTALLER_DIR L"\\" INSTALLER_FILENAME
 
 namespace WindowsAppRuntimeInstallerTests
 {

--- a/installer/test/InstallerFunctionalTests/helpers.cpp
+++ b/installer/test/InstallerFunctionalTests/helpers.cpp
@@ -118,6 +118,10 @@ namespace WindowsAppRuntimeInstallerTests
 
     std::filesystem::path GetModulePath(HMODULE hmodule)
     {
+        if (hmodule == NULL)
+        {
+            hmodule = GetModuleHandle(L"InstallerFunctionalTests.dll");
+        }
         auto path{ GetModuleFileName(hmodule) };
         return path.remove_filename();
     }
@@ -134,12 +138,12 @@ namespace WindowsAppRuntimeInstallerTests
 
         // TAEF runs as a package under the installer, so we have to go way up the parent root in order to
         // get to the common project root and then get to the build output.
-        return path.parent_path().parent_path().parent_path().parent_path().parent_path().parent_path().parent_path();
+        return path.parent_path().parent_path();
     }
 
     std::filesystem::path GetInstallerPath()
     {
         auto path{ GetCommonRootPath() };
-        return path /= INSTALLER_EXE_PATH;
+        return path += INSTALLER_EXE_PATH;
     }
 }


### PR DESCRIPTION
This PR fixes the following issues for the Windows App SDK Installer functional tests: 
- The test expects the installer to be copied to a different directory instead of where the test module is located. 
- The tests do not construct the installer path correctly 
_Error: Verify:IsTrue(std::filesystem::exists(GetInstallerPath())) [File: \installer\test\InstallerFunctionalTests\FunctionalTests.cpp, Function: WindowsAppRunTimeInstallerTests::FunctionalTests::ClassInit, Line 32]
Error: TAEF: Setup fixture ‘WindowsAppRunTimeInstallerTests::FunctionalTests::ClassInit’ for the scope ‘WindowsAppRunTimeInstallerTests::FunctionalTests’ failed._
- The installer does not return the expected exit code when run with the argument --help. 
_Error: Verify: AreEqual(S_OK, result) - Values (0, -2147024895), \installer\test\InstallerFunctionalTests\FunctionalTests.cpp, Function: WindowsAppRuntimeInstallerTests::FunctionalTests::VerifyArgsHelp, Line: 68_

The changes were confirmed by executing the functional tests and verifying that they all passed successfully.


-----------------------------------------------------------------------------------------------------------------------------------------------
A microsoft employee must use /azp run to validate using the pipelines below.

WARNING:
Comments made by azure-pipelines bot maybe inaccurate.
Please see pipeline link to verify that the build is being ran.

For status checks on the main branch, please use TransportPackage-Foundation-PR
(https://microsoft.visualstudio.com/ProjectReunion/_build?definitionId=81063&_a=summary)
and run the build against your PR branch with the default parameters.
