### PR TITLE
Task 57156413: [SFI][GetSecure] Vulnerability Management - Redeploy With Updated Code References - 4 issues in MMS2019 

### DIFF
--- a/build/WindowsAppSDK-TDBuild.yml
+++ b/build/WindowsAppSDK-TDBuild.yml
@@ -12,7 +12,11 @@ variables:
 
 jobs:
 - job: Localization
-  pool: 'ProjectReunionESPool'
+  pool:
+    type: windows
+    isCustom: true
+    name: 'ProjectReunionESPool-2022'
+    demands: ImageOverride -equals MMS2022
   steps:
   - template: AzurePipelinesTemplates\WindowsAppSDK-CallTouchDownBuild-Steps.yml
     parameters:


### PR DESCRIPTION
Upgrade OS image from MMS2019 to MMS2022 to reduce dependency on the not well maintained public image MMS2019.
Once we get ride of all references to MMS2019 in WinAppSDK yml files, we can remove the MMS2019 image from our 1ES hosted pool.

The MMS2019 OS image is only being used in ProjectReunionESPool. Only 2 places in WinAppSDK's code is using ProjectReunionESPool, this one, and another instance in the WindowsAppSDKArcadeServices repo.

///////////

A microsoft employee must use /azp run to validate using the pipelines below.

WARNING:
Comments made by azure-pipelines bot maybe inaccurate.
Please see pipeline link to verify that the build is being ran.

For status checks on the main branch, please use TransportPackage-Foundation-PR
(https://microsoft.visualstudio.com/ProjectReunion/_build?definitionId=81063&_a=summary)
and run the build against your PR branch with the default parameters.
