### PR TITLE
Adding IXP & FrameworkUDK to Central Package Management

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -6,7 +6,8 @@
 -->
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup>
-    <PackageVersion Include="Microsoft.ProjectReunion.InteractiveExperiences.TransportPackage" Version="1.8.0-CI-26107.1720.241003-1631.3" />
+    <PackageVersion Include="Microsoft.ProjectReunion.InteractiveExperiences.TransportPackage" Version="$(MicrosoftProjectReunionInteractiveExperiencesTransportPackagePackageVersion)" />
+    <PackageVersion Include="Microsoft.FrameworkUDK" Version="$(MicrosoftFrameworkUDKVersion)" />
     <PackageVersion Include="Microsoft.Windows.CsWinRT" Version="$(MicrosoftWindowsCsWinRTPackageVersion)" />
     <PackageVersion Include="Microsoft.SourceLink.Common" Version="$(MicrosoftSourceLinkCommonVersion)" />
     <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="$(MicrosoftSourceLinkGitHubVersion)" />

--- a/dev/WindowsAppRuntime_DLL/packages.config
+++ b/dev/WindowsAppRuntime_DLL/packages.config
@@ -5,6 +5,4 @@
   <package id="Microsoft.SourceLink.GitHub" version="1.1.1" targetFramework="native" developmentDependency="true" />
   <package id="Microsoft.Windows.CppWinRT" version="2.0.230706.1" targetFramework="native" />
   <package id="Microsoft.Windows.ImplementationLibrary" version="1.0.240803.1" targetFramework="native" />
-  <package id="Microsoft.FrameworkUdk" version="1.8.0-CI-26107.1720.241003-1631.3" targetFramework="native" />
-  <package id="Microsoft.ProjectReunion.InteractiveExperiences.TransportPackage" version="1.8.0-CI-26107.1720.241003-1631.3" targetFramework="native" />
 </packages>

--- a/test/CameraCaptureUITests/packages.config
+++ b/test/CameraCaptureUITests/packages.config
@@ -3,5 +3,4 @@
   <package id="Microsoft.Taef" version="10.94.240624002" targetFramework="native" />
   <package id="Microsoft.Windows.CppWinRT" version="2.0.230706.1" targetFramework="native" />
   <package id="Microsoft.Windows.ImplementationLibrary" version="1.0.240803.1" targetFramework="native" />
-  <package id="Microsoft.ProjectReunion.InteractiveExperiences.TransportPackage" version="1.8.0-CI-26107.1720.241003-1631.3" targetFramework="native" />
 </packages>

--- a/test/OAuth2ManagerTests/packages.config
+++ b/test/OAuth2ManagerTests/packages.config
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.ProjectReunion.InteractiveExperiences.TransportPackage" version="1.8.0-CI-26107.1720.241003-1631.3" targetFramework="native" />
   <package id="Microsoft.Taef" version="10.94.240624002" targetFramework="native" />
   <package id="Microsoft.Windows.CppWinRT" version="2.0.240915.1" targetFramework="native" />
   <package id="Microsoft.Windows.ImplementationLibrary" version="1.0.240803.1" targetFramework="native" />

--- a/test/PackageManager/API/packages.config
+++ b/test/PackageManager/API/packages.config
@@ -6,5 +6,4 @@
   <package id="Microsoft.Taef" version="10.94.240624002" targetFramework="native" />
   <package id="Microsoft.Windows.CppWinRT" version="2.0.230706.1" targetFramework="native" />
   <package id="Microsoft.Windows.ImplementationLibrary" version="1.0.240803.1" targetFramework="native" />
-  <package id="Microsoft.FrameworkUdk" version="1.8.0-CI-26107.1720.241003-1631.3" targetFramework="native" />
 </packages>


### PR DESCRIPTION
The hardcoded versions are going to get stale since Maestro isnt able to update these!

This PR adds FrameworkUDK and IXP to Central Package Management by adding them to Directory.Packages.props. Additionally, hardcoded package references have been removed from packages.config to align with best practices.

https://task.ms/55990470
