### PR TITLE
search vars should persist, not be loop local

### DIFF
--- a/dev/MRTCore/mrt/Core/src/MRM.cpp
+++ b/dev/MRTCore/mrt/Core/src/MRM.cpp
@@ -1014,12 +1014,11 @@ STDAPI MrmGetFilePathFromName(_In_opt_ PCWSTR filename, _Outptr_ PWSTR* filePath
     //   - if exeDir != baseDir
     //      - search under exeDir for resources.pri
     //      - search under exeDir for [modulename].pri
+    PWSTR searchDir{};
+    size_t searchDirCount{};
+    PCWSTR searchFilename{};
     for (SearchPass pass = searchStart; pass < SearchPass::Final; pass = SearchPass(pass+1))
     {
-        PWSTR searchDir{};
-        size_t searchDirCount{};
-        PCWSTR searchFilename{};
-
         switch(pass)
         {
             // Search, given FileName


### PR DESCRIPTION
A microsoft employee must use /azp run to validate using the pipelines below.

WARNING:
Comments made by azure-pipelines bot maybe inaccurate.
Please see pipeline link to verify that the build is being ran.

For status checks on the main branch, please use TransportPackage-Foundation-PR
(https://microsoft.visualstudio.com/ProjectReunion/_build?definitionId=81063&_a=summary)
and run the build against your PR branch with the default parameters.
