### PR TITLE
Add TraceLogging tagging and generic fields to failure events. 

### DIFF
--- a/installer/dev/tracelogging.cpp
+++ b/installer/dev/tracelogging.cpp
@@ -43,7 +43,11 @@ void __stdcall wilResultLoggingCallback(const wil::FailureInfo& failure) noexcep
                 }
                 else
                 {
-                    WindowsAppRuntimeInstaller_WriteEventWithActivity("FailureLog");
+                    WindowsAppRuntimeInstaller_WriteEventWithActivity(
+                        "FailureLog",
+                        _GENERIC_PARTB_FIELDS_ENABLED,
+                        TelemetryPrivacyDataTag(PDT_ProductAndServicePerformance),
+                        TraceLoggingKeyword(MICROSOFT_KEYWORD_CRITICAL_DATA));
                 }
                 installActivityContext.LogInstallerFailureEvent(failure.hr);
                 break;
@@ -52,9 +56,10 @@ void __stdcall wilResultLoggingCallback(const wil::FailureInfo& failure) noexcep
             {
                 WindowsAppRuntimeInstaller_WriteEventWithActivity(
                     "Exception",
-                    TraceLoggingCountedWideString(
-                        installActivityContext.GetCurrentResourceId().c_str(),
-                        static_cast<ULONG>(installActivityContext.GetCurrentResourceId().size()), "currentResource"));
+                    _GENERIC_PARTB_FIELDS_ENABLED,
+                    WindowsAppRuntimeInstaller_TraceLoggingWString(installActivityContext.GetCurrentResourceId(), "currentResource"),
+                    TelemetryPrivacyDataTag(PDT_ProductAndServicePerformance),
+                    TraceLoggingKeyword(MICROSOFT_KEYWORD_CRITICAL_DATA));
 
                 // Don't stop the Install activity here. Instead, give the Installer main a chance to Stop the Activity before returning error to the caller.
                 // Hence, save the wil failure info here for later use.
@@ -65,9 +70,10 @@ void __stdcall wilResultLoggingCallback(const wil::FailureInfo& failure) noexcep
             {
                 WindowsAppRuntimeInstaller_WriteEventWithActivity(
                     "FailFast",
-                    TraceLoggingCountedWideString(
-                        installActivityContext.GetCurrentResourceId().c_str(),
-                        static_cast<ULONG>(installActivityContext.GetCurrentResourceId().size()), "currentResource"));
+                    _GENERIC_PARTB_FIELDS_ENABLED,
+                    WindowsAppRuntimeInstaller_TraceLoggingWString(installActivityContext.GetCurrentResourceId(), "currentResource"),
+                    TelemetryPrivacyDataTag(PDT_ProductAndServicePerformance),
+                    TraceLoggingKeyword(MICROSOFT_KEYWORD_CRITICAL_DATA));
 
                 installActivityContext.GetActivity().StopWithResult(
                     failure.hr,
@@ -89,9 +95,10 @@ void __stdcall wilResultLoggingCallback(const wil::FailureInfo& failure) noexcep
             {
                 WindowsAppRuntimeInstaller_WriteEventWithActivity(
                     "FailureReturn",
-                    TraceLoggingCountedWideString(
-                        installActivityContext.GetCurrentResourceId().c_str(),
-                        static_cast<ULONG>(installActivityContext.GetCurrentResourceId().size()), "currentResource"));
+                    _GENERIC_PARTB_FIELDS_ENABLED,
+                    WindowsAppRuntimeInstaller_TraceLoggingWString(installActivityContext.GetCurrentResourceId(), "currentResource"),
+                    TelemetryPrivacyDataTag(PDT_ProductAndServicePerformance),
+                    TraceLoggingKeyword(MICROSOFT_KEYWORD_CRITICAL_DATA));
 
                 // If this is due to CATCH_RETURN(), we want to keep the failure info from THROW* and not overwrite that from RETURN*
                 if (!(installActivityContext.GetLastFailure().type == wil::FailureType::Exception &&


### PR DESCRIPTION
This updates the WIL failure events in the installer to include the same Tracelogging tags and fields used elsewhere in the installer flow.

What's changed:

- Added TelemetryPrivacyDataTag and TraceLoggingKeyword to FailureLog, Exception, FailFast, and FailureReturn events so they show up properly in logs.

- Included _GENERIC_PARTB_FIELDS_ENABLED for version/channel/debug info to match other logged events like Install/Start.

- Replaced direct TraceLoggingCountedWideString(...) calls with the existing WindowsAppRuntimeInstaller_TraceLoggingWString(...) macro for consistency and readability.

These events should now appear as expected in Kusto, with consistent structure and tagging across the installer.
