### PR TITLE
Revert "[main] Update dependencies from microsoft/LiftedIXP/DCPP"

### DIFF
--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -27,7 +27,7 @@
     -->
 <Dependencies>
   <ProductDependencies>
-    <Dependency Name="Microsoft.FrameworkUdk" Version="1.9.0-CI-26108.1805.250410-1448.0">
+    <Dependency Name="Microsoft.FrameworkUdk" Version="1.9.0-CI-26108.1804.250407-0932.0">
       <Uri>https://dev.azure.com/microsoft/LiftedIXP/_git/DCPP</Uri>
       <Sha>bc5dd07ec77079c367657d193154a29681300d42</Sha>
     </Dependency>
@@ -35,7 +35,7 @@
       <Uri>https://dev.azure.com/microsoft/ProjectReunion/_git/WindowsAppSDKClosed</Uri>
       <Sha>f52676312ebf1d66ef59731feb4fad29a713a897</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.ProjectReunion.InteractiveExperiences.TransportPackage" Version="1.9.0-CI-26108.1805.250410-1448.0">
+    <Dependency Name="Microsoft.ProjectReunion.InteractiveExperiences.TransportPackage" Version="1.9.0-CI-26108.1804.250407-0932.0">
       <Uri>https://dev.azure.com/microsoft/LiftedIXP/_git/DCPP</Uri>
       <Sha>bc5dd07ec77079c367657d193154a29681300d42</Sha>
     </Dependency>


### PR DESCRIPTION
Reverts microsoft/WindowsAppSDK#5329
As WinUI repo has test issue with newer version of IXP (1.9.0-CI-26108.1805.250410-1448.0)