### PR TITLE
Fix TerminalVelocityFeatures-CallingPreviewSupport.h to be generated.

### DIFF
--- a/build/AzurePipelinesTemplates/WindowsAppSDK-SetupBuildEnvironment-Steps.yml
+++ b/build/AzurePipelinesTemplates/WindowsAppSDK-SetupBuildEnvironment-Steps.yml
@@ -148,6 +148,14 @@ steps:
     workingDirectory: '$(Build.SourcesDirectory)'
 
 - task: powershell@2
+  displayName: 'Create CallingPreviewSupport TerminalVelocity features'
+  inputs:
+    targetType: filePath
+    filePath: tools\TerminalVelocity\Generate-TerminalVelocityFeatures.ps1
+    arguments: -Path $(Build.SourcesDirectory)\dev\common\TerminalVelocityFeatures-AppNotifications.xml -Channel $(channel) -Language C++ -Namespace Microsoft.Windows.CallingPreviewSupport -Output $(Build.SourcesDirectory)\dev\common\TerminalVelocityFeatures-CallingPreviewSupport.h
+    workingDirectory: '$(Build.SourcesDirectory)'
+
+- task: powershell@2
   displayName: 'Create PushNotifications TerminalVelocity features'
   inputs:
     targetType: filePath

--- a/dev/AppNotifications/AppNotificationConferencingConfig.cpp
+++ b/dev/AppNotifications/AppNotificationConferencingConfig.cpp
@@ -5,6 +5,7 @@
 #include "AppNotificationConferencingConfig.h"
 #include "Microsoft.Windows.AppNotifications.AppNotificationConferencingConfig.g.cpp"
 #include <IsWindowsVersion.h>
+#include "TerminalVelocityFeatures-CallingPreviewSupport.h"
 
 namespace winrt::Microsoft::Windows::AppNotifications::implementation
 {
@@ -48,3 +49,15 @@ namespace winrt::Microsoft::Windows::AppNotifications::implementation
         return false;
     }
 }
+
+// This function (not in the "implementation" namespace) is not defined when the feature is disabled,
+// resulting in a linker error. Define the function for that scenario.
+#if WINDOWSAPPRUNTIME_MICROSOFT_WINDOWS_CALLINGPREVIEWSUPPORT_FEATURE_CALLINGPREVIEWSUPPORT_ENABLED != 1
+namespace winrt::Microsoft::Windows::AppNotifications
+{
+    bool AppNotificationConferencingConfig::IsCallingPreviewSupported()
+    {
+        return false;
+    }
+}
+#endif


### PR DESCRIPTION
TerminalVelocityFeatures-CallingPreviewSupport.h is not correctly being generated today, resulting in the velocity having the wrong state in preview/stable. Add the proper generation.