### PR TITLE
Switch auto initializer targets to add via BeforeClCompileTargets

### DIFF
--- a/build/NuSpecs/WindowsAppSDK-Nuget-Native.Bootstrap.targets
+++ b/build/NuSpecs/WindowsAppSDK-Nuget-Native.Bootstrap.targets
@@ -1,6 +1,6 @@
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 
-    <Target Name="GenerateBootstrapCpp" BeforeTargets="ClCompile">
+    <Target Name="GenerateBootstrapCpp">
         <ItemGroup>
             <ClCompile Include="$(MSBuildThisFileDirectory)..\..\include\MddBootstrapAutoInitializer.cpp">
                 <PrecompiledHeader>NotUsing</PrecompiledHeader>
@@ -14,5 +14,11 @@
             </ClCompile>
         </ItemGroup>
     </Target>
+
+    <PropertyGroup>
+        <BeforeClCompileTargets>
+            $(BeforeClCompileTargets); GenerateBootstrapCpp;
+        </BeforeClCompileTargets>
+    </PropertyGroup>
 
 </Project>

--- a/build/NuSpecs/WindowsAppSDK-Nuget-Native.DeploymentManager.targets
+++ b/build/NuSpecs/WindowsAppSDK-Nuget-Native.DeploymentManager.targets
@@ -1,6 +1,6 @@
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 
-    <Target Name="GenerateDeploymentManagerCpp" BeforeTargets="ClCompile">
+    <Target Name="GenerateDeploymentManagerCpp">
         <ItemGroup>
             <ClCompile Include="$(MSBuildThisFileDirectory)..\..\include\DeploymentManagerAutoInitializer.cpp">
                 <PrecompiledHeader>NotUsing</PrecompiledHeader>
@@ -10,5 +10,11 @@
             </ClCompile>
         </ItemGroup>
     </Target>
+
+    <PropertyGroup>
+        <BeforeClCompileTargets>
+            $(BeforeClCompileTargets); GenerateDeploymentManagerCpp;
+        </BeforeClCompileTargets>
+    </PropertyGroup>
 
 </Project>

--- a/build/NuSpecs/WindowsAppSDK-Nuget-Native.UndockedRegFreeWinRT.targets
+++ b/build/NuSpecs/WindowsAppSDK-Nuget-Native.UndockedRegFreeWinRT.targets
@@ -1,11 +1,16 @@
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 
-    <Target Name="GenerateUndockedRegFreeWinRTCpp" BeforeTargets="ClCompile" Condition="'$(WindowsAppSdkUndockedRegFreeWinRTInitialize)' == 'true'">
+    <Target Name="AddUndockedRegFreeWinRTCppDefines" BeforeTargets="ClCompile" Condition="'$(WindowsAppSdkUndockedRegFreeWinRTInitialize)' == 'true'">
         <ItemGroup>
             <ClCompile>
                 <PreprocessorDefinitions>MICROSOFT_WINDOWSAPPSDK_UNDOCKEDREGFREEWINRT_AUTO_INITIALIZE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
                 <PreprocessorDefinitions Condition="'$(WindowsAppSdkUndockedRegFreeWinRTInitializeLoadLibrary)' == 'true'">MICROSOFT_WINDOWSAPPSDK_UNDOCKEDREGFREEWINRT_AUTO_INITIALIZE_LOADLIBRARY;%(PreprocessorDefinitions)</PreprocessorDefinitions>
             </ClCompile>
+        </ItemGroup>
+    </Target>
+
+    <Target Name="GenerateUndockedRegFreeWinRTCpp" Condition="'$(WindowsAppSdkUndockedRegFreeWinRTInitialize)' == 'true'">
+        <ItemGroup>
             <ClCompile Include="$(MSBuildThisFileDirectory)..\..\include\UndockedRegFreeWinRT-AutoInitializer.cpp">
                 <PrecompiledHeader>NotUsing</PrecompiledHeader>
                 <PreprocessorDefinitions>MICROSOFT_WINDOWSAPPSDK_UNDOCKEDREGFREEWINRT_AUTO_INITIALIZE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
@@ -13,5 +18,11 @@
             </ClCompile>
         </ItemGroup>
     </Target>
+
+    <PropertyGroup>
+        <BeforeClCompileTargets>
+            $(BeforeClCompileTargets); GenerateUndockedRegFreeWinRTCpp;
+        </BeforeClCompileTargets>
+    </PropertyGroup>
 
 </Project>


### PR DESCRIPTION
Add auto initializer targets via `<BeforeClCompileTargets>` (rather than `BeforeTargets="ClCompile"`) to get better timing for picking up added compiler options. This helps to ensure they are added after dynmically-added compiler options, such as `/arm64ec`.

A separate `AddUndockedRegFreeWinRTCppDefines` target was created to ensure those global defines are still added with the same timing they had previously. (I'm not sure if those global defines are required, but that is a question for another day.)