### PR TITLE
[Fix] Add try-catch to Storage Picker's Localization Code

### DIFF
--- a/dev/Interop/StoragePickers/FileOpenPicker.cpp
+++ b/dev/Interop/StoragePickers/FileOpenPicker.cpp
@@ -76,7 +76,7 @@ namespace winrt::Microsoft::Windows::Storage::Pickers::implementation
         auto logTelemetry{ StoragePickersTelemetry::FileOpenPickerPickSingleFile::Start(m_telemetryHelper) };
 
         PickerCommon::PickerParameters parameters{};
-        parameters.AllFilesText = PickerLocalization::GetStoragePickersLocalizationText(PickerCommon::AllFilesLocalizationKey);
+        parameters.AllFilesText = PickerLocalization::GetStoragePickersLocalizationText(PickerCommon::AllFilesLocalizationKey, parameters.AllFilesText);
 
         CaptureParameters(parameters);
 
@@ -129,7 +129,7 @@ namespace winrt::Microsoft::Windows::Storage::Pickers::implementation
 
         // capture parameters to avoid using get strong referece of picker
         PickerCommon::PickerParameters parameters{};
-        parameters.AllFilesText = PickerLocalization::GetStoragePickersLocalizationText(PickerCommon::AllFilesLocalizationKey);
+        parameters.AllFilesText = PickerLocalization::GetStoragePickersLocalizationText(PickerCommon::AllFilesLocalizationKey, parameters.AllFilesText);
 
         CaptureParameters(parameters);
 

--- a/dev/Interop/StoragePickers/FileSavePicker.cpp
+++ b/dev/Interop/StoragePickers/FileSavePicker.cpp
@@ -98,7 +98,7 @@ namespace winrt::Microsoft::Windows::Storage::Pickers::implementation
         auto logTelemetry{ StoragePickersTelemetry::FileSavePickerPickSingleFile::Start(m_telemetryHelper) };
 
         PickerCommon::PickerParameters parameters{};
-        parameters.AllFilesText = PickerLocalization::GetStoragePickersLocalizationText(PickerCommon::AllFilesLocalizationKey);
+        parameters.AllFilesText = PickerLocalization::GetStoragePickersLocalizationText(PickerCommon::AllFilesLocalizationKey, parameters.AllFilesText);
 
         CaptureParameters(parameters);
 

--- a/dev/Interop/StoragePickers/FolderPicker.cpp
+++ b/dev/Interop/StoragePickers/FolderPicker.cpp
@@ -75,7 +75,7 @@ namespace winrt::Microsoft::Windows::Storage::Pickers::implementation
         auto logTelemetry{ StoragePickersTelemetry::FolderPickerPickSingleFolder::Start(m_telemetryHelper) };
 
         PickerCommon::PickerParameters parameters{};
-        parameters.AllFilesText = PickerLocalization::GetStoragePickersLocalizationText(PickerCommon::AllFilesLocalizationKey);
+        parameters.AllFilesText = PickerLocalization::GetStoragePickersLocalizationText(PickerCommon::AllFilesLocalizationKey, parameters.AllFilesText);
 
         CaptureParameters(parameters);
         

--- a/dev/Interop/StoragePickers/PickerLocalization.cpp
+++ b/dev/Interop/StoragePickers/PickerLocalization.cpp
@@ -9,13 +9,13 @@
 #include "PickerLocalization.h"
 #include <winrt\base.h>
 #include <winrt\Microsoft.Windows.ApplicationModel.Resources.h>
