### PR TITLE
Task 56847091: [WASDK][Compliance] Update the WindowsAppSDK repo to use the global default LKG compiler version on the Config repo 

### DIFF
--- a/build/AzurePipelinesTemplates/WindowsAppSDK-Build-Stage.yml
+++ b/build/AzurePipelinesTemplates/WindowsAppSDK-Build-Stage.yml
@@ -57,16 +57,42 @@ stages:
           buildConfiguration: 'release'
           normalizedConfiguration: 'fre'
     variables:
-      ob_outputDirectory: '$(REPOROOT)\out'
-      ob_sdl_codeSignValidation_excludes: '-|**\Release\**;-|**\packages\**'
-      ob_artifactBaseName: "FoundationBinaries_$(buildConfiguration)_$(buildPlatform)"
-      ${{ if parameters.runStaticAnalysis }}:
-        ob_sdl_apiscan_enabled: true
-      ${{ if not( parameters.runStaticAnalysis ) }}:
-        ob_sdl_apiscan_enabled: false
-      ob_sdl_apiscan_softwareFolder: '$(build.SourcesDirectory)\APIScanTarget'
-      ob_sdl_apiscan_symbolsFolder: '$(build.SourcesDirectory)\APIScanTarget;SRV*https://symweb.azurefd.net'
+      - name: ob_outputDirectory
+        value: '$(REPOROOT)\out'
+      - name: ob_sdl_codeSignValidation_excludes
+        value: '-|**\Release\**;-|**\packages\**'
+      - name: ob_artifactBaseName
+        value: "FoundationBinaries_$(buildConfiguration)_$(buildPlatform)"
+      - name: ob_sdl_apiscan_enabled
+        ${{ if parameters.runStaticAnalysis }}:
+          value: true
+        ${{ else }}:
+          value: false
+      - name: ob_sdl_apiscan_softwareFolder
+        value: '$(build.SourcesDirectory)\APIScanTarget'
+      - name: ob_sdl_apiscan_symbolsFolder
+        value: '$(build.SourcesDirectory)\APIScanTarget;SRV*https://symweb.azurefd.net'
+      - template: AzurePipelinesTemplates/WindowsAppSDK-Global-LKGVersions.yml@WindowsAppSDKConfigSourceBranch
+      - name: localCompilerOverridePackageName
+        value: $[coalesce(variables.compilerOverridePackageName, variables.global_CompilerOverridePackageName)]
+      - name: localCompilerOverridePackageVersion
+        value: $[coalesce(variables.compilerOverridePackageVersion, variables.global_CompilerOverridePackageVersion)]
+      - name: localCompilerOverrideNupkgVersion
+        value: $[coalesce(variables.compilerOverrideNupkgVersion, variables.global_CompilerOverrideNupkgVersion)]    
     steps:
+    - script: |
+        echo Build.SourceBranch=$(Build.SourceBranch)
+        echo Build.Reason=$(Build.Reason)
+        echo compilerOverridePackageName=$(compilerOverridePackageName)
+        echo compilerOverridePackageVersion=$(compilerOverridePackageVersion)
+        echo global_CompilerOverridePackageName=$(global_CompilerOverridePackageName)
+        echo global_CompilerOverridePackageVersion=$(global_CompilerOverridePackageVersion)
+        echo localCompilerOverridePackageName=$(localCompilerOverridePackageName)
+        echo localCompilerOverridePackageVersion=$(localCompilerOverridePackageVersion)
+        echo localCompilerOverrideNupkgVersion=$(localCompilerOverrideNupkgVersion)
+        echo System.PullRequest.targetBranchName=$(System.PullRequest.targetBranchName)
+        echo mySourceBranch=$(mySourceBranch)        
+
     - template: WindowsAppSDK-BuildFoundation-Steps.yml@self
       parameters:
         SignOutput: ${{ parameters.SignOutput }}
@@ -128,17 +154,44 @@ stages:
           buildConfiguration: 'Release'
           normalizedConfiguration: 'fre'
     variables:
