### PR TITLE
Fix Bootstrapper only use Win11 DynamicDependency API if available AND WinAppSDK target >= 1.7

### DIFF
--- a/WindowsAppRuntime.sln
+++ b/WindowsAppRuntime.sln
@@ -67,6 +67,8 @@ Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "Framework.Math.Multiply", "
 EndProject
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "Microsoft.WindowsAppRuntime.Framework", "test\DynamicDependency\data\Microsoft.WindowsAppRuntime.Framework\Microsoft.WindowsAppRuntime.Framework.vcxproj", "{9C1A6C58-52D6-4514-9120-5C339C5DF4BE}"
 	ProjectSection(ProjectDependencies) = postProject
+		{4410D374-A90C-4ADF-8B15-AA2AAE2636BF} = {4410D374-A90C-4ADF-8B15-AA2AAE2636BF}
+		{BC5E5A3E-E733-4388-8B00-F8495DA7C778} = {BC5E5A3E-E733-4388-8B00-F8495DA7C778}
 		{BF3FCED0-CADB-490A-93A7-4D90E1F45AB0} = {BF3FCED0-CADB-490A-93A7-4D90E1F45AB0}
 	EndProjectSection
 EndProject

--- a/WindowsAppRuntime.sln
+++ b/WindowsAppRuntime.sln
@@ -67,8 +67,7 @@ Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "Framework.Math.Multiply", "
 EndProject
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "Microsoft.WindowsAppRuntime.Framework", "test\DynamicDependency\data\Microsoft.WindowsAppRuntime.Framework\Microsoft.WindowsAppRuntime.Framework.vcxproj", "{9C1A6C58-52D6-4514-9120-5C339C5DF4BE}"
 	ProjectSection(ProjectDependencies) = postProject
-		{4410D374-A90C-4ADF-8B15-AA2AAE2636BF} = {4410D374-A90C-4ADF-8B15-AA2AAE2636BF}
-		{BC5E5A3E-E733-4388-8B00-F8495DA7C778} = {BC5E5A3E-E733-4388-8B00-F8495DA7C778}
+		{BF3FCED0-CADB-490A-93A7-4D90E1F45AB0} = {BF3FCED0-CADB-490A-93A7-4D90E1F45AB0}
 	EndProjectSection
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "DynamicDependencyDataStore", "DynamicDependencyDataStore", "{441A3BB0-7FD2-4902-AEDB-A1C57B528C77}"

--- a/dev/WindowsAppRuntime_BootstrapDLL/MddBootstrap.cpp
+++ b/dev/WindowsAppRuntime_BootstrapDLL/MddBootstrap.cpp
@@ -81,7 +81,7 @@ enum class UsingWin11Support
     Unknown = 0,
     Yes,
     No,
-}
+};
 static UsingWin11Support g_usingWin11Support{ UsingWin11Support.Unknown };
 
 static IDynamicDependencyLifetimeManager* g_lifetimeManager{};

--- a/dev/WindowsAppRuntime_BootstrapDLL/MddBootstrap.cpp
+++ b/dev/WindowsAppRuntime_BootstrapDLL/MddBootstrap.cpp
@@ -82,7 +82,7 @@ enum class UsingWin11Support
     Yes,
     No,
 };
-static UsingWin11Support g_usingWin11Support{ UsingWin11Support.Unknown };
+static UsingWin11Support g_usingWin11Support{ UsingWin11Support::Unknown };
 
 static IDynamicDependencyLifetimeManager* g_lifetimeManager{};
 static wil::unique_event g_endTheLifetimeManagerEvent;
@@ -269,7 +269,7 @@ STDAPI_(void) MddBootstrapShutdown() noexcept
             g_lifetimeManager = nullptr;
         }
 
-        g_usingWin11Support = UsingWin11Support.Unknown;
+        g_usingWin11Support = UsingWin11Support::Unknown;
     }
 
     if (activityContext.GetShutdownActivity().IsRunning())
