### PR TITLE
Throw right exception in case of CoCreateInstance failure

### DIFF
--- a/dev/WindowsAppRuntime_UniversalBGTaskDLL/Task.cpp
+++ b/dev/WindowsAppRuntime_UniversalBGTaskDLL/Task.cpp
@@ -23,7 +23,7 @@ namespace winrt::Microsoft::Windows::ApplicationModel::Background::UniversalBGTa
         auto lookupobj = values.Lookup(lookupStr);
         winrt::guid comClsId = winrt::unbox_value<winrt::guid>(lookupobj);
 
-        THROW_IF_FAILED(CoCreateInstance(comClsId, nullptr, CLSCTX_LOCAL_SERVER, IID_IBackgroundTask, reinterpret_cast<void**>(m_bgTask.put())));
+        THROW_IF_FAILED(CoCreateInstance(comClsId, nullptr, CLSCTX_LOCAL_SERVER, IID_IBackgroundTask, reinterpret_cast<void**>(&m_bgTask)));
         m_bgTask.Run(taskInstance);
     }
 }

--- a/dev/WindowsAppRuntime_UniversalBGTaskDLL/Task.cpp
+++ b/dev/WindowsAppRuntime_UniversalBGTaskDLL/Task.cpp
@@ -24,6 +24,6 @@ namespace winrt::Microsoft::Windows::ApplicationModel::Background::UniversalBGTa
         winrt::guid comClsId = winrt::unbox_value<winrt::guid>(lookupobj);
 
         THROW_IF_FAILED(CoCreateInstance(comClsId, nullptr, CLSCTX_LOCAL_SERVER, IID_IBackgroundTask, reinterpret_cast<void**>(m_bgTask.put())));
-        m_bgTask->Run(&taskInstance);
+        m_bgTask.Run(taskInstance);
     }
 }

--- a/dev/WindowsAppRuntime_UniversalBGTaskDLL/Task.cpp
+++ b/dev/WindowsAppRuntime_UniversalBGTaskDLL/Task.cpp
@@ -6,6 +6,7 @@
 #if __has_include("Task.g.cpp")
 #include "Task.g.cpp"
 #endif
+#include <wil/result_macros.h>
 
 using namespace winrt;
 using namespace winrt::Windows::ApplicationModel::Background;
@@ -22,8 +23,7 @@ namespace winrt::Microsoft::Windows::ApplicationModel::Background::UniversalBGTa
         auto lookupobj = values.Lookup(lookupStr);
         winrt::guid comClsId = winrt::unbox_value<winrt::guid>(lookupobj);
 
-        winrt::Windows::ApplicationModel::Background::IBackgroundTask bgTask = nullptr;
-        winrt::hresult hr = CoCreateInstance(comClsId, nullptr, CLSCTX_LOCAL_SERVER, IID_IBackgroundTask, reinterpret_cast<void**>(&bgTask));
-        bgTask.Run(taskInstance);
+        THROW_IF_FAILED(CoCreateInstance(comClsId, nullptr, CLSCTX_LOCAL_SERVER, IID_IBackgroundTask, reinterpret_cast<void**>(m_bgTask.put())));
+        m_bgTask->Run(&taskInstance);
     }
 }

--- a/dev/WindowsAppRuntime_UniversalBGTaskDLL/Task.h
+++ b/dev/WindowsAppRuntime_UniversalBGTaskDLL/Task.h
@@ -12,6 +12,7 @@ namespace winrt::Microsoft::Windows::ApplicationModel::Background::UniversalBGTa
         Task() = default;
 
         void Run(winrt::Windows::ApplicationModel::Background::IBackgroundTaskInstance taskInstance);
+        winrt::com_ptr<winrt::Windows::ApplicationModel::Background::IBackgroundTask> m_bgTask = nullptr;
     };
 }
 

--- a/dev/WindowsAppRuntime_UniversalBGTaskDLL/Task.h
+++ b/dev/WindowsAppRuntime_UniversalBGTaskDLL/Task.h
@@ -12,6 +12,7 @@ namespace winrt::Microsoft::Windows::ApplicationModel::Background::UniversalBGTa
         Task() = default;
 
         void Run(winrt::Windows::ApplicationModel::Background::IBackgroundTaskInstance taskInstance);
+    private:
         winrt::com_ptr<winrt::Windows::ApplicationModel::Background::IBackgroundTask> m_bgTask = nullptr;
     };
 }

--- a/dev/WindowsAppRuntime_UniversalBGTaskDLL/Task.h
+++ b/dev/WindowsAppRuntime_UniversalBGTaskDLL/Task.h
@@ -13,7 +13,7 @@ namespace winrt::Microsoft::Windows::ApplicationModel::Background::UniversalBGTa
 
         void Run(winrt::Windows::ApplicationModel::Background::IBackgroundTaskInstance taskInstance);
     private:
-        winrt::com_ptr<winrt::Windows::ApplicationModel::Background::IBackgroundTask> m_bgTask = nullptr;
+        winrt::Windows::ApplicationModel::Background::IBackgroundTask m_bgTask = nullptr;
     };
 }
 


### PR DESCRIPTION
In case `CoCreateInstance` fails, currently backgroundtaskhost process terminates with access violation, this change is to throw the right exception before termination which helps in debugging.
