### PR TITLE
Adding Microsoft.WindowsAppSDK.Foundation

### DIFF
--- a/BuildAll.ps1
+++ b/BuildAll.ps1
@@ -351,10 +351,10 @@ Try {
         }
         else
         {
-            $componentLicenseFilePath = "..\WindowsAppSDKConfig\NuGetLicense\preview\license.txt"
+            $componentLicenseFilePath = "WindowsAppSDKConfig\NuGetLicense\preview\license.txt"
             if ($env:Channel -eq 'stable')
             {
-                $componentLicenseFilePath = "..\WindowsAppSDKConfig\NuGetLicense\release\license.txt"
+                $componentLicenseFilePath = "WindowsAppSDKConfig\NuGetLicense\release\license.txt"
             }
         }
 

--- a/BuildAll.ps1
+++ b/BuildAll.ps1
@@ -374,6 +374,13 @@ Try {
             -Source (Join-Path $BasePath 'build') `
             -dest (Join-Path $ComponentBasePath 'buildTransitive')
 
+        # Copy transport package specific props / targets after we are done copying
+        # for the other package.
+        Copy-Item -Path "$nuSpecsPath\Microsoft.WindowsAppSDK.Foundation.TransportPackage.targets" -Destination "$BasePath\build"
+        Copy-Item -Path "$nuSpecsPath\Microsoft.WindowsAppSDK.Foundation.TransportPackage.props" -Destination "$BasePath\build"
+        Copy-Item -Path "$nuSpecsPath\Microsoft.WindowsAppSDK.Foundation.TransportPackage.targets" -Destination "$BasePath\build\native"
+        Copy-Item -Path "$nuSpecsPath\Microsoft.WindowsAppSDK.Foundation.TransportPackage.props" -Destination "$BasePath\build\native"
+
         build\Scripts\RobocopyWrapper.ps1 `
             -Source (Join-Path $BasePath 'lib\uap10.0') `
             -dest (Join-Path $ComponentBasePath 'metadata')

--- a/BuildAll.ps1
+++ b/BuildAll.ps1
@@ -364,6 +364,8 @@ Try {
             exit 1
         }
 
+        Copy-Item -Path "$nuSpecsPath\package.appxfragment" -Destination "$ComponentBasePath\runtimes-framework\package.appxfragment"
+
         build\Scripts\RobocopyWrapper.ps1 `
             -Source (Join-Path $BasePath 'build') `
             -dest (Join-Path $ComponentBasePath 'build')

--- a/BuildAll.ps1
+++ b/BuildAll.ps1
@@ -364,8 +364,6 @@ Try {
             exit 1
         }
 
-        Copy-Item -Path "$nuSpecsPath\package.appxfragment" -Destination "$ComponentBasePath\runtimes-framework\package.appxfragment"
-
         build\Scripts\RobocopyWrapper.ps1 `
             -Source (Join-Path $BasePath 'build') `
             -dest (Join-Path $ComponentBasePath 'build')
@@ -415,6 +413,8 @@ Try {
                     'native\RestartAgent.exe') `
                 -TargetDir "$ComponentBasePath\runtimes-framework\win-$platformToRun"
         }
