### PR TITLE
fix Component Governance file can't find warning

### DIFF
--- a/build/AzurePipelinesTemplates/WindowsAppSDK-Build-Per-Platform-Stage.yml
+++ b/build/AzurePipelinesTemplates/WindowsAppSDK-Build-Per-Platform-Stage.yml
@@ -42,12 +42,12 @@ stages:
         ${{ format('Release_{0}', parameters.buildPlatform) }}:
           ${{ if ne(parameters.buildPlatform, 'arm64') }}:
             buildPlatform: ${{ parameters.buildPlatform }}
-            buildConfiguration: 'release'
+            buildConfiguration: 'Release'
             normalizedConfiguration: 'fre'
             PGOBuildMode: 'Optimize'
           ${{ else }}:
             buildPlatform: ${{ parameters.buildPlatform }}
-            buildConfiguration: 'release'
+            buildConfiguration: 'Release'
             normalizedConfiguration: 'fre'
     variables:
       - name: ob_outputDirectory

--- a/build/NuSpecs/WindowsAppSDK-Nuget-Native.AutoInitializer.targets
+++ b/build/NuSpecs/WindowsAppSDK-Nuget-Native.AutoInitializer.targets
@@ -2,14 +2,21 @@
 <!-- Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT License. See LICENSE in the project root for license information. -->
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 
+  <PropertyGroup>
+    <AutoInitializerPreprocessorDefinitions>
+        $(AutoInitializerPreprocessorDefinitions);
+        $(WindowsAppSdkBootstrapInitialize)=='true' ? MICROSOFT_WINDOWSAPPSDK_AUTOINITIALIZE_BOOTSTRAP : ;
+        $(WindowsAppSdkDeploymentManagerInitialize)=='true' ? MICROSOFT_WINDOWSAPPSDK_AUTOINITIALIZE_DEPLOYMENTMANAGER : ;
+        $(WindowsAppSdkUndockedRegFreeWinRTInitialize)=='true' ? MICROSOFT_WINDOWSAPPSDK_AUTOINITIALIZE_UNDOCKEDREGFREEWINRT : ;
+        $(WindowsAppSdkCompatibilityInitialize)=='true' ? MICROSOFT_WINDOWSAPPSDK_AUTOINITIALIZE_COMPATIBILITY : ;
+    </AutoInitializerPreprocessorDefinitions>
+</PropertyGroup>
+
   <Target Name="WindowsAppRuntimeAutoInitializer">
     <ItemGroup>
       <ClCompile Include="$(MSBuildThisFileDirectory)..\..\include\WindowsAppRuntimeAutoInitializer.cpp">
         <PrecompiledHeader>NotUsing</PrecompiledHeader>
-        <PreprocessorDefinitions Condition="'$(WindowsAppSdkBootstrapInitialize)'=='true'">MICROSOFT_WINDOWSAPPSDK_AUTOINITIALIZE_BOOTSTRAP;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-        <PreprocessorDefinitions Condition="'$(WindowsAppSdkDeploymentManagerInitialize)'=='true'">MICROSOFT_WINDOWSAPPSDK_AUTOINITIALIZE_DEPLOYMENTMANAGER;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-        <PreprocessorDefinitions Condition="'$(WindowsAppSdkUndockedRegFreeWinRTInitialize)'=='true'">MICROSOFT_WINDOWSAPPSDK_AUTOINITIALIZE_UNDOCKEDREGFREEWINRT;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-        <PreprocessorDefinitions Condition="'$(WindowsAppSdkCompatibilityInitialize)'=='true'">MICROSOFT_WINDOWSAPPSDK_AUTOINITIALIZE_COMPATIBILITY;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+        <PreprocessorDefinitions>$(AutoInitializerPreprocessorDefinitions);%(PreprocessorDefinitions)</PreprocessorDefinitions>
       </ClCompile>
     </ItemGroup>
   </Target>


### PR DESCRIPTION
This PR fixes Component Governance warnings that were occurring due to inconsistent capitalization of the configuration parameter across the build system. The warnings showed paths like:

```
##[warning]Project path C:\__w\1\s\eng\PackageReference\IXP\IXP.TransportPackage.PackageReference.csproj specified by D:\a\_work\1\s\obj\release\x86\IXP.TransportPackage.PackageReference\project.assets.json does not exist.
##[warning]Project output path C:\__w\1\s\obj\Release\x86\IXP.TransportPackage.PackageReference\ specified by D:\a\_work\1\s\obj\release\x86\IXP.TransportPackage.PackageReference\project.assets.json does not exist.
```

## Root Cause
The issue was caused by inconsistent configuration parameter casing:
- `BuildAll.ps1` defaults to `"Release"` (uppercase R)
- Azure DevOps pipelines explicitly passed `"release"` (lowercase r) 
- `build-nupkg.ps1` defaulted to `"release"` (lowercase r)

This caused `project.assets.json` files to reference different obj directory paths (`obj\Release\` vs `obj\release\`), creating Component Governance warnings about non-existent paths.