### PR TITLE
fix Component Governance file can't find warning caused by mismatched letter case

### DIFF
--- a/build/AzurePipelinesTemplates/WindowsAppSDK-Build-Per-Platform-Stage.yml
+++ b/build/AzurePipelinesTemplates/WindowsAppSDK-Build-Per-Platform-Stage.yml
@@ -42,12 +42,12 @@ stages:
         ${{ format('Release_{0}', parameters.buildPlatform) }}:
           ${{ if ne(parameters.buildPlatform, 'arm64') }}:
             buildPlatform: ${{ parameters.buildPlatform }}
-            buildConfiguration: 'release'
+            buildConfiguration: 'Release'
             normalizedConfiguration: 'fre'
             PGOBuildMode: 'Optimize'
           ${{ else }}:
             buildPlatform: ${{ parameters.buildPlatform }}
-            buildConfiguration: 'release'
+            buildConfiguration: 'Release'
             normalizedConfiguration: 'fre'
     variables:
       - name: ob_outputDirectory


### PR DESCRIPTION
This PR fixes Component Governance warnings that were occurring due to inconsistent capitalization of the configuration parameter across the build system. The warnings showed paths like:

```
##[warning]Project path C:\__w\1\s\eng\PackageReference\IXP\IXP.TransportPackage.PackageReference.csproj specified by D:\a\_work\1\s\obj\release\x86\IXP.TransportPackage.PackageReference\project.assets.json does not exist.
##[warning]Project output path C:\__w\1\s\obj\Release\x86\IXP.TransportPackage.PackageReference\ specified by D:\a\_work\1\s\obj\release\x86\IXP.TransportPackage.PackageReference\project.assets.json does not exist.
```

## Root Cause
The issue was caused by inconsistent configuration parameter casing:
- `BuildAll.ps1` defaults to `"Release"` (uppercase R)
- Azure DevOps pipelines explicitly passed `"release"` (lowercase r) 
- `build-nupkg.ps1` defaulted to `"release"` (lowercase r)

This caused `project.assets.json` files to reference different obj directory paths (`obj\Release\` vs `obj\release\`), creating Component Governance warnings about non-existent paths.