### PR TITLE
Update TouchdownBuildTask to 5

### DIFF
--- a/build/AzurePipelinesTemplates/WindowsAppSDK-CallTouchDownBuild-Steps.yml
+++ b/build/AzurePipelinesTemplates/WindowsAppSDK-CallTouchDownBuild-Steps.yml
@@ -32,4 +32,10 @@ steps:
     resourceFilePath: ${{ parameters.ResourceFilePath }}
     appendRelativeDir: true
     cultureMappingType: 'None'
-    gitAction: ${{ parameters.GitAction }}
+    outputDirectoryRoot: '$(Build.ArtifactStagingDirectory)'
+
+- task: PublishPipelineArtifact@1
+  condition: succeededOrFailed()
+  inputs:
+    targetPath: '$(Build.ArtifactStagingDirectory)'
+    artifact: 'LocalizedFiles'

--- a/build/AzurePipelinesTemplates/WindowsAppSDK-CallTouchDownBuild-Steps.yml
+++ b/build/AzurePipelinesTemplates/WindowsAppSDK-CallTouchDownBuild-Steps.yml
@@ -21,7 +21,7 @@ steps:
     git config --global user.email "DoNotEmailThis@dev.null.microsoft.com"
     git config --global user.name "TDBuild"
 
-- task: TouchdownBuildTask@4
+- task: TouchdownBuildTask@5
   inputs:
     environment: 'PRODEXT'
     teamId: ${{ parameters.TeamID }}


### PR DESCRIPTION
A microsoft employee must use /azp run to validate using the pipelines below.

WARNING:
Comments made by azure-pipelines bot maybe inaccurate.
Please see pipeline link to verify that the build is being ran.

For status checks on the main branch, please use TransportPackage-Foundation-PR
(https://microsoft.visualstudio.com/ProjectReunion/_build?definitionId=81063&_a=summary)
and run the build against your PR branch with the default parameters.
