### PR TITLE
[Build] Update WindowsAppSDK-BuildFoundation-Steps.yml

### DIFF
--- a/build/AzurePipelinesTemplates/WindowsAppSDK-BuildFoundation-Steps.yml
+++ b/build/AzurePipelinesTemplates/WindowsAppSDK-BuildFoundation-Steps.yml
@@ -95,12 +95,24 @@ steps:
     inputs:
       SourceFolder: '$(build.SourcesDirectory)\BuildOutput'
       TargetFolder: '$(build.SourcesDirectory)\APIScanTarget'
+      # Excluding from APIScan:
+      # - arm/arm64 binaries because APIScan does not support them currently.
+      # - TAEF binaries: te.*, wex.*.
+      # - HelloWorldAdvancedC* - These are test binaries w/o the word "test" in their file paths. We currently depririoritize APIScan for test binaries.
       contents: |
         **
         !**\*test*\**
         !**\*packages*\**
         !**\*Demoapp*\**
         !**\*Demopackage\**
+        !**\HelloWorldAdvancedC*\**        
+        !**\arm\**        
+        !**\arm64\**     
+        !**\te.*exe
+        !**\te.*dll
+        !**\wex.*exe
+        !**\wex.*dll
+        !**\wttlog.dll
         !**\*.json
         !**\*.msix
         !**\*.png


### PR DESCRIPTION
Reducing the number of binaries we feed to APIscan, to void the recent problem of APIScan hitting timeout failure.
After last Tuesday, APIScan started hitting timeout error because the number of binaries to scan increased from 331 to 367.
This PR reduces the number of binaries to scan to 217, by skipping 1) arm/arm64 binaries, 2) test binaries, 3) TAEF binaries.
A private pipeline run showed that APIScan no longer hit the timeout error.

//////////////////////////////
A microsoft employee must use /azp run to validate using the pipelines below.

WARNING:
Comments made by azure-pipelines bot maybe inaccurate.
Please see pipeline link to verify that the build is being ran.

For status checks on the main branch, please use TransportPackage-Foundation-PR
(https://microsoft.visualstudio.com/ProjectReunion/_build?definitionId=81063&_a=summary)
and run the build against your PR branch with the default parameters.
