### PR TITLE
Improve TraceLogging

### DIFF
--- a/dev/Deployment/DeploymentTraceLogging.h
+++ b/dev/Deployment/DeploymentTraceLogging.h
@@ -35,7 +35,8 @@ public:
             TraceLoggingValue(isPackagedProcess, "isPackagedProcess"),
             TraceLoggingValue(isFullTrustPackage, "isFullTrustPackage"),
             TraceLoggingValue(integrityLevel, "integrityLevel"),
-            TraceLoggingValue(isRepair, "isRepairAPI"));
+            TraceLoggingValue(isRepair, "isRepairAPI"),
+            TelemetryPrivacyDataTag(PDT_ProductAndServicePerformance));
     }
     void StopWithResult(
         HRESULT hresult,
@@ -71,7 +72,8 @@ public:
                 TraceLoggingValue(deploymentErrorExtendedHResult, "DeploymentErrorExtendedHResult"),
                 TraceLoggingValue(deploymentErrorText, "DeploymentErrorText"),
                 TraceLoggingValue(deploymentErrorActivityId, "DeploymentErrorActivityId"),
-                TraceLoggingValue(useExistingPackageIfHigherVersion, "useExistingPackageIfHigherVersion"));
+                TraceLoggingValue(useExistingPackageIfHigherVersion, "useExistingPackageIfHigherVersion"),
+                TelemetryPrivacyDataTag(PDT_ProductAndServicePerformance));
         }
         else
         {

--- a/dev/Deployment/DeploymentTraceLogging.h
+++ b/dev/Deployment/DeploymentTraceLogging.h
@@ -103,4 +103,5 @@ public:
     TraceLoggingValue(failure.uLineNumber, "Line"),\
     TraceLoggingValue(failure.pszMessage, "Message"),\
     TraceLoggingValue(failure.pszModule, "Module"),\
+    _GENERIC_PARTB_FIELDS_ENABLED,\
     __VA_ARGS__)

--- a/dev/Deployment/DeploymentTracelogging.cpp
+++ b/dev/Deployment/DeploymentTracelogging.cpp
@@ -27,7 +27,6 @@ void __stdcall wilResultLoggingCallback(const wil::FailureInfo& failure) noexcep
                     // Failure in restarting PushNotificationsLRP is non-blocking to the installer functionality
                     WindowsAppRuntimeDeployment_WriteEventWithActivity(
                         "RestartPushNotificationsLRPFailed",
-                        _GENERIC_PARTB_FIELDS_ENABLED,
                         TelemetryPrivacyDataTag(PDT_ProductAndServicePerformance),
                         TraceLoggingKeyword(MICROSOFT_KEYWORD_CRITICAL_DATA));
                 }

--- a/dev/PackageManager/API/M.W.M.D.PackageDeploymentManager.cpp
+++ b/dev/PackageManager/API/M.W.M.D.PackageDeploymentManager.cpp
@@ -254,6 +254,7 @@ namespace winrt::Microsoft::Windows::Management::Deployment::implementation
                     TraceLoggingWideString(packageSetItem.PackageFamilyName().c_str(), "Criteria.PackageFamilyName"),
                     TraceLoggingHexUInt64(minVersion.Version, "Criteria.MinVersion"),
                     TraceLoggingHexInt32(static_cast<std::int32_t>(packageSetItem.ProcessorArchitectureFilter()), "Criteria.ArchitectureFilter"),
+                    _GENERIC_PARTB_FIELDS_ENABLED,
                     TraceLoggingLevel(WINEVENT_LEVEL_VERBOSE),
                     TelemetryPrivacyDataTag(PDT_ProductAndServicePerformance));
                 return false;
@@ -351,6 +352,7 @@ namespace winrt::Microsoft::Windows::Management::Deployment::implementation
                     TraceLoggingHexUInt64(minVersion.Version, "Criteria.MinVersion"),
                     TraceLoggingHexInt32(static_cast<std::int32_t>(packageSetItem.ProcessorArchitectureFilter()), "Criteria.ArchitectureFilter"),
                     TraceLoggingInt32(static_cast<std::int32_t>(status), "PackageReadyOrNewerAvailableStatus"),
+                    _GENERIC_PARTB_FIELDS_ENABLED,
                     TraceLoggingLevel(WINEVENT_LEVEL_VERBOSE),
                     TelemetryPrivacyDataTag(PDT_ProductAndServicePerformance));
                 return winrt::Microsoft::Windows::Management::Deployment::PackageReadyOrNewerAvailableStatus::NotReady;
