### PR TITLE
56138352: Use the global default version of LKG compiler

### DIFF
--- a/build/AzurePipelinesTemplates/WindowsAppSDK-Build-Stage.yml
+++ b/build/AzurePipelinesTemplates/WindowsAppSDK-Build-Stage.yml
@@ -57,18 +57,52 @@ stages:
           buildConfiguration: 'release'
           normalizedConfiguration: 'fre'
     variables:
-      ob_outputDirectory: '$(REPOROOT)\out'
-      ob_sdl_codeSignValidation_excludes: '-|**\Release\**;-|**\packages\**'
-      ob_artifactBaseName: "FoundationBinaries_$(buildConfiguration)_$(buildPlatform)"
-      ${{ if parameters.runStaticAnalysis }}:
-        ob_sdl_apiscan_enabled: true
-      ${{ if not( parameters.runStaticAnalysis ) }}:
-        ob_sdl_apiscan_enabled: false
-      ob_sdl_apiscan_softwareFolder: '$(build.SourcesDirectory)\APIScanTarget'
-      ob_sdl_apiscan_symbolsFolder: '$(build.SourcesDirectory)\APIScanTarget;SRV*https://symweb.azurefd.net'
-      localCompilerOverridePackageName: $[coalesce(variables.compilerOverridePackageName, variables.global_CompilerOverridePackageName)]
-      localCompilerOverridePackageVersion: $[coalesce(variables.compilerOverridePackageVersion, variables.global_CompilerOverridePackageVersion)]      
+      - name: ob_outputDirectory
+        value: '$(REPOROOT)\out'
+      - name: ob_sdl_codeSignValidation_excludes
+        value: '-|**\Release\**;-|**\packages\**'
+      - name: ob_artifactBaseName
+        value: "FoundationBinaries_$(buildConfiguration)_$(buildPlatform)"
+      - name: ob_sdl_apiscan_enabled
+        ${{ if parameters.runStaticAnalysis }}:
+          value: true
+        ${{ else }}:
+          value: false
+      - name: ob_sdl_apiscan_softwareFolder
+        value: '$(build.SourcesDirectory)\APIScanTarget'
+      - name: ob_sdl_apiscan_symbolsFolder
+        value: '$(build.SourcesDirectory)\APIScanTarget;SRV*https://symweb.azurefd.net'
+      - ${{ if contains(variables['Build.SourceBranch'], 'user') }}:
+        # If this pipeline run is targetting a developer's private branch, most of the time there is no
+        # corresponding private branch on the Agg repo. Therefore, by default, map to the Main branch on
+        # the Agg repo to avoid a "file not found" error. 
+        # In the uncommon case that the developer means to target the corresponding private branch on the
+        # Agg repo, change WindowsAppSDKAggregatorMainBranch to WindowsAppSDKAggregatorSourceBranch below.
+        - template: build/AzurePipelinesTemplates/WindowsAppSDK-Global-LKGVersions.yml@WindowsAppSDKAggregatorMainBranch
+      - ${{ elseif and(startsWith(variables['Build.SourceBranch'], 'refs/heads/release'), not(or(startsWith(variables['Build.SourceBranch'], 'refs/heads/release-1.0'), startsWith(variables['Build.SourceBranch'], 'refs/heads/release-1.1'), startsWith(variables['Build.SourceBranch'], 'refs/heads/release-1.2'), startsWith(variables['Build.SourceBranch'], 'refs/heads/release-1.3'), startsWith(variables['Build.SourceBranch'], 'refs/heads/release-1.4'), startsWith(variables['Build.SourceBranch'], 'refs/heads/release-1.5'), startsWith(variables['Build.SourceBranch'], 'refs/heads/release-1.6'), startsWith(variables['Build.SourceBranch'], 'refs/heads/release-1.7')))) }}:    
+        # If this pipeline run is targetting a servicing branch which is new enough (1.8+), then we expect
+        # the file WindowsAppSDK-Global-LKGVersions.yml to exists on the Agg repo in the corresponding 
+        # branch, so target the corresponding branch on the Agg repo.
+        - template: build/AzurePipelinesTemplates/WindowsAppSDK-Global-LKGVersions.yml@WindowsAppSDKAggregatorSourceBranch
+      - ${{ else }}:
+        # If this pipeline run is targetting the Main branch, a Pull Request branch (e.g., refs/pull/12460423/merge),
+        # or some other unexpected branch, target the Main branch on the Agg repo by default.
+        - template: build/AzurePipelinesTemplates/WindowsAppSDK-Global-LKGVersions.yml@WindowsAppSDKAggregatorMainBranch
+      - name: localCompilerOverridePackageName
+        value: $[coalesce(variables.compilerOverridePackageName, variables.global_CompilerOverridePackageName)]
+      - name: localCompilerOverridePackageVersion
+        value: $[coalesce(variables.compilerOverridePackageVersion, variables.global_CompilerOverridePackageVersion)]
     steps:
+    # In case we picked the wrong branch for the Agg repo in the variables section above, this helps diagnose that problem.
+    - script: |
+        echo Build.SourceBranch=$(Build.SourceBranch)
+        echo compilerOverridePackageName=$(compilerOverridePackageName)
+        echo compilerOverridePackageVersion=$(compilerOverridePackageVersion)
+        echo global_CompilerOverridePackageName=$(global_CompilerOverridePackageName)
+        echo global_CompilerOverridePackageVersion=$(global_CompilerOverridePackageVersion)
+        echo localCompilerOverridePackageName=$(localCompilerOverridePackageName)
+        echo localCompilerOverridePackageVersion=$(localCompilerOverridePackageVersion)
+
     - template: WindowsAppSDK-BuildFoundation-Steps.yml@self
       parameters:
         SignOutput: ${{ parameters.SignOutput }}
