### PR TITLE
Remove NuGetToolInstaller Tasks; Update DevCheck

### DIFF
--- a/build/AzurePipelinesTemplates/WindowsAppSDK-Build-Stage.yml
+++ b/build/AzurePipelinesTemplates/WindowsAppSDK-Build-Stage.yml
@@ -69,6 +69,13 @@ stages:
         IsOneBranch: ${{ parameters.IsOneBranch }}
         runStaticAnalysis : ${{ parameters.runStaticAnalysis }}
 
+    # This is a temporarily workaround to avoid getting non-fatal "folder C:\__t\NativeCompilerPrefast not found"
+    # errors from the Guardian PREfast task, which shouldn't even be run in the first place, because its pre-
+    # requisite of isNative=true isn't met currently.
+    - script: |
+        md "C:\__t\NativeCompilerPrefast"
+      displayName: 'Creating C:\__t\NativeCompilerPrefast to prevent errors from Guardian PREfast'
+
   - job: BuildFoundation_release_anycpu
     # For now, this job just builds Microsoft.WindowsAppRuntime.Bootstrap.Net.dll in AnyCPU
     # Can be expanded to add any other binary as needed
@@ -95,6 +102,13 @@ stages:
         SignOutput: ${{ parameters.SignOutput }}
         IsOneBranch: ${{ parameters.IsOneBranch }}
         runStaticAnalysis : ${{ parameters.runStaticAnalysis }}
+
+    # This is a temporarily workaround to avoid getting non-fatal "folder C:\__t\NativeCompilerPrefast not found"
+    # errors from the Guardian PREfast task, which shouldn't even be run in the first place, because its pre-
+    # requisite of isNative=true isn't met currently.
+    - script: |
+        md "C:\__t\NativeCompilerPrefast"
+      displayName: 'Creating C:\__t\NativeCompilerPrefast to prevent errors from Guardian PREfast'
 
   - job: BuildMRT
     pool:
@@ -141,3 +155,10 @@ stages:
         SignOutput: ${{ parameters.SignOutput }}
         IsOneBranch: ${{ parameters.IsOneBranch }}
         runStaticAnalysis : ${{ parameters.runStaticAnalysis }}
+
+    # This is a temporarily workaround to avoid getting non-fatal "folder C:\__t\NativeCompilerPrefast not found"
+    # errors from the Guardian PREfast task, which shouldn't even be run in the first place, because its pre-
+    # requisite of isNative=true isn't met currently.
+    - script: |
+        md "C:\__t\NativeCompilerPrefast"
+      displayName: 'Creating C:\__t\NativeCompilerPrefast to prevent errors from Guardian PREfast'

--- a/build/AzurePipelinesTemplates/WindowsAppSDK-BuildFoundation-AnyCPU-Steps.yml
+++ b/build/AzurePipelinesTemplates/WindowsAppSDK-BuildFoundation-AnyCPU-Steps.yml
@@ -10,8 +10,6 @@ parameters:
   default: True
 
 steps:
-- task: NuGetToolInstaller@1
-
 - task: NuGetAuthenticate@1
   inputs:
     nuGetServiceConnections: 'TelemetryInternal'

--- a/build/AzurePipelinesTemplates/WindowsAppSDK-BuildFoundation-Steps.yml
+++ b/build/AzurePipelinesTemplates/WindowsAppSDK-BuildFoundation-Steps.yml
@@ -10,8 +10,6 @@ parameters:
   default: True
 
 steps:
-- task: NuGetToolInstaller@1
-
 - task: NuGetAuthenticate@1
   inputs:
     nuGetServiceConnections: 'TelemetryInternal'

--- a/build/AzurePipelinesTemplates/WindowsAppSDK-BuildInstaller-Steps.yml
+++ b/build/AzurePipelinesTemplates/WindowsAppSDK-BuildInstaller-Steps.yml
@@ -63,7 +63,7 @@ steps:
   inputs:
     targetType: filePath
     filePath: $(foundationRepoPath)eng\common\DevCheck.ps1
-    arguments: -NoInteractive -Offline -Verbose -CertPassword 'BuildPipeline' -CheckTestPfx -Clean
+    arguments: -NoInteractive -Offline -Verbose -CheckTestPfx -Clean
     workingDirectory: '$(Build.SourcesDirectory)'
 
 - task: powershell@2

--- a/build/AzurePipelinesTemplates/WindowsAppSDK-BuildVSIX-Steps.yml
+++ b/build/AzurePipelinesTemplates/WindowsAppSDK-BuildVSIX-Steps.yml
@@ -88,8 +88,6 @@ steps:
       }
       Exit 1
 
