### PR TITLE
[1.7 servicing] PackageDeploymentManager - Fix .Stop() events not being generated. Include PackageReadyOrNewerAvailableStatus in .Stop() events

### DIFF
--- a/dev/PackageManager/API/M.W.M.D.PackageDeploymentManager.cpp
+++ b/dev/PackageManager/API/M.W.M.D.PackageDeploymentManager.cpp
@@ -352,6 +352,7 @@ namespace winrt::Microsoft::Windows::Management::Deployment::implementation
                     TraceLoggingWideString(packageSetItem.PackageFamilyName().c_str(), "Criteria.PackageFamilyName"),
                     TraceLoggingHexUInt64(minVersion.Version, "Criteria.MinVersion"),
                     TraceLoggingHexInt32(static_cast<std::int32_t>(packageSetItem.ProcessorArchitectureFilter()), "Criteria.ArchitectureFilter"),
+                    TraceLoggingInt32(static_cast<std::int32_t>(status), "PackageReadyOrNewerAvailableStatus"),
                     TraceLoggingLevel(WINEVENT_LEVEL_VERBOSE),
                     TelemetryPrivacyDataTag(PDT_ProductAndServicePerformance));
                 return winrt::Microsoft::Windows::Management::Deployment::PackageReadyOrNewerAvailableStatus::NotReady;
@@ -366,6 +367,7 @@ namespace winrt::Microsoft::Windows::Management::Deployment::implementation
                     TraceLoggingWideString(packageSetItem.PackageFamilyName().c_str(), "Criteria.PackageFamilyName"),
                     TraceLoggingHexUInt64(minVersion.Version, "Criteria.MinVersion"),
                     TraceLoggingHexInt32(static_cast<std::int32_t>(packageSetItem.ProcessorArchitectureFilter()), "Criteria.ArchitectureFilter"),
+                    TraceLoggingInt32(static_cast<std::int32_t>(status), "PackageReadyOrNewerAvailableStatus"),
                     TraceLoggingLevel(WINEVENT_LEVEL_VERBOSE),
                     TelemetryPrivacyDataTag(PDT_ProductAndServicePerformance));
                 newerAvailable = true;
@@ -574,9 +576,8 @@ namespace winrt::Microsoft::Windows::Management::Deployment::implementation
                 PackageDeploymentStatus::CompletedFailure, activityId, error, extendedError, errorText);
         }
 
-        co_return winrt::make<PackageDeploymentResult>(PackageDeploymentStatus::CompletedSuccess, activityId);
-
         logTelemetry.Stop(packageUriAsString);
+        co_return winrt::make<PackageDeploymentResult>(PackageDeploymentStatus::CompletedSuccess, activityId);
     }
     winrt::Windows::Foundation::IAsyncOperationWithProgress<winrt::Microsoft::Windows::Management::Deployment::PackageDeploymentResult, winrt::Microsoft::Windows::Management::Deployment::PackageDeploymentProgress>
     PackageDeploymentManager::AddPackageSetAsync(winrt::Microsoft::Windows::Management::Deployment::PackageSet packageSet, winrt::Microsoft::Windows::Management::Deployment::AddPackageOptions options)
@@ -640,9 +641,8 @@ namespace winrt::Microsoft::Windows::Management::Deployment::implementation
             }
         }
 
-        co_return winrt::make<PackageDeploymentResult>(PackageDeploymentStatus::CompletedSuccess, activityId);
-
         logTelemetry.Stop(packageSet.Id());
+        co_return winrt::make<PackageDeploymentResult>(PackageDeploymentStatus::CompletedSuccess, activityId);
     }
     winrt::Windows::Foundation::IAsyncOperationWithProgress<winrt::Microsoft::Windows::Management::Deployment::PackageDeploymentResult, winrt::Microsoft::Windows::Management::Deployment::PackageDeploymentProgress>
     PackageDeploymentManager::StagePackageAsync(hstring package, winrt::Microsoft::Windows::Management::Deployment::StagePackageOptions options)