@@ -130,17 +164,54 @@ stages:
           buildConfiguration: 'Release'
           normalizedConfiguration: 'fre'
     variables:
-      ob_outputDirectory: '$(REPOROOT)\out'
-      ob_sdl_codeSignValidation_excludes: '-|**\Release\**'
-      ob_sdl_suppression_suppressionSet: default
-      ob_artifactBaseName: "MrtBinaries_$(buildConfiguration)_$(buildPlatform)"
-      ${{ if parameters.runStaticAnalysis }}:
-        ob_sdl_apiscan_enabled: true
-      ${{ if not( parameters.runStaticAnalysis ) }}:
-        ob_sdl_apiscan_enabled: false
-      ob_sdl_apiscan_softwareFolder: '$(build.SourcesDirectory)\APIScanTarget'
-      ob_sdl_apiscan_symbolsFolder: '$(build.SourcesDirectory)\APIScanTarget;SRV*https://symweb.azurefd.net'
+      - name: ob_outputDirectory
+        value: '$(REPOROOT)\out'
+      - name: ob_sdl_codeSignValidation_excludes
+        value: '-|**\Release\**'
+      - name: ob_sdl_suppression_suppressionSet
+        value: default
+      - name: ob_artifactBaseName
+        value: "MrtBinaries_$(buildConfiguration)_$(buildPlatform)"
+      - name: ob_sdl_apiscan_enabled
+        ${{ if parameters.runStaticAnalysis }}
+          value: true
+        ${{ else }}:
+          value: false
+      - name: ob_sdl_apiscan_softwareFolder
+        value: '$(build.SourcesDirectory)\APIScanTarget'
+      - name: ob_sdl_apiscan_symbolsFolder
+        value: '$(build.SourcesDirectory)\APIScanTarget;SRV*https://symweb.azurefd.net'
+      - ${{ if contains(variables['Build.SourceBranch'], 'user') }}:
+        # If this pipeline run is targetting a developer's private branch, most of the time there is no
+        # corresponding private branch on the Agg repo. Therefore, by default, map to the Main branch on
+        # the Agg repo to avoid a "file not found" error. 
+        # In the uncommon case that the developer means to target the corresponding private branch on the
+        # Agg repo, change WindowsAppSDKAggregatorMainBranch to WindowsAppSDKAggregatorSourceBranch below.
+        - template: build/AzurePipelinesTemplates/WindowsAppSDK-Global-LKGVersions.yml@WindowsAppSDKAggregatorMainBranch
+      - ${{ elseif and(startsWith(variables['Build.SourceBranch'], 'refs/heads/release'), not(or(startsWith(variables['Build.SourceBranch'], 'refs/heads/release-1.0'), startsWith(variables['Build.SourceBranch'], 'refs/heads/release-1.1'), startsWith(variables['Build.SourceBranch'], 'refs/heads/release-1.2'), startsWith(variables['Build.SourceBranch'], 'refs/heads/release-1.3'), startsWith(variables['Build.SourceBranch'], 'refs/heads/release-1.4'), startsWith(variables['Build.SourceBranch'], 'refs/heads/release-1.5'), startsWith(variables['Build.SourceBranch'], 'refs/heads/release-1.6'), startsWith(variables['Build.SourceBranch'], 'refs/heads/release-1.7')))) }}:    
+        # If this pipeline run is targetting a servicing branch which is new enough (1.8+), then we expect
+        # the file WindowsAppSDK-Global-LKGVersions.yml to exists on the Agg repo in the corresponding 
+        # branch, so target the corresponding branch on the Agg repo.
+        - template: build/AzurePipelinesTemplates/WindowsAppSDK-Global-LKGVersions.yml@WindowsAppSDKAggregatorSourceBranch
+      - ${{ else }}:
+        # If this pipeline run is targetting the Main branch, a Pull Request branch (e.g., refs/pull/12460423/merge),
+        # or some other unexpected branch, target the Main branch on the Agg repo by default.
+        - template: build/AzurePipelinesTemplates/WindowsAppSDK-Global-LKGVersions.yml@WindowsAppSDKAggregatorMainBranch
+      - name: localCompilerOverridePackageName
+        value: $[coalesce(variables.compilerOverridePackageName, variables.global_CompilerOverridePackageName)]
+      - name: localCompilerOverridePackageVersion
+        value: $[coalesce(variables.compilerOverridePackageVersion, variables.global_CompilerOverridePackageVersion)]
     steps:
+    # In case we picked the wrong branch for the Agg repo in the variables section above, this helps diagnose that problem.
+    - script: |
+        echo Build.SourceBranch=$(Build.SourceBranch)
+        echo compilerOverridePackageName=$(compilerOverridePackageName)
+        echo compilerOverridePackageVersion=$(compilerOverridePackageVersion)
+        echo global_CompilerOverridePackageName=$(global_CompilerOverridePackageName)
+        echo global_CompilerOverridePackageVersion=$(global_CompilerOverridePackageVersion)
+        echo localCompilerOverridePackageName=$(localCompilerOverridePackageName)
+        echo localCompilerOverridePackageVersion=$(localCompilerOverridePackageVersion)
+        
     - template: WindowsAppSDK-BuildMRT-Steps.yml@self
       parameters:
         SignOutput: ${{ parameters.SignOutput }}

--- a/build/AzurePipelinesTemplates/WindowsAppSDK-Build-Stage.yml
+++ b/build/AzurePipelinesTemplates/WindowsAppSDK-Build-Stage.yml
@@ -173,7 +173,7 @@ stages:
       - name: ob_artifactBaseName
         value: "MrtBinaries_$(buildConfiguration)_$(buildPlatform)"
       - name: ob_sdl_apiscan_enabled
