### PR TITLE
Update IXP in hardcoded packages.config

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -6,7 +6,7 @@
 -->
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup>
-    <PackageVersion Include="Microsoft.ProjectReunion.InteractiveExperiences.TransportPackage" Version="1.8.0-CI-26107.1720.241003-1631.3" />
+    <PackageVersion Include="Microsoft.ProjectReunion.InteractiveExperiences.TransportPackage" Version="1.7.3-CI-26107.1735.250116-1144.4" />
     <PackageVersion Include="Microsoft.Windows.CsWinRT" Version="$(MicrosoftWindowsCsWinRTPackageVersion)" />
     <PackageVersion Include="Microsoft.SourceLink.Common" Version="$(MicrosoftSourceLinkCommonVersion)" />
     <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="$(MicrosoftSourceLinkGitHubVersion)" />

--- a/dev/WindowsAppRuntime_DLL/packages.config
+++ b/dev/WindowsAppRuntime_DLL/packages.config
@@ -5,6 +5,6 @@
   <package id="Microsoft.SourceLink.GitHub" version="1.1.1" targetFramework="native" developmentDependency="true" />
   <package id="Microsoft.Windows.CppWinRT" version="2.0.230706.1" targetFramework="native" />
   <package id="Microsoft.Windows.ImplementationLibrary" version="1.0.240803.1" targetFramework="native" />
-  <package id="Microsoft.FrameworkUdk" version="1.8.0-CI-26107.1720.241003-1631.3" targetFramework="native" />
-  <package id="Microsoft.ProjectReunion.InteractiveExperiences.TransportPackage" version="1.8.0-CI-26107.1720.241003-1631.3" targetFramework="native" />
+  <package id="Microsoft.FrameworkUdk" version="1.7.3-CI-26107.1735.250116-1144.4" targetFramework="native" />
+  <package id="Microsoft.ProjectReunion.InteractiveExperiences.TransportPackage" version="1.7.3-CI-26107.1735.250116-1144.4" targetFramework="native" />
 </packages>

--- a/test/CameraCaptureUITests/packages.config
+++ b/test/CameraCaptureUITests/packages.config
@@ -3,5 +3,5 @@
   <package id="Microsoft.Taef" version="10.94.240624002" targetFramework="native" />
   <package id="Microsoft.Windows.CppWinRT" version="2.0.230706.1" targetFramework="native" />
   <package id="Microsoft.Windows.ImplementationLibrary" version="1.0.240803.1" targetFramework="native" />
-  <package id="Microsoft.ProjectReunion.InteractiveExperiences.TransportPackage" version="1.8.0-CI-26107.1720.241003-1631.3" targetFramework="native" />
+  <package id="Microsoft.ProjectReunion.InteractiveExperiences.TransportPackage" version="1.7.3-CI-26107.1735.250116-1144.4" targetFramework="native" />
 </packages>

--- a/test/OAuth2ManagerTests/packages.config
+++ b/test/OAuth2ManagerTests/packages.config
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.ProjectReunion.InteractiveExperiences.TransportPackage" version="1.8.0-CI-26107.1720.241003-1631.3" targetFramework="native" />
+  <package id="Microsoft.ProjectReunion.InteractiveExperiences.TransportPackage" version="1.7.3-CI-26107.1735.250116-1144.4" targetFramework="native" />
   <package id="Microsoft.Taef" version="10.94.240624002" targetFramework="native" />
   <package id="Microsoft.Windows.CppWinRT" version="2.0.240915.1" targetFramework="native" />
   <package id="Microsoft.Windows.ImplementationLibrary" version="1.0.240803.1" targetFramework="native" />

--- a/test/PackageManager/API/packages.config
+++ b/test/PackageManager/API/packages.config
@@ -6,5 +6,5 @@
   <package id="Microsoft.Taef" version="10.94.240624002" targetFramework="native" />
   <package id="Microsoft.Windows.CppWinRT" version="2.0.230706.1" targetFramework="native" />
   <package id="Microsoft.Windows.ImplementationLibrary" version="1.0.240803.1" targetFramework="native" />
-  <package id="Microsoft.FrameworkUdk" version="1.8.0-CI-26107.1720.241003-1631.3" targetFramework="native" />
+  <package id="Microsoft.FrameworkUdk" version="1.7.3-CI-26107.1735.250116-1144.4" targetFramework="native" />
 </packages>


### PR DESCRIPTION
This is a mitigation. A real fix for these to use the version.details.xml coming soon.

WARNING:
Comments made by azure-pipelines bot maybe inaccurate.
Please see pipeline link to verify that the build is being ran.

For status checks on the main branch, please use TransportPackage-Foundation-PR
(https://microsoft.visualstudio.com/ProjectReunion/_build?definitionId=81063&_a=summary)
and run the build against your PR branch with the default parameters.