@@ -324,7 +324,7 @@ void VerifyInitializationIsCompatible(
     // g_windowsAppRuntimeDll is only relevant if not delegating to OS APIs
     FAIL_FAST_HR_IF(E_UNEXPECTED, g_packageDependencyId == nullptr);
     FAIL_FAST_HR_IF(E_UNEXPECTED, g_packageDependencyContext == nullptr);
-    FAIL_FAST_HR_IF(E_UNEXPECTED, (g_usingWin11Support == UsingWin11Support.Yes) && (g_windowsAppRuntimeDll != nullptr));
+    FAIL_FAST_HR_IF(E_UNEXPECTED, (g_usingWin11Support == UsingWin11Support::No) && (g_windowsAppRuntimeDll == nullptr));
 
     // Verify the parameter(s)
     // NOTE: GetFrameworkPackageFamilyName() verifies the resulting package family name is valid.
@@ -405,7 +405,7 @@ void FirstTimeInitialization(
         }
 
         // Track our initialized state
-        g_usingWin11Support = UsingWin11Support.Yes;
+        g_usingWin11Support = UsingWin11Support::Yes;
         //
         g_packageDependencyId = std::move(packageDependencyId);
         g_packageDependencyContext = packageDependencyContext;
@@ -479,7 +479,7 @@ void FirstTimeInitialization(
         }
 
         // Track our initialized state
-        g_usingWin11Support = UsingWin11Support.No;
+        g_usingWin11Support = UsingWin11Support::No;
         //
         g_lifetimeManager = lifetimeManager.detach();
         g_endTheLifetimeManagerEvent = std::move(endTheLifetimeManagerEvent);

--- a/dev/WindowsAppRuntime_BootstrapDLL/MddBootstrap.cpp
+++ b/dev/WindowsAppRuntime_BootstrapDLL/MddBootstrap.cpp
@@ -76,6 +76,14 @@ HRESULT MddBootstrapInitialize_ShowUI_OnNoMatch(
 
 static std::mutex g_initializationLock;
 
+enum class UsingWin11Support
+{
+    Unknown = 0,
+    Yes,
+    No,
+}
+static UsingWin11Support g_usingWin11Support{ UsingWin11Support.Unknown };
+
 static IDynamicDependencyLifetimeManager* g_lifetimeManager{};
 static wil::unique_event g_endTheLifetimeManagerEvent;
 static wil::unique_hmodule g_windowsAppRuntimeDll;
@@ -235,7 +243,7 @@ STDAPI_(void) MddBootstrapShutdown() noexcept
     if (initializationCount == 1)
     {
         // Last one out turn out the lights...
-        if (g_packageDependencyContext && (MddCore::Win11::IsSupported() || g_windowsAppRuntimeDll))
+        if (g_packageDependencyContext)
         {
             MddRemovePackageDependency(g_packageDependencyContext);
             g_packageDependencyContext = nullptr;
@@ -251,7 +259,7 @@ STDAPI_(void) MddBootstrapShutdown() noexcept
             g_endTheLifetimeManagerEvent.reset();
         }
 
-        HRESULT hrLifetimeManagerShutdown = S_OK;
+        HRESULT hrLifetimeManagerShutdown{};
         if (g_lifetimeManager)
         {
             hrLifetimeManagerShutdown = g_lifetimeManager->Shutdown();
@@ -260,6 +268,8 @@ STDAPI_(void) MddBootstrapShutdown() noexcept
             g_lifetimeManager->Release();
             g_lifetimeManager = nullptr;
         }
+
+        g_usingWin11Support = UsingWin11Support.Unknown;
     }
 
     if (activityContext.GetShutdownActivity().IsRunning())
@@ -312,9 +322,9 @@ void VerifyInitializationIsCompatible(
     // g_lifetimeManager is optional. Don't check it
     // g_endTheLifetimeManagerEvent is optional. Don't check it
     // g_windowsAppRuntimeDll is only relevant if not delegating to OS APIs
-    FAIL_FAST_HR_IF(E_UNEXPECTED, !MddCore::Win11::IsSupported() && (g_windowsAppRuntimeDll == nullptr));
     FAIL_FAST_HR_IF(E_UNEXPECTED, g_packageDependencyId == nullptr);
     FAIL_FAST_HR_IF(E_UNEXPECTED, g_packageDependencyContext == nullptr);
+    FAIL_FAST_HR_IF(E_UNEXPECTED, (g_usingWin11Support == UsingWin11Support.Yes) && (g_windowsAppRuntimeDll != nullptr));
 
     // Verify the parameter(s)
     // NOTE: GetFrameworkPackageFamilyName() verifies the resulting package family name is valid.
@@ -363,8 +373,9 @@ void FirstTimeInitialization(
     // Make a copy of the versionTag in preparation of succcess
     const std::wstring packageVersionTag{ !versionTag ? L"" : versionTag };
 
-    // Use the Win11 APIs if available (instead of WinAppSDK's implementation)
-    if (MddCore::Win11::IsSupported())
+    // Use the Win11 APIs (instead of WinAppSDK's implementation) if target WinAppSDK >=1.7 and Win11 APIs are available
+    const UINT32 minVersionToUseWin11Support{ 0x00010007 };
+    if ((majorMinorVersion >= minVersionToUseWin11Support) && MddCore::Win11::IsSupported())
     {
         // Add the framework package to the package graph
         const std::wstring frameworkPackageFamilyName{ GetFrameworkPackageFamilyName(majorMinorVersion, packageVersionTag.c_str()) };
@@ -394,6 +405,8 @@ void FirstTimeInitialization(
         }
 
         // Track our initialized state
+        g_usingWin11Support = UsingWin11Support.Yes;
+        //
         g_packageDependencyId = std::move(packageDependencyId);
         g_packageDependencyContext = packageDependencyContext;
         //
@@ -466,6 +479,8 @@ void FirstTimeInitialization(
         }
 
         // Track our initialized state
+        g_usingWin11Support = UsingWin11Support.No;
+        //
         g_lifetimeManager = lifetimeManager.detach();
         g_endTheLifetimeManagerEvent = std::move(endTheLifetimeManagerEvent);
         g_windowsAppRuntimeDll = std::move(windowsAppRuntimeDll);


### PR DESCRIPTION
Bootstrapper uses the Win11 OS DynamicDependency API when available but should only do so for versions of WinAppSDK using the OS API, i.e. WinAppSDK >= 1.7

Also fixed a dependency build order issue

NOTE: This fix is for main/1.8. A separate PR will fix 1.7 per https://task.ms/57143286