-        ${{ if parameters.runStaticAnalysis }}
+        ${{ if parameters.runStaticAnalysis }}:
           value: true
         ${{ else }}:
           value: false

--- a/build/AzurePipelinesTemplates/WindowsAppSDK-Build-Stage.yml
+++ b/build/AzurePipelinesTemplates/WindowsAppSDK-Build-Stage.yml
@@ -79,7 +79,7 @@ stages:
         # In the uncommon case that the developer means to target the corresponding private branch on the
         # Agg repo, change WindowsAppSDKAggregatorMainBranch to WindowsAppSDKAggregatorSourceBranch below.
         - template: build/AzurePipelinesTemplates/WindowsAppSDK-Global-LKGVersions.yml@WindowsAppSDKAggregatorMainBranch
-      - ${{ elseif and(startsWith(variables['Build.SourceBranch'], 'refs/heads/release'), not(or(startsWith(variables['Build.SourceBranch'], 'refs/heads/release-1.0'), startsWith(variables['Build.SourceBranch'], 'refs/heads/release-1.1'), startsWith(variables['Build.SourceBranch'], 'refs/heads/release-1.2'), startsWith(variables['Build.SourceBranch'], 'refs/heads/release-1.3'), startsWith(variables['Build.SourceBranch'], 'refs/heads/release-1.4'), startsWith(variables['Build.SourceBranch'], 'refs/heads/release-1.5'), startsWith(variables['Build.SourceBranch'], 'refs/heads/release-1.6'), startsWith(variables['Build.SourceBranch'], 'refs/heads/release-1.7')))) }}:    
+      - ${{ elseif and(startsWith(variables['Build.SourceBranch'], 'refs/heads/release'), not(startsWith(variables['Build.SourceBranch'], 'refs/heads/release-1.7'))) }}:    
         # If this pipeline run is targetting a servicing branch which is new enough (1.8+), then we expect
         # the file WindowsAppSDK-Global-LKGVersions.yml to exists on the Agg repo in the corresponding 
         # branch, so target the corresponding branch on the Agg repo.

--- a/build/AzurePipelinesTemplates/WindowsAppSDK-Build-Stage.yml
+++ b/build/AzurePipelinesTemplates/WindowsAppSDK-Build-Stage.yml
@@ -66,6 +66,8 @@ stages:
         ob_sdl_apiscan_enabled: false
       ob_sdl_apiscan_softwareFolder: '$(build.SourcesDirectory)\APIScanTarget'
       ob_sdl_apiscan_symbolsFolder: '$(build.SourcesDirectory)\APIScanTarget;SRV*https://symweb.azurefd.net'
+      localCompilerOverridePackageName: $[coalesce(variables.compilerOverridePackageName, variables.global_CompilerOverridePackageName)]
+      localCompilerOverridePackageVersion: $[coalesce(variables.compilerOverridePackageVersion, variables.global_CompilerOverridePackageVersion)]      
     steps:
     - template: WindowsAppSDK-BuildFoundation-Steps.yml@self
       parameters:

--- a/build/AzurePipelinesTemplates/WindowsAppSDK-BuildFoundation-Steps.yml
+++ b/build/AzurePipelinesTemplates/WindowsAppSDK-BuildFoundation-Steps.yml
@@ -58,8 +58,8 @@ steps:
   displayName: 'Setup native compiler version override'
   inputs:
     microsoftDropReadPat: $(System.AccessToken)
-    compilerPackageName: $(compilerOverridePackageName)
-    compilerPackageVersion: $(compilerOverridePackageVersion)
+    compilerPackageName: $(localCompilerOverridePackageName)
+    compilerPackageVersion: $(localCompilerOverridePackageVersion)
     slnDirectory: $(Build.SourcesDirectory)
     includeUCRT: true
     ucrtFeedPat: $(System.AccessToken)

--- a/build/AzurePipelinesTemplates/WindowsAppSDK-BuildInstaller-Stage.yml
+++ b/build/AzurePipelinesTemplates/WindowsAppSDK-BuildInstaller-Stage.yml
@@ -40,7 +40,7 @@ stages:
         # In the uncommon case that the developer means to target the corresponding private branch on the
         # Agg repo, change WindowsAppSDKAggregatorMainBranch to WindowsAppSDKAggregatorSourceBranch below.
         - template: build/AzurePipelinesTemplates/WindowsAppSDK-Global-LKGVersions.yml@WindowsAppSDKAggregatorMainBranch
-      - ${{ elseif and(startsWith(variables['Build.SourceBranch'], 'refs/heads/release'), not(or(startsWith(variables['Build.SourceBranch'], 'refs/heads/release-1.0'), startsWith(variables['Build.SourceBranch'], 'refs/heads/release-1.1'), startsWith(variables['Build.SourceBranch'], 'refs/heads/release-1.2'), startsWith(variables['Build.SourceBranch'], 'refs/heads/release-1.3'), startsWith(variables['Build.SourceBranch'], 'refs/heads/release-1.4'), startsWith(variables['Build.SourceBranch'], 'refs/heads/release-1.5'), startsWith(variables['Build.SourceBranch'], 'refs/heads/release-1.6'), startsWith(variables['Build.SourceBranch'], 'refs/heads/release-1.7')))) }}:    
+      - ${{ elseif and(startsWith(variables['Build.SourceBranch'], 'refs/heads/release'), not(startsWith(variables['Build.SourceBranch'], 'refs/heads/release-1.7'))) }}:    
         # If this pipeline run is targetting a servicing branch which is new enough (1.8+), then we expect
         # the file WindowsAppSDK-Global-LKGVersions.yml to exists on the Agg repo in the corresponding 
         # branch, so target the corresponding branch on the Agg repo.