@@ -699,9 +699,8 @@ namespace winrt::Microsoft::Windows::Management::Deployment::implementation
                 PackageDeploymentStatus::CompletedFailure, activityId, error, extendedError, errorText);
         }
 
-        co_return winrt::make<PackageDeploymentResult>(PackageDeploymentStatus::CompletedSuccess, activityId);
-
         logTelemetry.Stop(packageUriAsString);
+        co_return winrt::make<PackageDeploymentResult>(PackageDeploymentStatus::CompletedSuccess, activityId);
     }
     winrt::Windows::Foundation::IAsyncOperationWithProgress<winrt::Microsoft::Windows::Management::Deployment::PackageDeploymentResult, winrt::Microsoft::Windows::Management::Deployment::PackageDeploymentProgress>
     PackageDeploymentManager::StagePackageSetAsync(winrt::Microsoft::Windows::Management::Deployment::PackageSet packageSet, winrt::Microsoft::Windows::Management::Deployment::StagePackageOptions options)
@@ -765,9 +764,8 @@ namespace winrt::Microsoft::Windows::Management::Deployment::implementation
             }
         }
 
-        co_return winrt::make<PackageDeploymentResult>(PackageDeploymentStatus::CompletedSuccess, activityId);
-
         logTelemetry.Stop(packageSet.Id());
+        co_return winrt::make<PackageDeploymentResult>(PackageDeploymentStatus::CompletedSuccess, activityId);
     }
     winrt::Windows::Foundation::IAsyncOperationWithProgress<winrt::Microsoft::Windows::Management::Deployment::PackageDeploymentResult, winrt::Microsoft::Windows::Management::Deployment::PackageDeploymentProgress>
     PackageDeploymentManager::RegisterPackageAsync(hstring package, winrt::Microsoft::Windows::Management::Deployment::RegisterPackageOptions options)
@@ -834,9 +832,8 @@ namespace winrt::Microsoft::Windows::Management::Deployment::implementation
                 PackageDeploymentStatus::CompletedFailure, activityId, error, extendedError, errorText);
         }
 
-        co_return winrt::make<PackageDeploymentResult>(PackageDeploymentStatus::CompletedSuccess, activityId);
-
         logTelemetry.Stop(packageUriAsString);
+        co_return winrt::make<PackageDeploymentResult>(PackageDeploymentStatus::CompletedSuccess, activityId);
     }
     winrt::Windows::Foundation::IAsyncOperationWithProgress<winrt::Microsoft::Windows::Management::Deployment::PackageDeploymentResult, winrt::Microsoft::Windows::Management::Deployment::PackageDeploymentProgress>
     PackageDeploymentManager::RegisterPackageSetAsync(winrt::Microsoft::Windows::Management::Deployment::PackageSet packageSet, winrt::Microsoft::Windows::Management::Deployment::RegisterPackageOptions options)
@@ -910,9 +907,8 @@ namespace winrt::Microsoft::Windows::Management::Deployment::implementation
             }
         }
 
-        co_return winrt::make<PackageDeploymentResult>(PackageDeploymentStatus::CompletedSuccess, activityId);
-
         logTelemetry.Stop(packageSet.Id());
+        co_return winrt::make<PackageDeploymentResult>(PackageDeploymentStatus::CompletedSuccess, activityId);
     }
     winrt::Windows::Foundation::IAsyncOperationWithProgress<winrt::Microsoft::Windows::Management::Deployment::PackageDeploymentResult, winrt::Microsoft::Windows::Management::Deployment::PackageDeploymentProgress>
     PackageDeploymentManager::RemovePackageAsync(hstring package, winrt::Microsoft::Windows::Management::Deployment::RemovePackageOptions options)
@@ -977,9 +973,8 @@ namespace winrt::Microsoft::Windows::Management::Deployment::implementation
                 PackageDeploymentStatus::CompletedFailure, activityId, error, extendedError, errorText);
         }
 
-        co_return winrt::make<PackageDeploymentResult>(PackageDeploymentStatus::CompletedSuccess, activityId);
-
         logTelemetry.Stop(packageFullName);
