### PR TITLE
Use older IXP package version to produce release candidate

### DIFF
--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -27,17 +27,17 @@
     -->
 <Dependencies>
   <ProductDependencies>
-    <Dependency Name="Microsoft.FrameworkUdk" Version="1.8.4-CI-26108.1805.250410-1448.1">
+    <Dependency Name="Microsoft.FrameworkUdk" Version="1.8.4-CI-26108.1804.250407-0932.0">
       <Uri>https://dev.azure.com/microsoft/LiftedIXP/_git/DCPP</Uri>
-      <Sha>aaee24f9a54adad0612b7f29001111ab4ee691cc</Sha>
+      <Sha>bc5dd07ec77079c367657d193154a29681300d42</Sha>
     </Dependency>
     <Dependency Name="Microsoft.WindowsAppSDK.AppLicensingInternal.TransportPackage" Version="1.8.0-exp.20250408.0">
       <Uri>https://dev.azure.com/microsoft/ProjectReunion/_git/WindowsAppSDKClosed</Uri>
       <Sha>86bc69818cea6cf2253ef523fac3586e0a7e0de5</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.ProjectReunion.InteractiveExperiences.TransportPackage" Version="1.8.4-CI-26108.1805.250410-1448.1">
+    <Dependency Name="Microsoft.ProjectReunion.InteractiveExperiences.TransportPackage" Version="1.8.4-CI-26108.1804.250407-0932.0">
       <Uri>https://dev.azure.com/microsoft/LiftedIXP/_git/DCPP</Uri>
-      <Sha>aaee24f9a54adad0612b7f29001111ab4ee691cc</Sha>
+      <Sha>bc5dd07ec77079c367657d193154a29681300d42</Sha>
     </Dependency>
   </ProductDependencies>
   <ToolsetDependencies>


### PR DESCRIPTION
A microsoft employee must use /azp run to validate using the pipelines below.

WARNING:
Comments made by azure-pipelines bot maybe inaccurate.
Please see pipeline link to verify that the build is being ran.

For status checks on the main branch, please use TransportPackage-Foundation-PR
(https://microsoft.visualstudio.com/ProjectReunion/_build?definitionId=81063&_a=summary)
and run the build against your PR branch with the default parameters.
