### PR TITLE
Add init_seg to ensure auto initialize runs before user defined static objects

### DIFF
--- a/dev/Common/WindowsAppRuntimeAutoInitializer.cpp
+++ b/dev/Common/WindowsAppRuntimeAutoInitializer.cpp
@@ -59,6 +59,8 @@ namespace Microsoft::Windows::ApplicationModel::WindowsAppRuntime::Common
 // Use init_seg(lib) to ensure this static object is initialized during the "lib" phase,
 // which occurs before user-defined static objects. This guarantees that WindowsAppRuntime
 // auto-initialization completes before any application static globals that might depend on it.
+#pragma warning(disable : 4073)
 #pragma init_seg(lib)
     static AutoInitialize g_autoInitialize;
+#pragma warning(default : 4073)
 }


### PR DESCRIPTION
A microsoft employee must use /azp run to validate using the pipelines below.

WARNING:
Comments made by azure-pipelines bot maybe inaccurate.
Please see pipeline link to verify that the build is being ran.

For status checks on the main branch, please use TransportPackage-Foundation-PR
(https://microsoft.visualstudio.com/ProjectReunion/_build?definitionId=81063&_a=summary)
and run the build against your PR branch with the default parameters.