+        co_return winrt::make<PackageDeploymentResult>(PackageDeploymentStatus::CompletedSuccess, activityId);
     }
     winrt::Windows::Foundation::IAsyncOperationWithProgress<winrt::Microsoft::Windows::Management::Deployment::PackageDeploymentResult, winrt::Microsoft::Windows::Management::Deployment::PackageDeploymentProgress>
     PackageDeploymentManager::RemovePackageByFamilyNameAsync(hstring packageFamilyName, winrt::Microsoft::Windows::Management::Deployment::RemovePackageOptions options)
@@ -1024,9 +1019,8 @@ namespace winrt::Microsoft::Windows::Management::Deployment::implementation
                 PackageDeploymentStatus::CompletedFailure, activityId, error, extendedError, errorText);
         }
 
-        co_return winrt::make<PackageDeploymentResult>(PackageDeploymentStatus::CompletedSuccess, activityId);
-
         logTelemetry.Stop(packageFamilyName);
+        co_return winrt::make<PackageDeploymentResult>(PackageDeploymentStatus::CompletedSuccess, activityId);
     }
     winrt::Windows::Foundation::IAsyncOperationWithProgress<winrt::Microsoft::Windows::Management::Deployment::PackageDeploymentResult, winrt::Microsoft::Windows::Management::Deployment::PackageDeploymentProgress>
     PackageDeploymentManager::RemovePackageByUriAsync(winrt::Windows::Foundation::Uri packageUri, winrt::Microsoft::Windows::Management::Deployment::RemovePackageOptions options)
@@ -1096,9 +1090,8 @@ namespace winrt::Microsoft::Windows::Management::Deployment::implementation
                 PackageDeploymentStatus::CompletedFailure, activityId, error, extendedError, errorText);
         }
 
-        co_return winrt::make<PackageDeploymentResult>(PackageDeploymentStatus::CompletedSuccess, activityId);
-
         logTelemetry.Stop(packageUriAsString);
+        co_return winrt::make<PackageDeploymentResult>(PackageDeploymentStatus::CompletedSuccess, activityId);
     }
     winrt::Windows::Foundation::IAsyncOperationWithProgress<winrt::Microsoft::Windows::Management::Deployment::PackageDeploymentResult, winrt::Microsoft::Windows::Management::Deployment::PackageDeploymentProgress>
     PackageDeploymentManager::RemovePackageSetAsync(winrt::Microsoft::Windows::Management::Deployment::PackageSet packageSet, winrt::Microsoft::Windows::Management::Deployment::RemovePackageOptions options)
@@ -1172,9 +1165,8 @@ namespace winrt::Microsoft::Windows::Management::Deployment::implementation
             }
         }
 
-        co_return winrt::make<PackageDeploymentResult>(PackageDeploymentStatus::CompletedSuccess, activityId);
-
         logTelemetry.Stop(packageSet.Id());
+        co_return winrt::make<PackageDeploymentResult>(PackageDeploymentStatus::CompletedSuccess, activityId);
     }
     winrt::Windows::Foundation::IAsyncOperationWithProgress<winrt::Microsoft::Windows::Management::Deployment::PackageDeploymentResult, winrt::Microsoft::Windows::Management::Deployment::PackageDeploymentProgress>
     PackageDeploymentManager::ResetPackageAsync(hstring package)
@@ -1273,9 +1265,8 @@ namespace winrt::Microsoft::Windows::Management::Deployment::implementation
             }
         }
 
-        co_return winrt::make<PackageDeploymentResult>(PackageDeploymentStatus::CompletedSuccess, activityId);
-
         logTelemetry.Stop(packageSet.Id());
+        co_return winrt::make<PackageDeploymentResult>(PackageDeploymentStatus::CompletedSuccess, activityId);
     }
     winrt::Windows::Foundation::IAsyncOperationWithProgress<winrt::Microsoft::Windows::Management::Deployment::PackageDeploymentResult, winrt::Microsoft::Windows::Management::Deployment::PackageDeploymentProgress>
     PackageDeploymentManager::ResetPackageSetAsync(winrt::Microsoft::Windows::Management::Deployment::PackageSet packageSet)
