### PR TITLE
Fix DownloadPipelineArtifacts Failing With System.OutOfMemoryException on Arm64 Testjobs; Update Install-WindowsSdkISO.ps1 to use new FW links

### DIFF
--- a/build/AzurePipelinesTemplates/WindowsAppSDK-RunTestsInPipeline-Job.yml
+++ b/build/AzurePipelinesTemplates/WindowsAppSDK-RunTestsInPipeline-Job.yml
@@ -27,6 +27,7 @@ jobs:
   timeoutInMinutes: 120
   variables:
     testPayloadArtifactDir: $(Build.SourcesDirectory)\BuildOutput\$(buildConfiguration)\$(buildPlatform)
+    AZURE_PIPELINES_DEDUP_PARALLELISM: 16
   steps:
     - template: WindowsAppSDK-RunTests-Steps.yml
       parameters:

--- a/build/scripts/Install-WindowsSdkISO.ps1
+++ b/build/scripts/Install-WindowsSdkISO.ps1
@@ -262,8 +262,18 @@ if ($InstallWindowsSDK)
 {
     # Static(ish) link for Windows SDK
     # Note: there is a delay from Windows SDK announcements to availability via the static link
-    $uri = "https://software-download.microsoft.com/download/sg/Windows_InsiderPreview_SDK_en-us_$($buildNumber)_1.iso";
-
+    $uri = ""
+    if ($buildNumber -eq "18362")
+    {
+        $uri = "https://go.microsoft.com/fwlink/?linkid=2083448"
+    }
+    else 
+    {
+        Write-Host
+        Write-Host "Only version 18362 is available"
+        Write-Host
+        Exit 1
+    }
     if ($env:TEMP -eq $null)
     {
         $env:TEMP = Join-Path $env:SystemDrive 'temp'


### PR DESCRIPTION
…n on Arm64 Testjobs (#5080)

Also cherrypick of 
https://github.com/microsoft/WindowsAppSDK/pull/5020