-      ob_outputDirectory: '$(REPOROOT)\out'
-      ob_sdl_codeSignValidation_excludes: '-|**\Release\**'
-      ob_sdl_suppression_suppressionSet: default
-      ob_artifactBaseName: "MrtBinaries_$(buildConfiguration)_$(buildPlatform)"
-      ${{ if parameters.runStaticAnalysis }}:
-        ob_sdl_apiscan_enabled: true
-      ${{ if not( parameters.runStaticAnalysis ) }}:
-        ob_sdl_apiscan_enabled: false
-      ob_sdl_apiscan_softwareFolder: '$(build.SourcesDirectory)\APIScanTarget'
-      ob_sdl_apiscan_symbolsFolder: '$(build.SourcesDirectory)\APIScanTarget;SRV*https://symweb.azurefd.net'
+      - name: ob_outputDirectory
+        value: '$(REPOROOT)\out'
+      - name: ob_sdl_codeSignValidation_excludes
+        value: '-|**\Release\**'
+      - name: ob_sdl_suppression_suppressionSet
+        value: default
+      - name: ob_artifactBaseName
+        value: "MrtBinaries_$(buildConfiguration)_$(buildPlatform)"
+      - name: ob_sdl_apiscan_enabled
+        ${{ if parameters.runStaticAnalysis }}:
+          value: true
+        ${{ else }}:
+          value: false
+      - name: ob_sdl_apiscan_softwareFolder
+        value: '$(build.SourcesDirectory)\APIScanTarget'
+      - name: ob_sdl_apiscan_symbolsFolder
+        value: '$(build.SourcesDirectory)\APIScanTarget;SRV*https://symweb.azurefd.net'
+      - template: AzurePipelinesTemplates/WindowsAppSDK-Global-LKGVersions.yml@WindowsAppSDKConfigSourceBranch
+      - name: localCompilerOverridePackageName
+        value: $[coalesce(variables.compilerOverridePackageName, variables.global_CompilerOverridePackageName)]
+      - name: localCompilerOverridePackageVersion
+        value: $[coalesce(variables.compilerOverridePackageVersion, variables.global_CompilerOverridePackageVersion)]
+      - name: localCompilerOverrideNupkgVersion
+        value: $[coalesce(variables.compilerOverrideNupkgVersion, variables.global_CompilerOverrideNupkgVersion)]    
     steps:
+    - script: |
+        echo Build.SourceBranch=$(Build.SourceBranch)
+        echo Build.Reason=$(Build.Reason)
+        echo compilerOverridePackageName=$(compilerOverridePackageName)
+        echo compilerOverridePackageVersion=$(compilerOverridePackageVersion)
+        echo global_CompilerOverridePackageName=$(global_CompilerOverridePackageName)
+        echo global_CompilerOverridePackageVersion=$(global_CompilerOverridePackageVersion)
+        echo localCompilerOverridePackageName=$(localCompilerOverridePackageName)
+        echo localCompilerOverridePackageVersion=$(localCompilerOverridePackageVersion)
+        echo localCompilerOverrideNupkgVersion=$(localCompilerOverrideNupkgVersion)
+        echo System.PullRequest.targetBranchName=$(System.PullRequest.targetBranchName)
+        echo mySourceBranch=$(mySourceBranch)        
+
     - template: WindowsAppSDK-BuildMRT-Steps.yml@self
       parameters:
         SignOutput: ${{ parameters.SignOutput }}

--- a/build/AzurePipelinesTemplates/WindowsAppSDK-BuildFoundation-Steps.yml
+++ b/build/AzurePipelinesTemplates/WindowsAppSDK-BuildFoundation-Steps.yml
@@ -58,8 +58,8 @@ steps:
   displayName: 'Setup native compiler version override'
   inputs:
     microsoftDropReadPat: $(System.AccessToken)
-    compilerPackageName: $(compilerOverridePackageName)
-    compilerPackageVersion: $(compilerOverridePackageVersion)
+    compilerPackageName: $(localCompilerOverridePackageName)
+    compilerPackageVersion: $(localCompilerOverridePackageVersion)
     slnDirectory: $(Build.SourcesDirectory)
     includeUCRT: true
     ucrtFeedPat: $(System.AccessToken)

--- a/build/AzurePipelinesTemplates/WindowsAppSDK-BuildInstaller-Stage.yml
+++ b/build/AzurePipelinesTemplates/WindowsAppSDK-BuildInstaller-Stage.yml
@@ -23,12 +23,36 @@ stages:
           buildPlatform: 'arm64'
           buildConfiguration: 'Release'
     variables:
-      ob_outputDirectory: '$(REPOROOT)\out'
-      ob_artifactSuffix: '_$(buildConfiguration)_$(buildPlatform)'
-      ob_artifactBaseName: "Installer$(ob_artifactSuffix)"
+      - name: ob_outputDirectory
+        value: '$(REPOROOT)\out'
+      - name: ob_artifactSuffix
+        value: '_$(buildConfiguration)_$(buildPlatform)'
+      - name: ob_artifactBaseName
+        value: "Installer$(ob_artifactSuffix)"
       # foundationRepoPath should be empty because we are not doing multiple checkouts hence
       # it is not under $(Build.SourcesDirectory)\WindowsAppSDK
-      foundationRepoPath: ""
+      - name: foundationRepoPath
+        value: ""
+      - template: AzurePipelinesTemplates/WindowsAppSDK-Global-LKGVersions.yml@WindowsAppSDKConfigSourceBranch
+      - name: localCompilerOverridePackageName
+        value: $[coalesce(variables.compilerOverridePackageName, variables.global_CompilerOverridePackageName)]
+      - name: localCompilerOverridePackageVersion
+        value: $[coalesce(variables.compilerOverridePackageVersion, variables.global_CompilerOverridePackageVersion)]
+      - name: localCompilerOverrideNupkgVersion
+        value: $[coalesce(variables.compilerOverrideNupkgVersion, variables.global_CompilerOverrideNupkgVersion)]
     condition: ne(variables.LatestOfficialBuildID, '')
     steps:
+    - script: |
+        echo Build.SourceBranch=$(Build.SourceBranch)
+        echo Build.Reason=$(Build.Reason)
+        echo compilerOverridePackageName=$(compilerOverridePackageName)
+        echo compilerOverridePackageVersion=$(compilerOverridePackageVersion)
+        echo global_CompilerOverridePackageName=$(global_CompilerOverridePackageName)
+        echo global_CompilerOverridePackageVersion=$(global_CompilerOverridePackageVersion)
+        echo localCompilerOverridePackageName=$(localCompilerOverridePackageName)
+        echo localCompilerOverridePackageVersion=$(localCompilerOverridePackageVersion)
+        echo localCompilerOverrideNupkgVersion=$(localCompilerOverrideNupkgVersion)
+        echo System.PullRequest.targetBranchName=$(System.PullRequest.targetBranchName)      
+        echo mySourceBranch=$(mySourceBranch)       
+        
     - template: WindowsAppSDK-BuildInstaller-Steps.yml@self

--- a/build/AzurePipelinesTemplates/WindowsAppSDK-BuildInstaller-Steps.yml
+++ b/build/AzurePipelinesTemplates/WindowsAppSDK-BuildInstaller-Steps.yml
@@ -199,8 +199,8 @@ steps:
   displayName: 'Setup native compiler version override'
   inputs:
     microsoftDropReadPat: $(System.AccessToken)
-    compilerPackageName: $(compilerOverridePackageName)
-    compilerPackageVersion: $(compilerOverridePackageVersion)
+    compilerPackageName: $(localCompilerOverridePackageName)
+    compilerPackageVersion: $(localCompilerOverridePackageVersion)
     slnDirectory: $(Build.SourcesDirectory)\$(foundationRepoPath)installer\dev
     includeUCRT: true
     ucrtFeedPat: $(System.AccessToken)

--- a/build/AzurePipelinesTemplates/WindowsAppSDK-BuildMRT-Steps.yml
+++ b/build/AzurePipelinesTemplates/WindowsAppSDK-BuildMRT-Steps.yml
@@ -18,8 +18,8 @@ steps:
   displayName: 'Setup native compiler version override'
   inputs:
     microsoftDropReadPat: $(System.AccessToken)
-    compilerPackageName: $(compilerOverridePackageName)
-    compilerPackageVersion: $(compilerOverridePackageVersion)
+    compilerPackageName: $(localCompilerOverridePackageName)
+    compilerPackageVersion: $(localCompilerOverridePackageVersion)
     slnDirectory: $(Build.SourcesDirectory)\dev\MRTCore\mrt
     includeUCRT: true
     ucrtFeedPat: $(System.AccessToken)

--- a/build/ProjectReunion-BuildFoundation.yml
+++ b/build/ProjectReunion-BuildFoundation.yml
@@ -5,17 +5,22 @@ name: $(version)
 
 trigger: none
 