@@ -1342,9 +1333,8 @@ namespace winrt::Microsoft::Windows::Management::Deployment::implementation
             }
         }
 
-        co_return winrt::make<PackageDeploymentResult>(PackageDeploymentStatus::CompletedSuccess, activityId);
-
         logTelemetry.Stop(packageSet.Id());
+        co_return winrt::make<PackageDeploymentResult>(PackageDeploymentStatus::CompletedSuccess, activityId);
     }
     winrt::Windows::Foundation::IAsyncOperationWithProgress<winrt::Microsoft::Windows::Management::Deployment::PackageDeploymentResult, winrt::Microsoft::Windows::Management::Deployment::PackageDeploymentProgress>
     PackageDeploymentManager::RepairPackageAsync(hstring package)
@@ -1443,9 +1433,8 @@ namespace winrt::Microsoft::Windows::Management::Deployment::implementation
             }
         }
 
-        co_return winrt::make<PackageDeploymentResult>(PackageDeploymentStatus::CompletedSuccess, activityId);
-
         logTelemetry.Stop(packageSet.Id());
+        co_return winrt::make<PackageDeploymentResult>(PackageDeploymentStatus::CompletedSuccess, activityId);
     }
     winrt::Windows::Foundation::IAsyncOperationWithProgress<winrt::Microsoft::Windows::Management::Deployment::PackageDeploymentResult, winrt::Microsoft::Windows::Management::Deployment::PackageDeploymentProgress>
     PackageDeploymentManager::RepairPackageSetAsync(winrt::Microsoft::Windows::Management::Deployment::PackageSet packageSet)
@@ -1512,9 +1501,8 @@ namespace winrt::Microsoft::Windows::Management::Deployment::implementation
             }
         }
 
-        co_return winrt::make<PackageDeploymentResult>(PackageDeploymentStatus::CompletedSuccess, activityId);
-
         logTelemetry.Stop(packageSet.Id());
+        co_return winrt::make<PackageDeploymentResult>(PackageDeploymentStatus::CompletedSuccess, activityId);
     }
     bool PackageDeploymentManager::IsPackageProvisioned(hstring const& package)
     {
@@ -1695,9 +1683,8 @@ namespace winrt::Microsoft::Windows::Management::Deployment::implementation
                 PackageDeploymentStatus::CompletedFailure, activityId, error, extendedError, errorText);
         }
 
-        co_return winrt::make<PackageDeploymentResult>(PackageDeploymentStatus::CompletedSuccess, activityId);
-
         logTelemetry.Stop(packageFamilyName);
+        co_return winrt::make<PackageDeploymentResult>(PackageDeploymentStatus::CompletedSuccess, activityId);
     }
 
     winrt::Windows::Foundation::IAsyncOperationWithProgress<winrt::Microsoft::Windows::Management::Deployment::PackageDeploymentResult, winrt::Microsoft::Windows::Management::Deployment::PackageDeploymentProgress>
@@ -1743,9 +1730,8 @@ namespace winrt::Microsoft::Windows::Management::Deployment::implementation
                 PackageDeploymentStatus::CompletedFailure, activityId, error, extendedError, errorText);
         }
 
-        co_return winrt::make<PackageDeploymentResult>(PackageDeploymentStatus::CompletedSuccess, activityId);
-
         logTelemetry.Stop(packageFullName);
+        co_return winrt::make<PackageDeploymentResult>(PackageDeploymentStatus::CompletedSuccess, activityId);
     }
 
     winrt::hstring PackageDeploymentManager::GetUupProductIdIfMsUup(winrt::Windows::Foundation::Uri const& uri) const
@@ -1934,7 +1920,6 @@ namespace winrt::Microsoft::Windows::Management::Deployment::implementation
         errorText.clear();
         activityId = winrt::guid{};
 
