### PR TITLE
BadgeNotification: Onboarding Unit tests to the pipeline test runs

### DIFF
--- a/test/BadgeNotificationTest/BadgeNotification.testdef
+++ b/test/BadgeNotificationTest/BadgeNotification.testdef
@@ -1,0 +1,11 @@
+{
+    "Tests": [
+        {
+            "Description": "BadgeNotification API",
+            "Filename": "BadgeNotificationTest.dll",
+            "Parameters": "",
+            "Architectures": ["x64", "x86", "arm64"],
+            "Status": "Enabled"
+        }
+    ]
+}

--- a/test/BadgeNotificationTest/BadgeNotificationTest.vcxproj
+++ b/test/BadgeNotificationTest/BadgeNotificationTest.vcxproj
@@ -164,6 +164,7 @@
   <Target Name="CopyFiles" AfterTargets="AfterBuild">
     <Copy SourceFiles="$(OutDir)\..\WindowsAppRuntime_BootstrapDLL\Microsoft.WindowsAppRuntime.Bootstrap.dll" DestinationFolder="$(OutDir)" />
     <Copy SourceFiles="$(OutDir)\..\WindowsAppRuntime_DLL\Microsoft.Internal.FrameworkUdk.dll" DestinationFolder="$(OutDir)" />
+    <Copy SourceFiles="BadgeNotification.testdef" DestinationFolder="$(OutDir)" />
   </Target>
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>

--- a/test/BadgeNotificationTest/BadgeNotificationTest.vcxproj.filters
+++ b/test/BadgeNotificationTest/BadgeNotificationTest.vcxproj.filters
@@ -40,7 +40,7 @@
     <None Include="packages.config" />
   </ItemGroup>
   <ItemGroup>
-    <ResourceCompile Include="AppNotificationTests.rc">
+    <ResourceCompile Include="BadgeNotificationTests.rc">
       <Filter>Resource Files</Filter>
     </ResourceCompile>
   </ItemGroup>

--- a/test/BadgeNotificationTest/BadgeNotifications-AppxManifest.xml
+++ b/test/BadgeNotificationTest/BadgeNotifications-AppxManifest.xml
@@ -21,11 +21,11 @@
     <PublisherDisplayName>Windows APP SDK</PublisherDisplayName>
     <Logo>taef.png</Logo>
   </Properties>
-
-  <Dependencies>
-    <TargetDeviceFamily Name="Windows.Desktop" MinVersion="10.0.0.0" MaxVersionTested="12.0.0.0" />
-    <PackageDependency Name="Microsoft.WindowsAppRuntime.Framework.4.1" Publisher="CN=Microsoft Corporation, O=Microsoft Corporation, L=Redmond, S=Washington, C=US" MinVersion="0.0.0.0"/>
-  </Dependencies>
+  
+    <Dependencies>
+        <TargetDeviceFamily Name="Windows.Desktop" MinVersion="10.0.0.0" MaxVersionTested="12.0.0.0" />
+        <PackageDependency Name="Microsoft.WindowsAppRuntime.Framework.4.1" Publisher="CN=Microsoft Corporation, O=Microsoft Corporation, L=Redmond, S=Washington, C=US" MinVersion="0.0.0.0"/>
+    </Dependencies>
 
   <Resources>
     <Resource Language="en-us" />

--- a/test/BadgeNotificationTest/BadgeNotifications-AppxManifest.xml
+++ b/test/BadgeNotificationTest/BadgeNotifications-AppxManifest.xml
@@ -22,10 +22,10 @@
     <Logo>taef.png</Logo>
   </Properties>
   
-    <Dependencies>
-        <TargetDeviceFamily Name="Windows.Desktop" MinVersion="10.0.0.0" MaxVersionTested="12.0.0.0" />
-        <PackageDependency Name="Microsoft.WindowsAppRuntime.Framework.4.1" Publisher="CN=Microsoft Corporation, O=Microsoft Corporation, L=Redmond, S=Washington, C=US" MinVersion="0.0.0.0"/>
-    </Dependencies>
+  <Dependencies>
+    <TargetDeviceFamily Name="Windows.Desktop" MinVersion="10.0.0.0" MaxVersionTested="12.0.0.0" />
+    <PackageDependency Name="Microsoft.WindowsAppRuntime.Framework.4.1" Publisher="CN=Microsoft Corporation, O=Microsoft Corporation, L=Redmond, S=Washington, C=US" MinVersion="0.0.0.0"/>
+  </Dependencies>
 
   <Resources>
     <Resource Language="en-us" />

--- a/test/BadgeNotificationTest/PackagedTests.cpp
+++ b/test/BadgeNotificationTest/PackagedTests.cpp
@@ -18,7 +18,6 @@ using namespace winrt::Windows::Management::Deployment;
 using namespace winrt::Windows::Storage;
 using namespace winrt::Windows::System;
 using namespace winrt::Microsoft::Windows::BadgeNotifications;
-//using namespace AppNotifications::Test;
 
 void PackagedTests::VerifyBadgeNotificationManagerCurrent()
 {

--- a/test/BadgeNotificationTest/resource.h
+++ b/test/BadgeNotificationTest/resource.h
@@ -3,7 +3,7 @@
 
 //{{NO_DEPENDENCIES}}
 // Microsoft Visual C++ generated include file.
-// Used by AppNotificationTests.rc
+// Used by BadgeNotificationTests.rc
 
 // Next default values for new objects
 // 


### PR DESCRIPTION
The changes involve onboarding unit tests for the BadgeNotification API to run as part of the pipeline test runs (Checkin, Nightly, and Release).

Testing - In the build pipeline all tests are passing

A microsoft employee must use /azp run to validate using the pipelines below.

WARNING:
Comments made by azure-pipelines bot maybe inaccurate.
Please see pipeline link to verify that the build is being ran.

For status checks on the main branch, please use TransportPackage-Foundation-PR
(https://microsoft.visualstudio.com/ProjectReunion/_build?definitionId=81063&_a=summary)
and run the build against your PR branch with the default parameters.
