### PR TITLE
Pre-create nuget cache "packages" folder lowercase for binskim

### DIFF
--- a/build/AzurePipelinesTemplates/WindowsAppSDK-SetupBuildEnvironment-Steps.yml
+++ b/build/AzurePipelinesTemplates/WindowsAppSDK-SetupBuildEnvironment-Steps.yml
@@ -9,6 +9,13 @@ steps:
   inputs:
     version: 6.0.414
 
+- powershell: |
+    # Pre-create nuget cache "packages" folder lowercase for binskim compat
+    if (-not(Test-Path -Path  $(Build.SourcesDirectory)\packages))
+    {
+        New-Item -Path  $(Build.SourcesDirectory)\packages -ItemType Directory -Force
+    }
+
   # Extract the build revision number from Build.BuildNumber. This is needed to pass to build-nupkg.
   # This relies on the format of the pipeline name being of the format: $(date:yyMM).$(date:dd)$(rev:rrr)
   # We can't use those variables here (they only work in the *name* of the top level Yaml), so


### PR DESCRIPTION
A microsoft employee must use /azp run to validate using the pipelines below.

WARNING:
Comments made by azure-pipelines bot maybe inaccurate.
Please see pipeline link to verify that the build is being ran.

For status checks on the main branch, please use TransportPackage-Foundation-PR
(https://microsoft.visualstudio.com/ProjectReunion/_build?definitionId=81063&_a=summary)
and run the build against your PR branch with the default parameters.
