### PR TITLE
[Pipeline] Rename artifact base for PREfast stages

### DIFF
--- a/build/AzurePipelinesTemplates/WindowsAppSDK-Build-Per-Platform-Stage.yml
+++ b/build/AzurePipelinesTemplates/WindowsAppSDK-Build-Per-Platform-Stage.yml
@@ -51,7 +51,10 @@ stages:
       - name: ob_sdl_codeSignValidation_excludes
         value: '-|**\Release\**;-|**\packages\**'
       - name: ob_artifactBaseName
-        value: "FoundationBinaries_$(buildConfiguration)_$(buildPlatform)"
+        ${{ if parameters.runPREfast }}:
+          value: "FoundationBinaries_$(buildConfiguration)_$(buildPlatform)_PREfast"
+        ${{ else }}:
+          value: "FoundationBinaries_$(buildConfiguration)_$(buildPlatform)"
       - name: ob_sdl_apiscan_enabled
         ${{ if parameters.runApiScan }}:
           value: true
@@ -127,7 +130,10 @@ stages:
       - name: ob_sdl_suppression_suppressionSet
         value: default
       - name: ob_artifactBaseName
-        value: "MrtBinaries_$(buildConfiguration)_$(buildPlatform)"
+        ${{ if parameters.runPREfast }}:
+          value: "MrtBinaries_$(buildConfiguration)_$(buildPlatform)_PREfast"
+        ${{ else }}:
+          value: "MrtBinaries_$(buildConfiguration)_$(buildPlatform)"
       - name: ob_sdl_apiscan_enabled
         ${{ if parameters.runApiScan }}:
           value: true

--- a/build/AzurePipelinesTemplates/WindowsAppSDK-Build-Stage.yml
+++ b/build/AzurePipelinesTemplates/WindowsAppSDK-Build-Stage.yml
@@ -46,7 +46,10 @@ stages:
     variables:
       ob_outputDirectory: '$(REPOROOT)\out'
       ob_sdl_codeSignValidation_excludes: '-|**\Release\**'
-      ob_artifactBaseName: "FoundationBinaries_release_anycpu"
+      ${{ if parameters.runPREfast }}:
+        ob_artifactBaseName: "FoundationBinaries_release_anycpu_PREfast"
+      ${{ if not( parameters.runPREfast ) }}:
+        ob_artifactBaseName: "FoundationBinaries_release_anycpu"
       ${{ if parameters.runApiScan }}:
         ob_sdl_apiscan_enabled: true
       ${{ if not( parameters.runApiScan ) }}:


### PR DESCRIPTION
This is to address an issue caused by my previous PR #5364, which fails the [foundation nightly build](https://dev.azure.com/microsoft/ProjectReunion/_build/results?buildId=122095756&view=results) due to duplicate artifact publish (PREfast stage uploads once, and the normal build stage uploads another time)

![image](https://github.com/user-attachments/assets/3dc414b1-c981-4437-9999-3ece419b11e2)

Current fix is to assign a separate artifact base name for PREfast stage