@@ -366,6 +368,7 @@ namespace winrt::Microsoft::Windows::Management::Deployment::implementation
                     TraceLoggingHexUInt64(minVersion.Version, "Criteria.MinVersion"),
                     TraceLoggingHexInt32(static_cast<std::int32_t>(packageSetItem.ProcessorArchitectureFilter()), "Criteria.ArchitectureFilter"),
                     TraceLoggingInt32(static_cast<std::int32_t>(status), "PackageReadyOrNewerAvailableStatus"),
+                    _GENERIC_PARTB_FIELDS_ENABLED,
                     TraceLoggingLevel(WINEVENT_LEVEL_VERBOSE),
                     TelemetryPrivacyDataTag(PDT_ProductAndServicePerformance));
                 newerAvailable = true;

--- a/dev/PackageManager/API/PackageDeploymentResolver.cpp
+++ b/dev/PackageManager/API/PackageDeploymentResolver.cpp
@@ -187,6 +187,7 @@ winrt::hstring Microsoft::Windows::ApplicationModel::PackageDeploymentResolver::
         TraceLoggingWideString(packageFamilyName.c_str(), "Criteria.PackageFamilyName"),
         TraceLoggingHexUInt64(minVersion.Version, "Criteria.MinVersion"),
         TraceLoggingHexInt32(static_cast<std::int32_t>(processorArchitectureFilter), "Criteria.ArchitectureFilter"),
+        _GENERIC_PARTB_FIELDS_ENABLED,
         TraceLoggingLevel(WINEVENT_LEVEL_VERBOSE),
         TelemetryPrivacyDataTag(PDT_ProductAndServicePerformance));
     if (packages)
@@ -212,6 +213,7 @@ winrt::hstring Microsoft::Windows::ApplicationModel::PackageDeploymentResolver::
                     TraceLoggingWideString(packageFamilyName.c_str(), "Criteria.PackageFamilyName"),
                     TraceLoggingHexUInt64(minVersion.Version, "Criteria.MinVersion"),
                     TraceLoggingHexInt32(static_cast<std::int32_t>(processorArchitectureFilter), "Criteria.ArchitectureFilter"),
+                    _GENERIC_PARTB_FIELDS_ENABLED,
                     TraceLoggingLevel(WINEVENT_LEVEL_VERBOSE),
                     TelemetryPrivacyDataTag(PDT_ProductAndServicePerformance));
                 continue;
@@ -243,6 +245,7 @@ winrt::hstring Microsoft::Windows::ApplicationModel::PackageDeploymentResolver::
                         TraceLoggingInt32(static_cast<std::int32_t>(candidateArchitecture), "Architecture"),
                         TraceLoggingHexInt32(static_cast<std::int32_t>(supportedArchitectures), "SupportedArchitectures"),
                         TraceLoggingUInt16(static_cast<std::uint32_t>(nativeMachine), "NativeMachineArchitecture"),
+                        _GENERIC_PARTB_FIELDS_ENABLED,
                         TraceLoggingLevel(WINEVENT_LEVEL_VERBOSE),
                         TelemetryPrivacyDataTag(PDT_ProductAndServicePerformance));
                     continue;
@@ -260,6 +263,7 @@ winrt::hstring Microsoft::Windows::ApplicationModel::PackageDeploymentResolver::
                         TraceLoggingHexUInt64(minVersion.Version, "Criteria.MinVersion"),
                         TraceLoggingHexInt32(static_cast<std::int32_t>(processorArchitectureFilter), "Criteria.ArchitectureFilter"),
                         TraceLoggingInt32(static_cast<std::int32_t>(candidateArchitecture), "Architecture"),
+                        _GENERIC_PARTB_FIELDS_ENABLED,
                         TraceLoggingLevel(WINEVENT_LEVEL_VERBOSE),
                         TelemetryPrivacyDataTag(PDT_ProductAndServicePerformance));
                     continue;
@@ -278,6 +282,7 @@ winrt::hstring Microsoft::Windows::ApplicationModel::PackageDeploymentResolver::
                     TraceLoggingWideString(packageFamilyName.c_str(), "Criteria.PackageFamilyName"),
                     TraceLoggingHexUInt64(minVersion.Version, "Criteria.MinVersion"),
                     TraceLoggingHexInt32(static_cast<std::int32_t>(processorArchitectureFilter), "Criteria.ArchitectureFilter"),