--- a/build/AzurePipelinesTemplates/WindowsAppSDK-BuildInstaller-Stage.yml
+++ b/build/AzurePipelinesTemplates/WindowsAppSDK-BuildInstaller-Stage.yml
@@ -29,6 +29,8 @@ stages:
       # foundationRepoPath should be empty because we are not doing multiple checkouts hence
       # it is not under $(Build.SourcesDirectory)\WindowsAppSDK
       foundationRepoPath: ""
+      localCompilerOverridePackageName: $[coalesce(variables.compilerOverridePackageName, variables.global_CompilerOverridePackageName)]
+      localCompilerOverridePackageVersion: $[coalesce(variables.compilerOverridePackageVersion, variables.global_CompilerOverridePackageVersion)]
     condition: ne(variables.LatestOfficialBuildID, '')
     steps:
     - template: WindowsAppSDK-BuildInstaller-Steps.yml@self

--- a/build/AzurePipelinesTemplates/WindowsAppSDK-BuildInstaller-Stage.yml
+++ b/build/AzurePipelinesTemplates/WindowsAppSDK-BuildInstaller-Stage.yml
@@ -23,14 +23,46 @@ stages:
           buildPlatform: 'arm64'
           buildConfiguration: 'Release'
     variables:
-      ob_outputDirectory: '$(REPOROOT)\out'
-      ob_artifactSuffix: '_$(buildConfiguration)_$(buildPlatform)'
-      ob_artifactBaseName: "Installer$(ob_artifactSuffix)"
+      - name: ob_outputDirectory
+        value: '$(REPOROOT)\out'
+      - name: ob_artifactSuffix
+        value: '_$(buildConfiguration)_$(buildPlatform)'
+      - name: ob_artifactBaseName
+        value: "Installer$(ob_artifactSuffix)"
       # foundationRepoPath should be empty because we are not doing multiple checkouts hence
       # it is not under $(Build.SourcesDirectory)\WindowsAppSDK
-      foundationRepoPath: ""
-      localCompilerOverridePackageName: $[coalesce(variables.compilerOverridePackageName, variables.global_CompilerOverridePackageName)]
-      localCompilerOverridePackageVersion: $[coalesce(variables.compilerOverridePackageVersion, variables.global_CompilerOverridePackageVersion)]
+      - name: foundationRepoPath
+        value: ""
+      - ${{ if contains(variables['Build.SourceBranch'], 'user') }}:
+        # If this pipeline run is targetting a developer's private branch, most of the time there is no
+        # corresponding private branch on the Agg repo. Therefore, by default, map to the Main branch on
+        # the Agg repo to avoid a "file not found" error. 
+        # In the uncommon case that the developer means to target the corresponding private branch on the
+        # Agg repo, change WindowsAppSDKAggregatorMainBranch to WindowsAppSDKAggregatorSourceBranch below.
+        - template: build/AzurePipelinesTemplates/WindowsAppSDK-Global-LKGVersions.yml@WindowsAppSDKAggregatorMainBranch
+      - ${{ elseif and(startsWith(variables['Build.SourceBranch'], 'refs/heads/release'), not(or(startsWith(variables['Build.SourceBranch'], 'refs/heads/release-1.0'), startsWith(variables['Build.SourceBranch'], 'refs/heads/release-1.1'), startsWith(variables['Build.SourceBranch'], 'refs/heads/release-1.2'), startsWith(variables['Build.SourceBranch'], 'refs/heads/release-1.3'), startsWith(variables['Build.SourceBranch'], 'refs/heads/release-1.4'), startsWith(variables['Build.SourceBranch'], 'refs/heads/release-1.5'), startsWith(variables['Build.SourceBranch'], 'refs/heads/release-1.6'), startsWith(variables['Build.SourceBranch'], 'refs/heads/release-1.7')))) }}:    
+        # If this pipeline run is targetting a servicing branch which is new enough (1.8+), then we expect
+        # the file WindowsAppSDK-Global-LKGVersions.yml to exists on the Agg repo in the corresponding 
+        # branch, so target the corresponding branch on the Agg repo.
+        - template: build/AzurePipelinesTemplates/WindowsAppSDK-Global-LKGVersions.yml@WindowsAppSDKAggregatorSourceBranch
+      - ${{ else }}:
+        # If this pipeline run is targetting the Main branch, a Pull Request branch (e.g., refs/pull/12460423/merge),
+        # or some other unexpected branch, target the Main branch on the Agg repo by default.
+        - template: build/AzurePipelinesTemplates/WindowsAppSDK-Global-LKGVersions.yml@WindowsAppSDKAggregatorMainBranch
+      - name: localCompilerOverridePackageName
+        value: $[coalesce(variables.compilerOverridePackageName, variables.global_CompilerOverridePackageName)]
+      - name: localCompilerOverridePackageVersion
+        value: $[coalesce(variables.compilerOverridePackageVersion, variables.global_CompilerOverridePackageVersion)]
     condition: ne(variables.LatestOfficialBuildID, '')
     steps:
+    # In case we picked the wrong branch for the Agg repo in the variables section above, this helps diagnose that problem.
+    - script: |
+        echo Build.SourceBranch=$(Build.SourceBranch)
+        echo compilerOverridePackageName=$(compilerOverridePackageName)
+        echo compilerOverridePackageVersion=$(compilerOverridePackageVersion)
+        echo global_CompilerOverridePackageName=$(global_CompilerOverridePackageName)
+        echo global_CompilerOverridePackageVersion=$(global_CompilerOverridePackageVersion)
+        echo localCompilerOverridePackageName=$(localCompilerOverridePackageName)
+        echo localCompilerOverridePackageVersion=$(localCompilerOverridePackageVersion)
+
     - template: WindowsAppSDK-BuildInstaller-Steps.yml@self

