### PR TITLE
Rename PushNotificationCreateChannelStatus.extendedError to PushNotificationCreateChannelStatus.lastExtendedError

### DIFF
--- a/dev/PushNotifications/PushNotificationManager.cpp
+++ b/dev/PushNotifications/PushNotificationManager.cpp
@@ -324,7 +324,7 @@ namespace winrt::Microsoft::Windows::PushNotifications::implementation
 
                 if ((backOffTime <= c_maxBackoff) && IsChannelRequestRetryable(channelRequestException.code()))
                 {
-                    channelStatus.extendedError = channelRequestException.code();
+                    channelStatus.lastExtendedError = channelRequestException.code();
                     channelStatus.status = PushNotificationChannelStatus::InProgressRetry;
                     channelStatus.retryCount = ++retryCount;
 

--- a/dev/PushNotifications/PushNotifications.idl
+++ b/dev/PushNotifications/PushNotifications.idl
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft Corporation and Contributors.
+// Copyright (c) Microsoft Corporation and Contributors.
 // Licensed under the MIT License.
 
 namespace Microsoft.Windows.PushNotifications
@@ -37,7 +37,7 @@ namespace Microsoft.Windows.PushNotifications
         PushNotificationChannelStatus status;
 
         // The last extended error we failed Channel requests on that caused the inprogress retry status. E_PENDING if this is just progress status.
-        HRESULT extendedError;
+        HRESULT lastExtendedError;
 
         // Total Retries so far
         UInt32 retryCount;


### PR DESCRIPTION
Resolves #2229 

This pull request renames the PushNotificationCreateChannelStatus.extendedError to PushNotificationCreateChannelStatus.lastExtendedError.

A microsoft employee must use /azp run to validate using the pipelines below.

WARNING:
Comments made by azure-pipelines bot maybe inaccurate.
Please see pipeline link to verify that the build is being ran.

For status checks on the main branch, please use TransportPackage-Foundation-PR
(https://microsoft.visualstudio.com/ProjectReunion/_build?definitionId=81063&_a=summary)
and run the build against your PR branch with the default parameters.