+                    _GENERIC_PARTB_FIELDS_ENABLED,
                     TraceLoggingLevel(WINEVENT_LEVEL_VERBOSE),
                     TelemetryPrivacyDataTag(PDT_ProductAndServicePerformance));
                 continue;
@@ -293,6 +298,7 @@ winrt::hstring Microsoft::Windows::ApplicationModel::PackageDeploymentResolver::
                     TraceLoggingWideString(packageFamilyName.c_str(), "Criteria.PackageFamilyName"),
                     TraceLoggingHexUInt64(minVersion.Version, "Criteria.MinVersion"),
                     TraceLoggingHexInt32(static_cast<std::int32_t>(processorArchitectureFilter), "Criteria.ArchitectureFilter"),
+                    _GENERIC_PARTB_FIELDS_ENABLED,
                     TraceLoggingLevel(WINEVENT_LEVEL_VERBOSE),
                     TelemetryPrivacyDataTag(PDT_ProductAndServicePerformance));
                 return candidateFullName;
@@ -313,6 +319,7 @@ winrt::hstring Microsoft::Windows::ApplicationModel::PackageDeploymentResolver::
             TraceLoggingWideString(packageFamilyName.c_str(), "Criteria.PackageFamilyName"),
             TraceLoggingHexUInt64(minVersion.Version, "Criteria.MinVersion"),
             TraceLoggingHexInt32(static_cast<std::int32_t>(processorArchitectureFilter), "Criteria.ArchitectureFilter"),
+            _GENERIC_PARTB_FIELDS_ENABLED,
             TraceLoggingLevel(WINEVENT_LEVEL_VERBOSE),
             TelemetryPrivacyDataTag(PDT_ProductAndServicePerformance));
     }
@@ -325,6 +332,7 @@ winrt::hstring Microsoft::Windows::ApplicationModel::PackageDeploymentResolver::
             TraceLoggingWideString(packageFamilyName.c_str(), "Criteria.PackageFamilyName"),
             TraceLoggingHexUInt64(minVersion.Version, "Criteria.MinVersion"),
             TraceLoggingHexInt32(static_cast<std::int32_t>(processorArchitectureFilter), "Criteria.ArchitectureFilter"),
+            _GENERIC_PARTB_FIELDS_ENABLED,
             TraceLoggingLevel(WINEVENT_LEVEL_VERBOSE),
             TelemetryPrivacyDataTag(PDT_ProductAndServicePerformance));
     }

--- a/dev/WindowsAppRuntime_BootstrapDLL/MddBootstrap.cpp
+++ b/dev/WindowsAppRuntime_BootstrapDLL/MddBootstrap.cpp
@@ -904,6 +904,7 @@ void FindDDLMViaEnumeration(
         TraceLoggingHexUInt32(majorMinorVersion, "Criteria.MajorMinorVersion"),
         TraceLoggingWideString(!versionTag ? L"" : versionTag, "Criteria.VersionTag"),
         TraceLoggingHexUInt64(minVersion.Version, "Criteria.MinVersion"),
+        _GENERIC_PARTB_FIELDS_ENABLED,
         TraceLoggingLevel(WINEVENT_LEVEL_VERBOSE),
         TelemetryPrivacyDataTag(PDT_ProductAndServicePerformance));
     int packagesScanned{};
@@ -999,6 +1000,7 @@ void FindDDLMViaEnumeration(
                 TraceLoggingHexUInt32(majorMinorVersion, "Criteria.MajorMinorVersion"),
                 TraceLoggingWideString(!versionTag ? L"" : versionTag, "Criteria.VersionTag"),
                 TraceLoggingHexUInt64(minVersion.Version, "Criteria.MinVersion"),
+                _GENERIC_PARTB_FIELDS_ENABLED,
                 TraceLoggingLevel(WINEVENT_LEVEL_VERBOSE),
                 TelemetryPrivacyDataTag(PDT_ProductAndServicePerformance));
             continue;
@@ -1017,6 +1019,7 @@ void FindDDLMViaEnumeration(
                 TraceLoggingWideString(!versionTag ? L"" : versionTag, "Criteria.VersionTag"),
                 TraceLoggingHexUInt64(minVersion.Version, "Criteria.MinVersion"),
                 TraceLoggingWideString(::AppModel::Identity::GetCurrentArchitectureAsString(), "CurrentArchitecture"),
+                _GENERIC_PARTB_FIELDS_ENABLED,
                 TraceLoggingLevel(WINEVENT_LEVEL_VERBOSE),
                 TelemetryPrivacyDataTag(PDT_ProductAndServicePerformance));
             continue;
