### PR TITLE
Use WindowsAppSDK-Versions.yml from WindowsAppSDKConfig

### DIFF
--- a/BuildAll.ps1
+++ b/BuildAll.ps1
@@ -18,8 +18,8 @@ Main branch points to the external feed.
 #>
 
 Param(
-    [string]$PackageVersion = "1.1.1.1",
-    [string]$ComponentPackageVersion = "1.1.1.1",
+    [string]$PackageVersion = "",
+    [string]$ComponentPackageVersion = "",
     [string]$Platform = "x64",
     [string]$Configuration = "Release",
     [string]$AzureBuildStep = "all",
@@ -57,6 +57,23 @@ if ($Clean)
     }
 
     Exit
+}
+
+# Find the Version Value provided by WindowsAppSDKConfig in Version.Details.xml
+# The version field of Microsoft.WindowAppSDK.Version is the value provided byWindowsAppSDKConfig
+[xml]$versionDetailsPath = Get-Content -Path "$env:Build_SourcesDirectory\eng\Version.Details.xml"
+$versionFromConfig = $versionDetailsPath.Dependencies.ToolsetDependencies.Dependency | Where-Object { $_.Name -eq "Microsoft.WindowAppSDK.Version" }
+if ([string]::IsNullOrEmpty($PackageVersion))
+{
+    $PackageVersion = $versionFromConfig.Version;
+    Write-Host "Updating PackageVersion from Microsoft.WindowAppSDK.Version in eng\Version.Details.xml: $PackageVersion"
+}
+
+if ([string]::IsNullOrEmpty($ComponentPackageVersion))
+{
+    Write-Host $versionFromConfig.Version
+    $ComponentPackageVersion = $versionFromConfig.Version;
+    Write-Host "Updating ComponentPackageVersion from Microsoft.WindowAppSDK.Version in eng\Version.Details.xml: $ComponentPackageVersion"
 }
 
 $configurationForMrtAndAnyCPU = "Release"