-        winrt::Microsoft::Windows::Management::Deployment::PackageReadyOrNewerAvailableStatus readyOrNewerStatus{};
         if (WinAppSdk::Containment::IsChangeEnabled<WINAPPSDK_CHANGEID_56439870>() && options.RegisterNewerIfAvailable())
         {
             // Our caller already verified PackageDeploymentFeature::IsPackageReadyOrNewerAvailable is supported so no need to check again
@@ -2681,9 +2666,8 @@ namespace winrt::Microsoft::Windows::Management::Deployment::implementation
                 PackageDeploymentStatus::CompletedFailure, activityId, error, extendedError, errorText);
         }
 
-        co_return winrt::make<PackageDeploymentResult>(PackageDeploymentStatus::CompletedSuccess, activityId);
-
         logTelemetry.Stop(packageFamilyName);
+        co_return winrt::make<PackageDeploymentResult>(PackageDeploymentStatus::CompletedSuccess, activityId);
     }
 
     HRESULT PackageDeploymentManager::ResetPackageByFamilyName(
@@ -2793,9 +2777,8 @@ namespace winrt::Microsoft::Windows::Management::Deployment::implementation
                 PackageDeploymentStatus::CompletedFailure, activityId, error, extendedError, errorText);
         }
 
-        co_return winrt::make<PackageDeploymentResult>(PackageDeploymentStatus::CompletedSuccess, activityId);
-
         logTelemetry.Stop(packageFullName);
+        co_return winrt::make<PackageDeploymentResult>(PackageDeploymentStatus::CompletedSuccess, activityId);
     }
 
     HRESULT PackageDeploymentManager::ResetPackageByFullName(
@@ -2917,9 +2900,8 @@ namespace winrt::Microsoft::Windows::Management::Deployment::implementation
                 PackageDeploymentStatus::CompletedFailure, activityId, error, extendedError, errorText);
         }
 
-        co_return winrt::make<PackageDeploymentResult>(PackageDeploymentStatus::CompletedSuccess, activityId);
-
         logTelemetry.Stop(packageFamilyName);
+        co_return winrt::make<PackageDeploymentResult>(PackageDeploymentStatus::CompletedSuccess, activityId);
     }
 
     HRESULT PackageDeploymentManager::RepairPackageByFamilyName(
@@ -3029,9 +3011,8 @@ namespace winrt::Microsoft::Windows::Management::Deployment::implementation
                 PackageDeploymentStatus::CompletedFailure, activityId, error, extendedError, errorText);
         }
 
-        co_return winrt::make<PackageDeploymentResult>(PackageDeploymentStatus::CompletedSuccess, activityId);
-
         logTelemetry.Stop(packageFullName);
+        co_return winrt::make<PackageDeploymentResult>(PackageDeploymentStatus::CompletedSuccess, activityId);
     }
 
     HRESULT PackageDeploymentManager::RepairPackageByFullName(
@@ -3178,9 +3159,8 @@ namespace winrt::Microsoft::Windows::Management::Deployment::implementation
                 PackageDeploymentStatus::CompletedFailure, activityId, error, extendedError, errorText);
         }
 
-        co_return winrt::make<PackageDeploymentResult>(PackageDeploymentStatus::CompletedSuccess, activityId);
-
         logTelemetry.Stop(packageFamilyName);
+        co_return winrt::make<PackageDeploymentResult>(PackageDeploymentStatus::CompletedSuccess, activityId);
     }
 
     HRESULT PackageDeploymentManager::ProvisionPackageByFamilyName(
@@ -3293,9 +3273,8 @@ namespace winrt::Microsoft::Windows::Management::Deployment::implementation
                 PackageDeploymentStatus::CompletedFailure, activityId, error, extendedError, errorText);
         }
 
-        co_return winrt::make<PackageDeploymentResult>(PackageDeploymentStatus::CompletedSuccess, activityId);
-
         logTelemetry.Stop(packageFamilyName);