--- a/build/AzurePipelinesTemplates/WindowsAppSDK-BuildInstaller-Steps.yml
+++ b/build/AzurePipelinesTemplates/WindowsAppSDK-BuildInstaller-Steps.yml
@@ -199,8 +199,8 @@ steps:
   displayName: 'Setup native compiler version override'
   inputs:
     microsoftDropReadPat: $(System.AccessToken)
-    compilerPackageName: $(compilerOverridePackageName)
-    compilerPackageVersion: $(compilerOverridePackageVersion)
+    compilerPackageName: $(localCompilerOverridePackageName)
+    compilerPackageVersion: $(localCompilerOverridePackageVersion)
     slnDirectory: $(Build.SourcesDirectory)\$(foundationRepoPath)installer\dev
     includeUCRT: true
     ucrtFeedPat: $(System.AccessToken)

--- a/build/AzurePipelinesTemplates/WindowsAppSDK-BuildMRT-Steps.yml
+++ b/build/AzurePipelinesTemplates/WindowsAppSDK-BuildMRT-Steps.yml
@@ -18,8 +18,8 @@ steps:
   displayName: 'Setup native compiler version override'
   inputs:
     microsoftDropReadPat: $(System.AccessToken)
-    compilerPackageName: $(compilerOverridePackageName)
-    compilerPackageVersion: $(compilerOverridePackageVersion)
+    compilerPackageName: $(localCompilerOverridePackageName)
+    compilerPackageVersion: $(localCompilerOverridePackageVersion)
     slnDirectory: $(Build.SourcesDirectory)\dev\MRTCore\mrt
     includeUCRT: true
     ucrtFeedPat: $(System.AccessToken)

--- a/build/ProjectReunion-BuildFoundation.yml
+++ b/build/ProjectReunion-BuildFoundation.yml
@@ -11,11 +11,16 @@ resources:
       type: git
       name: ProjectReunion/WindowsAppSDKConfig
       ref: refs/heads/main
-
+    - repository: WindowsAppSDKAggregator
+      type: git
+      name: ProjectReunion/WindowsAppSDKAggregator
+      ref: ${{ variables['Build.SourceBranch'] }}
+      
 variables:
 - template: WindowsAppSDK-Versions.yml
 - template: WindowsAppSDK-CommonVariables.yml
 - template: WindowsAppSDK-Foundation-TestConfig.yml@WindowsAppSDKConfig
+- template: build/AzurePipelinesTemplates/WindowsAppSDK-Global-LKGVersions.yml@WindowsAppSDKAggregator
 
 stages:
 - template: AzurePipelinesTemplates\WindowsAppSDK-BuildInstaller-Stage.yml@self

--- a/build/ProjectReunion-BuildFoundation.yml
+++ b/build/ProjectReunion-BuildFoundation.yml
@@ -24,10 +24,6 @@ resources:
       type: git
       name: ProjectReunion/WindowsAppSDKConfig
       ref: refs/heads/main
-    - repository: WindowsAppSDKAggregator
-      type: git
-      name: ProjectReunion/WindowsAppSDKAggregator
-      ref: ${{ variables['Build.SourceBranch'] }}
     # Depending on the settings of this pipeline run, we will use exactly one of the following two definitions for the Agg repo.
     # Either we reference the Main branch, or the same branch as the branch that this pipeline is currently being run against.
     - repository: WindowsAppSDKAggregatorSourceBranch

--- a/build/ProjectReunion-BuildFoundation.yml
+++ b/build/ProjectReunion-BuildFoundation.yml
@@ -5,6 +5,19 @@ name: $(version)
 
 trigger: none
 
+variables:
+- template: WindowsAppSDK-Versions.yml
+- template: WindowsAppSDK-CommonVariables.yml
+- template: WindowsAppSDK-Foundation-TestConfig.yml@WindowsAppSDKConfig
+# If we pass ${{ variables['Build.SourceBranch'] }} directly to ref: below, then in a PR validation pipeline run scenario,
+# there will be an error parsing the resources->repositories->repository->WindowsAppSDKAggregatorSourceBranch because 
+# the branch Build.SourceBranch does not exist on the Agg repo. Avoid hitting that error by redirecting to the Main branch.
+- name: mySourceBranch
+  ${{ if eq(variables['Build.Reason'], 'PullRequest') }}:
+    value: refs/heads/main
+  ${{ else }}:
+    value: ${{ variables['Build.SourceBranch'] }}
+
 resources:
   repositories:
     - repository: WindowsAppSDKConfig
@@ -15,12 +28,16 @@ resources:
       type: git
       name: ProjectReunion/WindowsAppSDKAggregator
       ref: ${{ variables['Build.SourceBranch'] }}
-      
-variables:
-- template: WindowsAppSDK-Versions.yml
-- template: WindowsAppSDK-CommonVariables.yml
-- template: WindowsAppSDK-Foundation-TestConfig.yml@WindowsAppSDKConfig
-- template: build/AzurePipelinesTemplates/WindowsAppSDK-Global-LKGVersions.yml@WindowsAppSDKAggregator
+    # Depending on the settings of this pipeline run, we will use exactly one of the following two definitions for the Agg repo.
+    # Either we reference the Main branch, or the same branch as the branch that this pipeline is currently being run against.
+    - repository: WindowsAppSDKAggregatorSourceBranch
+      type: git
+      name: ProjectReunion/WindowsAppSDKAggregator
+      ref: ${{ variables['mySourceBranch'] }}
+    - repository: WindowsAppSDKAggregatorMainBranch
+      type: git
+      name: ProjectReunion/WindowsAppSDKAggregator
+      ref: refs/heads/main
 
 stages:
 - template: AzurePipelinesTemplates\WindowsAppSDK-BuildInstaller-Stage.yml@self

