### PR TITLE
Fix Foundation component package libs to be under native folder

### DIFF
--- a/BuildAll.ps1
+++ b/BuildAll.ps1
@@ -306,7 +306,7 @@ Try {
             Copy-Item -path "BuildOutput\$configurationForMrtAndAnyCPU\$platformToRun\Microsoft.Windows.ApplicationModel.Resources\Microsoft.Windows.ApplicationModel.Resources.pdb" -destination "$BasePath\runtimes\win10-$platformToRun\native" -force
             Copy-Item -path "BuildOutput\$configurationForMrtAndAnyCPU\$platformToRun\Microsoft.Windows.ApplicationModel.Resources\Microsoft.Windows.ApplicationModel.Resources.dll" -destination "$BasePath\runtimes\win10-$platformToRun\native" -force
 
-            Copy-Item -path "BuildOutput\$configurationForMrtAndAnyCPU\$platformToRun\mrm\MRM.lib" -destination "$BasePath\lib\win10-$platformToRun" -force
+            Copy-Item -path "BuildOutput\$configurationForMrtAndAnyCPU\$platformToRun\mrm\MRM.lib" -destination "$BasePath\lib\native\$platformToRun" -force
 
             if($platformToRun -eq "x86")
             {

--- a/BuildAll.ps1
+++ b/BuildAll.ps1
@@ -306,7 +306,7 @@ Try {
             Copy-Item -path "BuildOutput\$configurationForMrtAndAnyCPU\$platformToRun\Microsoft.Windows.ApplicationModel.Resources\Microsoft.Windows.ApplicationModel.Resources.pdb" -destination "$BasePath\runtimes\win10-$platformToRun\native" -force
             Copy-Item -path "BuildOutput\$configurationForMrtAndAnyCPU\$platformToRun\Microsoft.Windows.ApplicationModel.Resources\Microsoft.Windows.ApplicationModel.Resources.dll" -destination "$BasePath\runtimes\win10-$platformToRun\native" -force
 
-            Copy-Item -path "BuildOutput\$configurationForMrtAndAnyCPU\$platformToRun\mrm\MRM.lib" -destination "$BasePath\lib\native\$platformToRun" -force
+            Copy-Item -path "BuildOutput\$configurationForMrtAndAnyCPU\$platformToRun\mrm\MRM.lib" -destination "$BasePath\lib\win10-$platformToRun" -force
 
             if($platformToRun -eq "x86")
             {
@@ -424,7 +424,7 @@ Try {
         {
             build\Scripts\RobocopyWrapper.ps1 `
                 -Source "$PSScriptRoot\$BasePath\lib\win10-$platformToRun" `
-                -dest "$ComponentBasePath\lib\win-$platformToRun"
+                -dest "$ComponentBasePath\lib\native\$platformToRun"
 
             build\scripts\CopyContents.ps1 `
                 -SourceDir "$PSScriptRoot\$BasePath\runtimes\win10-$platformToRun" `
@@ -443,8 +443,8 @@ Try {
         if ($platform.Split(",") -contains "x64")
         {
             build\Scripts\RobocopyWrapper.ps1 `
-                -Source "$ComponentBasePath\lib\win-x64" `
-                -dest "$ComponentBasePath\lib\win-arm64ec"
+                -Source "$ComponentBasePath\lib\native\x64" `
+                -dest "$ComponentBasePath\lib\native\arm64ec"
 
             build\Scripts\RobocopyWrapper.ps1 `
                 -Source "$ComponentBasePath\runtimes\win-x64" `

--- a/build/AzurePipelinesTemplates/WindowsAppSDK-BuildInstaller-Steps.yml
+++ b/build/AzurePipelinesTemplates/WindowsAppSDK-BuildInstaller-Steps.yml
@@ -187,7 +187,7 @@ steps:
   inputs:
     targetType: "inline"
     script: |
-      $srcWinAppSDKNupkgPath = Get-Childitem -Path '$(System.ArtifactsDirectory)\NugetPackages' -File '*Microsoft.WindowsAppSDK.Runtimes*'
+      $srcWinAppSDKNupkgPath = Get-Childitem -Path '$(System.ArtifactsDirectory)\NugetPackages' -File '*Microsoft.WindowsAppSDK.Runtime*'
       if ($srcWinAppSDKNupkgPath -eq $null)
       {
         $srcWinAppSDKNupkgPath = Get-Childitem -Path '$(System.ArtifactsDirectory)\NugetPackages' -File '*Microsoft.WindowsAppSDK.Packages*'

--- a/build/CopyFilesToStagingDir.ps1
+++ b/build/CopyFilesToStagingDir.ps1
@@ -160,8 +160,8 @@ PublishFile $FullBuildOutput\WindowsAppRuntime_DLL\WindowsAppRuntimeInsights.h $
 PublishFile $FullBuildOutput\WindowsAppRuntime_DLL\Security.AccessControl.h $NugetDir\include\
 #
 # Libraries (*.lib)
-PublishFile $FullBuildOutput\WindowsAppRuntime_BootstrapDLL\Microsoft.WindowsAppRuntime.Bootstrap.lib $NugetDir\lib\win10-$Platform
-PublishFile $FullBuildOutput\WindowsAppRuntime_DLL\Microsoft.WindowsAppRuntime.lib $NugetDir\lib\win10-$Platform
+PublishFile $FullBuildOutput\WindowsAppRuntime_BootstrapDLL\Microsoft.WindowsAppRuntime.Bootstrap.lib $NugetDir\lib\native\$Platform
+PublishFile $FullBuildOutput\WindowsAppRuntime_DLL\Microsoft.WindowsAppRuntime.lib $NugetDir\lib\native\$Platform
 #
 # MSIX Framework package - DLLs/EXEs
 PublishFile $FullBuildOutput\WindowsAppRuntime_DLL\Microsoft.WindowsAppRuntime.dll $NugetDir\runtimes\win10-$Platform\native

--- a/build/CopyFilesToStagingDir.ps1
+++ b/build/CopyFilesToStagingDir.ps1
@@ -160,8 +160,8 @@ PublishFile $FullBuildOutput\WindowsAppRuntime_DLL\WindowsAppRuntimeInsights.h $
 PublishFile $FullBuildOutput\WindowsAppRuntime_DLL\Security.AccessControl.h $NugetDir\include\
 #
 # Libraries (*.lib)
-PublishFile $FullBuildOutput\WindowsAppRuntime_BootstrapDLL\Microsoft.WindowsAppRuntime.Bootstrap.lib $NugetDir\lib\native\$Platform
-PublishFile $FullBuildOutput\WindowsAppRuntime_DLL\Microsoft.WindowsAppRuntime.lib $NugetDir\lib\native\$Platform
+PublishFile $FullBuildOutput\WindowsAppRuntime_BootstrapDLL\Microsoft.WindowsAppRuntime.Bootstrap.lib $NugetDir\lib\win10-$Platform
+PublishFile $FullBuildOutput\WindowsAppRuntime_DLL\Microsoft.WindowsAppRuntime.lib $NugetDir\lib\win10-$Platform
 #
 # MSIX Framework package - DLLs/EXEs
 PublishFile $FullBuildOutput\WindowsAppRuntime_DLL\Microsoft.WindowsAppRuntime.dll $NugetDir\runtimes\win10-$Platform\native

--- a/build/NuSpecs/WindowsAppSDK-Nuget-Native.C.props
+++ b/build/NuSpecs/WindowsAppSDK-Nuget-Native.C.props
@@ -4,7 +4,7 @@
   <PropertyGroup>
     <_WindowsAppSDKFoundationPlatform Condition="'$(Platform)' == 'Win32'">x86</_WindowsAppSDKFoundationPlatform>
     <_WindowsAppSDKFoundationPlatform Condition="'$(Platform)' != 'Win32'">$(Platform)</_WindowsAppSDKFoundationPlatform>
-    <_FoundationLibFolder>$(MSBuildThisFileDirectory)..\..\lib\win-$(_WindowsAppSDKFoundationPlatform)</_FoundationLibFolder>
+    <_FoundationLibFolder>$(MSBuildThisFileDirectory)..\..\lib\native\$(_WindowsAppSDKFoundationPlatform)</_FoundationLibFolder>
     <_FoundationLibFolder Condition="'$(WindowsAppSDKAggregatePackage)' == 'true'">$(MSBuildThisFileDirectory)..\..\lib\win10-$(_WindowsAppSDKFoundationPlatform)</_FoundationLibFolder>
   </PropertyGroup>
 

--- a/build/NuSpecs/WindowsAppSDK-Nuget-Native.props
+++ b/build/NuSpecs/WindowsAppSDK-Nuget-Native.props
@@ -1,6 +1,7 @@
 ﻿<!-- Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT License. See LICENSE in the project root for license information. -->
 <Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$(MSBuildThisFileDirectory)..\Microsoft.WindowsAppSDK.Foundation.props"/>
+  <Import Project="$(MSBuildThisFileDirectory)MrtCore.props"/>
   <Import Project="$(MSBuildThisFileDirectory)WindowsAppSDK-Nuget-Native.C.props" />
   <Import Project="$(MSBuildThisFileDirectory)WindowsAppSDK-Nuget-Native.WinRt.props" />
 </Project>

--- a/dev/MRTCore/packaging/native/MrtCore.C.props
+++ b/dev/MRTCore/packaging/native/MrtCore.C.props
@@ -6,7 +6,7 @@
   <PropertyGroup>
     <_MrtCoreRuntimeIdentifier Condition="'$(Platform)' == 'Win32'">x86</_MrtCoreRuntimeIdentifier>
     <_MrtCoreRuntimeIdentifier Condition="'$(Platform)' != 'Win32'">$(Platform)</_MrtCoreRuntimeIdentifier>
-    <_MrtLibFolder>$(MSBuildThisFileDirectory)..\..\lib\win-$(_MrtCoreRuntimeIdentifier)</_MrtLibFolder>
+    <_MrtLibFolder>$(MSBuildThisFileDirectory)..\..\lib\native\$(_MrtCoreRuntimeIdentifier)</_MrtLibFolder>
     <_MrtLibFolder Condition="'$(WindowsAppSDKAggregatePackage)' == 'true'">$(MSBuildThisFileDirectory)..\..\lib\win10-$(_MrtCoreRuntimeIdentifier)</_MrtLibFolder>
 
     <!-- Set DefaultLanguage so that Multilingual Application Toolkit can be enabled when applicable -->


### PR DESCRIPTION
Restructuring the foundation libs to be under lib\native\<arch> rather than lib\<arch>.  And add back MrtCore.props as it is still needed and fix package name for Runtimes.

A microsoft employee must use /azp run to validate using the pipelines below.

WARNING:
Comments made by azure-pipelines bot maybe inaccurate.
Please see pipeline link to verify that the build is being ran.

For status checks on the main branch, please use TransportPackage-Foundation-PR
(https://microsoft.visualstudio.com/ProjectReunion/_build?definitionId=81063&_a=summary)
and run the build against your PR branch with the default parameters.