-- task: NuGetToolInstaller@1
-
 - task: NuGetAuthenticate@1
 
 - task: VSBuild@1

--- a/build/AzurePipelinesTemplates/WindowsAppSDK-PackTransportPackage-Stage.yml
+++ b/build/AzurePipelinesTemplates/WindowsAppSDK-PackTransportPackage-Stage.yml
@@ -33,6 +33,7 @@ stages:
     variables:
       ob_outputDirectory: '$(REPOROOT)\out'
       ob_artifactBaseName: "TransportPackage"
+      ob_sdl_prefast_enabled: false    # We currently do not build native code in this job.  
     steps:
     - task: NuGetAuthenticate@1
 

--- a/build/AzurePipelinesTemplates/WindowsAppSDK-RunTests-Steps.yml
+++ b/build/AzurePipelinesTemplates/WindowsAppSDK-RunTests-Steps.yml
@@ -11,7 +11,7 @@ steps:
     inputs:
       targetType: filePath
       filePath: eng\common\DevCheck.ps1
-      arguments: -NoInteractive -Offline -Verbose -CertPassword 'BuildPipeline' -CheckTestPfx -Clean -CheckDependencies -ShowSystemInfo
+      arguments: -NoInteractive -Offline -Verbose -CheckTestPfx -Clean -CheckDependencies -ShowSystemInfo
       workingDirectory: '$(Build.SourcesDirectory)'
 
   - task: DownloadPipelineArtifact@2

--- a/build/AzurePipelinesTemplates/WindowsAppSDK-SetupBuildEnvironment-Steps.yml
+++ b/build/AzurePipelinesTemplates/WindowsAppSDK-SetupBuildEnvironment-Steps.yml
@@ -72,7 +72,7 @@ steps:
   inputs:
     targetType: filePath
     filePath: eng\common\DevCheck.ps1
-    arguments: -NoInteractive -Offline -Verbose -CertPassword 'BuildPipeline' -CheckTestPfx -Clean -CheckDependencies -ShowSystemInfo
+    arguments: -NoInteractive -Offline -Verbose -CheckTestPfx -Clean -CheckDependencies -ShowSystemInfo
     workingDirectory: '$(Build.SourcesDirectory)'
 
 - task: PowerShell@2

--- a/build/ProjectReunion-CI.yml
+++ b/build/ProjectReunion-CI.yml
@@ -83,8 +83,6 @@ jobs:
   - checkout: self
     persistCredentials: true
 
-  - task: NuGetToolInstaller@1
-
   - template: AzurePipelinesTemplates\WindowsAppSDK-SetupBuildEnvironment-Steps.yml
     parameters:
       IsOneBranch: false
@@ -111,8 +109,6 @@ jobs:
   pool:
     vmImage: 'windows-2022'
   steps:
-  - task: NuGetToolInstaller@1
-
   - template: AzurePipelinesTemplates\WindowsAppSDK-SetupBuildEnvironment-Steps.yml
     parameters:
       IsOneBranch: false
@@ -147,8 +143,6 @@ jobs:
   variables:
     ob_artifactBaseName: "MrtBinaries_$(buildConfiguration)_$(buildPlatform)" # For BuildMRT to publish t
   steps:
-  - task: NuGetToolInstaller@1
-
   - template: AzurePipelinesTemplates\WindowsAppSDK-BuildMRT-Steps.yml
     parameters:
       IsOneBranch: false

--- a/eng/common/AzurePipelinesTemplates/WindowsAppSDK-BuildSetup-Steps.yml
+++ b/eng/common/AzurePipelinesTemplates/WindowsAppSDK-BuildSetup-Steps.yml
@@ -47,8 +47,6 @@ steps:
         $pfxPath = (Join-Path $userPath 'winappsdk.certificate.test.pfx')
         [System.IO.File]::WriteAllBytes($pfxPath, $certificateBytes)
 
-  - task: NuGetToolInstaller@1
-
   - task: NuGetAuthenticate@1
     inputs:
       nuGetServiceConnections: ${{ parameters.NuGetServiceConnectionName }}


### PR DESCRIPTION
This PR contains:
- changes to DevCheck.ps1 that are a wholesale copy of the DevCheck.ps1 from main.
- remove all NuGetToolInstaller tasks
- cherrypick of [5324](https://github.com/microsoft/WindowsAppSDK/pull/5324)


WARNING:
Comments made by azure-pipelines bot maybe inaccurate.
Please see pipeline link to verify that the build is being ran.

For status checks on the main branch, please use TransportPackage-Foundation-PR
(https://microsoft.visualstudio.com/ProjectReunion/_build?definitionId=81063&_a=summary)
and run the build against your PR branch with the default parameters.
