### PR TITLE
Update IsCallingPreviewSupported API

### DIFF
--- a/dev/AppNotifications/AppNotificationConferencingConfig.cpp
+++ b/dev/AppNotifications/AppNotificationConferencingConfig.cpp
@@ -43,10 +43,9 @@ namespace winrt::Microsoft::Windows::AppNotifications::implementation
     }
 
     ///Checks if the calling preview feature is supported on the current OS version
-    ///TO DO - This method needs implementation on framework UDK, for now it always returns false
     bool AppNotificationConferencingConfig::IsCallingPreviewSupported()
     {
-        return false;
+        return WindowsVersion::IsWindows11_22H2OrGreater();
     }
 }
 
@@ -57,7 +56,7 @@ namespace winrt::Microsoft::Windows::AppNotifications
 {
     bool AppNotificationConferencingConfig::IsCallingPreviewSupported()
     {
-        return false;
+        return WindowsVersion::IsWindows11_22H2OrGreater();
     }
 }
 #endif

--- a/dev/AppNotifications/AppNotificationConferencingConfig.cpp
+++ b/dev/AppNotifications/AppNotificationConferencingConfig.cpp
@@ -43,6 +43,7 @@ namespace winrt::Microsoft::Windows::AppNotifications::implementation
     }
 
     ///Checks if the calling preview feature is supported on the current OS version
+    ///TO DO - This method needs implementation on framework UDK for more accuracy, for now it always returns IsWindows11_22H2OrGreater
     bool AppNotificationConferencingConfig::IsCallingPreviewSupported()
     {
         return WindowsVersion::IsWindows11_22H2OrGreater();


### PR DESCRIPTION
### **What Changed?**

IsCallingPreviewSupported API from returning false to returning WindowsVersion::IsWindows11_22H2OrGreater(). All OS changes are completed.

**Note**: This the work around we are doing for now. Actual fix for this would be, to have an API on Framework Udk which would tell if feature were enabled or not for more accuracy which we are currently working on. TO DO in future PRs.

### **Why is this change required?**

We need to create sample test apps and test the feature end to end.

### **What happens when App calls the Interfaces and OS changes are not present?**

If the feature is not available in OS then default behaviour is handled from OS where new UI elements "Settings Button" and "Camera Preview" won't be visible, rest all UI elements will be visible and the notification pops successfully.