+
+        Copy-Item -Path "$nuSpecsPath\package.appxfragment" -Destination "$ComponentBasePath\runtimes-framework\package.appxfragment"
     }
     if (($AzureBuildStep -eq "all") -Or ($AzureBuildStep -eq "PackNuget"))
     {

--- a/BuildAll.ps1
+++ b/BuildAll.ps1
@@ -441,16 +441,16 @@ Try {
         if ($platform.Split(",") -contains "x64")
         {
             build\Scripts\RobocopyWrapper.ps1 `
-                -Source "$AppxContentFolder\lib\win-x64" `
-                -dest "$AppxContentFolder\lib\win-arm64ec"
+                -Source "$ComponentBasePath\lib\win-x64" `
+                -dest "$ComponentBasePath\lib\win-arm64ec"
 
             build\Scripts\RobocopyWrapper.ps1 `
-                -Source "$AppxContentFolder\runtimes\win-x64" `
-                -dest "$AppxContentFolder\runtimes\win-arm64ec"
+                -Source "$ComponentBasePath\runtimes\win-x64" `
+                -dest "$ComponentBasePath\runtimes\win-arm64ec"
 
             build\Scripts\RobocopyWrapper.ps1 `
-                -Source "$AppxContentFolder\runtimes-framework\win-x64" `
-                -dest "$AppxContentFolder\runtimes-framework\win-arm64ec"
+                -Source "$ComponentBasePath\runtimes-framework\win-x64" `
+                -dest "$ComponentBasePath\runtimes-framework\win-arm64ec"
         }
 
         Copy-Item -Path "$nuSpecsPath\package.appxfragment" -Destination "$ComponentBasePath\runtimes-framework\package.appxfragment"

--- a/BuildAll.ps1
+++ b/BuildAll.ps1
@@ -345,7 +345,26 @@ Try {
             exit 1
         }
 
-        Copy-Item -Path "LICENSE" -Destination "$ComponentBasePath" -force
+        if ([string]::IsNullOrEmpty($env:Channel))
+        {
+            $componentLicenseFilePath = "LICENSE"
+        }
+        else
+        {
+            $componentLicenseFilePath = "..\WindowsAppSDKConfig\NuGetLicense\preview\license.txt"
+            if ($env:Channel -eq 'stable')
+            {
+                $componentLicenseFilePath = "..\WindowsAppSDKConfig\NuGetLicense\release\license.txt"
+            }
+        }
+
+        Copy-Item -Path $componentLicenseFilePath -Destination "$ComponentBasePath\license.txt" -force
+
+        if ($lastexitcode -ne 0)
+        {
+            write-host "ERROR: Copy-Item -Path $componentLicenseFilePath FAILED."
+            exit 1
+        }
 
         # for some reason xslt.load changes the working directory to C:\windows\system32.
         # store the current working directory here.

--- a/BuildAll.ps1
+++ b/BuildAll.ps1
@@ -409,7 +409,7 @@ Try {
         build\scripts\CopyContents.ps1 `
             -SourceDir "$PSScriptRoot\$BasePath" `
             -ContentsList @('lib') `
-            -Exclude @('*.winmd', '*.pdb') `
+            -Exclude @('*.winmd', '*.pdb', '*.lib') `
             -TargetDir $ComponentBasePath
 
         build\scripts\CopyContents.ps1 `
@@ -420,6 +420,10 @@ Try {
 
         foreach($platformToRun in $platform.Split(","))
         {
+            build\Scripts\RobocopyWrapper.ps1 `
+                -Source "$PSScriptRoot\$BasePath\lib\win10-$platformToRun" `
+                -dest "$ComponentBasePath\lib\win-$platformToRun"
+
             build\scripts\CopyContents.ps1 `
                 -SourceDir "$PSScriptRoot\$BasePath\runtimes\win10-$platformToRun" `
                 -ContentsList @(
@@ -431,6 +435,22 @@ Try {
                     'native\PushNotificationsLongRunningTask.ProxyStub.dll',
                     'native\RestartAgent.exe') `
                 -TargetDir "$ComponentBasePath\runtimes-framework\win-$platformToRun"
+        }
+
+        # Populate ARM64EC folders with x64 content
+        if ($platform.Split(",") -contains "x64")
+        {
+            build\Scripts\RobocopyWrapper.ps1 `
+                -Source "$AppxContentFolder\lib\win-x64" `
+                -dest "$AppxContentFolder\lib\win-arm64ec"
+
+            build\Scripts\RobocopyWrapper.ps1 `
+                -Source "$AppxContentFolder\runtimes\win-x64" `
+                -dest "$AppxContentFolder\runtimes\win-arm64ec"
+
+            build\Scripts\RobocopyWrapper.ps1 `
+                -Source "$AppxContentFolder\runtimes-framework\win-x64" `
+                -dest "$AppxContentFolder\runtimes-framework\win-arm64ec"
         }
 
         Copy-Item -Path "$nuSpecsPath\package.appxfragment" -Destination "$ComponentBasePath\runtimes-framework\package.appxfragment"

--- a/BuildAll.ps1
+++ b/BuildAll.ps1
@@ -345,6 +345,8 @@ Try {
             exit 1
         }
 
+        Copy-Item -Path "LICENSE" -Destination "$ComponentBasePath" -force
+
         # for some reason xslt.load changes the working directory to C:\windows\system32.
         # store the current working directory here.
         $workingDirectory = get-location

--- a/build/AzurePipelinesTemplates/WindowsAppSDK-BuildInstaller-Steps.yml
+++ b/build/AzurePipelinesTemplates/WindowsAppSDK-BuildInstaller-Steps.yml
@@ -187,7 +187,7 @@ steps:
   inputs:
     targetType: "inline"
     script: |
-      $srcWinAppSDKNupkgPath = Get-Childitem -Path '$(System.ArtifactsDirectory)\NugetPackages' -File '*Microsoft.WindowsAppSDK*'
+      $srcWinAppSDKNupkgPath = Get-Childitem -Path '$(System.ArtifactsDirectory)\NugetPackages' -File '*Microsoft.WindowsAppSDK*' | Where-Object { $_.Name -notlike "*Microsoft.WindowsAppSDK.Base*.nupkg" }
       Copy-Item -Force $srcWinAppSDKNupkgPath.FullName '$(Build.SourcesDirectory)\$(foundationRepoPath)packages\'
       $destWinAppSDKNupkgPath = Get-Childitem -Path '$(Build.SourcesDirectory)\$(foundationRepoPath)packages\' -File '*Microsoft.WindowsAppSDK*'
       $winAppSDKZip = $destWinAppSDKNupkgPath.FullName -replace '.nupkg','.zip'

--- a/build/AzurePipelinesTemplates/WindowsAppSDK-BuildVSIX-Steps.yml
+++ b/build/AzurePipelinesTemplates/WindowsAppSDK-BuildVSIX-Steps.yml
@@ -57,7 +57,7 @@ steps:
       foreach ($file in $files) # Iterate through each package we restored in the directory
       {
         Write-Host "file:" $file.FullName
-        $nupkgPaths = Get-ChildItem $file.FullName -Filter "*WindowsAppSDK*.nupkg"
+        $nupkgPaths = Get-ChildItem $file.FullName -Filter "*WindowsAppSDK*.nupkg" | Where-Object { $_.Name -notlike "*Microsoft.WindowsAppSDK.Base*.nupkg" }
 
         # Extract nupkg to access the nuspec
         # The files in this directory does not contain the nuspec by default

--- a/build/AzurePipelinesTemplates/WindowsAppSDK-PackTransportPackage-Stage.yml
+++ b/build/AzurePipelinesTemplates/WindowsAppSDK-PackTransportPackage-Stage.yml
@@ -148,9 +148,9 @@ stages:
           Write-Host "##vso[task.setvariable variable=packageVersion;isOutput=true;]$packageVersion"
 
           Write-Host $packageVersion
-          [xml]$publicNuspec = Get-Content -Path $(Build.SourcesDirectory)\build\NuSpecs\Microsoft.WindowsAppSDK.Foundation.nuspec
+          [xml]$publicNuspec = Get-Content -Path $(Build.SourcesDirectory)\build\NuSpecs\Microsoft.WindowsAppSDK.Foundation.TransportPackage.nuspec
           $publicNuspec.package.metadata.version = $packageVersion
-          Set-Content -Value $publicNuspec.OuterXml $(Build.SourcesDirectory)\build\NuSpecs\Microsoft.WindowsAppSDK.Foundation.nuspec
+          Set-Content -Value $publicNuspec.OuterXml $(Build.SourcesDirectory)\build\NuSpecs\Microsoft.WindowsAppSDK.Foundation.TransportPackage.nuspec
 
     - task: PowerShell@2
       name: PackNuget

--- a/build/AzurePipelinesTemplates/WindowsAppSDK-PackTransportPackage-Stage.yml
+++ b/build/AzurePipelinesTemplates/WindowsAppSDK-PackTransportPackage-Stage.yml
@@ -36,6 +36,9 @@ stages:
       ob_artifactBaseName: "TransportPackage"
       ob_sdl_prefast_enabled: false    # We currently do not build native code in this job.  
     steps:
+    - ${{ if not( parameters.IsOneBranch ) }}:
+      - checkout: self
+
     - checkout: WindowsAppSDKConfig
     - task: NuGetAuthenticate@1
 

--- a/build/AzurePipelinesTemplates/WindowsAppSDK-PackTransportPackage-Stage.yml
+++ b/build/AzurePipelinesTemplates/WindowsAppSDK-PackTransportPackage-Stage.yml
@@ -36,6 +36,7 @@ stages:
       ob_artifactBaseName: "TransportPackage"
       ob_sdl_prefast_enabled: false    # We currently do not build native code in this job.  
     steps:
+    - checkout: WindowsAppSDKConfig
     - task: NuGetAuthenticate@1
 
     - task: DownloadPipelineArtifact@2

--- a/build/AzurePipelinesTemplates/WindowsAppSDK-PackTransportPackage-Stage.yml
+++ b/build/AzurePipelinesTemplates/WindowsAppSDK-PackTransportPackage-Stage.yml
@@ -38,7 +38,7 @@ stages:
     steps:
     - ${{ if not( parameters.IsOneBranch ) }}:
       - checkout: self
-        path: .
+        path: s
 
     - checkout: WindowsAppSDKConfig
     - task: NuGetAuthenticate@1

--- a/build/AzurePipelinesTemplates/WindowsAppSDK-PackTransportPackage-Stage.yml
+++ b/build/AzurePipelinesTemplates/WindowsAppSDK-PackTransportPackage-Stage.yml
@@ -38,6 +38,7 @@ stages:
     steps:
     - ${{ if not( parameters.IsOneBranch ) }}:
       - checkout: self
+        path: .
 
     - checkout: WindowsAppSDKConfig
     - task: NuGetAuthenticate@1

--- a/build/NuSpecs/Microsoft.WindowsAppSDK.Bootstrap.CS.targets
+++ b/build/NuSpecs/Microsoft.WindowsAppSDK.Bootstrap.CS.targets
@@ -8,6 +8,7 @@
         <DefineConstants Condition="'$(WindowsAppSDKBootstrapAutoInitializeOptions_OnError_FailFast)'=='true'">$(DefineConstants);MICROSOFT_WINDOWSAPPSDK_BOOTSTRAP_AUTO_INITIALIZE_OPTIONS_ONERROR_FAILFAST</DefineConstants>
         <DefineConstants Condition="'$(WindowsAppSDKBootstrapAutoInitializeOptions_OnNoMatch_ShowUI)'=='true'">$(DefineConstants);MICROSOFT_WINDOWSAPPSDK_BOOTSTRAP_AUTO_INITIALIZE_OPTIONS_ONNOMATCH_SHOWUI</DefineConstants>
         <DefineConstants Condition="'$(WindowsAppSDKBootstrapAutoInitializeOptions_OnPackageIdentity_NoOp)'=='true'">$(DefineConstants);MICROSOFT_WINDOWSAPPSDK_BOOTSTRAP_AUTO_INITIALIZE_OPTIONS_ONPACKAGEIDENTITY_NOOP</DefineConstants>
+        <DefineConstants>$(DefineConstants);MICROSOFT_WINDOWSAPPSDK_BOOTSTRAP_AUTO_INITIALIZE</DefineConstants>
         <WindowsAppSdkIncludeVersionInfo>true</WindowsAppSdkIncludeVersionInfo>
     </PropertyGroup>
 

--- a/build/NuSpecs/Microsoft.WindowsAppSDK.Foundation.TransportPackage.nuspec
+++ b/build/NuSpecs/Microsoft.WindowsAppSDK.Foundation.TransportPackage.nuspec
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
      <metadata minClientVersion="3.3">
-         <id>Microsoft.WindowsAppSDK.Foundation</id>
+         <id>Microsoft.WindowsAppSDK.Foundation.TransportPackage</id>
          <version>1.0</version>
          <title>$id$</title>
          <authors>Microsoft</authors>

--- a/build/NuSpecs/Microsoft.WindowsAppSDK.Foundation.TransportPackage.props
+++ b/build/NuSpecs/Microsoft.WindowsAppSDK.Foundation.TransportPackage.props
@@ -1,6 +1,10 @@
 ﻿<!-- Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT License. See LICENSE in the project root for license information. -->
 <Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 
+  <PropertyGroup>
+    <WindowsAppSdkFoundationTransportPackage>true</WindowsAppSdkFoundationTransportPackage>
+  </PropertyGroup>
+
   <Import Project="$(MSBuildThisFileDirectory)Microsoft.WindowsAppSDK.Foundation.props" />
 
 </Project>

--- a/build/NuSpecs/Microsoft.WindowsAppSDK.Foundation.TransportPackage.props
+++ b/build/NuSpecs/Microsoft.WindowsAppSDK.Foundation.TransportPackage.props
@@ -2,7 +2,7 @@
 <Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 
   <PropertyGroup>
-    <WindowsAppSdkFoundationTransportPackage>true</WindowsAppSdkFoundationTransportPackage>
+    <WindowsAppSDKAggregatePackage>true</WindowsAppSDKAggregatePackage>
   </PropertyGroup>
 
   <Import Project="$(MSBuildThisFileDirectory)Microsoft.WindowsAppSDK.Foundation.props" />

--- a/build/NuSpecs/Microsoft.WindowsAppSDK.Foundation.TransportPackage.props
+++ b/build/NuSpecs/Microsoft.WindowsAppSDK.Foundation.TransportPackage.props
@@ -1,0 +1,6 @@
+﻿<!-- Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT License. See LICENSE in the project root for license information. -->
+<Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+
+  <Import Project="$(MSBuildThisFileDirectory)Microsoft.WindowsAppSDK.Foundation.props" />
+
+</Project>

--- a/build/NuSpecs/Microsoft.WindowsAppSDK.Foundation.TransportPackage.targets
+++ b/build/NuSpecs/Microsoft.WindowsAppSDK.Foundation.TransportPackage.targets
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT License. See LICENSE in the project root for license information. -->
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+
+  <Import Project="$(MSBuildThisFileDirectory)Microsoft.WindowsAppSDK.Foundation.targets" />
+
+</Project>

--- a/build/NuSpecs/Microsoft.WindowsAppSDK.Foundation.nuspec
+++ b/build/NuSpecs/Microsoft.WindowsAppSDK.Foundation.nuspec
@@ -6,7 +6,7 @@
          <title>$id$</title>
          <authors>Microsoft</authors>
          <description>Windows App SDK</description>
-         <license type="file">LICENSE</license>
+         <license type="file">license.txt</license>
          <requireLicenseAcceptance>true</requireLicenseAcceptance>
          <projectUrl>https://aka.ms/windowsappsdk</projectUrl>
          <copyright>© Microsoft Corporation. All rights reserved.</copyright>

--- a/build/NuSpecs/Microsoft.WindowsAppSDK.Foundation.props
+++ b/build/NuSpecs/Microsoft.WindowsAppSDK.Foundation.props
@@ -9,7 +9,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <WindowsAppSdkComponentPackage Include="$(MSBuildThisFileDirectory)..\" />
+    <WindowsAppSdkComponentPackages Include="$(MSBuildThisFileDirectory)..\" />
   </ItemGroup>
 
 </Project>

--- a/build/NuSpecs/Microsoft.WindowsAppSDK.Foundation.props
+++ b/build/NuSpecs/Microsoft.WindowsAppSDK.Foundation.props
@@ -8,4 +8,8 @@
     <WindowsAppSdkFoundation>true</WindowsAppSdkFoundation>
   </PropertyGroup>
 
+  <ItemGroup>
+    <WindowsAppSdkComponentPackage Include="$(MSBuildThisFileDirectory)..\" />
+  </ItemGroup>
+
 </Project>

--- a/build/NuSpecs/Microsoft.WindowsAppSDK.Foundation.targets
+++ b/build/NuSpecs/Microsoft.WindowsAppSDK.Foundation.targets
@@ -20,20 +20,4 @@
     <Compile Condition="'$(WindowsAppSdkIncludeVersionInfo)'=='true'" Include="$(MSBuildThisFileDirectory)..\include\WindowsAppSDK-VersionInfo.cs" />
   </ItemGroup>
 
-  <!--Define compile-time constants-->
-  <!--TODO Move to windowsappsdk\build\NuSpecs\WindowsAppSDK-Nuget-Native.Bootstrap.targets -->
-  <Target Name="WindowsAppSDKBootstrapCompileTimeConstants"
-          BeforeTargets="ClCompile"
-          Condition="'$(WindowsAppSdkBootstrapInitialize)'=='true'">
-    <ItemGroup>
-      <ClCompile>
-        <PreprocessorDefinitions>%(PreprocessorDefinitions);MICROSOFT_WINDOWSAPPSDK_BOOTSTRAP_AUTO_INITIALIZE=1</PreprocessorDefinitions>
-      </ClCompile>
-    </ItemGroup>
-  </Target>
-  <!--TODO Move to windowsappsdk\build\NuSpecs\Microsoft.WindowsAppSDK.Bootstrap.CS.targets -->
-  <PropertyGroup Condition="'$(WindowsAppSdkBootstrapInitialize)'=='true'">
-    <DefineConstants>$(DefineConstants);MICROSOFT_WINDOWSAPPSDK_BOOTSTRAP_AUTO_INITIALIZE</DefineConstants>
-  </PropertyGroup>
-
 </Project>

--- a/build/NuSpecs/Microsoft.WindowsAppSDK.Foundation.targets
+++ b/build/NuSpecs/Microsoft.WindowsAppSDK.Foundation.targets
@@ -20,4 +20,20 @@
     <Compile Condition="'$(WindowsAppSdkIncludeVersionInfo)'=='true'" Include="$(MSBuildThisFileDirectory)..\include\WindowsAppSDK-VersionInfo.cs" />
   </ItemGroup>
 
+  <!--Define compile-time constants-->
+  <!--TODO Move to windowsappsdk\build\NuSpecs\WindowsAppSDK-Nuget-Native.Bootstrap.targets -->
+  <Target Name="WindowsAppSDKBootstrapCompileTimeConstants"
+          BeforeTargets="ClCompile"
+          Condition="'$(WindowsAppSdkBootstrapInitialize)'=='true'">
+    <ItemGroup>
+      <ClCompile>
+        <PreprocessorDefinitions>%(PreprocessorDefinitions);MICROSOFT_WINDOWSAPPSDK_BOOTSTRAP_AUTO_INITIALIZE=1</PreprocessorDefinitions>
+      </ClCompile>
+    </ItemGroup>
+  </Target>
+  <!--TODO Move to windowsappsdk\build\NuSpecs\Microsoft.WindowsAppSDK.Bootstrap.CS.targets -->
+  <PropertyGroup Condition="'$(WindowsAppSdkBootstrapInitialize)'=='true'">
+    <DefineConstants>$(DefineConstants);MICROSOFT_WINDOWSAPPSDK_BOOTSTRAP_AUTO_INITIALIZE</DefineConstants>
+  </PropertyGroup>
+
 </Project>

--- a/build/NuSpecs/WindowsAppSDK-Nuget-Native.Bootstrap.targets
+++ b/build/NuSpecs/WindowsAppSDK-Nuget-Native.Bootstrap.targets
@@ -11,6 +11,7 @@
                 <PreprocessorDefinitions Condition="'$(WindowsAppSDKBootstrapAutoInitializeOptions_OnError_FailFast)'=='true'">MICROSOFT_WINDOWSAPPSDK_BOOTSTRAP_AUTO_INITIALIZE_OPTIONS_ONERROR_FAILFAST;%(PreprocessorDefinitions)</PreprocessorDefinitions>
                 <PreprocessorDefinitions Condition="'$(WindowsAppSDKBootstrapAutoInitializeOptions_OnNoMatch_ShowUI)'=='true'">MICROSOFT_WINDOWSAPPSDK_BOOTSTRAP_AUTO_INITIALIZE_OPTIONS_ONNOMATCH_SHOWUI;%(PreprocessorDefinitions)</PreprocessorDefinitions>
                 <PreprocessorDefinitions Condition="'$(WindowsAppSDKBootstrapAutoInitializeOptions_OnPackageIdentity_NoOp)'=='true'">MICROSOFT_WINDOWSAPPSDK_BOOTSTRAP_AUTO_INITIALIZE_OPTIONS_ONPACKAGEIDENTITY_NOOP;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+                <PreprocessorDefinitions>%(PreprocessorDefinitions);MICROSOFT_WINDOWSAPPSDK_BOOTSTRAP_AUTO_INITIALIZE=1</PreprocessorDefinitions>
             </ClCompile>
         </ItemGroup>
     </Target>

--- a/build/NuSpecs/WindowsAppSDK-Nuget-Native.C.props
+++ b/build/NuSpecs/WindowsAppSDK-Nuget-Native.C.props
@@ -4,6 +4,8 @@
   <PropertyGroup>
     <_WindowsAppSDKFoundationPlatform Condition="'$(Platform)' == 'Win32'">x86</_WindowsAppSDKFoundationPlatform>
     <_WindowsAppSDKFoundationPlatform Condition="'$(Platform)' != 'Win32'">$(Platform)</_WindowsAppSDKFoundationPlatform>
+    <_FoundationLibFolder>$(MSBuildThisFileDirectory)..\..\lib\win-$(_WindowsAppSDKFoundationPlatform)</_FoundationLibFolder>
+    <_FoundationLibFolder Condition="'$(WindowsAppSdkFoundationTransportPackage)' == 'true'">$(MSBuildThisFileDirectory)..\..\lib\win10-$(_WindowsAppSDKFoundationPlatform)</_FoundationLibFolder>
   </PropertyGroup>
 
   <ItemDefinitionGroup>
@@ -15,7 +17,7 @@
   <ItemDefinitionGroup>
     <Link>
       <AdditionalDependencies>
-        $(MSBuildThisFileDirectory)..\..\lib\win10-$(_WindowsAppSDKFoundationPlatform)\Microsoft.WindowsAppRuntime.lib;
+        $(_FoundationLibFolder)\Microsoft.WindowsAppRuntime.lib;
         %(AdditionalDependencies);
       </AdditionalDependencies>
     </Link>
@@ -24,7 +26,7 @@
   <ItemDefinitionGroup Condition="'$(AppxPackage)' != 'true'">
     <Link>
       <AdditionalDependencies>
-        $(MSBuildThisFileDirectory)..\..\lib\win10-$(_WindowsAppSDKFoundationPlatform)\Microsoft.WindowsAppRuntime.Bootstrap.lib;
+        $(_FoundationLibFolder)\Microsoft.WindowsAppRuntime.Bootstrap.lib;
         %(AdditionalDependencies);
       </AdditionalDependencies>
     </Link>

--- a/build/NuSpecs/WindowsAppSDK-Nuget-Native.C.props
+++ b/build/NuSpecs/WindowsAppSDK-Nuget-Native.C.props
@@ -5,7 +5,7 @@
     <_WindowsAppSDKFoundationPlatform Condition="'$(Platform)' == 'Win32'">x86</_WindowsAppSDKFoundationPlatform>
     <_WindowsAppSDKFoundationPlatform Condition="'$(Platform)' != 'Win32'">$(Platform)</_WindowsAppSDKFoundationPlatform>
     <_FoundationLibFolder>$(MSBuildThisFileDirectory)..\..\lib\win-$(_WindowsAppSDKFoundationPlatform)</_FoundationLibFolder>
-    <_FoundationLibFolder Condition="'$(WindowsAppSdkFoundationTransportPackage)' == 'true'">$(MSBuildThisFileDirectory)..\..\lib\win10-$(_WindowsAppSDKFoundationPlatform)</_FoundationLibFolder>
+    <_FoundationLibFolder Condition="'$(WindowsAppSDKAggregatePackage)' == 'true'">$(MSBuildThisFileDirectory)..\..\lib\win10-$(_WindowsAppSDKFoundationPlatform)</_FoundationLibFolder>
   </PropertyGroup>
 
   <ItemDefinitionGroup>

--- a/build/NuSpecs/WindowsAppSDK-Nuget-Native.WinRt.props
+++ b/build/NuSpecs/WindowsAppSDK-Nuget-Native.WinRt.props
@@ -5,9 +5,9 @@
     <_WindowsAppSDKFoundationPlatform Condition="'$(Platform)' == 'Win32'">x86</_WindowsAppSDKFoundationPlatform>
     <_WindowsAppSDKFoundationPlatform Condition="'$(Platform)' != 'Win32'">$(Platform)</_WindowsAppSDKFoundationPlatform>
     <_FoundationMetadataFolder>$(MSBuildThisFileDirectory)..\..\metadata</_FoundationMetadataFolder>
-    <_FoundationMetadataFolder Condition="'$(WindowsAppSdkFoundationTransportPackage)' == 'true'">$(MSBuildThisFileDirectory)..\..\lib\uap10.0</_FoundationMetadataFolder>
+    <_FoundationMetadataFolder Condition="'$(WindowsAppSDKAggregatePackage)' == 'true'">$(MSBuildThisFileDirectory)..\..\lib\uap10.0</_FoundationMetadataFolder>
     <_FoundationRuntimesFrameworkFolder>$(MSBuildThisFileDirectory)..\..\runtimes-framework\win-$(_WindowsAppSDKFoundationPlatform)\native</_FoundationRuntimesFrameworkFolder>
-    <_FoundationRuntimesFrameworkFolder Condition="'$(WindowsAppSdkFoundationTransportPackage)' == 'true'">$(MSBuildThisFileDirectory)..\..\runtimes\win10-$(_WindowsAppSDKFoundationPlatform)\native</_FoundationRuntimesFrameworkFolder>
+    <_FoundationRuntimesFrameworkFolder Condition="'$(WindowsAppSDKAggregatePackage)' == 'true'">$(MSBuildThisFileDirectory)..\..\runtimes\win10-$(_WindowsAppSDKFoundationPlatform)\native</_FoundationRuntimesFrameworkFolder>
   </PropertyGroup>
 
   <ItemGroup Condition="'$(AppxPackage)' != 'true'">

--- a/build/NuSpecs/WindowsAppSDK-Nuget-Native.WinRt.props
+++ b/build/NuSpecs/WindowsAppSDK-Nuget-Native.WinRt.props
@@ -4,87 +4,91 @@
   <PropertyGroup>
     <_WindowsAppSDKFoundationPlatform Condition="'$(Platform)' == 'Win32'">x86</_WindowsAppSDKFoundationPlatform>
     <_WindowsAppSDKFoundationPlatform Condition="'$(Platform)' != 'Win32'">$(Platform)</_WindowsAppSDKFoundationPlatform>
+    <_FoundationMetadataFolder>$(MSBuildThisFileDirectory)..\..\metadata</_FoundationMetadataFolder>
+    <_FoundationMetadataFolder Condition="'$(WindowsAppSdkFoundationTransportPackage)' == 'true'">$(MSBuildThisFileDirectory)..\..\lib\uap10.0</_FoundationMetadataFolder>
+    <_FoundationRuntimesFrameworkFolder>$(MSBuildThisFileDirectory)..\..\runtimes-framework\win-$(_WindowsAppSDKFoundationPlatform)\native</_FoundationRuntimesFrameworkFolder>
+    <_FoundationRuntimesFrameworkFolder Condition="'$(WindowsAppSdkFoundationTransportPackage)' == 'true'">$(MSBuildThisFileDirectory)..\..\runtimes\win10-$(_WindowsAppSDKFoundationPlatform)\native</_FoundationRuntimesFrameworkFolder>
   </PropertyGroup>
 
   <ItemGroup Condition="'$(AppxPackage)' != 'true'">
     <Reference Include="Microsoft.Windows.ApplicationModel.DynamicDependency.winmd">
-      <HintPath>$(MSBuildThisFileDirectory)..\..\lib\uap10.0\Microsoft.Windows.ApplicationModel.DynamicDependency.winmd</HintPath>
-      <Implementation Condition="'$(WindowsAppSDKFrameworkPackage)' != 'true'">$(MSBuildThisFileDirectory)..\..\runtimes\win10-$(_WindowsAppSDKFoundationPlatform)\native\Microsoft.WindowsAppRuntime.dll</Implementation>
+      <HintPath>$(_FoundationMetadataFolder)\Microsoft.Windows.ApplicationModel.DynamicDependency.winmd</HintPath>
+      <Implementation Condition="'$(WindowsAppSDKFrameworkPackage)' != 'true'">$(_FoundationRuntimesFrameworkFolder)\Microsoft.WindowsAppRuntime.dll</Implementation>
       <IsWinMDFile>true</IsWinMDFile>
     </Reference>
   </ItemGroup>
 
   <ItemGroup>
     <Reference Include="Microsoft.Windows.ApplicationModel.WindowsAppRuntime.winmd">
-      <HintPath>$(MSBuildThisFileDirectory)..\..\lib\uap10.0\Microsoft.Windows.ApplicationModel.WindowsAppRuntime.winmd</HintPath>
-      <Implementation Condition="'$(WindowsAppSDKFrameworkPackage)' != 'true'">$(MSBuildThisFileDirectory)..\..\runtimes\win10-$(_WindowsAppSDKFoundationPlatform)\native\Microsoft.WindowsAppRuntime.dll</Implementation>
+      <HintPath>$(_FoundationMetadataFolder)\Microsoft.Windows.ApplicationModel.WindowsAppRuntime.winmd</HintPath>
+      <Implementation Condition="'$(WindowsAppSDKFrameworkPackage)' != 'true'">$(_FoundationRuntimesFrameworkFolder)\Microsoft.WindowsAppRuntime.dll</Implementation>
       <IsWinMDFile>true</IsWinMDFile>
     </Reference>
     <Reference Include="Microsoft.Windows.ApplicationModel.Background.winmd">
-      <HintPath>$(MSBuildThisFileDirectory)..\..\lib\uap10.0\Microsoft.Windows.ApplicationModel.Background.winmd</HintPath>
-      <Implementation Condition="'$(WindowsAppSDKFrameworkPackage)' != 'true'">$(MSBuildThisFileDirectory)..\..\runtimes\win10-$(_WindowsAppSDKFoundationPlatform)\native\Microsoft.WindowsAppRuntime.dll</Implementation>
+      <HintPath>$(_FoundationMetadataFolder)\Microsoft.Windows.ApplicationModel.Background.winmd</HintPath>
+      <Implementation Condition="'$(WindowsAppSDKFrameworkPackage)' != 'true'">$(_FoundationRuntimesFrameworkFolder)\Microsoft.WindowsAppRuntime.dll</Implementation>
       <IsWinMDFile>true</IsWinMDFile>
     </Reference>
     <Reference Include="Microsoft.Windows.ApplicationModel.Background.UniversalBGTask.winmd">
-      <HintPath>$(MSBuildThisFileDirectory)..\..\lib\uap10.0\Microsoft.Windows.ApplicationModel.Background.UniversalBGTask.winmd</HintPath>
+      <HintPath>$(_FoundationMetadataFolder)\Microsoft.Windows.ApplicationModel.Background.UniversalBGTask.winmd</HintPath>
       <Implementation Condition="'$(WindowsAppSDKBackgroundTask)' == 'true'">$(MSBuildThisFileDirectory)..\..\runtimes\win-$(_WindowsAppSDKFoundationPlatform)\native\Microsoft.Windows.ApplicationModel.UniversalBGTask.dll</Implementation>
       <IsWinMDFile>true</IsWinMDFile>
     </Reference>
     <Reference Include="Microsoft.Windows.AppLifecycle.winmd">
-      <HintPath>$(MSBuildThisFileDirectory)..\..\lib\uap10.0\Microsoft.Windows.AppLifecycle.winmd</HintPath>
-      <Implementation Condition="'$(WindowsAppSDKFrameworkPackage)' != 'true'">$(MSBuildThisFileDirectory)..\..\runtimes\win10-$(_WindowsAppSDKFoundationPlatform)\native\Microsoft.WindowsAppRuntime.dll</Implementation>
+      <HintPath>$(_FoundationMetadataFolder)\Microsoft.Windows.AppLifecycle.winmd</HintPath>
+      <Implementation Condition="'$(WindowsAppSDKFrameworkPackage)' != 'true'">$(_FoundationRuntimesFrameworkFolder)\Microsoft.WindowsAppRuntime.dll</Implementation>
       <IsWinMDFile>true</IsWinMDFile>
     </Reference>
     <Reference Include="Microsoft.Windows.Storage.winmd">
-      <HintPath>$(MSBuildThisFileDirectory)..\..\lib\uap10.0\Microsoft.Windows.Storage.winmd</HintPath>
-      <Implementation Condition="'$(WindowsAppSDKFrameworkPackage)' != 'true'">$(MSBuildThisFileDirectory)..\..\runtimes\win10-$(_WindowsAppSDKFoundationPlatform)\native\Microsoft.WindowsAppRuntime.dll</Implementation>
+      <HintPath>$(_FoundationMetadataFolder)\Microsoft.Windows.Storage.winmd</HintPath>
+      <Implementation Condition="'$(WindowsAppSDKFrameworkPackage)' != 'true'">$(_FoundationRuntimesFrameworkFolder)\Microsoft.WindowsAppRuntime.dll</Implementation>
       <IsWinMDFile>true</IsWinMDFile>
     </Reference>
     <Reference Include="Microsoft.Windows.System.Power.winmd">
-      <HintPath>$(MSBuildThisFileDirectory)..\..\lib\uap10.0\Microsoft.Windows.System.Power.winmd</HintPath>
-      <Implementation Condition="'$(WindowsAppSDKFrameworkPackage)' != 'true'">$(MSBuildThisFileDirectory)..\..\runtimes\win10-$(_WindowsAppSDKFoundationPlatform)\native\Microsoft.WindowsAppRuntime.dll</Implementation>
+      <HintPath>$(_FoundationMetadataFolder)\Microsoft.Windows.System.Power.winmd</HintPath>
+      <Implementation Condition="'$(WindowsAppSDKFrameworkPackage)' != 'true'">$(_FoundationRuntimesFrameworkFolder)\Microsoft.WindowsAppRuntime.dll</Implementation>
       <IsWinMDFile>true</IsWinMDFile>
     </Reference>
     <Reference Include="Microsoft.Windows.Security.AccessControl.winmd">
-      <HintPath>$(MSBuildThisFileDirectory)..\..\lib\uap10.0\Microsoft.Windows.Security.AccessControl.winmd</HintPath>
-      <Implementation Condition="'$(WindowsAppSDKFrameworkPackage)' != 'true'">$(MSBuildThisFileDirectory)..\..\runtimes\win10-$(_WindowsAppSDKFoundationPlatform)\native\Microsoft.WindowsAppRuntime.dll</Implementation>
+      <HintPath>$(_FoundationMetadataFolder)\Microsoft.Windows.Security.AccessControl.winmd</HintPath>
+      <Implementation Condition="'$(WindowsAppSDKFrameworkPackage)' != 'true'">$(_FoundationRuntimesFrameworkFolder)\Microsoft.WindowsAppRuntime.dll</Implementation>
       <IsWinMDFile>true</IsWinMDFile>
     </Reference>
     <!-- conditionally include experimental metadata -->
     <Reference Include="Microsoft.Windows.System.winmd"
-      Condition="Exists('$(MSBuildThisFileDirectory)..\..\lib\uap10.0\Microsoft.Windows.System.winmd')">
-      <HintPath>$(MSBuildThisFileDirectory)..\..\lib\uap10.0\Microsoft.Windows.System.winmd</HintPath>
-      <Implementation Condition="'$(WindowsAppSDKFrameworkPackage)' != 'true'">$(MSBuildThisFileDirectory)..\..\runtimes\win10-$(_WindowsAppSDKFoundationPlatform)\native\Microsoft.WindowsAppRuntime.dll</Implementation>
+      Condition="Exists('$(_FoundationMetadataFolder)\Microsoft.Windows.System.winmd')">
+      <HintPath>$(_FoundationMetadataFolder)\Microsoft.Windows.System.winmd</HintPath>
+      <Implementation Condition="'$(WindowsAppSDKFrameworkPackage)' != 'true'">$(_FoundationRuntimesFrameworkFolder)\Microsoft.WindowsAppRuntime.dll</Implementation>
       <IsWinMDFile>true</IsWinMDFile>
     </Reference>
     <Reference Include="Microsoft.Windows.PushNotifications.winmd"
-      Condition="Exists('$(MSBuildThisFileDirectory)..\..\lib\uap10.0\Microsoft.Windows.PushNotifications.winmd')">
-      <HintPath>$(MSBuildThisFileDirectory)..\..\lib\uap10.0\Microsoft.Windows.PushNotifications.winmd</HintPath>
-      <Implementation Condition="'$(WindowsAppSDKFrameworkPackage)' != 'true'">$(MSBuildThisFileDirectory)..\..\runtimes\win10-$(_WindowsAppSDKFoundationPlatform)\native\Microsoft.WindowsAppRuntime.dll</Implementation>
+      Condition="Exists('$(_FoundationMetadataFolder)\Microsoft.Windows.PushNotifications.winmd')">
+      <HintPath>$(_FoundationMetadataFolder)\Microsoft.Windows.PushNotifications.winmd</HintPath>
+      <Implementation Condition="'$(WindowsAppSDKFrameworkPackage)' != 'true'">$(_FoundationRuntimesFrameworkFolder)\Microsoft.WindowsAppRuntime.dll</Implementation>
       <IsWinMDFile>true</IsWinMDFile>
     </Reference>
     <Reference Include="Microsoft.Security.Authentication.OAuth.winmd"
-      Condition="Exists('$(MSBuildThisFileDirectory)..\..\lib\uap10.0\Microsoft.Security.Authentication.OAuth.winmd')">
-      <HintPath>$(MSBuildThisFileDirectory)..\..\lib\uap10.0\Microsoft.Security.Authentication.OAuth.winmd</HintPath>
-      <Implementation Condition="'$(WindowsAppSDKFrameworkPackage)' != 'true'">$(MSBuildThisFileDirectory)..\..\runtimes\win10-$(_WindowsAppSDKFoundationPlatform)\native\Microsoft.WindowsAppRuntime.dll</Implementation>
+      Condition="Exists('$(_FoundationMetadataFolder)\Microsoft.Security.Authentication.OAuth.winmd')">
+      <HintPath>$(_FoundationMetadataFolder)\Microsoft.Security.Authentication.OAuth.winmd</HintPath>
+      <Implementation Condition="'$(WindowsAppSDKFrameworkPackage)' != 'true'">$(_FoundationRuntimesFrameworkFolder)\Microsoft.WindowsAppRuntime.dll</Implementation>
       <IsWinMDFile>true</IsWinMDFile>
     </Reference>
     <Reference Include="Microsoft.Windows.Media.Capture.winmd"
-      Condition="Exists('$(MSBuildThisFileDirectory)..\..\lib\uap10.0\Microsoft.Windows.Media.Capture.winmd')">
-      <HintPath>$(MSBuildThisFileDirectory)..\..\lib\uap10.0\Microsoft.Windows.Media.Capture.winmd</HintPath>
-      <Implementation Condition="'$(WindowsAppSDKFrameworkPackage)' != 'true'">$(MSBuildThisFileDirectory)..\..\runtimes\win10-$(_WindowsAppSDKFoundationPlatform)\native\Microsoft.WindowsAppRuntime.dll</Implementation>
+      Condition="Exists('$(_FoundationMetadataFolder)\Microsoft.Windows.Media.Capture.winmd')">
+      <HintPath>$(_FoundationMetadataFolder)\Microsoft.Windows.Media.Capture.winmd</HintPath>
+      <Implementation Condition="'$(WindowsAppSDKFrameworkPackage)' != 'true'">$(_FoundationRuntimesFrameworkFolder)\Microsoft.WindowsAppRuntime.dll</Implementation>
       <IsWinMDFile>true</IsWinMDFile>
     </Reference>
     <Reference Include="Microsoft.Windows.BadgeNotifications.winmd"
-      Condition="Exists('$(MSBuildThisFileDirectory)..\..\lib\uap10.0\Microsoft.Windows.BadgeNotifications.winmd')">
-      <HintPath>$(MSBuildThisFileDirectory)..\..\lib\uap10.0\Microsoft.Windows.BadgeNotifications.winmd</HintPath>
-      <Implementation Condition="'$(WindowsAppSDKFrameworkPackage)' != 'true'">$(MSBuildThisFileDirectory)..\..\runtimes\win10-$(_WindowsAppSDKFoundationPlatform)\native\Microsoft.WindowsAppRuntime.dll</Implementation>
+      Condition="Exists('$(_FoundationMetadataFolder)\Microsoft.Windows.BadgeNotifications.winmd')">
+      <HintPath>$(_FoundationMetadataFolder)\Microsoft.Windows.BadgeNotifications.winmd</HintPath>
+      <Implementation Condition="'$(WindowsAppSDKFrameworkPackage)' != 'true'">$(_FoundationRuntimesFrameworkFolder)\Microsoft.WindowsAppRuntime.dll</Implementation>
       <IsWinMDFile>true</IsWinMDFile>
     </Reference>
     <Reference Include="Microsoft.Windows.Storage.Pickers.winmd"
-      Condition="Exists('$(MSBuildThisFileDirectory)..\..\lib\uap10.0\Microsoft.Windows.Storage.Pickers.winmd')">
-      <HintPath>$(MSBuildThisFileDirectory)..\..\lib\uap10.0\Microsoft.Windows.Storage.Pickers.winmd</HintPath>
-      <Implementation Condition="'$(WindowsAppSDKFrameworkPackage)' != 'true'">$(MSBuildThisFileDirectory)..\..\runtimes\win10-$(_WindowsAppSDKFoundationPlatform)\native\Microsoft.WindowsAppRuntime.dll</Implementation>
+      Condition="Exists('$(_FoundationMetadataFolder)\Microsoft.Windows.Storage.Pickers.winmd')">
+      <HintPath>$(_FoundationMetadataFolder)\Microsoft.Windows.Storage.Pickers.winmd</HintPath>
+      <Implementation Condition="'$(WindowsAppSDKFrameworkPackage)' != 'true'">$(_FoundationRuntimesFrameworkFolder)\Microsoft.WindowsAppRuntime.dll</Implementation>
       <IsWinMDFile>true</IsWinMDFile>
     </Reference>
   </ItemGroup>

--- a/build/NuSpecs/WindowsAppSDK-Nuget-Native.targets
+++ b/build/NuSpecs/WindowsAppSDK-Nuget-Native.targets
@@ -6,7 +6,7 @@
     <Native-Platform Condition="'$(Platform)' == 'Win32'">x86</Native-Platform>
     <Native-Platform Condition="'$(Platform)' != 'Win32'">$(Platform)</Native-Platform>
     <_FoundationMetadataFolder>$(MSBuildThisFileDirectory)..\..\metadata</_FoundationMetadataFolder>
-    <_FoundationMetadataFolder Condition="'$(WindowsAppSdkFoundationTransportPackage)' == 'true'">$(MSBuildThisFileDirectory)..\..\lib\uap10.0</_FoundationMetadataFolder>
+    <_FoundationMetadataFolder Condition="'$(WindowsAppSDKAggregatePackage)' == 'true'">$(MSBuildThisFileDirectory)..\..\lib\uap10.0</_FoundationMetadataFolder>
   </PropertyGroup>
 
   <ItemGroup Condition="'$(AppxPackage)' != 'true'">

--- a/build/NuSpecs/WindowsAppSDK-Nuget-Native.targets
+++ b/build/NuSpecs/WindowsAppSDK-Nuget-Native.targets
@@ -5,37 +5,39 @@
   <PropertyGroup>
     <Native-Platform Condition="'$(Platform)' == 'Win32'">x86</Native-Platform>
     <Native-Platform Condition="'$(Platform)' != 'Win32'">$(Platform)</Native-Platform>
+    <_FoundationMetadataFolder>$(MSBuildThisFileDirectory)..\..\metadata</_FoundationMetadataFolder>
+    <_FoundationMetadataFolder Condition="'$(WindowsAppSdkFoundationTransportPackage)' == 'true'">$(MSBuildThisFileDirectory)..\..\lib\uap10.0</_FoundationMetadataFolder>
   </PropertyGroup>
 
   <ItemGroup Condition="'$(AppxPackage)' != 'true'">
-    <Reference Include="$(MSBuildThisFileDirectory)..\..\lib\uap10.0\Microsoft.Windows.ApplicationModel.DynamicDependency.winmd">
+    <Reference Include="$(_FoundationMetadataFolder)\Microsoft.Windows.ApplicationModel.DynamicDependency.winmd">
       <Private>false</Private>
       <Implementation>Microsoft.WindowsAppRuntime.dll</Implementation>
     </Reference>
   </ItemGroup>
 
   <ItemGroup Condition="'$(AppxPackage)' == 'true'">
-    <Reference Include="$(MSBuildThisFileDirectory)..\..\lib\uap10.0\Microsoft.Windows.ApplicationModel.DynamicDependency.winmd">
+    <Reference Include="$(_FoundationMetadataFolder)\Microsoft.Windows.ApplicationModel.DynamicDependency.winmd">
       <Private>false</Private>
     </Reference>
   </ItemGroup>
 
   <ItemGroup>
-    <Reference Include="$(MSBuildThisFileDirectory)..\..\lib\uap10.0\Microsoft.Windows.ApplicationModel.WindowsAppRuntime.winmd">
+    <Reference Include="$(_FoundationMetadataFolder)\Microsoft.Windows.ApplicationModel.WindowsAppRuntime.winmd">
       <Private>false</Private>
       <Implementation>Microsoft.WindowsAppRuntime.dll</Implementation>
     </Reference>
   </ItemGroup>
 
   <ItemGroup>
-    <Reference Include="$(MSBuildThisFileDirectory)..\..\lib\uap10.0\Microsoft.Windows.ApplicationModel.Background.winmd">
+    <Reference Include="$(_FoundationMetadataFolder)\Microsoft.Windows.ApplicationModel.Background.winmd">
       <Private>false</Private>
       <Implementation>Microsoft.WindowsAppRuntime.dll</Implementation>
     </Reference>
   </ItemGroup>
 
 	<ItemGroup>
-		<Reference Include="$(MSBuildThisFileDirectory)..\..\lib\uap10.0\Microsoft.Windows.ApplicationModel.Background.UniversalBGTask.winmd">
+		<Reference Include="$(_FoundationMetadataFolder)\Microsoft.Windows.ApplicationModel.Background.UniversalBGTask.winmd">
 			<Private Condition="'$(WindowsAppSDKBackgroundTask)' == 'true'">true</Private>
 			<Private Condition="'$(WindowsAppSDKBackgroundTask)' != 'true'">false</Private>
 			<Implementation Condition="'$(WindowsAppSDKBackgroundTask)' == 'true'">$(MSBuildThisFileDirectory)..\..\runtimes\win-$(Platform)\native\Microsoft.Windows.ApplicationModel.Background.UniversalBGTask.dll</Implementation>
@@ -43,59 +45,59 @@
 	</ItemGroup>
 
   <ItemGroup>
-    <Reference Include="$(MSBuildThisFileDirectory)..\..\lib\uap10.0\Microsoft.Windows.AppLifecycle.winmd">
+    <Reference Include="$(_FoundationMetadataFolder)\Microsoft.Windows.AppLifecycle.winmd">
       <Private>false</Private>
       <Implementation>Microsoft.WindowsAppRuntime.dll</Implementation>
     </Reference>
   </ItemGroup>
 
   <ItemGroup>
-    <Reference Include="$(MSBuildThisFileDirectory)..\..\lib\uap10.0\Microsoft.Windows.AppNotifications.Builder.winmd">
+    <Reference Include="$(_FoundationMetadataFolder)\Microsoft.Windows.AppNotifications.Builder.winmd">
       <Private>false</Private>
     </Reference>
   </ItemGroup>
 
   <ItemGroup>
-    <Reference Include="$(MSBuildThisFileDirectory)..\..\lib\uap10.0\Microsoft.Windows.AppNotifications.winmd">
+    <Reference Include="$(_FoundationMetadataFolder)\Microsoft.Windows.AppNotifications.winmd">
       <Private>false</Private>
     </Reference>
   </ItemGroup>
 
   <ItemGroup>
-    <Reference Include="$(MSBuildThisFileDirectory)..\..\lib\uap10.0\Microsoft.Windows.Globalization.winmd">
+    <Reference Include="$(_FoundationMetadataFolder)\Microsoft.Windows.Globalization.winmd">
       <Private>false</Private>
     </Reference>
   </ItemGroup>
 
   <ItemGroup>
-    <Reference Include="$(MSBuildThisFileDirectory)..\..\lib\uap10.0\Microsoft.Windows.Management.Deployment.winmd">
+    <Reference Include="$(_FoundationMetadataFolder)\Microsoft.Windows.Management.Deployment.winmd">
       <Private>false</Private>
     </Reference>
   </ItemGroup>
 
   <ItemGroup>
-    <Reference Include="$(MSBuildThisFileDirectory)..\..\lib\uap10.0\Microsoft.Windows.Storage.winmd">
-      <Private>false</Private>
-      <Implementation>Microsoft.WindowsAppRuntime.dll</Implementation>
-    </Reference>
-  </ItemGroup>
-
-  <ItemGroup>
-    <Reference Include="$(MSBuildThisFileDirectory)..\..\lib\uap10.0\Microsoft.Windows.System.Power.winmd">
+    <Reference Include="$(_FoundationMetadataFolder)\Microsoft.Windows.Storage.winmd">
       <Private>false</Private>
       <Implementation>Microsoft.WindowsAppRuntime.dll</Implementation>
     </Reference>
   </ItemGroup>
 
   <ItemGroup>
-    <Reference Include="$(MSBuildThisFileDirectory)..\..\lib\uap10.0\Microsoft.Windows.Security.AccessControl.winmd">
+    <Reference Include="$(_FoundationMetadataFolder)\Microsoft.Windows.System.Power.winmd">
       <Private>false</Private>
       <Implementation>Microsoft.WindowsAppRuntime.dll</Implementation>
     </Reference>
   </ItemGroup>
 
   <ItemGroup>
-    <Reference Include="$(MSBuildThisFileDirectory)..\..\lib\uap10.0\Microsoft.Windows.ApplicationModel.Resources.winmd">
+    <Reference Include="$(_FoundationMetadataFolder)\Microsoft.Windows.Security.AccessControl.winmd">
+      <Private>false</Private>
+      <Implementation>Microsoft.WindowsAppRuntime.dll</Implementation>
+    </Reference>
+  </ItemGroup>
+
+  <ItemGroup>
+    <Reference Include="$(_FoundationMetadataFolder)\Microsoft.Windows.ApplicationModel.Resources.winmd">
       <Private>false</Private>
       <Implementation>Microsoft.Windows.ApplicationModel.Resources.dll</Implementation>
     </Reference>
@@ -103,47 +105,47 @@
 
   <!-- conditionally include experimental metadata -->
   <ItemGroup>
-    <Reference Include="$(MSBuildThisFileDirectory)..\..\lib\uap10.0\Microsoft.Windows.System.winmd"
-       Condition="Exists('$(MSBuildThisFileDirectory)..\..\lib\uap10.0\Microsoft.Windows.System.winmd')">
+    <Reference Include="$(_FoundationMetadataFolder)\Microsoft.Windows.System.winmd"
+       Condition="Exists('$(_FoundationMetadataFolder)\Microsoft.Windows.System.winmd')">
       <Private>false</Private>
       <Implementation>Microsoft.WindowsAppRuntime.dll</Implementation>
     </Reference>
   </ItemGroup>
 
   <ItemGroup>
-    <Reference Include="$(MSBuildThisFileDirectory)..\..\lib\uap10.0\Microsoft.Windows.PushNotifications.winmd"
-       Condition="Exists('$(MSBuildThisFileDirectory)..\..\lib\uap10.0\Microsoft.Windows.PushNotifications.winmd')">
+    <Reference Include="$(_FoundationMetadataFolder)\Microsoft.Windows.PushNotifications.winmd"
+       Condition="Exists('$(_FoundationMetadataFolder)\Microsoft.Windows.PushNotifications.winmd')">
       <Private>false</Private>
       <Implementation>Microsoft.WindowsAppRuntime.dll</Implementation>
     </Reference>
   </ItemGroup>
   <ItemGroup>
-    <Reference Include="$(MSBuildThisFileDirectory)..\..\lib\uap10.0\Microsoft.Security.Authentication.OAuth.winmd"
-       Condition="Exists('$(MSBuildThisFileDirectory)..\..\lib\uap10.0\Microsoft.Security.Authentication.OAuth.winmd')">
-      <Private>false</Private>
-      <Implementation>Microsoft.WindowsAppRuntime.dll</Implementation>
-    </Reference>
-  </ItemGroup>
-
-  <ItemGroup>
-    <Reference Include="$(MSBuildThisFileDirectory)..\..\lib\uap10.0\Microsoft.Windows.Media.Capture.winmd"
-       Condition="Exists('$(MSBuildThisFileDirectory)..\..\lib\uap10.0\Microsoft.Windows.Media.Capture.winmd')">
+    <Reference Include="$(_FoundationMetadataFolder)\Microsoft.Security.Authentication.OAuth.winmd"
+       Condition="Exists('$(_FoundationMetadataFolder)\Microsoft.Security.Authentication.OAuth.winmd')">
       <Private>false</Private>
       <Implementation>Microsoft.WindowsAppRuntime.dll</Implementation>
     </Reference>
   </ItemGroup>
 
   <ItemGroup>
-    <Reference Include="$(MSBuildThisFileDirectory)..\..\lib\uap10.0\Microsoft.Windows.BadgeNotifications.winmd"
-       Condition="Exists('$(MSBuildThisFileDirectory)..\..\lib\uap10.0\Microsoft.Windows.BadgeNotifications.winmd')">
+    <Reference Include="$(_FoundationMetadataFolder)\Microsoft.Windows.Media.Capture.winmd"
+       Condition="Exists('$(_FoundationMetadataFolder)\Microsoft.Windows.Media.Capture.winmd')">
       <Private>false</Private>
       <Implementation>Microsoft.WindowsAppRuntime.dll</Implementation>
     </Reference>
   </ItemGroup>
 
   <ItemGroup>
-    <Reference Include="$(MSBuildThisFileDirectory)..\..\lib\uap10.0\Microsoft.Windows.Storage.Pickers.winmd"
-       Condition="Exists('$(MSBuildThisFileDirectory)..\..\lib\uap10.0\Microsoft.Windows.Storage.Pickers.winmd')">
+    <Reference Include="$(_FoundationMetadataFolder)\Microsoft.Windows.BadgeNotifications.winmd"
+       Condition="Exists('$(_FoundationMetadataFolder)\Microsoft.Windows.BadgeNotifications.winmd')">
+      <Private>false</Private>
+      <Implementation>Microsoft.WindowsAppRuntime.dll</Implementation>
+    </Reference>
+  </ItemGroup>
+
+  <ItemGroup>
+    <Reference Include="$(_FoundationMetadataFolder)\Microsoft.Windows.Storage.Pickers.winmd"
+       Condition="Exists('$(_FoundationMetadataFolder)\Microsoft.Windows.Storage.Pickers.winmd')">
       <Private>false</Private>
       <Implementation>Microsoft.WindowsAppRuntime.dll</Implementation>
     </Reference>

--- a/build/NuSpecs/package.appxfragment
+++ b/build/NuSpecs/package.appxfragment
@@ -1,0 +1,123 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Fragment xmlns="http://schemas.microsoft.com/appx/manifest/foundation/windows10">
+    <Extensions>
+        <Extension Category="windows.activatableClass.inProcessServer">
+          <InProcessServer>
+            <Path>Microsoft.Windows.ApplicationModel.Resources.dll</Path>
+            <ActivatableClass ActivatableClassId="Microsoft.Windows.ApplicationModel.Resources.KnownResourceQualifierName" ThreadingModel="both" />
+            <ActivatableClass ActivatableClassId="Microsoft.Windows.ApplicationModel.Resources.ResourceCandidate" ThreadingModel="both" />
+            <ActivatableClass ActivatableClassId="Microsoft.Windows.ApplicationModel.Resources.ResourceLoader" ThreadingModel="both" />
+            <ActivatableClass ActivatableClassId="Microsoft.Windows.ApplicationModel.Resources.ResourceManager" ThreadingModel="both" />
+            <ActivatableClass ActivatableClassId="Microsoft.Windows.Globalization.ApplicationLanguages" ThreadingModel="both" />
+          </InProcessServer>
+        </Extension>
+        <Extension Category="windows.activatableClass.inProcessServer">
+          <InProcessServer>
+            <Path>Microsoft.WindowsAppRuntime.dll</Path>
+            <!-- NOTE: Keep ActivationClass elements sorted by absolute ActivatableClassId (namespace.class) -->
+
+            <!-- OAuth -->
+            <ActivatableClass ActivatableClassId="Microsoft.Security.Authentication.OAuth.AuthRequestParams" ThreadingModel="both" />
+            <ActivatableClass ActivatableClassId="Microsoft.Security.Authentication.OAuth.ClientAuthentication" ThreadingModel="both" />
+            <ActivatableClass ActivatableClassId="Microsoft.Security.Authentication.OAuth.OAuth2Manager" ThreadingModel="both" />
+            <ActivatableClass ActivatableClassId="Microsoft.Security.Authentication.OAuth.TokenRequestParams" ThreadingModel="both" />
+
+            <!-- Background Task -->
+            <ActivatableClass ActivatableClassId="Microsoft.Windows.ApplicationModel.Background.BackgroundTaskBuilder" ThreadingModel="both" />
+
+            <!-- Dynamic Dependency -->
+            <ActivatableClass ActivatableClassId="Microsoft.Windows.ApplicationModel.DynamicDependency.AddPackageDependencyOptions" ThreadingModel="both" />
+            <ActivatableClass ActivatableClassId="Microsoft.Windows.ApplicationModel.DynamicDependency.CreatePackageDependencyOptions" ThreadingModel="both" />
+            <ActivatableClass ActivatableClassId="Microsoft.Windows.ApplicationModel.DynamicDependency.PackageDependency" ThreadingModel="both" />
+            <ActivatableClass ActivatableClassId="Microsoft.Windows.ApplicationModel.DynamicDependency.PackageDependencyContext" ThreadingModel="both" />
+            <ActivatableClass ActivatableClassId="Microsoft.Windows.ApplicationModel.DynamicDependency.PackageDependencyRank" ThreadingModel="both" />
+
+            <!-- WinAppSDK Deployment -->
+            <ActivatableClass ActivatableClassId="Microsoft.Windows.ApplicationModel.WindowsAppRuntime.DeploymentManager" ThreadingModel="both" />
+            <ActivatableClass ActivatableClassId="Microsoft.Windows.ApplicationModel.WindowsAppRuntime.DeploymentResult" ThreadingModel="both" />
+            <ActivatableClass ActivatableClassId="Microsoft.Windows.ApplicationModel.WindowsAppRuntime.DeploymentInitializeOptions" ThreadingModel="both" />
+
+            <!-- VersionInfo -->
+            <ActivatableClass ActivatableClassId="Microsoft.Windows.ApplicationModel.WindowsAppRuntime.ReleaseInfo" ThreadingModel="both" />
+            <ActivatableClass ActivatableClassId="Microsoft.Windows.ApplicationModel.WindowsAppRuntime.RuntimeInfo" ThreadingModel="both" />
+
+            <!-- AppLifecycle -->
+            <ActivatableClass ActivatableClassId="Microsoft.Windows.AppLifecycle.ActivationRegistrationManager" ThreadingModel="both" />
+            <ActivatableClass ActivatableClassId="Microsoft.Windows.AppLifecycle.AppInstance" ThreadingModel="both" />
+
+            <!-- AppNotifications -->
+            <ActivatableClass ActivatableClassId="Microsoft.Windows.AppNotifications.AppNotificationManager" ThreadingModel="both" />
+            <ActivatableClass ActivatableClassId="Microsoft.Windows.AppNotifications.AppNotification" ThreadingModel="both" />
+            <ActivatableClass ActivatableClassId="Microsoft.Windows.AppNotifications.AppNotificationProgressData" ThreadingModel="both" />
+            <ActivatableClass ActivatableClassId="Microsoft.Windows.AppNotifications.AppNotificationActivatedEventArgs" ThreadingModel="both" />
+            <ActivatableClass ActivatableClassId="Microsoft.Windows.AppNotifications.AppNotificationConferencingConfig" ThreadingModel="both" />
+
+            <!-- AppNotificationBuilder -->
+            <ActivatableClass ActivatableClassId="Microsoft.Windows.AppNotifications.Builder.AppNotificationBuilder" ThreadingModel="both" />
+            <ActivatableClass ActivatableClassId="Microsoft.Windows.AppNotifications.Builder.AppNotificationTextProperties" ThreadingModel="both" />
+            <ActivatableClass ActivatableClassId="Microsoft.Windows.AppNotifications.Builder.AppNotificationButton" ThreadingModel="both" />
+            <ActivatableClass ActivatableClassId="Microsoft.Windows.AppNotifications.Builder.AppNotificationProgressBar" ThreadingModel="both" />
+            <ActivatableClass ActivatableClassId="Microsoft.Windows.AppNotifications.Builder.AppNotificationComboBox" ThreadingModel="both" />
+
+            <!-- Deployment -->
+            <ActivatableClass ActivatableClassId="Microsoft.Windows.Management.Deployment.AddPackageOptions" ThreadingModel="both" />
+            <ActivatableClass ActivatableClassId="Microsoft.Windows.Management.Deployment.EnsureReadyOptions" ThreadingModel="both" />
+            <ActivatableClass ActivatableClassId="Microsoft.Windows.Management.Deployment.PackageDeploymentManager" ThreadingModel="both" />
+            <ActivatableClass ActivatableClassId="Microsoft.Windows.Management.Deployment.PackageDeploymentResult" ThreadingModel="both" />
+            <ActivatableClass ActivatableClassId="Microsoft.Windows.Management.Deployment.PackageRuntimeManager" ThreadingModel="both" />
+            <ActivatableClass ActivatableClassId="Microsoft.Windows.Management.Deployment.PackageSet" ThreadingModel="both" />
+            <ActivatableClass ActivatableClassId="Microsoft.Windows.Management.Deployment.PackageSetItem" ThreadingModel="both" />
+            <ActivatableClass ActivatableClassId="Microsoft.Windows.Management.Deployment.PackageSetItemRuntimeDisposition" ThreadingModel="both" />
+            <ActivatableClass ActivatableClassId="Microsoft.Windows.Management.Deployment.PackageSetRuntimeDisposition" ThreadingModel="both" />
+            <ActivatableClass ActivatableClassId="Microsoft.Windows.Management.Deployment.PackageVolume" ThreadingModel="both" />
+            <ActivatableClass ActivatableClassId="Microsoft.Windows.Management.Deployment.ProvisionPackageOptions" ThreadingModel="both" />
+            <ActivatableClass ActivatableClassId="Microsoft.Windows.Management.Deployment.RegisterPackageOptions" ThreadingModel="both" />
+            <ActivatableClass ActivatableClassId="Microsoft.Windows.Management.Deployment.RemovePackageOptions" ThreadingModel="both" />
+            <ActivatableClass ActivatableClassId="Microsoft.Windows.Management.Deployment.StagePackageOptions" ThreadingModel="both" />
+
+            <!-- PushNotifications -->
+            <ActivatableClass ActivatableClassId="Microsoft.Windows.PushNotifications.PushNotificationChannel" ThreadingModel="both" />
+            <ActivatableClass ActivatableClassId="Microsoft.Windows.PushNotifications.PushNotificationCreateChannelResult" ThreadingModel="both" />
+            <ActivatableClass ActivatableClassId="Microsoft.Windows.PushNotifications.PushNotificationActivationInfo" ThreadingModel="both" />
+            <ActivatableClass ActivatableClassId="Microsoft.Windows.PushNotifications.PushNotificationReceivedEventArgs" ThreadingModel="both" />
+            <ActivatableClass ActivatableClassId="Microsoft.Windows.PushNotifications.PushNotificationRegistrationToken" ThreadingModel="both" />
+            <ActivatableClass ActivatableClassId="Microsoft.Windows.PushNotifications.PushNotificationManager" ThreadingModel="both" />
+
+            <!-- AccessControl -->
+            <ActivatableClass ActivatableClassId="Microsoft.Windows.Security.AccessControl.SecurityDescriptorHelpers" ThreadingModel="both" />
+
+            <!-- ApplicationData -->
+            <ActivatableClass ActivatableClassId="Microsoft.Windows.Storage.ApplicationData" ThreadingModel="both" />
+            <ActivatableClass ActivatableClassId="Microsoft.Windows.Storage.ApplicationDataContainer" ThreadingModel="both" />
+
+            <!-- Environment Manager -->
+            <ActivatableClass ActivatableClassId="Microsoft.Windows.System.EnvironmentManager" ThreadingModel="both" />
+
+            <!-- PowerNotifications -->
+            <ActivatableClass ActivatableClassId="Microsoft.Windows.System.Power.PowerManager" ThreadingModel="both" />
+
+            <!-- CameraCaptureUI -->
+            <ActivatableClass ActivatableClassId="Microsoft.Windows.Media.Capture.CameraCaptureUI" ThreadingModel="both" />
+
+            <!-- BadgeNotifications -->
+            <ActivatableClass ActivatableClassId="Microsoft.Windows.BadgeNotifications.BadgeNotificationManager" ThreadingModel="both" />
+
+            <!-- StoragePickers -->
+            <ActivatableClass ActivatableClassId="Microsoft.Windows.Storage.Pickers.FileOpenPicker" ThreadingModel="both" />
+            <ActivatableClass ActivatableClassId="Microsoft.Windows.Storage.Pickers.FileSavePicker" ThreadingModel="both" />
+            <ActivatableClass ActivatableClassId="Microsoft.Windows.Storage.Pickers.FolderPicker" ThreadingModel="both" />
+
+            <!-- RuntimeCompatibilityOptions -->
+            <ActivatableClass ActivatableClassId="Microsoft.Windows.ApplicationModel.WindowsAppRuntime.RuntimeCompatibilityOptions" ThreadingModel="both" />
+          </InProcessServer>
+        </Extension>
+        <Extension Category="windows.activatableClass.proxyStub">
+          <ProxyStub ClassId="71201C0F-21E1-4B80-945F-7B0A10F90883">
+            <Path>PushNotificationsLongRunningTask.ProxyStub.dll</Path>
+            <Interface Name="IWpnForegroundSink" InterfaceId="25604D55-9B17-426F-9D67-2B11B3A65598" />
+            <Interface Name="IWpnForegroundSink2" InterfaceId="559B4205-F810-4947-B02B-3EA9A311C6AD" />
+            <Interface Name="INotificationsLongRunningPlatform" InterfaceId="60FC21B2-B396-4D49-94F0-7555869FB93C" />
+          </ProxyStub>
+        </Extension>
+    </Extensions>
+</Fragment>

--- a/build/scripts/CopyContents.ps1
+++ b/build/scripts/CopyContents.ps1
@@ -1,0 +1,38 @@
+param (
+  [string]$SourceDir = '',
+  $ContentsList = @(),
+  $Exclude = @(),
+  $Include = @(),
+  [string]$TargetDir = ''
+)
+
+foreach ($Contents in $ContentsList)
+{
+    $ContentsPath = (Join-Path $SourceDir $Contents)
+
+    if (Test-Path ($ContentsPath) -PathType Leaf)
+    {
+        $targetFile = (Join-Path $TargetDir $Contents)
+        [void](New-Item -ItemType File -Path $targetFile -Force)
+        Copy-Item $ContentsPath -destination $targetFile
+        echo ('Copying '+$ContentsPath+' to '+$targetFile)
+    }
+    else
+    {
+        # Get-ChildItem only goes down one directory when doing recurse with a wildcard in the path.
+        # To compensate, grab all nested directories, then compare to desired paths
+        $directories = Get-ChildItem ($SourceDir) -Directory -Recurse | ? {$_.FullName -like ($ContentsPath)} | % {$_.FullName}
+
+        foreach ($directory in $directories)
+        {
+            $files = Get-ChildItem ($directory) -File -Recurse -Exclude $Exclude -Include $Include
+            foreach ($file in $files)
+            {
+                $targetFile = (Join-Path $TargetDir ($file.FullName.SubString($SourceDir.Length)))
+                [void](New-Item -ItemType File -Path $targetFile -Force)
+                Copy-Item $file.FullName -destination $targetFile
+                echo ('Copying '+$file.FullName+' to '+$targetFile)
+            }
+        }
+    }
+}

--- a/build/scripts/RobocopyWrapper.ps1
+++ b/build/scripts/RobocopyWrapper.ps1
@@ -1,0 +1,24 @@
+param (
+    [string]$source = "", 
+    [string]$dest = "",
+    [string]$options = "/E /XC /XN /XO /NJH /NJS /NDL /NP /NFL"
+)
+$robocopyCmd = "robocopy $source $dest $options"
+
+Invoke-Expression $robocopyCmd
+
+if ($LASTEXITCODE -eq 0) 
+{
+    Write-Host "Robocopy operation completed successfully."
+} 
+elseif ($LASTEXITCODE -lt 4) 
+{
+    $LASTEXITCODE = 0
+    Write-Host "Robocopy operation completed with some files copied."
+} 
+else 
+{
+    Write-Host "Copy operation encountered errors."
+}
+
+exit $LASTEXITCODE

--- a/dev/MRTCore/packaging/native/MrtCore.C.props
+++ b/dev/MRTCore/packaging/native/MrtCore.C.props
@@ -7,7 +7,7 @@
     <_MrtCoreRuntimeIdentifier Condition="'$(Platform)' == 'Win32'">x86</_MrtCoreRuntimeIdentifier>
     <_MrtCoreRuntimeIdentifier Condition="'$(Platform)' != 'Win32'">$(Platform)</_MrtCoreRuntimeIdentifier>
     <_MrtLibFolder>$(MSBuildThisFileDirectory)..\..\lib\win-$(_MrtCoreRuntimeIdentifier)</_MrtLibFolder>
-    <_MrtLibFolder Condition="'$(WindowsAppSdkFoundationTransportPackage)' == 'true'">$(MSBuildThisFileDirectory)..\..\lib\win10-$(_MrtCoreRuntimeIdentifier)</_MrtLibFolder>
+    <_MrtLibFolder Condition="'$(WindowsAppSDKAggregatePackage)' == 'true'">$(MSBuildThisFileDirectory)..\..\lib\win10-$(_MrtCoreRuntimeIdentifier)</_MrtLibFolder>
 
     <!-- Set DefaultLanguage so that Multilingual Application Toolkit can be enabled when applicable -->
     <DefaultLanguage Condition="'$(DefaultLanguage)' == ''">en-US</DefaultLanguage>

--- a/dev/MRTCore/packaging/native/MrtCore.C.props
+++ b/dev/MRTCore/packaging/native/MrtCore.C.props
@@ -6,6 +6,8 @@
   <PropertyGroup>
     <_MrtCoreRuntimeIdentifier Condition="'$(Platform)' == 'Win32'">x86</_MrtCoreRuntimeIdentifier>
     <_MrtCoreRuntimeIdentifier Condition="'$(Platform)' != 'Win32'">$(Platform)</_MrtCoreRuntimeIdentifier>
+    <_MrtLibFolder>$(MSBuildThisFileDirectory)..\..\lib\win-$(_MrtCoreRuntimeIdentifier)</_MrtLibFolder>
+    <_MrtLibFolder Condition="'$(WindowsAppSdkFoundationTransportPackage)' == 'true'">$(MSBuildThisFileDirectory)..\..\lib\win10-$(_MrtCoreRuntimeIdentifier)</_MrtLibFolder>
 
     <!-- Set DefaultLanguage so that Multilingual Application Toolkit can be enabled when applicable -->
     <DefaultLanguage Condition="'$(DefaultLanguage)' == ''">en-US</DefaultLanguage>
@@ -24,7 +26,7 @@
   <ItemDefinitionGroup>
     <Link>
       <AdditionalDependencies>
-        $(MSBuildThisFileDirectory)..\..\lib\win10-$(_MrtCoreRuntimeIdentifier)\mrm.lib;
+        $(_MrtLibFolder)\mrm.lib;
         %(AdditionalDependencies);
       </AdditionalDependencies>
     </Link>


### PR DESCRIPTION
Adding Microsoft.WindowsAppSDK.Foundation as another way to consume the foundation APIs.
Ensure both the preview way and this way works by using `WindowsAppSDKAggregatePackage` to pivot in shared targets.

A microsoft employee must use /azp run to validate using the pipelines below.

WARNING:
Comments made by azure-pipelines bot maybe inaccurate.
Please see pipeline link to verify that the build is being ran.

For status checks on the main branch, please use TransportPackage-Foundation-PR
(https://microsoft.visualstudio.com/ProjectReunion/_build?definitionId=81063&_a=summary)
and run the build against your PR branch with the default parameters.
