### PR TITLE
[Build] Eliminate non-fatal PREfast errors with a temporarily workaround

### DIFF
--- a/build/AzurePipelinesTemplates/WindowsAppSDK-Build-Stage.yml
+++ b/build/AzurePipelinesTemplates/WindowsAppSDK-Build-Stage.yml
@@ -99,6 +99,13 @@ stages:
         IsOneBranch: ${{ parameters.IsOneBranch }}
         runStaticAnalysis : ${{ parameters.runStaticAnalysis }}
 
+    # This is a temporarily workaround to avoid getting non-fatal "folder C:\__t\NativeCompilerPrefast not found"
+    # errors from the Guardian PREfast task, which shouldn't even be run in the first place, because its pre-
+    # requisite of isNative=true isn't met currently.
+    - script: |
+        md "C:\__t\NativeCompilerPrefast"
+      displayName: 'Creating C:\__t\NativeCompilerPrefast to prevent errors from Guardian PREfast'
+
   - job: BuildFoundation_release_anycpu
     # For now, this job just builds Microsoft.WindowsAppRuntime.Bootstrap.Net.dll in AnyCPU
     # Can be expanded to add any other binary as needed
@@ -125,6 +132,13 @@ stages:
         SignOutput: ${{ parameters.SignOutput }}
         IsOneBranch: ${{ parameters.IsOneBranch }}
         runStaticAnalysis : ${{ parameters.runStaticAnalysis }}
+
+    # This is a temporarily workaround to avoid getting non-fatal "folder C:\__t\NativeCompilerPrefast not found"
+    # errors from the Guardian PREfast task, which shouldn't even be run in the first place, because its pre-
+    # requisite of isNative=true isn't met currently.
+    - script: |
+        md "C:\__t\NativeCompilerPrefast"
+      displayName: 'Creating C:\__t\NativeCompilerPrefast to prevent errors from Guardian PREfast'
 
   - job: BuildMRT
     pool:
@@ -197,3 +211,10 @@ stages:
         SignOutput: ${{ parameters.SignOutput }}
         IsOneBranch: ${{ parameters.IsOneBranch }}
         runStaticAnalysis : ${{ parameters.runStaticAnalysis }}
+
+    # This is a temporarily workaround to avoid getting non-fatal "folder C:\__t\NativeCompilerPrefast not found"
+    # errors from the Guardian PREfast task, which shouldn't even be run in the first place, because its pre-
+    # requisite of isNative=true isn't met currently.
+    - script: |
+        md "C:\__t\NativeCompilerPrefast"
+      displayName: 'Creating C:\__t\NativeCompilerPrefast to prevent errors from Guardian PREfast'

--- a/build/AzurePipelinesTemplates/WindowsAppSDK-PackTransportPackage-Stage.yml
+++ b/build/AzurePipelinesTemplates/WindowsAppSDK-PackTransportPackage-Stage.yml
@@ -35,7 +35,7 @@ stages:
       ob_outputDirectory: '$(REPOROOT)\out'
       ob_artifactBaseName: "TransportPackage"
       ob_sdl_prefast_enabled: false    # We currently do not build native code in this job.  
-steps:
+    steps:
     - task: NuGetAuthenticate@1
 
     - task: DownloadPipelineArtifact@2

--- a/build/AzurePipelinesTemplates/WindowsAppSDK-PackTransportPackage-Stage.yml
+++ b/build/AzurePipelinesTemplates/WindowsAppSDK-PackTransportPackage-Stage.yml
@@ -34,7 +34,8 @@ stages:
     variables:
       ob_outputDirectory: '$(REPOROOT)\out'
       ob_artifactBaseName: "TransportPackage"
-    steps:
+      ob_sdl_prefast_enabled: false    # We currently do not build native code in this job.  
+steps:
     - task: NuGetAuthenticate@1
 
     - task: DownloadPipelineArtifact@2


### PR DESCRIPTION
The temporarily workaround is simply creating an empty folder for Guardian PREfast to find, so it would stop throwing the "folder not found" error, which the pipeline run currently treats as non-fatal.
But these non-fatal errors are noisy, plaguing Foundation repo pipelines.

Because our Foundation pipelines currently set isNativeCode to false, while that value being true is a pre-requisite for running Guardian PREfast, hence at least in theory, the Guardian PREfast task shouldn't even run in the first place, but it did any way.

AFAICT, when the Guardian PREfast task 1) starts honoring its own isNativeCode pre-requisite and not run unless the pre-req is met, or 2) return to pre-Mar 17, 2025 behavior and stop throwing "folder not found" errors when the pre-req isn't even met, then we can remove the temp workaround. Until then, the simple workaround in this PR is deemed benign.

Similar changes have been applied to the Agg repo.

How tested:
- Private run of internal pipeline confirmed that with these changes, the non-fatal "folder not found" PREfast errors are gone.

///////////////////

A microsoft employee must use /azp run to validate using the pipelines below.

WARNING:
Comments made by azure-pipelines bot maybe inaccurate.
Please see pipeline link to verify that the build is being ran.

For status checks on the main branch, please use TransportPackage-Foundation-PR
(https://microsoft.visualstudio.com/ProjectReunion/_build?definitionId=81063&_a=summary)
and run the build against your PR branch with the default parameters.
