### PR TITLE
Adding implementation for IsCallingPreviewSupported method

### DIFF
--- a/dev/AppNotifications/AppNotificationConferencingConfig.cpp
+++ b/dev/AppNotifications/AppNotificationConferencingConfig.cpp
@@ -6,6 +6,7 @@
 #include "Microsoft.Windows.AppNotifications.AppNotificationConferencingConfig.g.cpp"
 #include <IsWindowsVersion.h>
 #include "TerminalVelocityFeatures-CallingPreviewSupport.h"
+#include <frameworkudk/wnpnotifications.h>
 
 namespace winrt::Microsoft::Windows::AppNotifications::implementation
 {
@@ -42,11 +43,12 @@ namespace winrt::Microsoft::Windows::AppNotifications::implementation
         m_audioOutputDeviceId = value;
     }
 
-    ///Checks if the calling preview feature is supported on the current OS version
-    ///TO DO - This method needs implementation on framework UDK, for now it always returns false
+    //Checks if the calling preview feature is supported on the current OS version
     bool AppNotificationConferencingConfig::IsCallingPreviewSupported()
     {
-        return false;
+        BOOL isSupported{};
+        THROW_IF_FAILED(WnpNotifications_IsCallingPreviewSupported(&isSupported));
+        return isSupported;
     }
 }
 


### PR DESCRIPTION
**What Changed?**
Adding implementation for IsCallingPreviewSupported method. The implementation could call the Framework Udk method to check if feature is enabled on the user's OS.

**Why is this change required?**
Currently this method always returns false.
Original PR : https://github.com/microsoft/WindowsAppSDK/pull/4783

A microsoft employee must use /azp run to validate using the pipelines below.

WARNING:
Comments made by azure-pipelines bot maybe inaccurate.
Please see pipeline link to verify that the build is being ran.

For status checks on the main branch, please use TransportPackage-Foundation-PR
(https://microsoft.visualstudio.com/ProjectReunion/_build?definitionId=81063&_a=summary)
and run the build against your PR branch with the default parameters.
