### PR TITLE
Remove terminal velocity feature tag from OAuth2Manager APIs, enabling for stable release

### DIFF
--- a/dev/Common/TerminalVelocityFeatures-OAuth.xml
+++ b/dev/Common/TerminalVelocityFeatures-OAuth.xml
@@ -12,9 +12,5 @@
         <name>Feature_OAuth</name>
         <description>OAuth for the WindowsAppRuntime</description>
         <state>AlwaysEnabled</state>
-        <alwaysDisabledChannelTokens>
-          <channelToken>Preview</channelToken>
-          <channelToken>Stable</channelToken>
-        </alwaysDisabledChannelTokens>
     </feature>
 </features>

--- a/dev/OAuth/AuthRequestParams.cpp
+++ b/dev/OAuth/AuthRequestParams.cpp
@@ -18,8 +18,7 @@ namespace winrt::Microsoft::Security::Authentication::OAuth::implementation
     AuthRequestParams::AuthRequestParams(const winrt::hstring& responseType, const winrt::hstring& clientId) :
         m_responseType(responseType),
         m_clientId(clientId)
-    {
-        THROW_HR_IF(E_NOTIMPL, !::Microsoft::Security::Authentication::OAuth::Feature_OAuth::IsEnabled());
+    {  
     }
 
     AuthRequestParams::AuthRequestParams(const winrt::hstring& responseType, const winrt::hstring& clientId,
@@ -27,8 +26,7 @@ namespace winrt::Microsoft::Security::Authentication::OAuth::implementation
         m_responseType(responseType),
         m_clientId(clientId),
         m_redirectUri(redirectUri)
-    {
-        THROW_HR_IF(E_NOTIMPL, !::Microsoft::Security::Authentication::OAuth::Feature_OAuth::IsEnabled());
+    { 
     }
 
     oauth::AuthRequestParams AuthRequestParams::CreateForAuthorizationCodeRequest(const winrt::hstring& clientId)

--- a/dev/OAuth/ClientAuthentication.cpp
+++ b/dev/OAuth/ClientAuthentication.cpp
@@ -17,13 +17,11 @@ namespace winrt::Microsoft::Security::Authentication::OAuth::implementation
 {
     ClientAuthentication::ClientAuthentication()
     {
-        THROW_HR_IF(E_NOTIMPL, !::Microsoft::Security::Authentication::OAuth::Feature_OAuth::IsEnabled());
     }
 
     ClientAuthentication::ClientAuthentication(const HttpCredentialsHeaderValue& authorization) :
         m_authorization(authorization)
     {
-        THROW_HR_IF(E_NOTIMPL, !::Microsoft::Security::Authentication::OAuth::Feature_OAuth::IsEnabled());
     }
 
     oauth::ClientAuthentication ClientAuthentication::CreateForBasicAuthorization(const winrt::hstring& clientId,

--- a/dev/OAuth/OAuth.idl
+++ b/dev/OAuth/OAuth.idl
@@ -1,14 +1,12 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
-#include <TerminalVelocityFeatures-OAuth.h>
-
 namespace Microsoft.Security.Authentication.OAuth
 {
     [contractversion(1)]
     apicontract OAuthContract {};
 
-    [contract(OAuthContract, 1), feature(Feature_OAuth)]
+    [contract(OAuthContract, 1)]
     runtimeclass ClientAuthentication
     {
         ClientAuthentication();
@@ -26,7 +24,7 @@ namespace Microsoft.Security.Authentication.OAuth
         Windows.Foundation.Collections.IMap<String, String> AdditionalHeaders { get; };
     }
 
-    [contract(OAuthContract, 1), feature(Feature_OAuth)]
+    [contract(OAuthContract, 1)]
     static runtimeclass OAuth2Manager
     {
         // Initiates an authorization request in the user's default browser as described by RFC 6749 section 3.1. The
@@ -56,7 +54,7 @@ namespace Microsoft.Security.Authentication.OAuth
 
     // Correlates to the 'code_challenge_method' as described by section 4.3 of RFC 7636: Proof Key for Code Exchange by
     // OAuth Public Clients (https://www.rfc-editor.org/rfc/rfc7636.html#section-4.3)
-    [contract(OAuthContract, 1), feature(Feature_OAuth)]
+    [contract(OAuthContract, 1)]
     enum CodeChallengeMethodKind
     {
         // Suppresses the use of a code verifier. An error will be thrown if a code challenge string is set when this
@@ -68,7 +66,7 @@ namespace Microsoft.Security.Authentication.OAuth
         Plain = 2,
     };
 
-    [contract(OAuthContract, 1), feature(Feature_OAuth)]
+    [contract(OAuthContract, 1)]
     runtimeclass AuthRequestParams
     {
         // Construct with required parameters
@@ -143,7 +141,7 @@ namespace Microsoft.Security.Authentication.OAuth
         Windows.Foundation.Collections.IMap<String, String> AdditionalParams { get; };
     }
 
-    [contract(OAuthContract, 1), feature(Feature_OAuth)]
+    [contract(OAuthContract, 1)]
     runtimeclass AuthResponse
     {
         // From the "state" parameter of the authorization response. This property will always be set because a state
@@ -185,7 +183,7 @@ namespace Microsoft.Security.Authentication.OAuth
         Windows.Foundation.Collections.IMapView<String, String> AdditionalParams { get; };
     }
 
-    [contract(OAuthContract, 1), feature(Feature_OAuth)]
+    [contract(OAuthContract, 1)]
     runtimeclass AuthFailure
     {
         // From the "error" parameter of the error response. The value of this property will map to a well known string
@@ -224,7 +222,7 @@ namespace Microsoft.Security.Authentication.OAuth
         Windows.Foundation.Collections.IMapView<String, String> AdditionalParams { get; };
     }
 
-    [contract(OAuthContract, 1), feature(Feature_OAuth)]
+    [contract(OAuthContract, 1)]
     runtimeclass AuthRequestResult
     {
         // The raw URI that was used to complete the request.
@@ -237,7 +235,7 @@ namespace Microsoft.Security.Authentication.OAuth
         AuthFailure Failure { get; };
     }
 
-    [contract(OAuthContract, 1), feature(Feature_OAuth)]
+    [contract(OAuthContract, 1)]
     runtimeclass TokenRequestParams
     {
         // Construct with required parameters
@@ -338,7 +336,7 @@ namespace Microsoft.Security.Authentication.OAuth
         Windows.Foundation.Collections.IMap<String, String> AdditionalParams { get; };
     }
 
-    [contract(OAuthContract, 1), feature(Feature_OAuth)]
+    [contract(OAuthContract, 1)]
     runtimeclass TokenResponse
     {
         // From the "access_token" parameter of the token response. A required property that should always be set.
@@ -378,7 +376,7 @@ namespace Microsoft.Security.Authentication.OAuth
         Windows.Foundation.Collections.IMapView<String, Windows.Data.Json.IJsonValue> AdditionalParams { get; };
     }
 
-    [contract(OAuthContract, 1), feature(Feature_OAuth)]
+    [contract(OAuthContract, 1)]
     enum TokenFailureKind
     {
         // The server responded with an error response as described by RFC 6749 section 5.2. This means that the failure
@@ -394,7 +392,7 @@ namespace Microsoft.Security.Authentication.OAuth
         InvalidResponse = 2,
     };
 
-    [contract(OAuthContract, 1), feature(Feature_OAuth)]
+    [contract(OAuthContract, 1)]
     runtimeclass TokenFailure
     {
         // Indicates the type of failure that this object describes, which will indicate which properties might be set.
@@ -428,7 +426,7 @@ namespace Microsoft.Security.Authentication.OAuth
         Windows.Foundation.Collections.IMapView<String, Windows.Data.Json.IJsonValue> AdditionalParams { get; };
     }
 
-    [contract(OAuthContract, 1), feature(Feature_OAuth)]
+    [contract(OAuthContract, 1)]
     runtimeclass TokenRequestResult
     {
         // The raw HTTP response that was used to complete the request

--- a/dev/OAuth/OAuth2Manager.cpp
+++ b/dev/OAuth/OAuth2Manager.cpp
@@ -28,8 +28,6 @@ namespace winrt::Microsoft::Security::Authentication::OAuth::factory_implementat
         const Uri& authEndpoint,
         const oauth::AuthRequestParams& params)
     {
-        THROW_HR_IF(E_NOTIMPL, !::Microsoft::Security::Authentication::OAuth::Feature_OAuth::IsEnabled());
-
 
         bool isAppPackaged = m_telemetryHelper.IsPackagedApp();
         PCWSTR appName = m_telemetryHelper.GetAppName().c_str();
@@ -63,7 +61,6 @@ namespace winrt::Microsoft::Security::Authentication::OAuth::factory_implementat
 
     bool OAuth2Manager::CompleteAuthRequest(const Uri& responseUri)
     {
-        THROW_HR_IF(E_NOTIMPL, !::Microsoft::Security::Authentication::OAuth::Feature_OAuth::IsEnabled());
 
         bool isAppPackaged = m_telemetryHelper.IsPackagedApp();
         PCWSTR appName = m_telemetryHelper.GetAppName().c_str();
@@ -172,7 +169,6 @@ namespace winrt::Microsoft::Security::Authentication::OAuth::factory_implementat
     IAsyncOperation<oauth::TokenRequestResult> OAuth2Manager::RequestTokenAsync(Uri tokenEndpoint,
         oauth::TokenRequestParams params, oauth::ClientAuthentication clientAuth)
     {
-        THROW_HR_IF(E_NOTIMPL, !::Microsoft::Security::Authentication::OAuth::Feature_OAuth::IsEnabled());
 
         bool isAppPackaged = m_telemetryHelper.IsPackagedApp();
         PCWSTR appName = m_telemetryHelper.GetAppName().c_str();

--- a/dev/OAuth/TokenRequestParams.cpp
+++ b/dev/OAuth/TokenRequestParams.cpp
@@ -16,7 +16,6 @@ namespace winrt::Microsoft::Security::Authentication::OAuth::implementation
 {
     TokenRequestParams::TokenRequestParams(const winrt::hstring& grantType) : m_grantType(grantType)
     {
-        THROW_HR_IF(E_NOTIMPL, !::Microsoft::Security::Authentication::OAuth::Feature_OAuth::IsEnabled());
     }
 
     oauth::TokenRequestParams TokenRequestParams::CreateForAuthorizationCodeRequest(

--- a/dev/OAuth/common.h
+++ b/dev/OAuth/common.h
@@ -11,8 +11,6 @@
 #include <winrt/Windows.Web.Http.h>
 #include <winrt/Windows.Web.Http.Headers.h>
 
-#include <TerminalVelocityFeatures-OAuth.h>
-
 namespace collections = winrt::Windows::Foundation::Collections;
 namespace crypto = winrt::Windows::Security::Cryptography;
 namespace foundation = winrt::Windows::Foundation;

--- a/test/OAuth2ManagerTests/OAuth2APITests.cpp
+++ b/test/OAuth2ManagerTests/OAuth2APITests.cpp
@@ -15,7 +15,6 @@
 #include <WexTestClass.h>
 #include <WinSock2.h>
 
-#include <TerminalVelocityFeatures-OAuth.h>
 #include <winrt/Microsoft.Security.Authentication.OAuth.h>
 #include <winrt/Windows.Data.Json.h>
 #include <winrt/Windows.Security.Cryptography.h>
@@ -270,22 +269,12 @@ namespace OAuth2ManagerTests
 
         TEST_METHOD(Protocol_AuthorizationCode_BasicEndToEnd)
         {
-            if (!::Microsoft::Security::Authentication::OAuth::Feature_OAuth::IsEnabled())
-            {
-                Log::Result(TestResults::Skipped, L"OAuth2Manager API Features are not enabled.");
-                return;
-            }
             static constexpr std::wstring_view client_id = GRANT_TYPE_CODE REDIRECT_TYPE_PROTOCOL;
             DoBasicEndToEndAuthCodeTest(client_id, protocol_redirect_uri);
         }
 
         TEST_METHOD(AuthorizationCodeWithClientAuth)
         {
-            if (!::Microsoft::Security::Authentication::OAuth::Feature_OAuth::IsEnabled())
-            {
-                Log::Result(TestResults::Skipped, L"OAuth2Manager API Features are not enabled.");
-                return;
-            }
             // NOTE: This is testing client auth, which is a token request only thing, hence only using a single redirection type
             static constexpr std::wstring_view client_id = GRANT_TYPE_CODE REDIRECT_TYPE_LOCALHOST AUTH_TYPE_HEADER;
             auto requestParams = AuthRequestParams::CreateForAuthorizationCodeRequest(client_id, Uri{ localhost_redirect_uri });
@@ -305,11 +294,6 @@ namespace OAuth2ManagerTests
 
         TEST_METHOD(ClientCredentialsTokenRequest)
         {
-            if (!::Microsoft::Security::Authentication::OAuth::Feature_OAuth::IsEnabled())
-            {
-                Log::Result(TestResults::Skipped, L"OAuth2Manager API Features are not enabled.");
-                return;
-            }
             static constexpr std::wstring_view client_id = GRANT_TYPE_CLIENT AUTH_TYPE_HEADER;
             auto tokenParams = TokenRequestParams::CreateForClientCredentials();
             auto auth = ClientAuthentication::CreateForBasicAuthorization(client_id, L"password");
@@ -318,11 +302,6 @@ namespace OAuth2ManagerTests
 
         TEST_METHOD(RefreshTokenRequest)
         {
-            if (!::Microsoft::Security::Authentication::OAuth::Feature_OAuth::IsEnabled())
-            {
-                Log::Result(TestResults::Skipped, L"OAuth2Manager API Features are not enabled.");
-                return;
-            }
             static constexpr std::wstring_view client_id = GRANT_TYPE_REFRESH AUTH_TYPE_HEADER;
             auto tokenParams = TokenRequestParams::CreateForRefreshToken(refresh_token_old);
             auto auth = ClientAuthentication::CreateForBasicAuthorization(client_id, L"password");
@@ -331,11 +310,6 @@ namespace OAuth2ManagerTests
 
         TEST_METHOD(ExtensionTokenRequest)
         {
-            if (!::Microsoft::Security::Authentication::OAuth::Feature_OAuth::IsEnabled())
-            {
-                Log::Result(TestResults::Skipped, L"OAuth2Manager API Features are not enabled.");
-                return;
-            }
             static constexpr std::wstring_view client_id = GRANT_TYPE_EXTENSION AUTH_TYPE_HEADER;
             auto tokenParams = TokenRequestParams::CreateForExtension(Uri{ extension_grant_uri });
             auto auth = ClientAuthentication::CreateForBasicAuthorization(client_id, L"password");
@@ -344,11 +318,6 @@ namespace OAuth2ManagerTests
 
         TEST_METHOD(TokenRequestErrorResponse)
         {
-            if (!::Microsoft::Security::Authentication::OAuth::Feature_OAuth::IsEnabled())
-            {
-                Log::Result(TestResults::Skipped, L"OAuth2Manager API Features are not enabled.");
-                return;
-            }
             static constexpr std::wstring_view client_id = GRANT_TYPE_CLIENT TOKEN_ERROR_RESPONSE;
             auto tokenParams = TokenRequestParams::CreateForClientCredentials();
             auto auth = ClientAuthentication::CreateForBasicAuthorization(client_id, L"password");
@@ -376,11 +345,6 @@ namespace OAuth2ManagerTests
 
         TEST_METHOD(AdditionalParams)
         {
-            if (!::Microsoft::Security::Authentication::OAuth::Feature_OAuth::IsEnabled())
-            {
-                Log::Result(TestResults::Skipped, L"OAuth2Manager API Features are not enabled.");
-                return;
-            }
             static constexpr std::wstring_view client_id = GRANT_TYPE_CODE REDIRECT_TYPE_LOCALHOST ADDITIONAL_PARAMS;
             auto requestParams = AuthRequestParams::CreateForAuthorizationCodeRequest(client_id, Uri{ localhost_redirect_uri });
             auto additionalRequestParams = requestParams.AdditionalParams();
@@ -402,11 +366,6 @@ namespace OAuth2ManagerTests
 
         TEST_METHOD(CompleteInvalidState)
         {
-            if (!::Microsoft::Security::Authentication::OAuth::Feature_OAuth::IsEnabled())
-            {
-                Log::Result(TestResults::Skipped, L"OAuth2Manager API Features are not enabled.");
-                return;
-            }
             VERIFY_IS_FALSE(OAuth2Manager::CompleteAuthRequest(Uri{ L"unknown-protocol:" })); // No query parameters at all
             VERIFY_IS_FALSE(OAuth2Manager::CompleteAuthRequest(Uri{ L"http://127.0.0.1/oauth?code=abc123" })); // Missing state
             VERIFY_IS_FALSE(OAuth2Manager::CompleteAuthRequest(Uri{ L"oauthtestapp:oauth?code=abc&state=invalid" }));


### PR DESCRIPTION
This PR removes the TerminalVelocity mechanism from the OAuth2Manager API, which was previously used to control its visibility across different release channels (Preview, Stable, Experimental). As the feature is now moving towards broader availability (Preview Release) and no longer needs the experimental feature flagging, we are removing the TerminalVelocity-related checks.

The API has gone through spec-review: #4772 

A microsoft employee must use /azp run to validate using the pipelines below.

WARNING:
Comments made by azure-pipelines bot maybe inaccurate.
Please see pipeline link to verify that the build is being ran.

For status checks on the main branch, please use TransportPackage-Foundation-PR
(https://microsoft.visualstudio.com/ProjectReunion/_build?definitionId=81063&_a=summary)
and run the build against your PR branch with the default parameters.
