### PR TITLE
[Build] Avoid pipeline break due to timeout error by increasing the job time limit when APIScan is enabled

### DIFF
--- a/build/AzurePipelinesTemplates/WindowsAppSDK-Build-Per-Platform-Stage.yml
+++ b/build/AzurePipelinesTemplates/WindowsAppSDK-Build-Per-Platform-Stage.yml
@@ -31,7 +31,11 @@ stages:
         type: windows
         isCustom: true
         name: 'ProjectReunionESPool-2022'
-    timeoutInMinutes: 120
+      # In the less likely case of running APIScan, give it more time.
+      ${{ if parameters.runApiScan }}:
+        timeoutInMinutes: 180
+      ${{ else }}:
+        timeoutInMinutes: 120
     strategy:
       maxParallel: 10
       matrix:
@@ -108,7 +112,11 @@ stages:
         type: windows
         isCustom: true
         name: 'ProjectReunionESPool-2022'
-    timeoutInMinutes: 120
+    # In the less likely case of running APIScan, give it more time.
+    ${{ if parameters.runApiScan }}:
+      timeoutInMinutes: 150
+    ${{ else }}:
+      timeoutInMinutes: 120
     strategy:
       maxParallel: 10
       matrix:

--- a/build/AzurePipelinesTemplates/WindowsAppSDK-Build-Per-Platform-Stage.yml
+++ b/build/AzurePipelinesTemplates/WindowsAppSDK-Build-Per-Platform-Stage.yml
@@ -31,11 +31,11 @@ stages:
         type: windows
         isCustom: true
         name: 'ProjectReunionESPool-2022'
-      # In the less likely case of running APIScan, give it more time.
-      ${{ if parameters.runApiScan }}:
-        timeoutInMinutes: 180
-      ${{ else }}:
-        timeoutInMinutes: 120
+    # In the less likely case of running APIScan and/or PREfast, give it more time.
+    ${{ if or(parameters.runApiScan, parameters.runPREfast) }}:
+      timeoutInMinutes: 180
+    ${{ else }}:
+      timeoutInMinutes: 120
     strategy:
       maxParallel: 10
       matrix:
@@ -112,8 +112,8 @@ stages:
         type: windows
         isCustom: true
         name: 'ProjectReunionESPool-2022'
-    # In the less likely case of running APIScan, give it more time.
-    ${{ if parameters.runApiScan }}:
+    # In the less likely case of running APIScan and/or PREfast, give it more time.
+    ${{ if or(parameters.runApiScan, parameters.runPREfast) }}:
       timeoutInMinutes: 150
     ${{ else }}:
       timeoutInMinutes: 120


### PR DESCRIPTION
When APIScan (or PREfast) is enabled, building Foundation for each architecture currently takes ~1.5 hrs, resulting in timeout error due to hitting the 120 min limit for jobs.
Avoiding the timeout error by setting a higher time limit when APIScan (or PREfast) enabled.

How built:
- These changes will go through PR validation as usual.

How tested:
- In a private run of the Foundation nightly pipeline, the build jobs doing APIScan all passed, e.g., with elapsed time 2hr 28 sec, i.e., this would have hit the original timeout limit of 120 min causing the pipeline run to fail.

/////////////////////////

A microsoft employee must use /azp run to validate using the pipelines below.

WARNING:
Comments made by azure-pipelines bot maybe inaccurate.
Please see pipeline link to verify that the build is being ran.

For status checks on the main branch, please use TransportPackage-Foundation-PR
(https://microsoft.visualstudio.com/ProjectReunion/_build?definitionId=81063&_a=summary)
and run the build against your PR branch with the default parameters.