@@ -1032,6 +1035,7 @@ void FindDDLMViaEnumeration(
                 TraceLoggingHexUInt32(majorMinorVersion, "Criteria.MajorMinorVersion"),
                 TraceLoggingWideString(!versionTag ? L"" : versionTag, "Criteria.VersionTag"),
                 TraceLoggingHexUInt64(minVersion.Version, "Criteria.MinVersion"),
+                _GENERIC_PARTB_FIELDS_ENABLED,
                 TraceLoggingLevel(WINEVENT_LEVEL_VERBOSE),
                 TelemetryPrivacyDataTag(PDT_ProductAndServicePerformance));
             bestFitVersion = version;
@@ -1055,6 +1059,7 @@ void FindDDLMViaEnumeration(
         TraceLoggingWideString(!versionTag ? L"" : versionTag, "Criteria.VersionTag"),
         TraceLoggingHexUInt64(minVersion.Version, "Criteria.MinVersion"),
         TraceLoggingInt32(packagesScanned, "PackagesScanned"),
+        _GENERIC_PARTB_FIELDS_ENABLED,
         TraceLoggingLevel(WINEVENT_LEVEL_VERBOSE),
         TelemetryPrivacyDataTag(PDT_ProductAndServicePerformance));
     ddlmPackageFamilyName = bestFitPackageFamilyName.c_str();

--- a/dev/WindowsAppRuntime_BootstrapDLL/MddBootstrapTracelogging.h
+++ b/dev/WindowsAppRuntime_BootstrapDLL/MddBootstrapTracelogging.h
@@ -4,6 +4,7 @@
 #pragma once
 
 #include "pch.h"
+#include <WindowsAppRuntimeInsights.h>
 
 bool __stdcall wilResultLoggingThreadCallback(const wil::FailureInfo& failure) noexcept;
 

--- a/dev/WindowsAppRuntime_BootstrapDLL/MddBootstrapTracelogging.h
+++ b/dev/WindowsAppRuntime_BootstrapDLL/MddBootstrapTracelogging.h
@@ -4,7 +4,27 @@
 #pragma once
 
 #include "pch.h"
-#include <WindowsAppRuntimeInsights.h>
+
+#if __has_include("WindowsAppSDK-VersionInfo.h")
+#include "WindowsAppSDK-VersionInfo.h"
+#endif
+
+#if defined(__WINDOWSAPPSDK_VERSIONINFO_H__)
+#define TOSTRING_HELPER(x) #x
+#define TOSTRING(x) TOSTRING_HELPER(x)
+#define WINDOWSAPPSDK_RELEASE_VERSION TOSTRING(WINDOWSAPPSDK_RELEASE_MAJOR.WINDOWSAPPSDK_RELEASE_MINOR.WINDOWSAPPSDK_RELEASE_PATCH)
+#else
+#define WINDOWSAPPSDK_RELEASE_VERSION "0.0.0"
+#define WINDOWSAPPSDK_RELEASE_CHANNEL "dev"
+#define WINDOWSAPPSDK_RELEASE_CHANNEL_W L"dev"
+#endif
+_GENERIC_PARTB_FIELDS_ENABLED
+#define _GENERIC_PARTB_FIELDS_ENABLED \
+            TraceLoggingStruct(4, "COMMON_WINDOWSAPPSDK_PARAMS"), \
+            TraceLoggingString(WINDOWSAPPSDK_RELEASE_VERSION, "Version"), \
+            TraceLoggingString(WINDOWSAPPSDK_RELEASE_CHANNEL, "WindowsAppSDKChannel"), \
+            TraceLoggingBool(wil::details::IsDebuggerPresent(), "IsDebugging"), \
+            TraceLoggingBool(true, "UTCReplace_AppSessionGuid")
 
 bool __stdcall wilResultLoggingThreadCallback(const wil::FailureInfo& failure) noexcept;
 
@@ -137,11 +157,11 @@ public:
         _eventname_,\
         _activityId_,\
         nullptr,\
-        _GENERIC_PARTB_FIELDS_ENABLED,\
         TraceLoggingValue(static_cast<uint32_t>(failure.type), "Type"),\
         TraceLoggingValue(failure.hr, "HResult"),\
         TraceLoggingValue(failure.pszFile, "File"),\
         TraceLoggingValue(failure.uLineNumber,"Line"),\
         TraceLoggingValue(failure.pszModule, "Module"),\
         TraceLoggingValue(failure.pszMessage,"Message"),\