--- a/build/ProjectReunion-CI.yml
+++ b/build/ProjectReunion-CI.yml
@@ -1,19 +1,32 @@
 # see https://docs.microsoft.com/azure/devops/pipelines/process/phases for info on yaml ADO jobs
 name: $(version)
 
-resources:
-  repositories:
-    - repository: WindowsAppSDKAggregator
-      type: git
-      name: ProjectReunion/WindowsAppSDKAggregator
-      ref: ${{ variables['Build.SourceBranch'] }}
-
 variables:
-- template: build/AzurePipelinesTemplates/WindowsAppSDK-Global-LKGVersions.yml@WindowsAppSDKAggregator
 - template: WindowsAppSDK-Versions.yml
 - template: WindowsAppSDK-CommonVariables.yml
 - name: buildOutputDir
   value: $(Build.SourcesDirectory)\BuildOutput
+# If we pass ${{ variables['Build.SourceBranch'] }} directly to ref: below, then in a PR validation pipeline run scenario,
+# there will be an error parsing the resources->repositories->repository->WindowsAppSDKAggregatorSourceBranch because 
+# the branch Build.SourceBranch does not exist on the Agg repo. Avoid hitting that error by redirecting to the Main branch.
+- name: mySourceBranch
+  ${{ if eq(variables['Build.Reason'], 'PullRequest') }}:
+    value: refs/heads/main
+  ${{ else }}:
+    value: ${{ variables['Build.SourceBranch'] }}
+
+resources:
+  repositories:
+    # Depending on the settings of this pipeline run, we will use exactly one of the following two definitions for the Agg repo.
+    # Either we reference the Main branch, or the same branch as the branch that this pipeline is currently being run against.
+    - repository: WindowsAppSDKAggregatorSourceBranch
+      type: git
+      name: ProjectReunion/WindowsAppSDKAggregator
+      ref: ${{ variables['mySourceBranch'] }}
+    - repository: WindowsAppSDKAggregatorMainBranch
+      type: git
+      name: ProjectReunion/WindowsAppSDKAggregator
+      ref: refs/heads/main
 
 jobs:
 - job: PreChecks

--- a/build/ProjectReunion-CI.yml
+++ b/build/ProjectReunion-CI.yml
@@ -1,7 +1,15 @@
 # see https://docs.microsoft.com/azure/devops/pipelines/process/phases for info on yaml ADO jobs
 name: $(version)
 
+resources:
+  repositories:
+    - repository: WindowsAppSDKAggregator
+      type: git
+      name: ProjectReunion/WindowsAppSDKAggregator
+      ref: ${{ variables['Build.SourceBranch'] }}
+
 variables:
+- template: build/AzurePipelinesTemplates/WindowsAppSDK-Global-LKGVersions.yml@WindowsAppSDKAggregator
 - template: WindowsAppSDK-Versions.yml
 - template: WindowsAppSDK-CommonVariables.yml
 - name: buildOutputDir

--- a/build/WindowsAppSDK-CommonVariables.yml
+++ b/build/WindowsAppSDK-CommonVariables.yml
@@ -19,10 +19,14 @@ variables:
 
   # Native compiler version override for win undock. The two values below are for Ge, defined in:
   # https://dev.azure.com/microsoft/OS/_git/UndockedES?path=/Pipelines/Config/CompilerToolsSettings.json
-  compilerOverridePackageName: "DevDiv.rel.LKG18.VCTools"
-  compilerOverridePackageVersion: "19.42.3443710001+DevDivGIT.CI20250110.04-466784EE54DF2F302AD0CD6790031C954EF41DA23DA4415D73A76ADF260F2D21"
+  # Normally, the 3 variables below should remain null, so that we resort to using the corresponding global_compilerOverride* 
+  # values for compiling native code. Another legitimate scenario is to point all 3 variables below to a different LKG compiler
+  # version, say, for working around a problem with the LKG compiler pointed at by the corresponding global_compilerOverride* 
+  # values, for compiling native code.
+  compilerOverridePackageName: ""
+  compilerOverridePackageVersion: ""
   # Use the following corresponding version string instead of the above when calling nuget install directly.
-  compilerOverrideNupkgVersion: "19.42.34437100"
+  compilerOverrideNupkgVersion: ""
 
   # Docker image which is used to build the project https://aka.ms/obpipelines/containers
   WindowsContainerImage: 'onebranch.azurecr.io/windows/ltsc2019/vse2022:latest'

--- a/build/WindowsAppSDK-Foundation-Nightly.yml
+++ b/build/WindowsAppSDK-Foundation-Nightly.yml
@@ -44,11 +44,16 @@ resources:
       type: git
       name: ProjectReunion/WindowsAppSDKConfig
       ref: refs/heads/main
-
+    - repository: WindowsAppSDKAggregator
+      type: git
+      name: ProjectReunion/WindowsAppSDKAggregator
+      ref: ${{ variables['Build.SourceBranch'] }}
+      
 variables:
 - template: WindowsAppSDK-Versions.yml
 - template: WindowsAppSDK-CommonVariables.yml
 - template: WindowsAppSDK-Foundation-TestConfig.yml@WindowsAppSDKConfig
+- template: build/AzurePipelinesTemplates/WindowsAppSDK-Global-LKGVersions.yml@WindowsAppSDKAggregator
 
 extends:
   template: v2/Microsoft.NonOfficial.yml@templates # https://aka.ms/obpipelines/templates

--- a/build/WindowsAppSDK-Foundation-Nightly.yml
+++ b/build/WindowsAppSDK-Foundation-Nightly.yml
@@ -34,6 +34,19 @@ parameters:
   type: boolean
   default: true
 
