### PR TITLE
Marking CameraCaptureUI Telemetry as Critical 

### DIFF
--- a/dev/Interop/CameraCaptureUI/CameraCaptureUI/CameraCaptureUITelemetry.h
+++ b/dev/Interop/CameraCaptureUI/CameraCaptureUI/CameraCaptureUITelemetry.h
@@ -15,7 +15,7 @@ class CameraCaptureUITelemetry : public wil::TraceLoggingProvider
     IMPLEMENT_TELEMETRY_CLASS(CameraCaptureUITelemetry, CameraCaptureUITelemetryProvider);
 
 public:
-    BEGIN_COMPLIANT_MEASURES_ACTIVITY_CLASS(CameraCaptureOperation, PDT_ProductAndServicePerformance);
+    BEGIN_COMPLIANT_CRITICAL_DATA_ACTIVITY_CLASS(CameraCaptureOperation, PDT_ProductAndServicePerformance);
         DEFINE_ACTIVITY_START(bool isAppPackaged, PCWSTR appName, PCWSTR captureMode) noexcept try
         {
             TraceLoggingClassWriteStart(


### PR DESCRIPTION
This PR updates CameraCaptureUI telemetry to critical to ensure we collect complete data on its reliability and usage.
