### PR TITLE
[1.7] 56439870: A/B Containment for EnsurePackage*ReadyAsync()

### DIFF
--- a/dev/PackageManager/API/M.W.M.D.PackageDeploymentManager.cpp
+++ b/dev/PackageManager/API/M.W.M.D.PackageDeploymentManager.cpp
@@ -34,6 +34,8 @@ namespace ABI::Windows::Management::Deployment
 
 #include <IsWindowsVersion.h>
 
+#include "PackageManager.Containment.h"
+
 static_assert(static_cast<int>(winrt::Microsoft::Windows::Management::Deployment::StubPackageOption::Default) == static_cast<int>(winrt::Windows::Management::Deployment::StubPackageOption::Default),
               "winrt::Microsoft::Windows::Management::Deployment::StubPackageOption::Default != winrt::Windows::Management::Deployment::StubPackageOption::Default");
 static_assert(static_cast<int>(winrt::Microsoft::Windows::Management::Deployment::StubPackageOption::InstallFull) == static_cast<int>(winrt::Windows::Management::Deployment::StubPackageOption::InstallFull),

--- a/dev/PackageManager/API/M.W.M.D.PackageDeploymentManager.cpp
+++ b/dev/PackageManager/API/M.W.M.D.PackageDeploymentManager.cpp
@@ -1930,7 +1930,7 @@ namespace winrt::Microsoft::Windows::Management::Deployment::implementation
         activityId = winrt::guid{};
 
         winrt::Microsoft::Windows::Management::Deployment::PackageReadyOrNewerAvailableStatus readyOrNewerStatus{};
-        if (options.RegisterNewerIfAvailable())
+        if (WinAppSdk::Containment::IsChangeEnabled<WINAPPSDK_CHANGEID_56439870>() && options.RegisterNewerIfAvailable())
         {
             // Our caller already verified PackageDeploymentFeature::IsPackageReadyOrNewerAvailable is supported so no need to check again
             readyOrNewerStatus = IsReadyOrNewerAvailable(packageSetItem);

--- a/dev/PackageManager/API/PackageManager.Containment.h
+++ b/dev/PackageManager/API/PackageManager.Containment.h
@@ -1,0 +1,9 @@
+// Copyright (c) Microsoft Corporation and Contributors.
+// Licensed under the MIT License.
+
+#pragma once
+
+#include <FrameworkUdk/Containment.h>
+
+// 56439870: EnsurePackage*ReadyAsync() doesn't register v2 if v1 is registered and caller asks for minVersion=v1
+#define WINAPPSDK_CHANGEID_56439870 56439870, WinAppSDK_1_7_1

--- a/dev/PackageManager/API/PackageManager.vcxitems
+++ b/dev/PackageManager/API/PackageManager.vcxitems
@@ -47,6 +47,7 @@
     <ClInclude Include="$(MSBuildThisFileDirectory)M.W.M.D.StagePackageOptions.h" />
     <ClInclude Include="$(MSBuildThisFileDirectory)MsixPackageManager.h" />
     <ClInclude Include="$(MSBuildThisFileDirectory)PackageDeploymentResolver.h" />
+    <ClInclude Include="$(MSBuildThisFileDirectory)PackageManager.Containment.h" />
   </ItemGroup>
   <ItemGroup>
     <Midl Include="$(MSBuildThisFileDirectory)PackageManager.idl">

--- a/dev/PackageManager/API/PackageManager.vcxitems.filters
+++ b/dev/PackageManager/API/PackageManager.vcxitems.filters
@@ -103,6 +103,9 @@
     <ClInclude Include="$(MSBuildThisFileDirectory)PackageDeploymentResolver.h">
       <Filter>Header Files</Filter>
     </ClInclude>
+    <ClInclude Include="$(MSBuildThisFileDirectory)PackageManager.Containment.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
     <ClInclude Include="$(MSBuildThisFileDirectory)M.W.M.D.RemovePackageOptions.h">
       <Filter>Header Files</Filter>
     </ClInclude>

--- a/dev/PackageManager/API/pch.h
+++ b/dev/PackageManager/API/pch.h
@@ -34,5 +34,8 @@
 
 #include "MsixPackageManager.h"
 
+#include <FrameworkUdk/Containment.h>
 #include <FrameworkUdk/PackageManagement.h>
 #include <FrameworkUdk/UupStateRepository.h>
+
+#include "PackageManager.Containment.h"

--- a/dev/WindowsAppRuntime_DLL/pch.h
+++ b/dev/WindowsAppRuntime_DLL/pch.h
@@ -51,6 +51,8 @@
 #include <winrt/Windows.Storage.Streams.h>
 #include <winrt/Windows.System.h>
 
+#include <FrameworkUdk/Containment.h>
+
 #include <MsixDynamicDependency.h>
 
 #include <appmodel.identity.h>


### PR DESCRIPTION
56439870: A/B Containment for EnsurePackage*ReadyAsync() doesn't register v2 if v1 is registered and caller asks for minVersion=v1

Adds A/B Containment for [[1.7] EnsurePackage*ReadyAsync() doesn't register v2 if v1 is registered and caller asks for minVersion=v1 #5182 #5191](https://github.com/microsoft/WindowsAppSDK/pull/5191)

https://task.ms/56439870