### PR TITLE
Remove terminal velocity feature tag from Badge Notification APIs, enabling it for stable release

### DIFF
--- a/dev/Common/TerminalVelocityFeatures-BadgeNotifications.xml
+++ b/dev/Common/TerminalVelocityFeatures-BadgeNotifications.xml
@@ -14,10 +14,6 @@
     <name>Feature_BadgeNotifications</name>
     <description>Enables Local Badge sourced Notifications for packaged apps on the device</description>
     <state>AlwaysEnabled</state>
-    <alwaysDisabledChannelTokens>
-      <channelToken>Preview</channelToken>
-      <channelToken>Stable</channelToken>
-    </alwaysDisabledChannelTokens>
   </feature>
 </features>
 

--- a/dev/Notifications/BadgeNotifications/BadgeNotifications.idl
+++ b/dev/Notifications/BadgeNotifications/BadgeNotifications.idl
@@ -1,15 +1,13 @@
 // Copyright (c) Microsoft Corporation and Contributors.
 // Licensed under the MIT License.
 
-#include <TerminalVelocityFeatures-BadgeNotifications.h>
-
 namespace Microsoft.Windows.BadgeNotifications
 {
     [contractversion(1)]
     apicontract BadgeNotificationsContract {};
 
     // Set of predefined glyphs that can be used to represent various statuses or notifications on an application's badge
-    [contract(BadgeNotificationsContract, 1), feature(Feature_BadgeNotifications)]
+    [contract(BadgeNotificationsContract, 1)]
     enum BadgeNotificationGlyph
     {
         None, // No glyph. A blank tile appears in the badge.
@@ -28,7 +26,7 @@ namespace Microsoft.Windows.BadgeNotifications
     };
 
     // The manager class which encompasses all Badge Notification API Functionality
-    [contract(BadgeNotificationsContract, 1), feature(Feature_BadgeNotifications)]
+    [contract(BadgeNotificationsContract, 1)]
     runtimeclass BadgeNotificationManager
     {
         // Gets a Default instance of a BadgeNotificationManager


### PR DESCRIPTION
This PR removes the TerminalVelocity mechanism from the Badge NotificationAPI, which was previously used to control its visibility across different release channels (Preview, Stable, Experimental). As the feature is now moving towards broader availability (Preview Release) and no longer needs the experimental feature flagging, we are removing the TerminalVelocity-related checks.

API Spec PR - https://github.com/microsoft/WindowsAppSDK/pull/4823

A microsoft employee must use /azp run to validate using the pipelines below.

WARNING:
Comments made by azure-pipelines bot maybe inaccurate.
Please see pipeline link to verify that the build is being ran.

For status checks on the main branch, please use TransportPackage-Foundation-PR
(https://microsoft.visualstudio.com/ProjectReunion/_build?definitionId=81063&_a=summary)
and run the build against your PR branch with the default parameters.