+variables:
+- template: WindowsAppSDK-Versions.yml
+- template: WindowsAppSDK-CommonVariables.yml
+- template: WindowsAppSDK-Foundation-TestConfig.yml@WindowsAppSDKConfig
+- template: WindowsAppSDK-SetSourceBranchVariableForConfigRepo.yml@WindowsAppSDKConfig
+
 resources:
   repositories:
     - repository: WindowsAppSDKConfig
       type: git
       name: ProjectReunion/WindowsAppSDKConfig
       ref: refs/heads/main
-
-variables:
-- template: WindowsAppSDK-Versions.yml
-- template: WindowsAppSDK-CommonVariables.yml
-- template: WindowsAppSDK-Foundation-TestConfig.yml@WindowsAppSDKConfig
+    - repository: WindowsAppSDKConfigSourceBranch
+      type: git
+      name: ProjectReunion/WindowsAppSDKConfig
+      ref: ${{ variables['mySourceBranch'] }}
 
 stages:
 - template: AzurePipelinesTemplates\WindowsAppSDK-BuildInstaller-Stage.yml@self

--- a/build/ProjectReunion-CI.yml
+++ b/build/ProjectReunion-CI.yml
@@ -6,6 +6,14 @@ variables:
 - template: WindowsAppSDK-CommonVariables.yml
 - name: buildOutputDir
   value: $(Build.SourcesDirectory)\BuildOutput
+- template: WindowsAppSDK-SetSourceBranchVariableForConfigRepo.yml@WindowsAppSDKConfig
+
+resources:
+  repositories:
+    - repository: WindowsAppSDKConfigSourceBranch
+      type: git
+      name: ProjectReunion/WindowsAppSDKConfig
+      ref: ${{ variables['mySourceBranch'] }}
 
 jobs:
 - job: PreChecks

--- a/build/WindowsAppSDK-CommonVariables.yml
+++ b/build/WindowsAppSDK-CommonVariables.yml
@@ -17,12 +17,13 @@ variables:
   OUTPUTROOT: $(REPOROOT)\out
   NUGET_XMLDOC_MODE: none
 
-  # Native compiler version override for win undock. The two values below are for Ge, defined in:
+  # When the following 3 values are unpopulated, then on this repo we align to the global default LKG compiler version.
+  # In case we need to temporarily use a different LKG compiler version for this repo, possible values can be found in:
   # https://dev.azure.com/microsoft/OS/_git/UndockedES?path=/Pipelines/Config/CompilerToolsSettings.json
-  compilerOverridePackageName: "DevDiv.rel.LKG18.VCTools"
-  compilerOverridePackageVersion: "19.42.3443710001+DevDivGIT.CI20250110.04-466784EE54DF2F302AD0CD6790031C954EF41DA23DA4415D73A76ADF260F2D21"
+  compilerOverridePackageName: ""
+  compilerOverridePackageVersion: ""
   # Use the following corresponding version string instead of the above when calling nuget install directly.
-  compilerOverrideNupkgVersion: "19.42.34437100"
+  compilerOverrideNupkgVersion: ""
 
   # Docker image which is used to build the project https://aka.ms/obpipelines/containers
   WindowsContainerImage: 'onebranch.azurecr.io/windows/ltsc2019/vse2022:latest'

--- a/build/WindowsAppSDK-Foundation-Nightly.yml
+++ b/build/WindowsAppSDK-Foundation-Nightly.yml
@@ -34,6 +34,12 @@ parameters:
   type: boolean
   default: true
 
+variables:
+- template: WindowsAppSDK-Versions.yml
+- template: WindowsAppSDK-CommonVariables.yml
+- template: WindowsAppSDK-Foundation-TestConfig.yml@WindowsAppSDKConfig
+- template: WindowsAppSDK-SetSourceBranchVariableForConfigRepo.yml@WindowsAppSDKConfig
+
 resources:
   repositories:
     - repository: templates
@@ -44,11 +50,10 @@ resources:
       type: git
       name: ProjectReunion/WindowsAppSDKConfig
       ref: refs/heads/main
