### PR TITLE
56138352 - Upgrade the Foundation repo to use the latest LKG18 native compiler

### DIFF
--- a/build/WindowsAppSDK-CommonVariables.yml
+++ b/build/WindowsAppSDK-CommonVariables.yml
@@ -19,10 +19,10 @@ variables:
 
   # Native compiler version override for win undock. The two values below are for Ge, defined in:
   # https://dev.azure.com/microsoft/OS/_git/UndockedES?path=/Pipelines/Config/CompilerToolsSettings.json
-  compilerOverridePackageName: "DevDiv.rel.LKG17.VCTools"
-  compilerOverridePackageVersion: "19.40.3381710000+DevDivGIT.CI20241121.01-A7709BD1A1FF6F17ECC06FFEE65876673883D1A8"
+  compilerOverridePackageName: "DevDiv.rel.LKG18.VCTools"
+  compilerOverridePackageVersion: "19.42.3443710001+DevDivGIT.CI20250110.04-466784EE54DF2F302AD0CD6790031C954EF41DA23DA4415D73A76ADF260F2D21"
   # Use the following corresponding version string instead of the above when calling nuget install directly.
-  compilerOverrideNupkgVersion: "19.40.33817100"
+  compilerOverrideNupkgVersion: "19.42.34437100"
 
   # Docker image which is used to build the project https://aka.ms/obpipelines/containers
   WindowsContainerImage: 'onebranch.azurecr.io/windows/ltsc2019/vse2022:latest'


### PR DESCRIPTION
Upgrade the Foundation repo to use the latest LKG18 native compiler.
Similar changes have been applied to the Closed repo.

How tested:
- The PR validation pipeline run is successful. Verified that LKG18 was used to build the product.

/////

A microsoft employee must use /azp run to validate using the pipelines below.

WARNING:
Comments made by azure-pipelines bot maybe inaccurate.
Please see pipeline link to verify that the build is being ran.

For status checks on the main branch, please use TransportPackage-Foundation-PR
(https://microsoft.visualstudio.com/ProjectReunion/_build?definitionId=81063&_a=summary)
and run the build against your PR branch with the default parameters.
