### PR TITLE
Create a PublishToFeed parameter option for both OneBranch and non-OneBranch PR pipelines

### DIFF
--- a/build/ProjectReunion-BuildFoundation.yml
+++ b/build/ProjectReunion-BuildFoundation.yml
@@ -2,6 +2,11 @@
 # Prior to 1.4, this file was used to build official release builds. This role has been moved to WindowsAppSDK-Foundation-Release.yml
 trigger: none
 
+parameters: # parameters are shown up in ADO UI in a build queue time
+- name: PublishToFeed
+  type: boolean
+  default: false
+
 resources:
   repositories:
     - repository: WindowsAppSDKConfig
@@ -29,6 +34,6 @@ stages:
 - template: AzurePipelinesTemplates\WindowsAppSDK-PackTransportPackage-Stage.yml@self
   parameters:
     SignOutput: false
-    PublishPackage: false
+    PublishPackage: ${{ parameters.PublishToFeed }}
     IsOneBranch: false
     BuildMockWindowsAppSDK: false

--- a/build/WindowsAppSDK-Foundation-PR.yml
+++ b/build/WindowsAppSDK-Foundation-PR.yml
@@ -21,6 +21,9 @@
 trigger: none
 
 parameters: # parameters are shown up in ADO UI in a build queue time
+- name: PublishToFeed
+  type: boolean
+  default: false
 - name: runStaticAnalysis
   displayName: "Run Static Analysis (e.g., PREFast, APIScan)"
   type: boolean
@@ -92,5 +95,5 @@ extends:
     - template: AzurePipelinesTemplates\WindowsAppSDK-PackTransportPackage-Stage.yml@self
       parameters:
         SignOutput: false
-        PublishPackage: false
+        PublishPackage: ${{ parameters.PublishToFeed }}
         


### PR DESCRIPTION
This will reduce needing to push the branch internally to run a test build that is pushed to the feed