### PR TITLE
Updates the telemetry activities in the StoragePickersTelemetry class to use critical data activity classes

### DIFF
--- a/dev/Interop/StoragePickers/StoragePickersTelemetry.h
+++ b/dev/Interop/StoragePickers/StoragePickersTelemetry.h
@@ -15,7 +15,7 @@ class StoragePickersTelemetry : public wil::TraceLoggingProvider
     IMPLEMENT_TELEMETRY_CLASS(StoragePickersTelemetry, StoragePickersTelemetryProvider);
 
 public:
-    BEGIN_COMPLIANT_MEASURES_ACTIVITY_CLASS(FileOpenPickerPickSingleFile, PDT_ProductAndServicePerformance);
+    BEGIN_COMPLIANT_CRITICAL_DATA_ACTIVITY_CLASS(FileOpenPickerPickSingleFile, PDT_ProductAndServicePerformance);
         DEFINE_ACTIVITY_START(StoragePickersTelemetryHelper& telemetryHelper) noexcept try
         {
             TraceLoggingClassWriteStart(
@@ -43,7 +43,7 @@ public:
         CATCH_LOG()
     END_ACTIVITY_CLASS();
 
-    BEGIN_COMPLIANT_MEASURES_ACTIVITY_CLASS(FileOpenPickerPickMultipleFile, PDT_ProductAndServicePerformance);
+    BEGIN_COMPLIANT_CRITICAL_DATA_ACTIVITY_CLASS(FileOpenPickerPickMultipleFile, PDT_ProductAndServicePerformance);
         DEFINE_ACTIVITY_START(StoragePickersTelemetryHelper& telemetryHelper) noexcept try
         {
             TraceLoggingClassWriteStart(
@@ -71,7 +71,7 @@ public:
         CATCH_LOG()
     END_ACTIVITY_CLASS();
 
-    BEGIN_COMPLIANT_MEASURES_ACTIVITY_CLASS(FileSavePickerPickSingleFile, PDT_ProductAndServicePerformance);
+    BEGIN_COMPLIANT_CRITICAL_DATA_ACTIVITY_CLASS(FileSavePickerPickSingleFile, PDT_ProductAndServicePerformance);
         DEFINE_ACTIVITY_START(StoragePickersTelemetryHelper& telemetryHelper) noexcept try
         {
             TraceLoggingClassWriteStart(
@@ -98,7 +98,7 @@ public:
         CATCH_LOG()
     END_ACTIVITY_CLASS();
 
-    BEGIN_COMPLIANT_MEASURES_ACTIVITY_CLASS(FolderPickerPickSingleFolder, PDT_ProductAndServicePerformance);
+    BEGIN_COMPLIANT_CRITICAL_DATA_ACTIVITY_CLASS(FolderPickerPickSingleFolder, PDT_ProductAndServicePerformance);
         DEFINE_ACTIVITY_START(StoragePickersTelemetryHelper& telemetryHelper) noexcept try
         {
             TraceLoggingClassWriteStart(


### PR DESCRIPTION
This pull request updates the telemetry activity classes in the `StoragePickersTelemetry` class to use critical data activity classes instead of measures activity classes.

Telemetry updates:

* Changed `BEGIN_COMPLIANT_MEASURES_ACTIVITY_CLASS` to `BEGIN_COMPLIANT_CRITICAL_DATA_ACTIVITY_CLASS` for the `FileOpenPickerPickSingleFile` activity.
* Changed `BEGIN_COMPLIANT_MEASURES_ACTIVITY_CLASS` to `BEGIN_COMPLIANT_CRITICAL_DATA_ACTIVITY_CLASS` for the `FileOpenPickerPickMultipleFile` activity.
* Changed `BEGIN_COMPLIANT_MEASURES_ACTIVITY_CLASS` to `BEGIN_COMPLIANT_CRITICAL_DATA_ACTIVITY_CLASS` for the `FileSavePickerPickSingleFile` activity.
* Changed `BEGIN_COMPLIANT_MEASURES_ACTIVITY_CLASS` to `BEGIN_COMPLIANT_CRITICAL_DATA_ACTIVITY_CLASS` for the `FolderPickerPickSingleFolder` activity.