+        co_return winrt::make<PackageDeploymentResult>(PackageDeploymentStatus::CompletedSuccess, activityId);
     }
 
     HRESULT PackageDeploymentManager::DeprovisionPackageByFamilyName(

--- a/dev/PackageManager/API/M.W.M.D.PackageDeploymentManager.cpp
+++ b/dev/PackageManager/API/M.W.M.D.PackageDeploymentManager.cpp
@@ -428,8 +428,6 @@ namespace winrt::Microsoft::Windows::Management::Deployment::implementation
             logTelemetry.Stop(packageUri.ToString());
             co_return co_await EnsurePackageSetReadyAsync(packageSet, options);
         }
-
-        logTelemetry.Stop(packageUri.ToString());
     }
     winrt::Windows::Foundation::IAsyncOperationWithProgress<winrt::Microsoft::Windows::Management::Deployment::PackageDeploymentResult, winrt::Microsoft::Windows::Management::Deployment::PackageDeploymentProgress>
     PackageDeploymentManager::EnsurePackageSetReadyAsync(winrt::Microsoft::Windows::Management::Deployment::PackageSet packageSet, winrt::Microsoft::Windows::Management::Deployment::EnsureReadyOptions options)

--- a/dev/PackageManager/API/M.W.M.D.PackageDeploymentManager.cpp
+++ b/dev/PackageManager/API/M.W.M.D.PackageDeploymentManager.cpp
@@ -460,18 +460,21 @@ namespace winrt::Microsoft::Windows::Management::Deployment::implementation
         const double c_progressPercentageStartOfIsReady{ 0.01 };
         packageDeploymentProgress.Progress = c_progressPercentageStartOfIsReady;
         progress(packageDeploymentProgress);
-        bool isReady{};
+        winrt::Microsoft::Windows::Management::Deployment::PackageReadyOrNewerAvailableStatus readyOrNewerStatus{};
         if (options.RegisterNewerIfAvailable())
         {
             THROW_HR_IF_MSG(E_NOTIMPL, !IsPackageDeploymentFeatureSupported(winrt::Microsoft::Windows::Management::Deployment::PackageDeploymentFeature::IsPackageReadyOrNewerAvailable), "RegisterNewerIfAvailable is not supported on this system");
-            isReady = (IsPackageSetReadyOrNewerAvailable(packageSet) == winrt::Microsoft::Windows::Management::Deployment::PackageReadyOrNewerAvailableStatus::Ready);
+            readyOrNewerStatus = IsPackageSetReadyOrNewerAvailable(packageSet);
         }
         else
         {
-            isReady = IsPackageSetReady(packageSet);
+            readyOrNewerStatus = IsPackageSetReady(packageSet) ?
+                winrt::Microsoft::Windows::Management::Deployment::PackageReadyOrNewerAvailableStatus::Ready :
+                winrt::Microsoft::Windows::Management::Deployment::PackageReadyOrNewerAvailableStatus::NotReady;
         }
-        if (isReady)
+        if (readyOrNewerStatus == winrt::Microsoft::Windows::Management::Deployment::PackageReadyOrNewerAvailableStatus::Ready)
         {
+            logTelemetry.Stop(packageSet.Id(), readyOrNewerStatus);
             co_return winrt::make<PackageDeploymentResult>(PackageDeploymentStatus::CompletedSuccess, winrt::guid{});
         }
 
@@ -484,7 +487,6 @@ namespace winrt::Microsoft::Windows::Management::Deployment::implementation
         HRESULT extendedError{};
         winrt::hstring errorText;
         winrt::guid activityId{};
