### PR TITLE
Bug 55435589: MrtCore build now fails due to mrt.gdnsuppress exclusions not being found, due to case sensitive of nuget package cache

### DIFF
--- a/build/WindowsAppSDK-Foundation-Nightly.yml
+++ b/build/WindowsAppSDK-Foundation-Nightly.yml
@@ -86,6 +86,7 @@ extends:
       binskim:
         enabled: true
         break: true
+        analyzeTargetGlob: "-:f|**\packages\**\*.dll"
       prefast:
         ${{ if eq(parameters.runStaticAnalysis, 'true') }}:
           enabled: true

--- a/build/WindowsAppSDK-Foundation-Nightly.yml
+++ b/build/WindowsAppSDK-Foundation-Nightly.yml
@@ -86,7 +86,7 @@ extends:
       binskim:
         enabled: true
         break: true
-        analyzeTargetGlob: "-:f|**\packages\**\*.dll"
+        analyzeTargetGlob: +:f|**.exe;+:f|**.dll;-:f|**\packages\**\*.dll;-:f|**\packages\**\*.exe
       prefast:
         ${{ if eq(parameters.runStaticAnalysis, 'true') }}:
           enabled: true

--- a/build/WindowsAppSDK-Foundation-Official.yml
+++ b/build/WindowsAppSDK-Foundation-Official.yml
@@ -71,7 +71,7 @@ extends:
       binskim:
         enabled: true
         break: true
-        analyzeTargetGlob: "-:f|**\packages\**\*.dll"
+        analyzeTargetGlob: +:f|**.exe;+:f|**.dll;-:f|**\packages\**\*.dll;-:f|**\packages\**\*.exe
       prefast:
         ${{ if eq(parameters.runStaticAnalysis, 'true') }}:
           enabled: true

--- a/build/WindowsAppSDK-Foundation-Official.yml
+++ b/build/WindowsAppSDK-Foundation-Official.yml
@@ -71,6 +71,7 @@ extends:
       binskim:
         enabled: true
         break: true
+        analyzeTargetGlob: "-:f|**\packages\**\*.dll"
       prefast:
         ${{ if eq(parameters.runStaticAnalysis, 'true') }}:
           enabled: true

--- a/build/WindowsAppSDK-Foundation-PR.yml
+++ b/build/WindowsAppSDK-Foundation-PR.yml
@@ -63,6 +63,7 @@ extends:
       binskim:
         enabled: true
         break: true
+        analyzeTargetGlob: "-:f|**\packages\**\*.dll"
       prefast:
         ${{ if eq(parameters.runStaticAnalysis, 'true') }}:
           enabled: true

--- a/build/WindowsAppSDK-Foundation-PR.yml
+++ b/build/WindowsAppSDK-Foundation-PR.yml
@@ -63,7 +63,7 @@ extends:
       binskim:
         enabled: true
         break: true
-        analyzeTargetGlob: "-:f|**\packages\**\*.dll"
+        analyzeTargetGlob: +:f|**.exe;+:f|**.dll;-:f|**\packages\**\*.dll;-:f|**\packages\**\*.exe
       prefast:
         ${{ if eq(parameters.runStaticAnalysis, 'true') }}:
           enabled: true


### PR DESCRIPTION
The Packages folder contain binaries that are from external sources. 
We've applied the policy of "each repo should focus on scanning its own binaries" to most other repos, so adding exclusion of the Packages folder to skip BinSkim scans on the Foundation repo.

How verified:
- A private pipeline run shows the Build Stage is successful (no BinSkim errors) with the changes in this PR.

/////

A microsoft employee must use /azp run to validate using the pipelines below.

WARNING:
Comments made by azure-pipelines bot maybe inaccurate.
Please see pipeline link to verify that the build is being ran.

For status checks on the main branch, please use TransportPackage-Foundation-PR
(https://microsoft.visualstudio.com/ProjectReunion/_build?definitionId=81063&_a=summary)
and run the build against your PR branch with the default parameters.
