### PR TITLE
[1.7 servicing] WinAppSdk 1.7 installer not able to install Singleton package when WinAppSdk 1.6 is installed and 1.6 Singleton is being used in the background

### DIFF
--- a/dev/Deployment/DeploymentManager.cpp
+++ b/dev/Deployment/DeploymentManager.cpp
@@ -543,12 +543,7 @@ namespace winrt::Microsoft::Windows::ApplicationModel::WindowsAppRuntime::implem
         initializeActivity.SetInstallStage(::WindowsAppRuntime::Deployment::Activity::DeploymentStage::AddPackage);
         for (auto package : c_targetPackages)
         {
-            auto isSingleton{ false };
-            if (CompareStringOrdinal(package.identifier.c_str(), -1, WINDOWSAPPRUNTIME_PACKAGE_SUBTYPENAME_SINGLETON, -1, TRUE) == CSTR_EQUAL)
-            {
-                isSingleton = true;
-            }
-
+            auto isSingleton{ CompareStringOrdinal(package.identifier.c_str(), -1, WINDOWSAPPRUNTIME_PACKAGE_SUBTYPENAME_SINGLETON, -1, TRUE) == CSTR_EQUAL };
             initializeActivity.Reset();
             initializeActivity.SetCurrentResourceId(package.identifier);
 
@@ -573,7 +568,7 @@ namespace winrt::Microsoft::Windows::ApplicationModel::WindowsAppRuntime::implem
 
             // If the current application has runFullTrust capability, then Deploy the target package in a Breakaway process.
             // Otherwise, call PackageManager API to deploy the target package.
-             // The Singleton package will always set true for forceDeployment and the running process will be terminated to update the package.
+            // The Singleton package will always set true for forceDeployment and the running process will be terminated to update the package.
             if (initializeActivity.GetIsFullTrustPackage())
             {
 


### PR DESCRIPTION
A microsoft employee must use /azp run to validate using the pipelines below.

WARNING:
Comments made by azure-pipelines bot maybe inaccurate.
Please see pipeline link to verify that the build is being ran.

For status checks on the main branch, please use TransportPackage-Foundation-PR
(https://microsoft.visualstudio.com/ProjectReunion/_build?definitionId=81063&_a=summary)
and run the build against your PR branch with the default parameters.

--------------------------------------------------------------------------------------------------------------------------------------
This is a back-port of #5445 to release/1.7-stable. 
[https://task.ms/58022587](https://task.ms/58022587)
