### PR TITLE
Remove erroneous UniversalBGTask.Task.Run definition

### DIFF
--- a/dev/WindowsAppRuntime_UniversalBGTaskDLL/Task.cpp
+++ b/dev/WindowsAppRuntime_UniversalBGTaskDLL/Task.cpp
@@ -14,7 +14,6 @@ using namespace winrt::Windows::Storage;
 
 namespace winrt::Microsoft::Windows::ApplicationModel::Background::UniversalBGTask::implementation
 {
-    inline constexpr CLSID IID_IBackgroundTask = { 2098451764, 64786, 17358, 140, 34, 234, 31, 241, 60, 6, 223 };
     void Task::Run(winrt::Windows::ApplicationModel::Background::IBackgroundTaskInstance taskInstance)
     {
         winrt::hstring lookupStr = winrt::to_hstring(taskInstance.Task().TaskId());
@@ -23,7 +22,7 @@ namespace winrt::Microsoft::Windows::ApplicationModel::Background::UniversalBGTa
         auto lookupobj = values.Lookup(lookupStr);
         winrt::guid comClsId = winrt::unbox_value<winrt::guid>(lookupobj);
 
-        THROW_IF_FAILED(CoCreateInstance(comClsId, nullptr, CLSCTX_LOCAL_SERVER, IID_IBackgroundTask, reinterpret_cast<void**>(&m_bgTask)));
+        THROW_IF_FAILED(CoCreateInstance(comClsId, nullptr, CLSCTX_LOCAL_SERVER, winrt::guid_of<winrt::Windows::ApplicationModel::Background::IBackgroundTask>(), winrt::put_abi(m_bgTask)));
         m_bgTask.Run(taskInstance);
     }
 }

--- a/dev/WindowsAppRuntime_UniversalBGTaskDLL/Task.idl
+++ b/dev/WindowsAppRuntime_UniversalBGTaskDLL/Task.idl
@@ -11,6 +11,5 @@ namespace Microsoft.Windows.ApplicationModel.Background.UniversalBGTask
     runtimeclass Task : Windows.ApplicationModel.Background.IBackgroundTask
     {
         Task();
-        void Run(Windows.ApplicationModel.Background.IBackgroundTaskInstance taskInstance);
     }
 }


### PR DESCRIPTION
Drive-by: improve CoCreateInstance call (avoids leaks and hardcoded GUID)

Solves https://github.com/microsoft/cppwinrt/issues/1485

A microsoft employee must use /azp run to validate using the pipelines below.

WARNING:
Comments made by azure-pipelines bot maybe inaccurate.
Please see pipeline link to verify that the build is being ran.

For status checks on the main branch, please use TransportPackage-Foundation-PR
(https://microsoft.visualstudio.com/ProjectReunion/_build?definitionId=81063&_a=summary)
and run the build against your PR branch with the default parameters.
