### PR TITLE
Bugfix - Storage Pickers cannot launch on ARM64

### DIFF
--- a/dev/Interop/StoragePickers/FileOpenPicker.cpp
+++ b/dev/Interop/StoragePickers/FileOpenPicker.cpp
@@ -87,7 +87,7 @@ namespace winrt::Microsoft::Windows::Storage::Pickers::implementation
             co_return nullptr;
         }
 
-        auto dialog = create_instance<IFileOpenDialog>(CLSID_FileOpenDialog, CONTEXT_ALL);
+        auto dialog = create_instance<IFileOpenDialog>(CLSID_FileOpenDialog, CLSCTX_ALL);
 
         parameters.ConfigureDialog(dialog);
 
@@ -139,7 +139,7 @@ namespace winrt::Microsoft::Windows::Storage::Pickers::implementation
             co_return results.GetView();
         }
 
-        auto dialog = create_instance<IFileOpenDialog>(CLSID_FileOpenDialog, CONTEXT_ALL);
+        auto dialog = create_instance<IFileOpenDialog>(CLSID_FileOpenDialog, CLSCTX_ALL);
 
         parameters.ConfigureDialog(dialog);
 

--- a/dev/Interop/StoragePickers/FileOpenPicker.cpp
+++ b/dev/Interop/StoragePickers/FileOpenPicker.cpp
@@ -87,7 +87,7 @@ namespace winrt::Microsoft::Windows::Storage::Pickers::implementation
             co_return nullptr;
         }
 
-        auto dialog = create_instance<IFileOpenDialog>(CLSID_FileOpenDialog, CLSCTX_ALL);
+        auto dialog = create_instance<IFileOpenDialog>(CLSID_FileOpenDialog, CLSCTX_INPROC_SERVER);
 
         parameters.ConfigureDialog(dialog);
 
@@ -139,7 +139,7 @@ namespace winrt::Microsoft::Windows::Storage::Pickers::implementation
             co_return results.GetView();
         }
 
-        auto dialog = create_instance<IFileOpenDialog>(CLSID_FileOpenDialog, CLSCTX_ALL);
+        auto dialog = create_instance<IFileOpenDialog>(CLSID_FileOpenDialog, CLSCTX_INPROC_SERVER);
 
         parameters.ConfigureDialog(dialog);
 

--- a/dev/Interop/StoragePickers/FileSavePicker.cpp
+++ b/dev/Interop/StoragePickers/FileSavePicker.cpp
@@ -113,7 +113,7 @@ namespace winrt::Microsoft::Windows::Storage::Pickers::implementation
             co_return nullptr;
         }
 
-        auto dialog = create_instance<IFileSaveDialog>(CLSID_FileSaveDialog, CONTEXT_ALL);
+        auto dialog = create_instance<IFileSaveDialog>(CLSID_FileSaveDialog, CLSCTX_ALL);
         parameters.ConfigureDialog(dialog);
 
         if (!PickerCommon::IsHStringNullOrEmpty(defaultFileExtension))

--- a/dev/Interop/StoragePickers/FileSavePicker.cpp
+++ b/dev/Interop/StoragePickers/FileSavePicker.cpp
@@ -113,7 +113,7 @@ namespace winrt::Microsoft::Windows::Storage::Pickers::implementation
             co_return nullptr;
         }
 
-        auto dialog = create_instance<IFileSaveDialog>(CLSID_FileSaveDialog, CLSCTX_ALL);
+        auto dialog = create_instance<IFileSaveDialog>(CLSID_FileSaveDialog, CLSCTX_INPROC_SERVER);
         parameters.ConfigureDialog(dialog);
 
         if (!PickerCommon::IsHStringNullOrEmpty(defaultFileExtension))

--- a/dev/Interop/StoragePickers/FolderPicker.cpp
+++ b/dev/Interop/StoragePickers/FolderPicker.cpp
@@ -85,7 +85,7 @@ namespace winrt::Microsoft::Windows::Storage::Pickers::implementation
             co_return nullptr;
         }
 
-        auto dialog = create_instance<IFileOpenDialog>(CLSID_FileOpenDialog, CLSCTX_ALL);
+        auto dialog = create_instance<IFileOpenDialog>(CLSID_FileOpenDialog, CLSCTX_INPROC_SERVER);
 
         parameters.ConfigureDialog(dialog);
         dialog->SetOptions(FOS_PICKFOLDERS);

--- a/dev/Interop/StoragePickers/FolderPicker.cpp
+++ b/dev/Interop/StoragePickers/FolderPicker.cpp
@@ -85,7 +85,7 @@ namespace winrt::Microsoft::Windows::Storage::Pickers::implementation
             co_return nullptr;
         }
 
-        auto dialog = create_instance<IFileOpenDialog>(CLSID_FileOpenDialog, CONTEXT_ALL);
+        auto dialog = create_instance<IFileOpenDialog>(CLSID_FileOpenDialog, CLSCTX_ALL);
 
         parameters.ConfigureDialog(dialog);
         dialog->SetOptions(FOS_PICKFOLDERS);


### PR DESCRIPTION
This pull request fixes the context parameter used when creating file dialog instances across multiple picker implementations to ensure using the intended context. Specifically, we're replacing `CONTEXT_ALL` with `CLSCTX_INPROC_SERVER` - fixing an error causes the storage pickers to fail to launch on ARM64 devices, throwing error "Class not registered"

This issue did not appear on x64 machines because the value of CONTEXT_ALL on x64 machines happens to be the same as that of CLSCTX_INPROC_SERVER. However, these two values differ on ARM64, thereby exposing the problem during bug bash on ARM64 devices.

### Updates to context parameter in dialog creation:

* [`dev/Interop/StoragePickers/FileOpenPicker.cpp`](diffhunk://#diff-919dfd32a08a1aa703097fd0fe1b95dd36e0164229d91a3e22e194c7d015187eL90-R90): Replaced `CONTEXT_ALL` with `CLSCTX_INPROC_SERVER` in two instances where `IFileOpenDialog` is created. [[1]](diffhunk://#diff-919dfd32a08a1aa703097fd0fe1b95dd36e0164229d91a3e22e194c7d015187eL90-R90) [[2]](diffhunk://#diff-919dfd32a08a1aa703097fd0fe1b95dd36e0164229d91a3e22e194c7d015187eL142-R142)
* [`dev/Interop/StoragePickers/FileSavePicker.cpp`](diffhunk://#diff-59e025f2c0bb98d7a12bb6b5d5bdcc1f63b0ee4f150ef4fde1338a5de4650fc4L116-R116): Updated the context parameter from `CONTEXT_ALL` to `CLSCTX_INPROC_SERVER` when creating an `IFileSaveDialog` instance.
* [`dev/Interop/StoragePickers/FolderPicker.cpp`](diffhunk://#diff-fafd9b82668f2ebe3d318ec048dab1bf54074c05dd6f56dc392b0d3e5c0294c1L88-R88): Modified the context parameter for `IFileOpenDialog` creation from `CONTEXT_ALL` to `CLSCTX_INPROC_SERVER` in the folder picker implementation.