### PR TITLE
Fix FolderPicker crash when selecting "This PC" or special paths

### DIFF
--- a/dev/Interop/StoragePickers/FolderPicker.cpp
+++ b/dev/Interop/StoragePickers/FolderPicker.cpp
@@ -88,7 +88,7 @@ namespace winrt::Microsoft::Windows::Storage::Pickers::implementation
         auto dialog = create_instance<IFileOpenDialog>(CLSID_FileOpenDialog, CLSCTX_INPROC_SERVER);
 
         parameters.ConfigureDialog(dialog);
-        dialog->SetOptions(FOS_PICKFOLDERS);
+        dialog->SetOptions(FOS_PICKFOLDERS | FOS_FORCEFILESYSTEM);
 
         {
             auto hr = dialog->Show(parameters.HWnd);


### PR DESCRIPTION
## Issue

When users attempt to select "This PC" or other special paths in the FolderPicker, the dialog closes unexpectedly and crashes instead of providing guidance.

**gif for the behavior before fix**
![new-picker-pick-pc](https://github.com/user-attachments/assets/af7ec664-10f0-44c1-aa16-8e9cca1870d6)


## Expect
After end user have selected "This PC" in the folder picker dialog, the dialog shows a message to inform user this is not valid, instead of crashing

## Fix

* [`dev/Interop/StoragePickers/FolderPicker.cpp`](diffhunk://#diff-fafd9b82668f2ebe3d318ec048dab1bf54074c05dd6f56dc392b0d3e5c0294c1L91-R91): Updated the `SetOptions` method to include the `FOS_FORCEFILESYSTEM` flag in addition to `FOS_PICKFOLDERS`, ensuring that the folder picker dialog enforces the selection of filesystem objects.

**gif for the behavior after fix**
![after-fix-pick-pc](https://github.com/user-attachments/assets/d64565b0-c161-44cf-bda2-63d9849791ff)