--- a/BuildAll.ps1
+++ b/BuildAll.ps1
@@ -562,12 +562,9 @@ Try {
         $publicNuspec.package.metadata.version = $ComponentPackageVersion
 
         # Update dependency versions in the nuspec
-        $versionDetailsPath = ".\eng\Version.Details.xml"
-        [xml]$buildConfig = Get-Content -Path $versionDetailsPath
-
         foreach ($dependency in $publicNuspec.package.metadata.dependencies.dependency)
         {
-            $buildDependency = $buildConfig.Dependencies.ProductDependencies.Dependency | Where-Object { $_.Name -eq $dependency.Id }
+            $buildDependency = $versionDetailsPath.Dependencies.ProductDependencies.Dependency | Where-Object { $_.Name -eq $dependency.Id }
             if (-not($buildDependency))
             {
                 write-host "ERROR: NuGet package dependency $($dependency.Id) not found."

--- a/BuildAll.ps1
+++ b/BuildAll.ps1
@@ -60,20 +60,20 @@ if ($Clean)
 }
 
 # Find the Version Value provided by WindowsAppSDKConfig in Version.Details.xml
-# The version field of Microsoft.WindowAppSDK.Version is the value provided byWindowsAppSDKConfig
+# The version field of Microsoft.WindowsAppSDK.Version is the value provided byWindowsAppSDKConfig
 [xml]$versionDetailsPath = Get-Content -Path "$env:Build_SourcesDirectory\eng\Version.Details.xml"
-$versionFromConfig = $versionDetailsPath.Dependencies.ToolsetDependencies.Dependency | Where-Object { $_.Name -eq "Microsoft.WindowAppSDK.Version" }
+$versionFromConfig = $versionDetailsPath.Dependencies.ToolsetDependencies.Dependency | Where-Object { $_.Name -eq "Microsoft.WindowsAppSDK.Version" }
 if ([string]::IsNullOrEmpty($PackageVersion))
 {
     $PackageVersion = $versionFromConfig.Version;
-    Write-Host "Updating PackageVersion from Microsoft.WindowAppSDK.Version in eng\Version.Details.xml: $PackageVersion"
+    Write-Host "Updating PackageVersion from Microsoft.WindowsAppSDK.Version in eng\Version.Details.xml: $PackageVersion"
 }
 
 if ([string]::IsNullOrEmpty($ComponentPackageVersion))
 {
     Write-Host $versionFromConfig.Version
     $ComponentPackageVersion = $versionFromConfig.Version;
-    Write-Host "Updating ComponentPackageVersion from Microsoft.WindowAppSDK.Version in eng\Version.Details.xml: $ComponentPackageVersion"
+    Write-Host "Updating ComponentPackageVersion from Microsoft.WindowsAppSDK.Version in eng\Version.Details.xml: $ComponentPackageVersion"
 }
 
 $configurationForMrtAndAnyCPU = "Release"

--- a/build/AzurePipelinesTemplates/WindowsAppSDK-Build-Per-Platform-Stage.yml
+++ b/build/AzurePipelinesTemplates/WindowsAppSDK-Build-Per-Platform-Stage.yml
@@ -68,7 +68,7 @@ stages:
         value: '$(build.SourcesDirectory)\APIScanTarget'
       - name: ob_sdl_apiscan_symbolsFolder
         value: '$(build.SourcesDirectory)\APIScanTarget;SRV*https://symweb.azurefd.net'
-      - template: AzurePipelinesTemplates/WindowsAppSDK-Global-LKGVersions.yml@WindowsAppSDKConfigSourceBranch
+      - template: AzurePipelinesTemplates/WindowsAppSDK-Global-LKGVersions.yml@WindowsAppSDKVersionConfig
       - name: localCompilerOverridePackageName
         value: $[coalesce(variables.compilerOverridePackageName, variables.global_CompilerOverridePackageName)]
       - name: localCompilerOverridePackageVersion
@@ -151,7 +151,7 @@ stages:
         value: '$(build.SourcesDirectory)\APIScanTarget'
       - name: ob_sdl_apiscan_symbolsFolder
         value: '$(build.SourcesDirectory)\APIScanTarget;SRV*https://symweb.azurefd.net'
-      - template: AzurePipelinesTemplates/WindowsAppSDK-Global-LKGVersions.yml@WindowsAppSDKConfigSourceBranch
+      - template: AzurePipelinesTemplates/WindowsAppSDK-Global-LKGVersions.yml@WindowsAppSDKVersionConfig
       - name: localCompilerOverridePackageName
         value: $[coalesce(variables.compilerOverridePackageName, variables.global_CompilerOverridePackageName)]
       - name: localCompilerOverridePackageVersion

--- a/build/AzurePipelinesTemplates/WindowsAppSDK-BuildInstaller-Stage.yml
+++ b/build/AzurePipelinesTemplates/WindowsAppSDK-BuildInstaller-Stage.yml
@@ -33,7 +33,7 @@ stages:
       # it is not under $(Build.SourcesDirectory)\WindowsAppSDK
       - name: foundationRepoPath
         value: ""
-      - template: AzurePipelinesTemplates/WindowsAppSDK-Global-LKGVersions.yml@WindowsAppSDKConfigSourceBranch
+      - template: AzurePipelinesTemplates/WindowsAppSDK-Global-LKGVersions.yml@WindowsAppSDKVersionConfig
       - name: localCompilerOverridePackageName
         value: $[coalesce(variables.compilerOverridePackageName, variables.global_CompilerOverridePackageName)]
       - name: localCompilerOverridePackageVersion

--- a/build/AzurePipelinesTemplates/WindowsAppSDK-PackTransportPackage-Stage.yml
+++ b/build/AzurePipelinesTemplates/WindowsAppSDK-PackTransportPackage-Stage.yml
@@ -185,7 +185,7 @@ stages:
           }
 
           $buildType = '$(channel)'
-          $majorMinorPatchRev = '$(major).$(minor).$(versionMinDate)'
+          $majorMinorPatchRev = '$(MajorVersion).$(MinorVersion).$(versionMinDate)'
           $majorMinorPatchRev = $majorMinorPatchRev + $paddedRevision
           $version = $majorMinorPatchRev + '-' + $buildType
 
@@ -194,7 +194,7 @@ stages:
 
           if ('${{ parameters.IsOfficial }}' -eq 'true')
           {
-            $versionTag = '$(versionTag)'
+            $versionTag = '$(VersionTag)'
             Write-Host "VersionTag: " $versionTag
             if ($buildType -ne "stable" -and -not $versionTag.StartsWith($buildType))
             {

--- a/build/AzurePipelinesTemplates/WindowsAppSDK-SetupBuildEnvironment-Steps.yml
+++ b/build/AzurePipelinesTemplates/WindowsAppSDK-SetupBuildEnvironment-Steps.yml
@@ -80,8 +80,8 @@ steps:
   inputs:
     filePath: '$(Build.SourcesDirectory)\build\VersionInfo\GenerateVersionInfo.ps1'
     arguments: >
-      -ProductMajor "$(major)"
-      -ProductMinor "$(minor)"
+      -ProductMajor "$(MajorVersion)"
+      -ProductMinor "$(MinorVersion)"
 
 - task: PowerShell@2
   displayName: 'Download dotnet installer'

--- a/build/ProjectReunion-BuildFoundation.yml
+++ b/build/ProjectReunion-BuildFoundation.yml
@@ -6,9 +6,9 @@ name: $(version)
 trigger: none
 
 variables:
-- template: WindowsAppSDK-Versions.yml
-- template: WindowsAppSDK-CommonVariables.yml
 - template: WindowsAppSDK-Foundation-TestConfig.yml@WindowsAppSDKConfig
+- template: AzurePipelinesTemplates\WindowsAppSDK-Versions.yml@WindowsAppSDKConfig
+- template: WindowsAppSDK-CommonVariables.yml
 
 resources:
   repositories:

--- a/build/ProjectReunion-BuildFoundation.yml
+++ b/build/ProjectReunion-BuildFoundation.yml
@@ -7,7 +7,7 @@ trigger: none
 
 variables:
 - template: WindowsAppSDK-Foundation-TestConfig.yml@WindowsAppSDKConfig
-- template: AzurePipelinesTemplates\WindowsAppSDK-Versions.yml@WindowsAppSDKConfig
+- template: AzurePipelinesTemplates\WindowsAppSDK-Versions.yml@WindowsAppSDKVersionConfig
 - template: WindowsAppSDK-CommonVariables.yml
 
 resources:
@@ -16,7 +16,7 @@ resources:
       type: git
       name: ProjectReunion/WindowsAppSDKConfig
       ref: refs/heads/main
-    - repository: WindowsAppSDKConfigSourceBranch
+    - repository: WindowsAppSDKVersionConfig
       type: git
       name: ProjectReunion/WindowsAppSDKConfig
       ref: refs/heads/main

--- a/build/ProjectReunion-CI.yml
+++ b/build/ProjectReunion-CI.yml
@@ -2,14 +2,18 @@
 name: $(version)
 
 variables:
-- template: AzurePipelinesTemplates\WindowsAppSDK-Versions.yml@WindowsAppSDKConfig
+- template: AzurePipelinesTemplates\WindowsAppSDK-Versions.yml@WindowsAppSDKVersionConfig
 - template: WindowsAppSDK-CommonVariables.yml
 - name: buildOutputDir
   value: $(Build.SourcesDirectory)\BuildOutput
 
 resources:
   repositories:
-    - repository: WindowsAppSDKConfigSourceBranch
+    - repository: WindowsAppSDKConfig
+      type: git
+      name: ProjectReunion/WindowsAppSDKConfig
+      ref: refs/heads/main
+    - repository: WindowsAppSDKVersionConfig
       type: git
       name: ProjectReunion/WindowsAppSDKConfig
       ref: refs/heads/main

--- a/build/ProjectReunion-CI.yml
+++ b/build/ProjectReunion-CI.yml
@@ -2,7 +2,7 @@
 name: $(version)
 
 variables:
-- template: WindowsAppSDK-Versions.yml
+- template: AzurePipelinesTemplates\WindowsAppSDK-Versions.yml@WindowsAppSDKConfig
 - template: WindowsAppSDK-CommonVariables.yml
 - name: buildOutputDir
   value: $(Build.SourcesDirectory)\BuildOutput

--- a/build/WindowsAppSDK-BuildDevCheck.yml
+++ b/build/WindowsAppSDK-BuildDevCheck.yml
@@ -6,7 +6,7 @@ parameters:
   default: true
 
 variables:
-- template: ${{variables['System.DefaultWorkingDirectory']}}\build\WindowsAppSDK-Versions.yml
+- template: AzurePipelinesTemplates\WindowsAppSDK-Versions.yml@WindowsAppSDKConfig
 - template: ${{variables['System.DefaultWorkingDirectory']}}\build\WindowsAppSDK-CommonVariables.yml
 
 resources:

--- a/build/WindowsAppSDK-BuildDevCheck.yml
+++ b/build/WindowsAppSDK-BuildDevCheck.yml
@@ -6,7 +6,7 @@ parameters:
   default: true
 
 variables:
-- template: AzurePipelinesTemplates\WindowsAppSDK-Versions.yml@WindowsAppSDKConfig
+- template: AzurePipelinesTemplates\WindowsAppSDK-Versions.yml@WindowsAppSDKVersionConfig
 - template: ${{variables['System.DefaultWorkingDirectory']}}\build\WindowsAppSDK-CommonVariables.yml
 
 resources:
@@ -14,6 +14,14 @@ resources:
     - repository: templates
       type: git
       name: OneBranch.Pipelines/GovernedTemplates
+      ref: refs/heads/main
+    - repository: WindowsAppSDKConfig
+      type: git
+      name: ProjectReunion/WindowsAppSDKConfig
+      ref: refs/heads/main
+    - repository: WindowsAppSDKVersionConfig
+      type: git
+      name: ProjectReunion/WindowsAppSDKConfig
       ref: refs/heads/main
 
 extends:

--- a/build/WindowsAppSDK-CommonVariables.yml
+++ b/build/WindowsAppSDK-CommonVariables.yml
@@ -7,8 +7,7 @@ variables:
   versionDate: $[format('{0:yyyyMMdd}', pipeline.startTime)]
   versionMinDate: $[format('{0:yyMMdd}', pipeline.startTime)]
   versionCounter: $[counter(variables['versionDate'], 0)]
-  version: $[format('{0}.{1}.{2}-{3}.{4}', variables['major'], variables['minor'], variables['patch'], variables['versionDate'], variables['versionCounter'])]
-  versionTag: $[coalesce(variables.VersionTagOverride, '')]
+  version: $[format('{0}.{1}.{2}-{3}.{4}', variables['MajorVersion'], variables['MinorVersion'], variables['PatchVersion'], variables['versionDate'], variables['versionCounter'])]
   
   #OneBranch Variables
   CDP_DEFINITION_BUILD_COUNT: $[counter('', 0)] # needed for onebranch.pipeline.version task https://aka.ms/obpipelines/versioning

--- a/build/WindowsAppSDK-Foundation-Nightly.yml
+++ b/build/WindowsAppSDK-Foundation-Nightly.yml
@@ -36,7 +36,7 @@ parameters:
 
 variables:
 - template: WindowsAppSDK-Foundation-TestConfig.yml@WindowsAppSDKConfig
-- template: AzurePipelinesTemplates\WindowsAppSDK-Versions.yml@WindowsAppSDKConfig
+- template: AzurePipelinesTemplates\WindowsAppSDK-Versions.yml@WindowsAppSDKVersionConfig
 - template: WindowsAppSDK-CommonVariables.yml
 
 resources:
@@ -49,7 +49,7 @@ resources:
       type: git
       name: ProjectReunion/WindowsAppSDKConfig
       ref: refs/heads/main
-    - repository: WindowsAppSDKConfigSourceBranch
+    - repository: WindowsAppSDKVersionConfig
       type: git
       name: ProjectReunion/WindowsAppSDKConfig
       ref: refs/heads/main

--- a/build/WindowsAppSDK-Foundation-Nightly.yml
+++ b/build/WindowsAppSDK-Foundation-Nightly.yml
@@ -35,9 +35,9 @@ parameters:
   default: true
 
 variables:
-- template: WindowsAppSDK-Versions.yml
-- template: WindowsAppSDK-CommonVariables.yml
 - template: WindowsAppSDK-Foundation-TestConfig.yml@WindowsAppSDKConfig
+- template: AzurePipelinesTemplates\WindowsAppSDK-Versions.yml@WindowsAppSDKConfig
+- template: WindowsAppSDK-CommonVariables.yml
 
 resources:
   repositories:

--- a/build/WindowsAppSDK-Foundation-Official.yml
+++ b/build/WindowsAppSDK-Foundation-Official.yml
@@ -36,7 +36,7 @@ parameters:
 
 variables:
 - template: WindowsAppSDK-Foundation-TestConfig.yml@WindowsAppSDKConfig
-- template: AzurePipelinesTemplates\WindowsAppSDK-Versions.yml@WindowsAppSDKConfig
+- template: AzurePipelinesTemplates\WindowsAppSDK-Versions.yml@WindowsAppSDKVersionConfig
 - template: WindowsAppSDK-CommonVariables.yml
 resources:
   repositories:
@@ -48,7 +48,7 @@ resources:
       type: git
       name: ProjectReunion/WindowsAppSDKConfig
       ref: refs/heads/main
-    - repository: WindowsAppSDKConfigSourceBranch
+    - repository: WindowsAppSDKVersionConfig
       type: git
       name: ProjectReunion/WindowsAppSDKConfig
       ref: refs/heads/main

--- a/build/WindowsAppSDK-Foundation-Official.yml
+++ b/build/WindowsAppSDK-Foundation-Official.yml
@@ -35,10 +35,9 @@ parameters:
   default: true
 
 variables:
-- template: WindowsAppSDK-Versions.yml
-- template: WindowsAppSDK-CommonVariables.yml
 - template: WindowsAppSDK-Foundation-TestConfig.yml@WindowsAppSDKConfig
-
+- template: AzurePipelinesTemplates\WindowsAppSDK-Versions.yml@WindowsAppSDKConfig
+- template: WindowsAppSDK-CommonVariables.yml
 resources:
   repositories:
     - repository: templates

--- a/build/WindowsAppSDK-Foundation-PR.yml
+++ b/build/WindowsAppSDK-Foundation-PR.yml
@@ -26,9 +26,9 @@ parameters: # parameters are shown up in ADO UI in a build queue time
   default: true
 
 variables:
-- template: WindowsAppSDK-Versions.yml
-- template: WindowsAppSDK-CommonVariables.yml
 - template: WindowsAppSDK-Foundation-TestConfig.yml@WindowsAppSDKConfig
+- template: AzurePipelinesTemplates\WindowsAppSDK-Versions.yml@WindowsAppSDKConfig
+- template: WindowsAppSDK-CommonVariables.yml
 
 resources:
   repositories:

--- a/build/WindowsAppSDK-Foundation-PR.yml
+++ b/build/WindowsAppSDK-Foundation-PR.yml
@@ -27,7 +27,7 @@ parameters: # parameters are shown up in ADO UI in a build queue time
 
 variables:
 - template: WindowsAppSDK-Foundation-TestConfig.yml@WindowsAppSDKConfig
-- template: AzurePipelinesTemplates\WindowsAppSDK-Versions.yml@WindowsAppSDKConfig
+- template: AzurePipelinesTemplates\WindowsAppSDK-Versions.yml@WindowsAppSDKVersionConfig
 - template: WindowsAppSDK-CommonVariables.yml
 
 resources:
@@ -40,7 +40,7 @@ resources:
       type: git
       name: ProjectReunion/WindowsAppSDKConfig
       ref: refs/heads/main
-    - repository: WindowsAppSDKConfigSourceBranch
+    - repository: WindowsAppSDKVersionConfig
       type: git
       name: ProjectReunion/WindowsAppSDKConfig
       ref: refs/heads/main

--- a/build/WindowsAppSDK-Versions.yml
+++ b/build/WindowsAppSDK-Versions.yml
@@ -1,5 +1,0 @@
-variables:
-  # Version Control
-  major: "1"
-  minor: "8"
-  patch: "0"

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -49,7 +49,7 @@
     </Dependency>
   </ProductDependencies>
   <ToolsetDependencies>
-    <Dependency Name="Microsoft.WindowAppSDK.Version" Version="1.8.0">
+    <Dependency Name="Microsoft.WindowsAppSDK.Version" Version="1.8.0">
       <Uri>https://dev.azure.com/microsoft/ProjectReunion/_git/WindowsAppSDKConfig</Uri>
       <Sha>7425c8ed21b96fcc72bf04bd17a4f1d2ee870fc4</Sha>
     </Dependency>

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -53,5 +53,21 @@
       <Uri>https://dev.azure.com/microsoft/ProjectReunion/_git/WindowsAppSDKConfig</Uri>
       <Sha>7425c8ed21b96fcc72bf04bd17a4f1d2ee870fc4</Sha>
     </Dependency>
+    <Dependency Name="Microsoft.Windows.CsWinRT" Version="2.1.1">
+      <Uri>https://github.com/microsoft/CsWinRT</Uri>
+      <Sha>fa7f5565cb53353dc15c28a09ebd500577dc0b72</Sha>
+    </Dependency>
+    <Dependency Name="CsWinRT.Dependency.DotNetCoreSdk" Version="6.0.425">
+      <Uri>https://github.com/microsoft/CsWinRT</Uri>
+      <Sha>fa7f5565cb53353dc15c28a09ebd500577dc0b72</Sha>
+    </Dependency>
+    <Dependency Name="CsWinRT.Dependency.DotNetCoreRuntime" Version="6.0.33">
+      <Uri>https://github.com/microsoft/CsWinRT</Uri>
+      <Sha>fa7f5565cb53353dc15c28a09ebd500577dc0b72</Sha>
+    </Dependency>
+    <Dependency Name="CsWinRT.Dependency.WindowsSdkVersionSuffix" Version="38">
+      <Uri>https://github.com/microsoft/CsWinRT</Uri>
+      <Sha>fa7f5565cb53353dc15c28a09ebd500577dc0b72</Sha>
+    </Dependency>
   </ToolsetDependencies>
 </Dependencies>

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -49,21 +49,9 @@
     </Dependency>
   </ProductDependencies>
   <ToolsetDependencies>
-    <Dependency Name="Microsoft.Windows.CsWinRT" Version="2.1.1">
-      <Uri>https://github.com/microsoft/CsWinRT</Uri>
-      <Sha>fa7f5565cb53353dc15c28a09ebd500577dc0b72</Sha>
-    </Dependency>
-    <Dependency Name="CsWinRT.Dependency.DotNetCoreSdk" Version="6.0.425">
-      <Uri>https://github.com/microsoft/CsWinRT</Uri>
-      <Sha>fa7f5565cb53353dc15c28a09ebd500577dc0b72</Sha>
-    </Dependency>
-    <Dependency Name="CsWinRT.Dependency.DotNetCoreRuntime" Version="6.0.33">
-      <Uri>https://github.com/microsoft/CsWinRT</Uri>
-      <Sha>fa7f5565cb53353dc15c28a09ebd500577dc0b72</Sha>
-    </Dependency>
-    <Dependency Name="CsWinRT.Dependency.WindowsSdkVersionSuffix" Version="38">
-      <Uri>https://github.com/microsoft/CsWinRT</Uri>
-      <Sha>fa7f5565cb53353dc15c28a09ebd500577dc0b72</Sha>
+    <Dependency Name="Microsoft.WindowAppSDK.Version" Version="1.8.0">
+      <Uri>https://dev.azure.com/microsoft/ProjectReunion/_git/WindowsAppSDKConfig</Uri>
+      <Sha>7425c8ed21b96fcc72bf04bd17a4f1d2ee870fc4</Sha>
     </Dependency>
   </ToolsetDependencies>
 </Dependencies>


### PR DESCRIPTION
A microsoft employee must use /azp run to validate using the pipelines below.

WARNING:
Comments made by azure-pipelines bot maybe inaccurate.
Please see pipeline link to verify that the build is being ran.

For status checks on the main branch, please use TransportPackage-Foundation-PR
(https://microsoft.visualstudio.com/ProjectReunion/_build?definitionId=81063&_a=summary)
and run the build against your PR branch with the default parameters.