-
-variables:
-- template: WindowsAppSDK-Versions.yml
-- template: WindowsAppSDK-CommonVariables.yml
-- template: WindowsAppSDK-Foundation-TestConfig.yml@WindowsAppSDKConfig
+    - repository: WindowsAppSDKConfigSourceBranch
+      type: git
+      name: ProjectReunion/WindowsAppSDKConfig
+      ref: ${{ variables['mySourceBranch'] }}
 
 extends:
   template: v2/Microsoft.NonOfficial.yml@templates # https://aka.ms/obpipelines/templates

--- a/build/WindowsAppSDK-Foundation-Official.yml
+++ b/build/WindowsAppSDK-Foundation-Official.yml
@@ -34,6 +34,12 @@ parameters:
   type: boolean
   default: true
 
+variables:
+- template: WindowsAppSDK-Versions.yml
+- template: WindowsAppSDK-CommonVariables.yml
+- template: WindowsAppSDK-Foundation-TestConfig.yml@WindowsAppSDKConfig
+- template: WindowsAppSDK-SetSourceBranchVariableForConfigRepo.yml@WindowsAppSDKConfig
+
 resources:
   repositories:
     - repository: templates
@@ -44,11 +50,10 @@ resources:
       type: git
       name: ProjectReunion/WindowsAppSDKConfig
       ref: refs/heads/main
-
-variables:
-- template: WindowsAppSDK-Versions.yml
-- template: WindowsAppSDK-CommonVariables.yml
-- template: WindowsAppSDK-Foundation-TestConfig.yml@WindowsAppSDKConfig
+    - repository: WindowsAppSDKConfigSourceBranch
+      type: git
+      name: ProjectReunion/WindowsAppSDKConfig
+      ref: ${{ variables['mySourceBranch'] }}
 
 extends:
   template: v2/Microsoft.Official.yml@templates # https://aka.ms/obpipelines/templates

--- a/build/WindowsAppSDK-Foundation-PR.yml
+++ b/build/WindowsAppSDK-Foundation-PR.yml
@@ -25,6 +25,12 @@ parameters: # parameters are shown up in ADO UI in a build queue time
   type: boolean
   default: true
 
+variables:
+- template: WindowsAppSDK-Versions.yml
+- template: WindowsAppSDK-CommonVariables.yml
+- template: WindowsAppSDK-Foundation-TestConfig.yml@WindowsAppSDKConfig
+- template: WindowsAppSDK-SetSourceBranchVariableForConfigRepo.yml@WindowsAppSDKConfig
+
 resources:
   repositories:
     - repository: templates
@@ -35,11 +41,10 @@ resources:
       type: git
       name: ProjectReunion/WindowsAppSDKConfig
       ref: refs/heads/main
-
-variables:
-- template: WindowsAppSDK-Versions.yml
-- template: WindowsAppSDK-CommonVariables.yml
-- template: WindowsAppSDK-Foundation-TestConfig.yml@WindowsAppSDKConfig
+    - repository: WindowsAppSDKConfigSourceBranch
+      type: git
+      name: ProjectReunion/WindowsAppSDKConfig
+      ref: ${{ variables['mySourceBranch'] }}
 
 extends:
   template: v2/Microsoft.NonOfficial.yml@templates # https://aka.ms/obpipelines/templates


### PR DESCRIPTION
The new yml file WindowsAppSDK-SetSourceBranchVariableForConfigRepo.yml on the Config repo specifies the global default LKG compiler version. Use that version information, which is branch-specific, unless a different LKG compiler version is specified by the local file WindowsAppSDK-CommonVariables.yml.

How built:
- These changes have passed PR validation

How tested:
Using internal private pipeline runs, verified that:
- Populating WindowsAppSDK-CommonVariables.yml with a different LKG compiler version supersedes the global default LKG compiler version, although that resulted in unrelated build issues due to mismatch of build tool versions.
- An auto triggered pull request pipeline run can succeed.
- Manual re-run of an auto-triggered pull request pipeline run can succeed.
- Manual trigger of the nightly pipeline can succeed.

/////////////////

A microsoft employee must use /azp run to validate using the pipelines below.

WARNING:
Comments made by azure-pipelines bot maybe inaccurate.
Please see pipeline link to verify that the build is being ran.

For status checks on the main branch, please use TransportPackage-Foundation-PR
(https://microsoft.visualstudio.com/ProjectReunion/_build?definitionId=81063&_a=summary)
and run the build against your PR branch with the default parameters.