+        _GENERIC_PARTB_FIELDS_ENABLED,\
         __VA_ARGS__)

--- a/dev/WindowsAppRuntime_BootstrapDLL/MddBootstrapTracelogging.h
+++ b/dev/WindowsAppRuntime_BootstrapDLL/MddBootstrapTracelogging.h
@@ -35,7 +35,8 @@ public:
             TraceLoggingValue(!versionTag ? L"": versionTag, "versionTag"),
             TraceLoggingValue(minVersion.Version, "minVersion"),
             TraceLoggingValue(mddInitializeOptions, "mddInitializeOptions"),
-            TraceLoggingValue(initializationCount, "initializationCount"));
+            TraceLoggingValue(initializationCount, "initializationCount"),
+            TelemetryPrivacyDataTag(PDT_ProductAndServicePerformance));
     }
     void StopWithResult(
         const HRESULT hresult,
@@ -61,7 +62,8 @@ public:
                 TraceLoggingValue(failureFile, "failureFile"),
                 TraceLoggingValue(failureLineNumber, "failureLineNumber"),
                 TraceLoggingValue(failureMessage, "failureMessage"),
-                TraceLoggingValue(failureModule, "failureModule"));
+                TraceLoggingValue(failureModule, "failureModule"),
+                TelemetryPrivacyDataTag(PDT_ProductAndServicePerformance));
         }
         else
         {
@@ -69,7 +71,8 @@ public:
                 _GENERIC_PARTB_FIELDS_ENABLED,
                 TraceLoggingValue(initializationCount, "initializationCount"),
                 TraceLoggingValue(IntegrityFlags, "IntegrityFlags"),
-                TraceLoggingValue(resolvedFrameworkPackageFullName, "resolvedFrameworkPackageFullName"));
+                TraceLoggingValue(resolvedFrameworkPackageFullName, "resolvedFrameworkPackageFullName"),
+                TelemetryPrivacyDataTag(PDT_ProductAndServicePerformance));
         }
     }
     END_ACTIVITY_CLASS();
@@ -86,7 +89,8 @@ public:
         TraceLoggingClassWriteStart(Shutdown,
             _GENERIC_PARTB_FIELDS_ENABLED,
             TraceLoggingValue(initializationCount, "initializationCount"),
-            TraceLoggingValue(resolvedFrameworkPackageFullName, "resolvedFrameworkPackageFullName"));
+            TraceLoggingValue(resolvedFrameworkPackageFullName, "resolvedFrameworkPackageFullName"),
+            TelemetryPrivacyDataTag(PDT_ProductAndServicePerformance));
     }
     void StopWithResult(
         HRESULT hresult,
@@ -108,13 +112,15 @@ public:
                 TraceLoggingValue(failureFile, "FailureFile"),
                 TraceLoggingValue(failureLineNumber, "FailureLineNumber"),
                 TraceLoggingValue(failureMessage, "FailureMessage"),
-                TraceLoggingValue(failureModule, "FailureModule"));
+                TraceLoggingValue(failureModule, "FailureModule"),
+                TelemetryPrivacyDataTag(PDT_ProductAndServicePerformance));
         }
         else
         {
             TraceLoggingClassWriteStop(Shutdown,
                 _GENERIC_PARTB_FIELDS_ENABLED,
-                TraceLoggingValue(initializationCount, "initializationCount"));
+                TraceLoggingValue(initializationCount, "initializationCount"),
+                TelemetryPrivacyDataTag(PDT_ProductAndServicePerformance));
         }
     }
     END_ACTIVITY_CLASS();

--- a/dev/WindowsAppRuntime_BootstrapDLL/MddBootstrapTracelogging.h
+++ b/dev/WindowsAppRuntime_BootstrapDLL/MddBootstrapTracelogging.h
@@ -136,11 +136,14 @@ public:
         _eventname_,\
         _activityId_,\
         nullptr,\
-        TraceLoggingValue(static_cast<uint32_t>(failure.type), "Type"),\
-        TraceLoggingValue(failure.hr, "HResult"),\
-        TraceLoggingValue(failure.pszFile, "File"),\
-        TraceLoggingValue(failure.uLineNumber,"Line"),\
-        TraceLoggingValue(failure.pszModule, "Module"),\
-        TraceLoggingValue(failure.pszMessage,"Message"),\
         _GENERIC_PARTB_FIELDS_ENABLED,\
