### PR TITLE
Fix DownloadPipelineArtifacts Failing With System.OutOfMemoryException on Arm64 Testjobs

### DIFF
--- a/build/AzurePipelinesTemplates/WindowsAppSDK-RunTestsInPipeline-Job.yml
+++ b/build/AzurePipelinesTemplates/WindowsAppSDK-RunTestsInPipeline-Job.yml
@@ -27,6 +27,7 @@ jobs:
   timeoutInMinutes: 120
   variables:
     testPayloadArtifactDir: $(Build.SourcesDirectory)\BuildOutput\$(buildConfiguration)\$(buildPlatform)
+    system.debug: true
   steps:
     - template: WindowsAppSDK-RunTests-Steps.yml
       parameters:

--- a/build/AzurePipelinesTemplates/WindowsAppSDK-RunTestsInPipeline-Job.yml
+++ b/build/AzurePipelinesTemplates/WindowsAppSDK-RunTestsInPipeline-Job.yml
@@ -28,6 +28,7 @@ jobs:
   variables:
     testPayloadArtifactDir: $(Build.SourcesDirectory)\BuildOutput\$(buildConfiguration)\$(buildPlatform)
     system.debug: true
+    AZURE_PIPELINES_DEDUP_PARALLELISM: 16
   steps:
     - template: WindowsAppSDK-RunTests-Steps.yml
       parameters:

--- a/build/AzurePipelinesTemplates/WindowsAppSDK-RunTestsInPipeline-Job.yml
+++ b/build/AzurePipelinesTemplates/WindowsAppSDK-RunTestsInPipeline-Job.yml
@@ -27,7 +27,6 @@ jobs:
   timeoutInMinutes: 120
   variables:
     testPayloadArtifactDir: $(Build.SourcesDirectory)\BuildOutput\$(buildConfiguration)\$(buildPlatform)
-    system.debug: true
     AZURE_PIPELINES_DEDUP_PARALLELISM: 16
   steps:
     - template: WindowsAppSDK-RunTests-Steps.yml


### PR DESCRIPTION
Validated in internal runs. 

> Brian Barthel
> Submitted at 2025-01-28 05:39:22 PST
> So I took a look at the run with debug logs and interestingly it doesn't show the machine being under any particular memory pressure when it was throwing OOM:
> 
> ##[debug]Agent environment resources - Disk: D:\ Available 148641.40 MB out of 153598.00 MB, Memory: Used 4792.00 MB out of 16380.00 MB, CPU: Usage 100.00%
> 
> 
> That doesn't really strike me as problematic memory usage.  At the beginning of the download it showed 3904.00 MB used so it doesn't appear to be going wild and even with only 8gb memory it isn't overwhelming the system.  This memory usage also follows the same pattern as the successful downloads.
> 
> Another thing that could be tried is to reduce the parallelism by setting the variable "AZURE_PIPELINES_DEDUP_PARALLELISM" to "16".  This should reduce concurrent memory allocations and allow us to make better use of our buffer pool.