+variables:
+- template: WindowsAppSDK-Versions.yml
+- template: WindowsAppSDK-CommonVariables.yml
+- template: WindowsAppSDK-Foundation-TestConfig.yml@WindowsAppSDKConfig
+# If we pass ${{ variables['Build.SourceBranch'] }} directly to ref: below, then in a PR validation pipeline run scenario,
+# there will be an error parsing the resources->repositories->repository->WindowsAppSDKAggregatorSourceBranch because 
+# the branch Build.SourceBranch does not exist on the Agg repo. Avoid hitting that error by redirecting to the Main branch.
+- name: mySourceBranch
+  ${{ if eq(variables['Build.Reason'], 'PullRequest') }}:
+    value: refs/heads/main
+  ${{ else }}:
+    value: ${{ variables['Build.SourceBranch'] }}
+
 resources:
   repositories:
     - repository: templates
@@ -44,16 +57,16 @@ resources:
       type: git
       name: ProjectReunion/WindowsAppSDKConfig
       ref: refs/heads/main
-    - repository: WindowsAppSDKAggregator
+    # Depending on the settings of this pipeline run, we will use exactly one of the following two definitions for the Agg repo.
+    # Either we reference the Main branch, or the same branch as the branch that this pipeline is currently being run against.
+    - repository: WindowsAppSDKAggregatorSourceBranch
       type: git
       name: ProjectReunion/WindowsAppSDKAggregator
-      ref: ${{ variables['Build.SourceBranch'] }}
-      
-variables:
-- template: WindowsAppSDK-Versions.yml
-- template: WindowsAppSDK-CommonVariables.yml
-- template: WindowsAppSDK-Foundation-TestConfig.yml@WindowsAppSDKConfig
-- template: build/AzurePipelinesTemplates/WindowsAppSDK-Global-LKGVersions.yml@WindowsAppSDKAggregator
+      ref: ${{ variables['mySourceBranch'] }}
+    - repository: WindowsAppSDKAggregatorMainBranch
+      type: git
+      name: ProjectReunion/WindowsAppSDKAggregator
+      ref: refs/heads/main
 
 extends:
   template: v2/Microsoft.NonOfficial.yml@templates # https://aka.ms/obpipelines/templates

--- a/build/WindowsAppSDK-Foundation-Official.yml
+++ b/build/WindowsAppSDK-Foundation-Official.yml
@@ -44,11 +44,16 @@ resources:
       type: git
       name: ProjectReunion/WindowsAppSDKConfig
       ref: refs/heads/main
+    - repository: WindowsAppSDKAggregator
+      type: git
+      name: ProjectReunion/WindowsAppSDKAggregator
+      ref: ${{ variables['Build.SourceBranch'] }}
 
 variables:
 - template: WindowsAppSDK-Versions.yml
 - template: WindowsAppSDK-CommonVariables.yml
 - template: WindowsAppSDK-Foundation-TestConfig.yml@WindowsAppSDKConfig
+- template: build/AzurePipelinesTemplates/WindowsAppSDK-Global-LKGVersions.yml@WindowsAppSDKAggregator
 
 extends:
   template: v2/Microsoft.Official.yml@templates # https://aka.ms/obpipelines/templates

--- a/build/WindowsAppSDK-Foundation-Official.yml
+++ b/build/WindowsAppSDK-Foundation-Official.yml
@@ -34,6 +34,19 @@ parameters:
   type: boolean
   default: true
 
+variables:
+- template: WindowsAppSDK-Versions.yml
+- template: WindowsAppSDK-CommonVariables.yml
+- template: WindowsAppSDK-Foundation-TestConfig.yml@WindowsAppSDKConfig
+# If we pass ${{ variables['Build.SourceBranch'] }} directly to ref: below, then in a PR validation pipeline run scenario,
+# there will be an error parsing the resources->repositories->repository->WindowsAppSDKAggregatorSourceBranch because 
+# the branch Build.SourceBranch does not exist on the Agg repo. Avoid hitting that error by redirecting to the Main branch.
+- name: mySourceBranch
+  ${{ if eq(variables['Build.Reason'], 'PullRequest') }}:
+    value: refs/heads/main
+  ${{ else }}:
+    value: ${{ variables['Build.SourceBranch'] }}
+
 resources:
   repositories:
     - repository: templates
@@ -44,16 +57,16 @@ resources:
       type: git
       name: ProjectReunion/WindowsAppSDKConfig
       ref: refs/heads/main
-    - repository: WindowsAppSDKAggregator
+    # Depending on the settings of this pipeline run, we will use exactly one of the following two definitions for the Agg repo.
+    # Either we reference the Main branch, or the same branch as the branch that this pipeline is currently being run against.
+    - repository: WindowsAppSDKAggregatorSourceBranch
       type: git
       name: ProjectReunion/WindowsAppSDKAggregator
-      ref: ${{ variables['Build.SourceBranch'] }}
-
-variables:
-- template: WindowsAppSDK-Versions.yml
-- template: WindowsAppSDK-CommonVariables.yml
-- template: WindowsAppSDK-Foundation-TestConfig.yml@WindowsAppSDKConfig
-- template: build/AzurePipelinesTemplates/WindowsAppSDK-Global-LKGVersions.yml@WindowsAppSDKAggregator
+      ref: ${{ variables['mySourceBranch'] }}
+    - repository: WindowsAppSDKAggregatorMainBranch
+      type: git
+      name: ProjectReunion/WindowsAppSDKAggregator
+      ref: refs/heads/main
 
 extends:
   template: v2/Microsoft.Official.yml@templates # https://aka.ms/obpipelines/templates