-        winrt::Microsoft::Windows::Management::Deployment::PackageReadyOrNewerAvailableStatus readyOrNewerStatus{};
         for (const winrt::Microsoft::Windows::Management::Deployment::PackageSetItem& packageSetItem : packageSetItems)
         {
             const auto packageFamilyName{ packageSetItem.PackageFamilyName() };

--- a/dev/PackageManager/API/M.W.M.D.PackageDeploymentManager.h
+++ b/dev/PackageManager/API/M.W.M.D.PackageDeploymentManager.h
@@ -95,7 +95,8 @@ namespace winrt::Microsoft::Windows::Management::Deployment::implementation
             const double progressMaxPerPackageSetItem,
             HRESULT& extendedError,
             winrt::hstring& errorText,
-            winrt::guid& activityId);
+            winrt::guid& activityId,
+            winrt::Microsoft::Windows::Management::Deployment::PackageReadyOrNewerAvailableStatus& readyOrNewerStatus);
         HRESULT AddPackage(
             winrt::Windows::Foundation::Uri const& packageUri,
             winrt::Microsoft::Windows::Management::Deployment::AddPackageOptions const& options,

--- a/dev/PackageManager/API/PackageManagerTelemetry.h
+++ b/dev/PackageManager/API/PackageManagerTelemetry.h
@@ -5,6 +5,8 @@
 
 #include <WindowsAppRuntimeInsights.h>
 
+#include "M.W.M.D.PackageDeploymentManager.h"
+
 DECLARE_TRACELOGGING_CLASS(PackageManagementTelemetryProvider,
     "Microsoft.WindowsAppSDK.Deployment.PackageManagementTelemetry",
     // {90ffebd9-9489-473d-9b38-7658b4826270}
@@ -135,7 +137,7 @@ public:
                 TraceLoggingWideString(package.c_str(), "Package"));
         }
         CATCH_LOG()
-        DEFINE_ACTIVITY_STOP(winrt::hstring const& package) noexcept try
+        DEFINE_ACTIVITY_STOP(winrt::hstring const& package, winrt::Microsoft::Windows::Management::Deployment::PackageReadyOrNewerAvailableStatus readyOrNewerStatus) noexcept try
         {
             TraceLoggingClassWriteStop(
                 EnsurePackageReadyAsync,
@@ -171,7 +173,7 @@ public:
                 TraceLoggingWideString(packageSetId.c_str(), "PackageSetId"));
         }
         CATCH_LOG()
-        DEFINE_ACTIVITY_STOP(winrt::hstring const& packageSetId) noexcept try
+        DEFINE_ACTIVITY_STOP(winrt::hstring const& packageSetId, winrt::Microsoft::Windows::Management::Deployment::PackageReadyOrNewerAvailableStatus readyOrNewerStatus) noexcept try
         {
             TraceLoggingClassWriteStop(
                 EnsurePackageSetReadyAsync,

--- a/dev/PackageManager/API/PackageManagerTelemetry.h
+++ b/dev/PackageManager/API/PackageManagerTelemetry.h
@@ -142,7 +142,8 @@ public:
             TraceLoggingClassWriteStop(
                 EnsurePackageReadyAsync,
                 _GENERIC_PARTB_FIELDS_ENABLED,
-                TraceLoggingWideString(package.c_str(), "Package"));
+                TraceLoggingWideString(package.c_str(), "Package"),
+                TraceLoggingInt32(static_cast<std::int32_t>(readyOrNewerStatus), "ReadyOrNewerStatus"));
         }
         CATCH_LOG()
     END_ACTIVITY_CLASS();
@@ -178,7 +179,8 @@ public:
             TraceLoggingClassWriteStop(
                 EnsurePackageSetReadyAsync,
                 _GENERIC_PARTB_FIELDS_ENABLED,
-                TraceLoggingWideString(packageSetId.c_str(), "PackageSetId"));
+                TraceLoggingWideString(packageSetId.c_str(), "PackageSetId"),
+                TraceLoggingInt32(static_cast<std::int32_t>(readyOrNewerStatus), "ReadyOrNewerStatus"));
         }
         CATCH_LOG()
     END_ACTIVITY_CLASS();


### PR DESCRIPTION
!cherry-pick 0562da1
!cherry-pick 3c17287

* PackageDeploymentManager - Fix .Stop() events not being generated. Include PackageReadyOrNewerAvailableStatus in .Stop() events. [#5278](https://github.com/microsoft/WindowsAppSDK/pull/5278)
* PackageDeploymentManager - Add missing .Stop() event on CompletedSuccess [#5284](https://github.com/microsoft/WindowsAppSDK/pull/5284)

https://task.ms/56951092