### PR TITLE
[Issue #3871] File activation for unpackaged App would fail when file path contains unicode characters or special characters

### DIFF
--- a/dev/AppLifecycle/ExtensionContract.h
+++ b/dev/AppLifecycle/ExtensionContract.h
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft Corporation and Contributors.
+// Copyright (c) Microsoft Corporation and Contributors.
 // Licensed under the MIT License.
 #pragma once
 
@@ -37,6 +37,17 @@ namespace winrt::Microsoft::Windows::AppLifecycle::implementation
 
     inline std::tuple<ExtendedActivationKind, winrt::Windows::Foundation::IInspectable> DecodeActivatedEventArgs(winrt::Windows::Foundation::Uri const& uri)
     {
+        // If the Uri strictly follows uri format from GenerateEncodedLaunchUri, first query parameter is ContractId
+        // This is to avoid calling uri.QueryParsed() as it can cause issues when uri contains unicode characters or special characters like &.
+        for (const auto& extension : c_extensionMap)
+        {
+            std::wstring contractIdQuery = L"?" + std::wstring(c_contractIdKeyName) + L"=" + std::wstring(extension.contractId);
+            if (CompareStringOrdinal(uri.Query().c_str(), (int)wcslen(contractIdQuery.c_str()), contractIdQuery.c_str(), -1, TRUE) == CSTR_EQUAL)
+            {
+                return { extension.kind, extension.factory(uri) };
+            }
+        }
+
         for (auto const& pair : uri.QueryParsed())
         {
             if (CompareStringOrdinal(pair.Name().c_str(), -1, c_contractIdKeyName, -1, TRUE) == CSTR_EQUAL)

--- a/dev/AppLifecycle/FileActivatedEventArgs.h
+++ b/dev/AppLifecycle/FileActivatedEventArgs.h
@@ -64,7 +64,7 @@ namespace winrt::Microsoft::Windows::AppLifecycle::implementation
             auto verbBegin = query.find(L"&Verb=");
             if (verbBegin == std::wstring::npos)
             {
-                throw winrt::hresult_invalid_argument();
+                throw winrt::hresult_invalid_argument(L"Query of encoded file protocol should contain 'Verb'");
             }
             verbBegin += 6; // Length of "&Verb="
 
@@ -77,7 +77,7 @@ namespace winrt::Microsoft::Windows::AppLifecycle::implementation
             auto fileBegin = query.find(L"&File=");
             if (fileBegin == std::wstring::npos)
             {
-                throw winrt::hresult_invalid_argument();
+                throw winrt::hresult_invalid_argument(L"Query of encoded file protocol should contain 'File'");
             }
             fileBegin += 6; // Length of "&File="
 

--- a/dev/AppLifecycle/FileActivatedEventArgs.h
+++ b/dev/AppLifecycle/FileActivatedEventArgs.h
@@ -48,15 +48,15 @@ namespace winrt::Microsoft::Windows::AppLifecycle::implementation
         static winrt::Windows::Foundation::IInspectable Deserialize(winrt::Windows::Foundation::Uri const& uri)
         {
             auto parsedQuery = uri.QueryParsed();
+
+            // By design parsed query should have a size of 3 (ContractId, Verb, File), in which case result from QueryParsed() can be used directly.
+            // However, it may have a size of 0 when uri contains unicode characters, or more than 3 when file path contains "&", which requires manual parsing with string functions.
             if (parsedQuery.Size() == 3)
             {
                 auto verb = parsedQuery.GetFirstValueByName(L"Verb");
                 auto file = parsedQuery.GetFirstValueByName(L"File");
                 return make<FileActivatedEventArgs>(verb, file);
             }
-
-            // parsed query may have a size of 0 when uri contains unicode characters, or more than 3 when file contains "&"
-            // In such cases, manually parse the query with string functions
 
             const std::wstring query = uri.Query().c_str();
             auto queryLength = query.length();


### PR DESCRIPTION
## Background
For unpackaged App, when opening a file with type registered with [RegisterForFileTypeActivation()](https://learn.microsoft.com/windows/windows-app-sdk/api/winrt/microsoft.windows.applifecycle.activationregistrationmanager.registerforfiletypeactivation?view=windows-app-sdk-1.6), current design is to execute the app with encoded protocol as argument (`----ms-protocol:ms-encodedlaunch:App?ContractId=Windows.File&Verb=open&File=%1`)

E.g.
`"C:\MyApp.exe" "----ms-protocol:ms-encodedlaunch:App?ContractId=Windows.File&Verb=open&File=C:\myfile.foo"`

## Expectation
The expectation is when the app calls `GetActivatedEventArgs()`, the returned value should has a type of `ExtendedActivationKind.File` with file path/name in the data.

## Problem
However, when the file path contains unicode characters or special characters like `&`, the file activation would fail as the encoded protocol is not correctly parsed. E.g.
### With unicode characters:
`"C:\MyApp.exe" "----ms-protocol:ms-encodedlaunch:App?ContractId=Windows.File&Verb=open&File=C:\你好.foo"`
This would result in activation type being parsed as `ExtendedActivationKind.Protocol`

### With special character:
`"C:\MyApp.exe" "----ms-protocol:ms-encodedlaunch:App?ContractId=Windows.File&Verb=open&File=C:\a&b.foo"`
This would crash the app on calling `GetActivatedEventArgs()`

## Root cause
The query in `winrt::Windows::Foundation::Uri` is parsed with `QueryParsed()`, which would split on `&` and cause problem when having unicode characters.

## Solution
The best way to address the issue, is to change the activation protocol design, such that file path, which may contain unicode characters or special characters, is not placed in the protocol uri not designed to handle file paths. 
E.g. instead of `----ms-protocol:ms-encodedlaunch:App?ContractId=Windows.File&Verb=open&File=%1`, we put the file path as separate parameter like:
`"----ms-protocol:ms-encodedlaunch:App?ContractId=Windows.File&Verb=open" "%1"`

However, this would require design changes in multiple components including registering, serializing and deserializing protocols. For now, this PR is a simple fix just on parsing logic.

Instead of using Uri.QueryParsed(), we use simple string operations to parse the uri query. (E.g. substring from "&File=" to get the file path). 

## Test
During the fix I locally created a sample app launched with below methods to test the change:

1. activation from file `abc.txt`
2. activation from file `你好.txt`
3. activation from file `a&b.txt`
4. activation from file `😀.txt`

Previously, 2 would give protocol type, and 3 would crash the app.
After fix, all three cases give file type, with correct file path contained in the returned value.

I have also added a functional test activating unpackaged app via a file with unicode characters and special character `&`

# Auto Generated PR Description


A microsoft employee must use /azp run to validate using the pipelines below.

WARNING:
Comments made by azure-pipelines bot maybe inaccurate.
Please see pipeline link to verify that the build is being ran.

For status checks on the main branch, please use TransportPackage-Foundation-PR
(https://microsoft.visualstudio.com/ProjectReunion/_build?definitionId=81063&_a=summary)
and run the build against your PR branch with the default parameters.