--- a/build/WindowsAppSDK-Foundation-PR.yml
+++ b/build/WindowsAppSDK-Foundation-PR.yml
@@ -35,11 +35,16 @@ resources:
       type: git
       name: ProjectReunion/WindowsAppSDKConfig
       ref: refs/heads/main
+    - repository: WindowsAppSDKAggregator
+      type: git
+      name: ProjectReunion/WindowsAppSDKAggregator
+      ref: ${{ variables['Build.SourceBranch'] }}
 
 variables:
 - template: WindowsAppSDK-Versions.yml
 - template: WindowsAppSDK-CommonVariables.yml
 - template: WindowsAppSDK-Foundation-TestConfig.yml@WindowsAppSDKConfig
+- template: build/AzurePipelinesTemplates/WindowsAppSDK-Global-LKGVersions.yml@WindowsAppSDKAggregator
 
 extends:
   template: v2/Microsoft.NonOfficial.yml@templates # https://aka.ms/obpipelines/templates

--- a/build/WindowsAppSDK-Foundation-PR.yml
+++ b/build/WindowsAppSDK-Foundation-PR.yml
@@ -25,6 +25,19 @@ parameters: # parameters are shown up in ADO UI in a build queue time
   type: boolean
   default: true
 
+variables:
+- template: WindowsAppSDK-Versions.yml
+- template: WindowsAppSDK-CommonVariables.yml
+- template: WindowsAppSDK-Foundation-TestConfig.yml@WindowsAppSDKConfig
+# If we pass ${{ variables['Build.SourceBranch'] }} directly to ref: below, then in a PR validation pipeline run scenario,
+# there will be an error parsing the resources->repositories->repository->WindowsAppSDKAggregatorSourceBranch because 
+# the branch Build.SourceBranch does not exist on the Agg repo. Avoid hitting that error by redirecting to the Main branch.
+- name: mySourceBranch
+  ${{ if eq(variables['Build.Reason'], 'PullRequest') }}:
+    value: refs/heads/main
+  ${{ else }}:
+    value: ${{ variables['Build.SourceBranch'] }}
+
 resources:
   repositories:
     - repository: templates
@@ -35,16 +48,16 @@ resources:
       type: git
       name: ProjectReunion/WindowsAppSDKConfig
       ref: refs/heads/main
-    - repository: WindowsAppSDKAggregator
+    # Depending on the settings of this pipeline run, we will use exactly one of the following two definitions for the Agg repo.
+    # Either we reference the Main branch, or the same branch as the branch that this pipeline is currently being run against.
+    - repository: WindowsAppSDKAggregatorSourceBranch
       type: git
       name: ProjectReunion/WindowsAppSDKAggregator
-      ref: ${{ variables['Build.SourceBranch'] }}
-
-variables:
-- template: WindowsAppSDK-Versions.yml
-- template: WindowsAppSDK-CommonVariables.yml
-- template: WindowsAppSDK-Foundation-TestConfig.yml@WindowsAppSDKConfig
-- template: build/AzurePipelinesTemplates/WindowsAppSDK-Global-LKGVersions.yml@WindowsAppSDKAggregator
+      ref: ${{ variables['mySourceBranch'] }}
+    - repository: WindowsAppSDKAggregatorMainBranch
+      type: git
+      name: ProjectReunion/WindowsAppSDKAggregator
+      ref: refs/heads/main
 
 extends:
   template: v2/Microsoft.NonOfficial.yml@templates # https://aka.ms/obpipelines/templates


### PR DESCRIPTION
Use the version of LKG compiler specified by the Agg repo as the global default (file build\AzurePipelinesTemplates\WindowsAppSDK-Global-LKGVersions.yml), unless a different version is specified as a repo-local override (in local file WindowsAppSDK-CommonVariables.yml).

Here's a summary of how the branch being used on this WindowsAppSDK repo determines the branch being used on the Agg repo for accessing the file WindowsAppSDK-Global-LKGVersions.yml:

- WindowsAppSDK : Main --> Agg: Main, this is likely the majority case.
- WindowsAppSDK : release-1.x --> Agg: release-1.x, when x is >= 8, i.e., for servicing branches new enough to support this mechanism, the servicing branch continue to use the LKG compiler version specified by the WindowsAppSDK-Global-LKGVersions.yml file on the Agg repo to build participating feeder repos.
- WindowsAppSDK : release-1.x --> Agg: Main, when x is <8. For those old servicing branches on Agg that don't contain have the WindowsAppSDK-CommonVariables.yml file, redirect to Agg: Main to avoid "file not found" error during yml parsing. At runtime, the local WindowsAppSDK-CommonVariables.yml file on the WindowsAppSDK repo specifies the LKG compiler version to use, ignoring the global default set in the Agg: Main branch.
- WindowsAppSDK : private branch --> Agg: Main, by default. That's because for most private branches on the WindowsAppSDK repo, the developer would not have a corresponding private branch on the Agg repo. But in case the developer does want to use a corresponding private branch on the Agg repo, in the private branch on the WindowsAppSDK repo, changing
build/AzurePipelinesTemplates/WindowsAppSDK-Global-LKGVersions.yml@WindowsAppSDKAggregatorMainBranch to
build/AzurePipelinesTemplates/WindowsAppSDK-Global-LKGVersions.yml@WindowsAppSDKAggregatorSourceBranch should get the desired behavior.

//////////////////////////////////////

A microsoft employee must use /azp run to validate using the pipelines below.

WARNING:
Comments made by azure-pipelines bot maybe inaccurate.
Please see pipeline link to verify that the build is being ran.

For status checks on the main branch, please use TransportPackage-Foundation-PR
(https://microsoft.visualstudio.com/ProjectReunion/_build?definitionId=81063&_a=summary)
and run the build against your PR branch with the default parameters.