+        _WRITE_FAILURE_INFO,\
         __VA_ARGS__)
+
+#define _WRITE_FAILURE_INFO \
+    TraceLoggingValue(static_cast<uint32_t>(failure.type), "Type"),\
+    TraceLoggingValue(failure.hr, "HResult"),\
+    TraceLoggingValue(failure.pszFile, "File"),\
+    TraceLoggingValue(failure.uLineNumber,"Line"),\
+    TraceLoggingValue(failure.pszModule, "Module"),\
+    TraceLoggingValue(failure.pszMessage,"Message")

--- a/dev/WindowsAppRuntime_BootstrapDLL/MddBootstrapTracelogging.h
+++ b/dev/WindowsAppRuntime_BootstrapDLL/MddBootstrapTracelogging.h
@@ -136,14 +136,10 @@ public:
         _eventname_,\
         _activityId_,\
         nullptr,\
-        _GENERIC_PARTB_FIELDS_ENABLED,\
-        _WRITE_FAILURE_INFO,\
+        TraceLoggingValue(static_cast<uint32_t>(failure.type), "Type"),\
+        TraceLoggingValue(failure.hr, "HResult"),\
+        TraceLoggingValue(failure.pszFile, "File"),\
+        TraceLoggingValue(failure.uLineNumber,"Line"),\
+        TraceLoggingValue(failure.pszModule, "Module"),\
+        TraceLoggingValue(failure.pszMessage,"Message"),\
         __VA_ARGS__)
-
-#define _WRITE_FAILURE_INFO \
-    TraceLoggingValue(static_cast<uint32_t>(failure.type), "Type"),\
-    TraceLoggingValue(failure.hr, "HResult"),\
-    TraceLoggingValue(failure.pszFile, "File"),\
-    TraceLoggingValue(failure.uLineNumber,"Line"),\
-    TraceLoggingValue(failure.pszModule, "Module"),\
-    TraceLoggingValue(failure.pszMessage,"Message")

--- a/dev/WindowsAppRuntime_BootstrapDLL/MddBootstrapTracelogging.h
+++ b/dev/WindowsAppRuntime_BootstrapDLL/MddBootstrapTracelogging.h
@@ -136,6 +136,7 @@ public:
         _eventname_,\
         _activityId_,\
         nullptr,\
+        _GENERIC_PARTB_FIELDS_ENABLED,\
         TraceLoggingValue(static_cast<uint32_t>(failure.type), "Type"),\
         TraceLoggingValue(failure.hr, "HResult"),\
         TraceLoggingValue(failure.pszFile, "File"),\

--- a/dev/WindowsAppRuntime_BootstrapDLL/MddBootstrapTracelogging.h
+++ b/dev/WindowsAppRuntime_BootstrapDLL/MddBootstrapTracelogging.h
@@ -136,13 +136,11 @@ public:
         _eventname_,\
         _activityId_,\
         nullptr,\
-        _WRITE_FAILURE_INFO,\
+        TraceLoggingValue(static_cast<uint32_t>(failure.type), "Type"),\
+        TraceLoggingValue(failure.hr, "HResult"),\
+        TraceLoggingValue(failure.pszFile, "File"),\
+        TraceLoggingValue(failure.uLineNumber,"Line"),\
+        TraceLoggingValue(failure.pszModule, "Module"),\
+        TraceLoggingValue(failure.pszMessage,"Message"),\
+        _GENERIC_PARTB_FIELDS_ENABLED,\
         __VA_ARGS__)
-
-#define _WRITE_FAILURE_INFO \
-    TraceLoggingValue(static_cast<uint32_t>(failure.type), "Type"),\
-    TraceLoggingValue(failure.hr, "HResult"),\
-    TraceLoggingValue(failure.pszFile, "File"),\
-    TraceLoggingValue(failure.uLineNumber,"Line"),\
-    TraceLoggingValue(failure.pszModule, "Module"),\
-    TraceLoggingValue(failure.pszMessage,"Message")


### PR DESCRIPTION
Recreating https://github.com/microsoft/WindowsAppSDK/pull/5285 to attempt a clean pipeline run.
______________________________
Improve TraceLogging

Always include _GENERIC_PARTB_FIELDS_ENABLED in TraceLoggingWrite calls for rich log information
Always specify PDT Keyword per PII practices. Usually TraceLoggingKeyword(PDT_ProductAndServicePerformance) (was in these cases but any future devs reading this should consult with your privacy representative)
[task.ms/56757819](https://task.ms/56757819)