-#include "StoragePickersTelemetry.h"
 
 namespace PickerLocalization {
     const winrt::hstring priPath = L"Microsoft.WindowsAppRuntime.pri";
     winrt::hstring GetStoragePickersLocalizationText(winrt::hstring key, winrt::hstring fallback)
     {
-        // adding try-catch to prevent localization error break picker experience
+        // adding try-catch to prevent localization error break picker experience on first shipping
+        // TODO: remove try-catch after stabilization period
         try
         {
             auto manager = winrt::Microsoft::Windows::ApplicationModel::Resources::ResourceManager(priPath);
@@ -23,7 +23,7 @@ namespace PickerLocalization {
         }
         catch (...)
         {
-            StoragePickersTelemetry::StoragePickerLocalizationLookupError(key.c_str());
+            LOG_CAUGHT_EXCEPTION();
             return fallback;
         }
     }

--- a/dev/Interop/StoragePickers/PickerLocalization.cpp
+++ b/dev/Interop/StoragePickers/PickerLocalization.cpp
@@ -9,7 +9,7 @@
 #include "PickerLocalization.h"
 #include <winrt\base.h>
 #include <winrt\Microsoft.Windows.ApplicationModel.Resources.h>
-#include <iostream>
+#include "StoragePickersTelemetry.h"
 
 namespace PickerLocalization {
     const winrt::hstring priPath = L"Microsoft.WindowsAppRuntime.pri";

--- a/dev/Interop/StoragePickers/PickerLocalization.cpp
+++ b/dev/Interop/StoragePickers/PickerLocalization.cpp
@@ -13,10 +13,19 @@
 
 namespace PickerLocalization {
     const winrt::hstring priPath = L"Microsoft.WindowsAppRuntime.pri";
-    winrt::hstring GetStoragePickersLocalizationText(winrt::hstring key)
+    winrt::hstring GetStoragePickersLocalizationText(winrt::hstring key, winrt::hstring fallback)
     {
-        auto manager = winrt::Microsoft::Windows::ApplicationModel::Resources::ResourceManager(priPath);
-        return manager.MainResourceMap().GetValue(key).ValueAsString();
+        // adding try-catch to prevent localization error break picker experience
+        try
+        {
+            auto manager = winrt::Microsoft::Windows::ApplicationModel::Resources::ResourceManager(priPath);
+            return manager.MainResourceMap().GetValue(key).ValueAsString();
+        }
+        catch (...)
+        {
+            StoragePickersTelemetry::StoragePickerLocalizationLookupError(key.c_str());
+            return fallback;
+        }
     }
 }
 

--- a/dev/Interop/StoragePickers/PickerLocalization.h
+++ b/dev/Interop/StoragePickers/PickerLocalization.h
@@ -5,6 +5,6 @@
 #include "PickerCommon.h"
 
 namespace PickerLocalization {
-    winrt::hstring GetStoragePickersLocalizationText(winrt::hstring key);
+    winrt::hstring GetStoragePickersLocalizationText(winrt::hstring key, winrt::hstring fallback);
 }
 

--- a/dev/Interop/StoragePickers/StoragePickers.vcxitems
+++ b/dev/Interop/StoragePickers/StoragePickers.vcxitems
@@ -49,19 +49,6 @@
     <Midl Include="$(MSBuildThisFileDirectory)Microsoft.Windows.Storage.Pickers.idl" />
   </ItemGroup>
   <ItemGroup>
-    <PRIResource Include="$(MSBuildThisFileDirectory)Strings\cs-CZ\StoragePickers.resw" />
-    <PRIResource Include="$(MSBuildThisFileDirectory)Strings\de-DE\StoragePickers.resw" />
-    <PRIResource Include="$(MSBuildThisFileDirectory)Strings\en-US\StoragePickers.resw" />
-    <PRIResource Include="$(MSBuildThisFileDirectory)Strings\es-ES\StoragePickers.resw" />
-    <PRIResource Include="$(MSBuildThisFileDirectory)Strings\fr-FR\StoragePickers.resw" />
-    <PRIResource Include="$(MSBuildThisFileDirectory)Strings\it-IT\StoragePickers.resw" />
-    <PRIResource Include="$(MSBuildThisFileDirectory)Strings\ja-JP\StoragePickers.resw" />
-    <PRIResource Include="$(MSBuildThisFileDirectory)Strings\ko-KR\StoragePickers.resw" />
-    <PRIResource Include="$(MSBuildThisFileDirectory)Strings\pl-PL\StoragePickers.resw" />
-    <PRIResource Include="$(MSBuildThisFileDirectory)Strings\pt-BR\StoragePickers.resw" />
-    <PRIResource Include="$(MSBuildThisFileDirectory)Strings\ru-RU\StoragePickers.resw" />
-    <PRIResource Include="$(MSBuildThisFileDirectory)Strings\tr-TR\StoragePickers.resw" />
-    <PRIResource Include="$(MSBuildThisFileDirectory)Strings\zh-CN\StoragePickers.resw" />
-    <PRIResource Include="$(MSBuildThisFileDirectory)Strings\zh-TW\StoragePickers.resw" />
+    <PRIResource Include="$(MSBuildThisFileDirectory)Strings\*\*.resw" />
   </ItemGroup>
 </Project>

--- a/dev/Interop/StoragePickers/StoragePickersTelemetry.h
+++ b/dev/Interop/StoragePickers/StoragePickersTelemetry.h
@@ -124,4 +124,6 @@ public:
         }
         CATCH_LOG()
     END_ACTIVITY_CLASS();
+
+    DEFINE_TRACELOGGING_EVENT_STRING(StoragePickerLocalizationLookupError, localizationKey);
 };

--- a/dev/Interop/StoragePickers/StoragePickersTelemetry.h
+++ b/dev/Interop/StoragePickers/StoragePickersTelemetry.h
@@ -124,6 +124,4 @@ public:
         }
         CATCH_LOG()
     END_ACTIVITY_CLASS();
-
-    DEFINE_TRACELOGGING_EVENT_STRING(StoragePickerLocalizationLookupError, localizationKey);
 };


### PR DESCRIPTION
Hot fix (mitigate) for pri file not found.

This happens when 

1 using WinAppSDK meta package, using component package works (already has fix PR on WinAppSDK aggregator Repo)
2 in non-self contained scenario - currently using this as a mitigation



example normal behavior (in zh-cn)
![image](https://github.com/user-attachments/assets/6c6b4aff-f8a3-43eb-889c-04dbbbe1dc09)

fall back behaviour
![image](https://github.com/user-attachments/assets/461d4a5c-a1f5-4dd8-a610-6ac326141cb8)


