### PR TITLE
Removing terminal velocity from CameraCaptureUI

### DIFF
--- a/dev/Common/TerminalVelocityFeatures-CameraCaptureUI.xml
+++ b/dev/Common/TerminalVelocityFeatures-CameraCaptureUI.xml
@@ -12,9 +12,5 @@
     <name>Feature_CameraCaptureUI</name>
     <description>CameraCaptureUI for the WindowsAppRuntime</description>
     <state>AlwaysEnabled</state>
-    <alwaysDisabledChannelTokens>
-      <channelToken>Preview</channelToken>
-      <channelToken>Stable</channelToken>
-    </alwaysDisabledChannelTokens>
   </feature>
 </features>

--- a/dev/Interop/CameraCaptureUI/CameraCaptureUI/CameraCaptureUI.h
+++ b/dev/Interop/CameraCaptureUI/CameraCaptureUI/CameraCaptureUI.h
@@ -5,7 +5,6 @@
 #include "CameraCaptureUIPhotoCaptureSettings.h"
 #include "CameraCaptureUIVideoCaptureSettings.h"
 #include "TelemetryHelper.h"
-#include <TerminalVelocityFeatures-CameraCaptureUI.h>
 
 namespace winrt::Microsoft::Windows::Media::Capture::implementation
 {
@@ -20,7 +19,6 @@ namespace winrt::Microsoft::Windows::Media::Capture::implementation
         CameraCaptureUI(winrt::Microsoft::UI::WindowId const& windowId) :
             m_windowId(windowId)
         {
-            THROW_HR_IF(E_NOTIMPL, !::Microsoft::Windows::Media::Capture::Feature_CameraCaptureUI::IsEnabled());
         }
 
         Microsoft::Windows::Media::Capture::CameraCaptureUIPhotoCaptureSettings PhotoSettings()

--- a/dev/Interop/CameraCaptureUI/CameraCaptureUI/CameraCaptureUI.idl
+++ b/dev/Interop/CameraCaptureUI/CameraCaptureUI/CameraCaptureUI.idl
@@ -1,6 +1,5 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
-#include <TerminalVelocityFeatures-CameraCaptureUI.h>
 
 namespace Microsoft.Windows.Media.Capture
 {
@@ -74,7 +73,6 @@ namespace Microsoft.Windows.Media.Capture
     }
 
     [contract(CameraCaptureUIContract, 1)]
-    [feature(Feature_CameraCaptureUI)]
     runtimeclass CameraCaptureUI
     {
         CameraCaptureUI(Microsoft.UI.WindowId windowId);

--- a/test/CameraCaptureUITests/APITests.cpp
+++ b/test/CameraCaptureUITests/APITests.cpp
@@ -9,7 +9,6 @@
 #include <mutex>
 #include <winrt/Windows.Storage.h>
 #include <winrt/Windows.Foundation.h>
-#include <TerminalVelocityFeatures-CameraCaptureUI.h>
 
 using namespace std::chrono_literals;
 using namespace WEX::Common;
@@ -60,11 +59,6 @@ namespace CameraCaptureUITests
         // Focusing solely on functional tests for now. 
         TEST_METHOD(CapturePhoto_ShouldReturnFile)
         {
-            if (!::Microsoft::Windows::Media::Capture::Feature_CameraCaptureUI::IsEnabled())
-            {
-                Log::Result(TestResults::Skipped, L"CameraCaptureUI API Features are not enabled.");
-                return;
-            }
             try
             {
                 auto parentWindow = ::GetForegroundWindow();
@@ -102,11 +96,6 @@ namespace CameraCaptureUITests
         }
         TEST_METHOD(VerifyRequestedPhotoFormatsAreReadCorrectly)
         {
-            if (!::Microsoft::Windows::Media::Capture::Feature_CameraCaptureUI::IsEnabled())
-            {
-                Log::Result(TestResults::Skipped, L"CameraCaptureUI API Features are not enabled.");
-                return;
-            }
             // Arrange
             auto parentWindow = ::GetForegroundWindow();
             winrt::Microsoft::UI::WindowId windowId{ reinterpret_cast<uint64_t>(parentWindow) };
@@ -128,11 +117,6 @@ namespace CameraCaptureUITests
 
         TEST_METHOD(VerifyRequestedVideoFormatsAreReadCorrectly)
         {
-            if (!::Microsoft::Windows::Media::Capture::Feature_CameraCaptureUI::IsEnabled())
-            {
-                Log::Result(TestResults::Skipped, L"CameraCaptureUI API Features are not enabled.");
-                return;
-            }
             // Arrange
             auto parentWindow = ::GetForegroundWindow();
             winrt::Microsoft::UI::WindowId windowId{ reinterpret_cast<uint64_t>(parentWindow) };
@@ -148,11 +132,6 @@ namespace CameraCaptureUITests
         }
         TEST_METHOD(VerifyMaxVideoResolutionValues)
         {
-            if (!::Microsoft::Windows::Media::Capture::Feature_CameraCaptureUI::IsEnabled())
-            {
-                Log::Result(TestResults::Skipped, L"CameraCaptureUI API Features are not enabled.");
-                return;
-            }
             // Arrange
             auto parentWindow = ::GetForegroundWindow();
             winrt::Microsoft::UI::WindowId windowId{ reinterpret_cast<uint64_t>(parentWindow) };
@@ -177,11 +156,6 @@ namespace CameraCaptureUITests
 
         TEST_METHOD(VerifyMaxPhotoResolutionValues)
         {
-            if (!::Microsoft::Windows::Media::Capture::Feature_CameraCaptureUI::IsEnabled())
-            {
-                Log::Result(TestResults::Skipped, L"CameraCaptureUI API Features are not enabled.");
-                return;
-            }
             // Arrange
             auto parentWindow = ::GetForegroundWindow();
             winrt::Microsoft::UI::WindowId windowId{ reinterpret_cast<uint64_t>(parentWindow) };


### PR DESCRIPTION
This PR removes the TerminalVelocity mechanism from the CameraCaptureUI API, which was previously used to control its visibility across different release channels (Preview, Stable, Experimental). As the feature is now moving towards broader availability (**Preview Release**) and no longer needs the experimental feature flagging, we are removing the TerminalVelocity-related checks.

The API has gone through spec-review:  https://github.com/microsoft/WindowsAppSDK/pull/4721

A microsoft employee must use /azp run to validate using the pipelines below.
