### PR TITLE
Match Build Number and Version

### DIFF
--- a/build/ProjectReunion-BuildFoundation.yml
+++ b/build/ProjectReunion-BuildFoundation.yml
@@ -1,5 +1,8 @@
 # This file has been adapted to use as a non-OneBranch PR validation yml in the WindowsAppSDK Foundation repository
 # Prior to 1.4, this file was used to build official release builds. This role has been moved to WindowsAppSDK-Foundation-Release.yml
+
+name: $(version)
+
 trigger: none
 
 resources:

--- a/build/ProjectReunion-CI.yml
+++ b/build/ProjectReunion-CI.yml
@@ -1,5 +1,6 @@
 # see https://docs.microsoft.com/azure/devops/pipelines/process/phases for info on yaml ADO jobs
-name: $(BuildDefinitionName)_$(date:yyMM).$(date:dd)$(rev:rrr)
+name: $(version)
+
 variables:
 - template: WindowsAppSDK-Versions.yml
 - template: WindowsAppSDK-CommonVariables.yml

--- a/build/WindowsAppSDK-Foundation-Nightly.yml
+++ b/build/WindowsAppSDK-Foundation-Nightly.yml
@@ -14,8 +14,7 @@
 #                                                                                                                                   #
 #####################################################################################################################################
 
-# Add this for VPack versioning when using Package ES Setup task
-# name: $(BuildDefinitionName)_$(date:yyMM).$(date:dd)$(rev:rrr)
+name: $(version)
 
 # https://aka.ms/obpipelines/triggers
 trigger: none

--- a/build/WindowsAppSDK-Foundation-Official.yml
+++ b/build/WindowsAppSDK-Foundation-Official.yml
@@ -14,8 +14,7 @@
 #                                                                                                                                   #
 #####################################################################################################################################
 
-# Add this for VPack versioning when using Package ES Setup task
-# name: $(BuildDefinitionName)_$(date:yyMM).$(date:dd)$(rev:rrr)
+name: $(version)
 
 # https://aka.ms/obpipelines/triggers
 trigger: none

--- a/build/WindowsAppSDK-Foundation-PR.yml
+++ b/build/WindowsAppSDK-Foundation-PR.yml
@@ -14,8 +14,7 @@
 #                                                                                                                                   #
 #####################################################################################################################################
 
-# Add this for VPack versioning when using Package ES Setup task
-# name: $(BuildDefinitionName)_$(date:yyMM).$(date:dd)$(rev:rrr)
+name: $(version)
 
 # https://aka.ms/obpipelines/triggers
 trigger: none


### PR DESCRIPTION
Build Number and Version should match.
Currently, the revision number are off by one.

Change is validated on the OneBranch pipelines.

WARNING:
Comments made by azure-pipelines bot maybe inaccurate.
Please see pipeline link to verify that the build is being ran.

For status checks on the main branch, please use TransportPackage-Foundation-PR
(https://microsoft.visualstudio.com/ProjectReunion/_build?definitionId=81063&_a=summary)
and run the build against your PR branch with the default parameters.
