### PR TITLE
Setting BackgroundTask API as AlwaysEnabled

### DIFF
--- a/dev/Common/TerminalVelocityFeatures-BackgroundTask.xml
+++ b/dev/Common/TerminalVelocityFeatures-BackgroundTask.xml
@@ -12,9 +12,5 @@
         <name>Feature_BackgroundTask</name>
         <description>Supports BackgroundTask executions for WinAppSDK apps</description>
         <state>AlwaysEnabled</state>
-        <alwaysDisabledChannelTokens>
-            <channelToken>Preview</channelToken>
-            <channelToken>Stable</channelToken>
-        </alwaysDisabledChannelTokens>
     </feature>
 </features>


### PR DESCRIPTION
As [spec](https://github.com/microsoft/WindowsAppSDK/blob/main/specs/BackgroundTask/BackgroundTaskBuilder.md) had gone through review and we haven't seen any feedbacks regarding API surface, we are good with enabling the APIs for stable release