### PR TITLE
[Cherry-pick to 1.7]Making the telemetry for OAuth2Manager Critical.

### DIFF
--- a/dev/OAuth/OAuth2ManagerTelemetry.h
+++ b/dev/OAuth/OAuth2ManagerTelemetry.h
@@ -11,11 +11,11 @@ class OAuth2ManagerTelemetry : public wil::TraceLoggingProvider
     //{27d8ee3f-d704-45d6-b66c-1dad95795ce5}
 public:
 
-    DEFINE_COMPLIANT_MEASURES_EVENT_PARAM3(RequestAuthWithParamsAsyncTriggered, PDT_ProductAndServicePerformance,
+    DEFINE_COMPLIANT_CRITICAL_DATA_EVENT_PARAM3(RequestAuthWithParamsAsyncTriggered, PDT_ProductAndServicePerformance,
         bool, IsAppPackaged, PCWSTR, AppName, PCWSTR, ResponseType);
 
-    DEFINE_COMPLIANT_MEASURES_EVENT_PARAM2(CompleteAuthRequestTriggered, PDT_ProductAndServiceUsage,
+    DEFINE_COMPLIANT_CRITICAL_DATA_EVENT_PARAM2(CompleteAuthRequestTriggered, PDT_ProductAndServiceUsage,
         bool, IsAppPackaged, PCWSTR, AppName);
-    DEFINE_COMPLIANT_MEASURES_EVENT_PARAM4(RequestTokenAsyncTriggered, PDT_ProductAndServiceUsage,
+    DEFINE_COMPLIANT_CRITICAL_DATA_EVENT_PARAM4(RequestTokenAsyncTriggered, PDT_ProductAndServiceUsage,
         bool, IsAppPackaged, PCWSTR, AppName, PCWSTR, GrantType, bool, IsClientAuthPassed);
 };


### PR DESCRIPTION
Making the telemetry for OAuth2Manager Critical.

A microsoft employee must use /azp run to validate using the pipelines below.

WARNING:
Comments made by azure-pipelines bot maybe inaccurate.
Please see pipeline link to verify that the build is being ran.

For status checks on the main branch, please use TransportPackage-Foundation-PR
(https://microsoft.visualstudio.com/ProjectReunion/_build?definitionId=81063&_a=summary)
and run the build against your PR branch with the default parameters.
