### PR TITLE
[OAuth2Manager] Remove APIs for Implicit grant type

### DIFF
--- a/dev/OAuth/AuthRequestAsyncOperation.h
+++ b/dev/OAuth/AuthRequestAsyncOperation.h
@@ -9,7 +9,6 @@ struct AuthRequestAsyncOperation :
     winrt::implements<AuthRequestAsyncOperation, foundation::IAsyncOperation<oauth::AuthRequestResult>,
     foundation::IAsyncInfo>
 {
-    AuthRequestAsyncOperation(winrt::hstring& state);
     AuthRequestAsyncOperation(oauth::implementation::AuthRequestParams* params);
     ~AuthRequestAsyncOperation();
 

--- a/dev/OAuth/OAuth.idl
+++ b/dev/OAuth/OAuth.idl
@@ -134,9 +134,7 @@ namespace Microsoft.Security.Authentication.OAuth
         String CodeChallenge{ get; set; };
 
         // Specifies the optional "code_challenge_method" parameter of the authorization request. For authorization code
-        // requests, this value defaults to 'S256'. For implicit requests, this value defaults to 'None' and cannot be
-        // changed.
-        //
+        // requests, this value defaults to 'S256'.
         // Defined by RFC 7636: Proof Key for Code Exchange by OAuth Public Clients, section 4.3
         //      https://www.rfc-editor.org/rfc/rfc7636#section-4.3
         CodeChallengeMethodKind CodeChallengeMethod { get; set; };
@@ -163,30 +161,22 @@ namespace Microsoft.Security.Authentication.OAuth
         //      https://www.rfc-editor.org/rfc/rfc6749#section-4.1.2
         String Code { get; };
 
-        // From the "access_token" parameter of the authorization response. Set only if the request was an implicit
-        // request.
-        //
+        // From the "access_token" parameter of the authorization response.
         // Defined by RFC 6749: The OAuth 2.0 Authorization Framework, section 4.2.2
         //      https://www.rfc-editor.org/rfc/rfc6749#section-4.2.2
         String AccessToken { get; };
 
-        // From the "token_type" parameter of the authorization response. Set only if the request was an implicit
-        // request.
-        //
+        // From the "token_type" parameter of the authorization response.
         // Defined by RFC 6749: The OAuth 2.0 Authorization Framework, section 4.2.2
         //      https://www.rfc-editor.org/rfc/rfc6749#section-4.2.2
         String TokenType { get; };
 
-        // From the "expires_in" parameter of the authorization response. An optional parameter that may be set only if
-        // the request was an implicit request.
-        //
+        // From the "expires_in" parameter of the authorization response.
         // Defined by RFC 6749: The OAuth 2.0 Authorization Framework, section 4.2.2
         //      https://www.rfc-editor.org/rfc/rfc6749#section-4.2.2
         String ExpiresIn { get; }; // TODO: DateTime?
 
-        // From the "scope" parameter of the authorization response. An optional parameter that may be set only if the
-        // request was an implicit request.
-        //
+        // From the "scope" parameter of the authorization response.
         // Defined by RFC 6749: The OAuth 2.0 Authorization Framework, section 4.2.2
         //      https://www.rfc-editor.org/rfc/rfc6749#section-4.2.2
         String Scope { get; };

--- a/dev/OAuth/OAuth.idl
+++ b/dev/OAuth/OAuth.idl
@@ -31,21 +31,6 @@ namespace Microsoft.Security.Authentication.OAuth
     {
         // Initiates an authorization request in the user's default browser as described by RFC 6749 section 3.1. The
         // returned 'IAsyncOperation' will remain in the 'Started' state until it is either cancelled or completed by a
-        // call to 'CompleteAuthRequest'. This performs authorization of response_type="token".
-        static Windows.Foundation.IAsyncOperation<AuthRequestResult> RequestAuthAsync(
-            Microsoft.UI.WindowId parentWindowId,
-            Windows.Foundation.Uri completeAuthEndpoint,
-            Windows.Foundation.Uri redirectUri);
-
-        // Initiates an authorization request in the user's default browser as described by RFC 6749 section 3.1. The
-        // returned 'IAsyncOperation' will remain in the 'Started' state until it is either cancelled or completed by a
-        // call to 'CompleteAuthRequest'.This performs authorization of response_type="token".
-        static Windows.Foundation.IAsyncOperation<AuthRequestResult> RequestAuthAsync(
-            Microsoft.UI.WindowId parentWindowId,
-            Windows.Foundation.Uri completeAuthEndpoint);
-
-        // Initiates an authorization request in the user's default browser as described by RFC 6749 section 3.1. The
-        // returned 'IAsyncOperation' will remain in the 'Started' state until it is either cancelled or completed by a
         // call to 'CompleteAuthRequest'.
         static Windows.Foundation.IAsyncOperation<AuthRequestResult> RequestAuthWithParamsAsync(
             Microsoft.UI.WindowId parentWindowId,
@@ -98,16 +83,8 @@ namespace Microsoft.Security.Authentication.OAuth
         // parameters as well as a redirect URI, which is frequently specified.
         static AuthRequestParams CreateForAuthorizationCodeRequest(String clientId, Windows.Foundation.Uri redirectUri);
 
-        // Helper method to create for an implicit grant request ("token" response type) with required parameters, per
-        // RFC 6749 section 4.2.1.
-        static AuthRequestParams CreateForImplicitRequest(String clientId);
-        // Helper method to create for an implicit grant request ("token" response type) with required parameters as
-        // well as a redirect URI, which is frequently specified.
-        static AuthRequestParams CreateForImplicitRequest(String clientId, Windows.Foundation.Uri redirectUri);
-
         // Specifies the required "response_type" parameter of the authorization request. This property is initialized
-        // by the creation function used ("code" for 'CreateForAuthorizationCodeRequest' and "token" for
-        // 'CreateForImplicitRequest').
+        // by the creation function used ("code" for 'CreateForAuthorizationCodeRequest').
         //
         // Defined by RFC 6749: The OAuth 2.0 Authorization Framework, sections 4.1.1 and 4.2.1
         //      https://www.rfc-editor.org/rfc/rfc6749#section-4.1.1
@@ -280,10 +257,6 @@ namespace Microsoft.Security.Authentication.OAuth
         // initialized with the required parameters extracted from the authorization response, per RFC 6749 section
         // 4.1.3.
         static TokenRequestParams CreateForAuthorizationCodeRequest(AuthResponse authResponse);
-
-        // Helper method to create for a resource owner password credentials grant request ("password" grant type),
-        // initialized with the required parameters, per RFC 6749 section 4.3.2.
-        static TokenRequestParams CreateForResourceOwnerPasswordCredentials(String username, String password);
 
         // Helper method to create for a client credentials grant request ("client_credentials" grant type), initialized
         // with the required parameters, per RFC 6749 section 4.4.2.

--- a/dev/OAuth/OAuth2Manager.cpp
+++ b/dev/OAuth/OAuth2Manager.cpp
@@ -23,74 +23,6 @@ using namespace winrt::Windows::Web::Http;
 
 namespace winrt::Microsoft::Security::Authentication::OAuth::factory_implementation
 {
-    IAsyncOperation<AuthRequestResult> OAuth2Manager::RequestAuthAsync(winrt::Microsoft::UI::WindowId const& parentWindowId,
-        const Uri& completeAuthEndpoint,
-        const Uri& redirectUri)
-    {
-        THROW_HR_IF(E_NOTIMPL, !::Microsoft::Security::Authentication::OAuth::Feature_OAuth::IsEnabled());
-
-        bool isAppPackaged = m_telemetryHelper.IsPackagedApp();
-        PCWSTR appName = m_telemetryHelper.GetAppName().c_str();
-        OAuth2ManagerTelemetry::RequestAuthAsyncTriggered(isAppPackaged, appName, true);
-
-        winrt::hstring state;
-        auto asyncOp = winrt::make_self<AuthRequestAsyncOperation>(state);
-
-        {
-            std::lock_guard guard{ m_mutex };
-            m_pendingAuthRequests.push_back(AuthRequestState{ state, asyncOp });
-        }
-
-        try
-        {
-            // Pipe server has been successfully set up. Initiate the launch
-            auto url = create_implicit_url(completeAuthEndpoint, state, redirectUri);
-
-            // Launch browser
-            execute_shell(parentWindowId, url);
-        }
-        catch (...)
-        {
-            try_remove(asyncOp.get());
-            throw;
-        }
-
-        return *asyncOp;
-    }
-
-    IAsyncOperation<AuthRequestResult> OAuth2Manager::RequestAuthAsync(winrt::Microsoft::UI::WindowId const& parentWindowId,
-        const Uri& completeAuthEndpoint)
-    {
-        THROW_HR_IF(E_NOTIMPL, !::Microsoft::Security::Authentication::OAuth::Feature_OAuth::IsEnabled());
-
-
-        bool isAppPackaged = m_telemetryHelper.IsPackagedApp();
-        PCWSTR appName = m_telemetryHelper.GetAppName().c_str();
-        OAuth2ManagerTelemetry::RequestAuthAsyncTriggered(isAppPackaged, appName, false);
-
-        winrt::hstring state;
-        auto asyncOp = winrt::make_self<AuthRequestAsyncOperation>(state);
-
-        {
-            std::lock_guard guard{ m_mutex };
-            m_pendingAuthRequests.push_back(AuthRequestState{ state, asyncOp });
-        }
-
-        try
-        {
-            // Pipe server has been successfully set up. Initiate the launch
-            auto url = create_implicit_url(completeAuthEndpoint, state, nullptr);
-
-            // Launch browser
-            execute_shell(parentWindowId, url);
-        }
-        catch (...)
-        {
-            try_remove(asyncOp.get());
-            throw;
-        }
-        return *asyncOp;
-    }
 
     IAsyncOperation<AuthRequestResult> OAuth2Manager::RequestAuthWithParamsAsync(winrt::Microsoft::UI::WindowId const& parentWindowId,
         const Uri& authEndpoint,
@@ -405,30 +337,6 @@ namespace winrt::Microsoft::Security::Authentication::OAuth::factory_implementat
             m_pendingAuthRequests.pop_back();
         }
 
-        return result;
-    }
-
-    std::wstring OAuth2Manager::create_implicit_url(const foundation::Uri& completeAuthEndpoint, const winrt::hstring& state, const foundation::Uri& redirectUri)
-    {
-        std::lock_guard guard{ m_mutex };
-        // Per RFC 6749 section 3.1, the auth endpoint URI *MAY* contain a query string, which must be retained
-        std::wstring result{ completeAuthEndpoint.RawUri() };
-        if (completeAuthEndpoint.Query().empty())
-        {
-            result += L"?state=";
-        }
-        else
-        {
-            result += L"&state=";
-        }
-        result += Uri::EscapeComponent(state);
-        result += L"&response_type=token";
-
-        if (redirectUri)
-        {
-            result += L"&redirect_uri=";
-            result += Uri::EscapeComponent(redirectUri.RawUri());
-        }
         return result;
     }
 

--- a/dev/OAuth/OAuth2Manager.h
+++ b/dev/OAuth/OAuth2Manager.h
@@ -21,10 +21,6 @@ namespace winrt::Microsoft::Security::Authentication::OAuth::factory_implementat
 
     struct OAuth2Manager : OAuth2ManagerT<OAuth2Manager, implementation::OAuth2Manager, winrt::static_lifetime>
     {
-        foundation::IAsyncOperation<oauth::AuthRequestResult> RequestAuthAsync(
-            winrt::Microsoft::UI::WindowId const& parentWindowId, const foundation::Uri& completeAuthEndpoint, const foundation::Uri& redirectUri);
-        foundation::IAsyncOperation<oauth::AuthRequestResult> RequestAuthAsync(
-            winrt::Microsoft::UI::WindowId const& parentWindowId, const foundation::Uri& completeAuthEndpoint);
         foundation::IAsyncOperation<oauth::AuthRequestResult> RequestAuthWithParamsAsync(
             winrt::Microsoft::UI::WindowId const& parentWindowId, const foundation::Uri& authEndpoint, const oauth::AuthRequestParams& params);
         bool CompleteAuthRequest(const foundation::Uri& responseUri);
@@ -41,7 +37,6 @@ namespace winrt::Microsoft::Security::Authentication::OAuth::factory_implementat
     private:
         AuthRequestState try_remove(AuthRequestAsyncOperation* op);
 
-        std::wstring create_implicit_url(const foundation::Uri& completeAuthEndpoint, const winrt::hstring& state, const foundation::Uri& redirectUri);
         void execute_shell(winrt::Microsoft::UI::WindowId const& parentWindowId, const std::wstring& url);
         std::shared_mutex m_mutex;
         TelemetryHelper m_telemetryHelper;
@@ -53,22 +48,6 @@ namespace winrt::Microsoft::Security::Authentication::OAuth::implementation
 {
     struct OAuth2Manager
     {
-        static foundation::IAsyncOperation<oauth::AuthRequestResult> RequestAuthAsync(
-            winrt::Microsoft::UI::WindowId const& parentWindowId,
-            foundation::Uri completeAuthEndpoint, foundation::Uri redirectUri)
-        {
-            return winrt::make_self<factory_implementation::OAuth2Manager>()->RequestAuthAsync(parentWindowId,
-                completeAuthEndpoint,
-                redirectUri);
-        }
-
-        static foundation::IAsyncOperation<oauth::AuthRequestResult> RequestAuthAsync(
-            winrt::Microsoft::UI::WindowId const& parentWindowId,
-            foundation::Uri completeAuthEndpoint)
-        {
-            return winrt::make_self<factory_implementation::OAuth2Manager>()->RequestAuthAsync(parentWindowId,
-                completeAuthEndpoint);
-        }
 
         static foundation::IAsyncOperation<oauth::AuthRequestResult> RequestAuthWithParamsAsync(
             winrt::Microsoft::UI::WindowId const& parentWindowId,

--- a/dev/OAuth/OAuth2ManagerTelemetry.h
+++ b/dev/OAuth/OAuth2ManagerTelemetry.h
@@ -10,8 +10,6 @@ class OAuth2ManagerTelemetry : public wil::TraceLoggingProvider
         (0x27d8ee3f, 0xd704, 0x45d6, 0xb6, 0x6c, 0x1d, 0xad, 0x95, 0x79, 0x5c, 0xe5));
     //{27d8ee3f-d704-45d6-b66c-1dad95795ce5}
 public:
-    DEFINE_COMPLIANT_MEASURES_EVENT_PARAM3(RequestAuthAsyncTriggered, PDT_ProductAndServicePerformance,
-      bool, IsAppPackaged, PCWSTR, AppName, bool, IsRedirectURIPassed);
 
     DEFINE_COMPLIANT_MEASURES_EVENT_PARAM3(RequestAuthWithParamsAsyncTriggered, PDT_ProductAndServicePerformance,
         bool, IsAppPackaged, PCWSTR, AppName, PCWSTR, ResponseType);

--- a/dev/OAuth/TokenRequestParams.cpp
+++ b/dev/OAuth/TokenRequestParams.cpp
@@ -45,16 +45,6 @@ namespace winrt::Microsoft::Security::Authentication::OAuth::implementation
         return *result;
     }
 
-    oauth::TokenRequestParams TokenRequestParams::CreateForResourceOwnerPasswordCredentials(
-        const winrt::hstring& username, const winrt::hstring& password)
-    {
-        auto result = winrt::make_self<TokenRequestParams>(L"password");
-        result->m_username = username;
-        result->m_password = password;
-
-        return *result;
-    }
-
     oauth::TokenRequestParams TokenRequestParams::CreateForClientCredentials()
     {
         return winrt::make<TokenRequestParams>(L"client_credentials");

--- a/dev/OAuth/TokenRequestParams.h
+++ b/dev/OAuth/TokenRequestParams.h
@@ -15,8 +15,6 @@ namespace winrt::Microsoft::Security::Authentication::OAuth::implementation
         TokenRequestParams(const winrt::hstring& grantType);
 
         static oauth::TokenRequestParams CreateForAuthorizationCodeRequest(const oauth::AuthResponse& authResponse);
-        static oauth::TokenRequestParams CreateForResourceOwnerPasswordCredentials(const winrt::hstring& username,
-            const winrt::hstring& password);
         static oauth::TokenRequestParams CreateForClientCredentials();
         static oauth::TokenRequestParams CreateForExtension(const foundation::Uri& extensionUri);
         static oauth::TokenRequestParams CreateForRefreshToken(const winrt::hstring& refreshToken);

--- a/specs/OAuth/OAuth2Manager.md
+++ b/specs/OAuth/OAuth2Manager.md
@@ -39,47 +39,6 @@ and OAuth 2.0 for Native Apps [RFC 8252](https://tools.ietf.org/html/rfc8252).
 
  ## Perform OAuth 2.0 (c++)
 
- Performing an Implicit Request with redirect URI(grant type/'response_type' = "token")
-
- ```c++
- // Get the WindowId for the application window
- Microsoft::UI::WindowId parentWindowId = this->AppWindow().Id();
-
-AuthRequestResult authRequestResult = co_await OAuth2Manager::RequestAuthAsync(parentWindowId,
-    Uri(L"https://my.server.com/oauth/authorize?client_id=<client ID>&scope=<Scope>"), Uri(L"my-app:/oauth-callback/"));
-if (AuthResponse authResponse = authRequestResult.Response())
-{
-    //To obtain the access token 
-    authResponse.AccessToken();
-}
-else
-{
-    AuthFailure authFailure = authRequestResult.Failure();
-    NotifyFailure(authFailure.Error(), authFailure.ErrorDescription());
-}
-```
-
-Performing an Implicit Request without redirect URI(grant type/'response_type' = "token")
-
- ```c++
- // Get the WindowId for the application window
- Microsoft::UI::WindowId parentWindowId = this->AppWindow().Id();
-
-AuthRequestResult authRequestResult = co_await OAuth2Manager::RequestAuthAsync(parentWindowId,
-    Uri(L"https://my.server.com/oauth/authorize?client_id=<client ID>&scope=<Scope>"));
-if (AuthResponse authResponse = authRequestResult.Response())
-{
-    //To obtain the access token 
-    authResponse.AccessToken();
-}
-else
-{
-    AuthFailure authFailure = authRequestResult.Failure();
-    NotifyFailure(authFailure.Error(), authFailure.ErrorDescription());
-}
-```
-
-
  Performing an Authorization Code Request (grant type/'response_type' = "code")
 
  ```c++
@@ -190,37 +149,6 @@ else
 }
 ```
 
-Performing an Implicit Request for a token (grant type/'response_type' = "token")
-
- ```c++
- // Get the WindowId for the application window
-Microsoft::UI::WindowId parentWindowId = this->AppWindow().Id();
-
-AuthRequestParams authRequestParams = AuthRequestParams::CreateForImplicitRequest(L"my_client_id",
-    Uri(L"my-app:/oauth-callback/"));
-authRequestParams.Scope(L"user:email user:birthday");
-
-AuthRequestResult authRequestResult = co_await OAuth2Manager::RequestAuthWithParamsAsync(parentWindowId, 
-    Uri(L"https://my.server.com/oauth/authorize"), authRequestParams);
-if (AuthResponse authResponse = authRequestResult.Response())
-{
-    //To obtain the access token
-    String accessToken = tokenResponse.AccessToken();
-
-    String tokenType = tokenResponse.TokenType();
-
-    // Use the access token for resources
-    DoRequestWithToken(accessToken, tokenType);
-}
-else
-{
-    AuthFailure authFailure = authRequestResult.Failure();
-    NotifyFailure(authFailure.Error(), authFailure.ErrorDescription());
-}
-```
-
-> Note: The authorization server MUST NOT issue a refresh token for implicit request.
-
 Completing an Authorization Request from a Protocol Activation
 
 ```c++
@@ -255,8 +183,6 @@ complete an authorization request, and request an access token for a user throug
 
 | Name | Description | Parameters | Returns |
 |-|-|-|-| 
-| RequestAuthAsync(Microsoft.UI.WindowId, Windows.Foundation.Uri, Windows.Foundation.Uri) | Initiates an authorization request in the user's default browser. This performs an access token request of implicit grant type. | Microsoft.UI.WindowId `parentWindowId`, Windows.Foundation.Uri `authEndPoint` , Windows.Foundation.Uri `redirectUri` | Windows.Foundation.IAsyncOperation< AuthRequestResult > |
-| RequestAuthAsync(Microsoft.UI.WindowId, Windows.Foundation.Uri) | Initiates an authorization request in the user's default browser. This performs an access token request of implicit grant type. | Microsoft.UI.WindowId `parentWindowId`, Windows.Foundation.Uri `authEndPoint` | Windows.Foundation.IAsyncOperation< AuthRequestResult > |
 | RequestAuthWithParamsAsync(Microsoft.UI.WindowId, Windows.Foundation.Uri, AuthRequestParams) | Intiates auth request for a user in the user's default browser through a client.| Microsoft.UI.WindowId `parentWindowId`, Windows.Foundation.Uri `authEndPoint`  , AuthRequestParams `params` | Windows.Foundation.IAsyncOperation< AuthRequestResult > |
 | CompleteAuthRequest(Windows.Foundation.Uri) | Completes an auth request through a redirect URI. | Windows.Foundation.Uri `responseUri` | Boolean |
 | RequestTokenAsync(Windows.Foundation.Uri, TokenRequestParams) | Initiates an access token request. | Windows.Foundation.Uri `tokenEndPoint` , TokenRequestParams `params` | Windows.Foundation.IAsyncOperation< TokenRequestResult > |
@@ -322,8 +248,6 @@ response_type is described in section 3.1.1 of [RFC 6749](https://www.rfc-editor
 |-|-|-|-|
 | CreateForAuthorizationCodeRequest(String) | Helper method to create for an authorization code grant request ("code" response type) with required parameters. | String `clientId` | AuthRequestParams |
 | CreateForAuthorizationCodeRequest(String, Windows.Foundation.Uri) | Helper method to create for an authorization code grant request ("code" response type) with required parameters. | String `clientId` , Windows.Foundation.Uri `redirectUri` | AuthRequestParams |
-| CreateForImplicitRequest(String) | Helper method to create for an implicit grant request ("token" response type) with required parameters. | String `clientId` | AuthRequestParams |
-| CreateForImplicitRequest(String, Windows.Foundation.Uri) | Helper method to create for an implicit grant request ("token" response type) with required parameters. | String `clientId` , Windows.Foundation.Uri `redirectUri` | AuthRequestParams |
 
 ## AuthRequestParams Properties
 
@@ -400,7 +324,6 @@ It's a class that provides methods to create a token request parameter object. T
 | Name | Description | Parameters | Returns |
 |-|-|-|-|
 | CreateForAuthorizationCodeRequest(AuthResponse) | Helper method to create for an authorization code grant request ("authorization_code" grant type) with required parameters extracted from the authorization response. | AuthResponse `authResponse` | TokenRequestParams |
-| CreateForResourceOwnerPasswordCredentials(String, String) | Helper method to create for a resource owner password credentials grant request ("password" grant type) with required parameters. | String `username` , String `password` | TokenRequestParams |
 | CreateForClientCredentials() | Helper method to create for a client credentials grant request ("client_credentials" grant type) with required parameters. | None | TokenRequestParams |
 | CreateForExtension(Windows.Foundation.Uri) | Helper method to create for an extension grant request, using the provided URI for the grant type. | Windows.Foundation.Uri `extensionUri` | TokenRequestParams |
 | CreateForRefreshToken(String) | Helper method to create for an access token refresh request ("refresh_token" grant type) with required parameters. | String `refreshToken` | TokenRequestParams |
@@ -505,18 +428,6 @@ namespace Microsoft.Security.Authentication.OAuth
     [contract(OAuthContract, 1)]
     static runtimeclass OAuth2Manager
     {
-        // Initiates an authorization request in the user's default browser as described by RFC 6749 section 3.1. The
-        // returned 'IAsyncOperation' will remain in the 'Started' state until it is either cancelled or completed by a
-        // call to 'CompleteAuthRequest'. This performs authorization of response_type="token".
-        static Windows.Foundation.IAsyncOperation<AuthRequestResult> RequestAuthAsync(Microsoft.UI.WindowId parentWindowId,
-            Windows.Foundation.Uri completeAuthEndpoint,
-            Windows.Foundation.Uri redirectUri);
-
-        // Initiates an authorization request in the user's default browser as described by RFC 6749 section 3.1. The
-        // returned 'IAsyncOperation' will remain in the 'Started' state until it is either cancelled or completed by a
-        // call to 'CompleteAuthRequest'.This performs authorization of response_type="token".
-        static Windows.Foundation.IAsyncOperation<AuthRequestResult> RequestAuthAsync(Microsoft.UI.WindowId parentWindowId,
-            Windows.Foundation.Uri completeAuthEndpoint);
 
         // Initiates an authorization request in the user's default browser as described by RFC 6749 section 3.1. The
         // returned 'IAsyncOperation' will remain in the 'Started' state until it is either cancelled or completed by a
@@ -572,17 +483,8 @@ namespace Microsoft.Security.Authentication.OAuth
         // parameters as well as a redirect URI, which is frequently specified.
         static AuthRequestParams CreateForAuthorizationCodeRequest(String clientId, Windows.Foundation.Uri redirectUri);
 
-        // Helper method to create for an implicit grant request ("token" response type) with required parameters, per
-        // RFC 6749 section 4.2.1.
-        static AuthRequestParams CreateForImplicitRequest(String clientId);
-
-        // Helper method to create for an implicit grant request ("token" response type) with required parameters as
-        // well as a redirect URI, which is frequently specified.
-        static AuthRequestParams CreateForImplicitRequest(String clientId, Windows.Foundation.Uri redirectUri);
-
         // Specifies the required "response_type" parameter of the authorization request. This property is initialized
-        // by the creation function used ("code" for 'CreateForAuthorizationCodeRequest' and "token" for
-        // 'CreateForImplicitRequest').
+        // by the creation function used ("code" for 'CreateForAuthorizationCodeRequest').
         //
         // Defined by RFC 6749: The OAuth 2.0 Authorization Framework, sections 4.1.1 and 4.2.1
         //      https://www.rfc-editor.org/rfc/rfc6749#section-4.1.1
@@ -755,10 +657,6 @@ namespace Microsoft.Security.Authentication.OAuth
         // initialized with the required parameters extracted from the authorization response, per RFC 6749 section
         // 4.1.3.
         static TokenRequestParams CreateForAuthorizationCodeRequest(AuthResponse authResponse);
-
-        // Helper method to create for a resource owner password credentials grant request ("password" grant type),
-        // initialized with the required parameters, per RFC 6749 section 4.3.2.
-        static TokenRequestParams CreateForResourceOwnerPasswordCredentials(String username, String password);
 
         // Helper method to create for a client credentials grant request ("client_credentials" grant type), initialized
         // with the required parameters, per RFC 6749 section 4.4.2.

--- a/specs/OAuth/OAuth2Manager.md
+++ b/specs/OAuth/OAuth2Manager.md
@@ -4,7 +4,9 @@ OAuth2Manager API
 This is the spec for proposal: [Issue #441](https://github.com/microsoft/WindowsAppSDK/issues/441)
 
 This spec details the API of a new `OAuth2Manager` in WinAppSDK,
-enabling desktop applications such as WinUI3 to seamlessly perform OAuth functionality across diverse Windows platforms.
+enabling desktop applications such as WinUI3 to seamlessly perform OAuth functionality across diverse Windows platforms. 
+OAuth2Manager API intentionally does not provide API for the implicit request & resource owner password credential because of the security concerns that follow it. It is recommended to use the 
+authorization code grant type using Proof Key for Code Exchange (PKCE).
 
 
 

--- a/specs/OAuth/OAuth2Manager.md
+++ b/specs/OAuth/OAuth2Manager.md
@@ -534,9 +534,7 @@ namespace Microsoft.Security.Authentication.OAuth
         String CodeChallenge { get; set; };
 
         // Specifies the optional "code_challenge_method" parameter of the authorization request. For authorization code
-        // requests, this value defaults to 'S256'. For implicit requests, this value defaults to 'None' and cannot be
-        // changed.
-        //
+        // requests, this value defaults to 'S256'.
         // Defined by RFC 7636: Proof Key for Code Exchange by OAuth Public Clients, section 4.3
         //      https://www.rfc-editor.org/rfc/rfc7636#section-4.3
         CodeChallengeMethodKind CodeChallengeMethod { get; set; };
@@ -563,30 +561,22 @@ namespace Microsoft.Security.Authentication.OAuth
         //      https://www.rfc-editor.org/rfc/rfc6749#section-4.1.2
         String Code { get; };
 
-        // From the "access_token" parameter of the authorization response. Set only if the request was an implicit
-        // request.
-        //
+        // From the "access_token" parameter of the authorization response. 
         // Defined by RFC 6749: The OAuth 2.0 Authorization Framework, section 4.2.2
         //      https://www.rfc-editor.org/rfc/rfc6749#section-4.2.2
         String AccessToken { get; };
 
-        // From the "token_type" parameter of the authorization response. Set only if the request was an implicit
-        // request.
-        //
+        // From the "token_type" parameter of the authorization response.
         // Defined by RFC 6749: The OAuth 2.0 Authorization Framework, section 4.2.2
         //      https://www.rfc-editor.org/rfc/rfc6749#section-4.2.2
         String TokenType { get; };
 
-        // From the "expires_in" parameter of the authorization response. An optional parameter that may be set only if
-        // the request was an implicit request.
-        //
+        // From the "expires_in" parameter of the authorization response.
         // Defined by RFC 6749: The OAuth 2.0 Authorization Framework, section 4.2.2
         //      https://www.rfc-editor.org/rfc/rfc6749#section-4.2.2
         String ExpiresIn { get; }; // TODO: DateTime?
 
-        // From the "scope" parameter of the authorization response. An optional parameter that may be set only if the
-        // request was an implicit request.
-        //
+        // From the "scope" parameter of the authorization response.
         // Defined by RFC 6749: The OAuth 2.0 Authorization Framework, section 4.2.2
         //      https://www.rfc-editor.org/rfc/rfc6749#section-4.2.2
         String Scope { get; };


### PR DESCRIPTION
Removing APIs added for Implicit grant type suggested by security review. 
Implicit grant type is not the recommended way to perform OAuth2.0. Authorization code grant type should be used.

A microsoft employee must use /azp run to validate using the pipelines below.

WARNING:
Comments made by azure-pipelines bot maybe inaccurate.
Please see pipeline link to verify that the build is being ran.

For status checks on the main branch, please use TransportPackage-Foundation-PR
(https://microsoft.visualstudio.com/ProjectReunion/_build?definitionId=81063&_a=summary)
and run the build against your PR branch with the default parameters.
