### PR TITLE
fix: MSB8027, two or more files with the same name

### DIFF
--- a/build/NuSpecs/WindowsAppSDK-Nuget-Native.AutoInitializer.targets
+++ b/build/NuSpecs/WindowsAppSDK-Nuget-Native.AutoInitializer.targets
@@ -1,21 +1,28 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT License. See LICENSE in the project root for license information. -->
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-
-  <Target Name="WindowsAppRuntimeAutoInitializer">
-    <!-- Build the preprocessor definitions based on conditions -->
+  
+  <Target Name="SetAutoInitializerPreprocessorDefinitions" BeforeTargets="BeforeClCompile" >
+    <!-- Build the AutoInitializer preprocessor definitions based on conditions -->
     <PropertyGroup>
       <AutoInitializerPreprocessorDefinitions></AutoInitializerPreprocessorDefinitions>
       <AutoInitializerPreprocessorDefinitions Condition="'$(WindowsAppSdkBootstrapInitialize)'=='true'">$(AutoInitializerPreprocessorDefinitions);MICROSOFT_WINDOWSAPPSDK_AUTOINITIALIZE_BOOTSTRAP</AutoInitializerPreprocessorDefinitions>
       <AutoInitializerPreprocessorDefinitions Condition="'$(WindowsAppSdkDeploymentManagerInitialize)'=='true'">$(AutoInitializerPreprocessorDefinitions);MICROSOFT_WINDOWSAPPSDK_AUTOINITIALIZE_DEPLOYMENTMANAGER</AutoInitializerPreprocessorDefinitions>
       <AutoInitializerPreprocessorDefinitions Condition="'$(WindowsAppSdkUndockedRegFreeWinRTInitialize)'=='true'">$(AutoInitializerPreprocessorDefinitions);MICROSOFT_WINDOWSAPPSDK_AUTOINITIALIZE_UNDOCKEDREGFREEWINRT</AutoInitializerPreprocessorDefinitions>
       <AutoInitializerPreprocessorDefinitions Condition="'$(WindowsAppSdkCompatibilityInitialize)'=='true'">$(AutoInitializerPreprocessorDefinitions);MICROSOFT_WINDOWSAPPSDK_AUTOINITIALIZE_COMPATIBILITY</AutoInitializerPreprocessorDefinitions>
+      <!-- Inherit the previous definitions based on condition -->
+      <AutoInitializerPreprocessorDefinitions Condition="'$(PreProcessorDefinitionsInheritance)'!='true'">$(AutoInitializerPreprocessorDefinitions);%(ClCompile.PreprocessorDefinitions)</AutoInitializerPreprocessorDefinitions>
+      <PreProcessorDefinitionsInheritance Condition="'$(PreProcessorDefinitionsInheritance)'!='true'">true</PreProcessorDefinitionsInheritance>
+      <!-- Set PreprocessorDefinitions final value for following target -->
+      <PreprocessorDefinitions>$(AutoInitializerPreprocessorDefinitions);$(PreprocessorDefinitions)</PreprocessorDefinitions>
     </PropertyGroup>
-    
+  </Target>
+
+  <Target Name="WindowsAppRuntimeAutoInitializer">
     <ItemGroup>
       <ClCompile Include="$(MSBuildThisFileDirectory)..\..\include\WindowsAppRuntimeAutoInitializer.cpp">
         <PrecompiledHeader>NotUsing</PrecompiledHeader>
-        <PreprocessorDefinitions>$(AutoInitializerPreprocessorDefinitions)</PreprocessorDefinitions>
+        <PreprocessorDefinitions>$(PreprocessorDefinitions)</PreprocessorDefinitions>
       </ClCompile>
     </ItemGroup>
   </Target>

--- a/build/NuSpecs/WindowsAppSDK-Nuget-Native.AutoInitializer.targets
+++ b/build/NuSpecs/WindowsAppSDK-Nuget-Native.AutoInitializer.targets
@@ -3,13 +3,19 @@
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 
   <Target Name="WindowsAppRuntimeAutoInitializer">
+    <!-- Build the preprocessor definitions based on conditions -->
+    <PropertyGroup>
+      <AutoInitializerPreprocessorDefinitions></AutoInitializerPreprocessorDefinitions>
+      <AutoInitializerPreprocessorDefinitions Condition="'$(WindowsAppSdkBootstrapInitialize)'=='true'">$(AutoInitializerPreprocessorDefinitions);MICROSOFT_WINDOWSAPPSDK_AUTOINITIALIZE_BOOTSTRAP</AutoInitializerPreprocessorDefinitions>
+      <AutoInitializerPreprocessorDefinitions Condition="'$(WindowsAppSdkDeploymentManagerInitialize)'=='true'">$(AutoInitializerPreprocessorDefinitions);MICROSOFT_WINDOWSAPPSDK_AUTOINITIALIZE_DEPLOYMENTMANAGER</AutoInitializerPreprocessorDefinitions>
+      <AutoInitializerPreprocessorDefinitions Condition="'$(WindowsAppSdkUndockedRegFreeWinRTInitialize)'=='true'">$(AutoInitializerPreprocessorDefinitions);MICROSOFT_WINDOWSAPPSDK_AUTOINITIALIZE_UNDOCKEDREGFREEWINRT</AutoInitializerPreprocessorDefinitions>
+      <AutoInitializerPreprocessorDefinitions Condition="'$(WindowsAppSdkCompatibilityInitialize)'=='true'">$(AutoInitializerPreprocessorDefinitions);MICROSOFT_WINDOWSAPPSDK_AUTOINITIALIZE_COMPATIBILITY</AutoInitializerPreprocessorDefinitions>
+    </PropertyGroup>
+    
     <ItemGroup>
       <ClCompile Include="$(MSBuildThisFileDirectory)..\..\include\WindowsAppRuntimeAutoInitializer.cpp">
         <PrecompiledHeader>NotUsing</PrecompiledHeader>
-        <PreprocessorDefinitions Condition="'$(WindowsAppSdkBootstrapInitialize)'=='true'">MICROSOFT_WINDOWSAPPSDK_AUTOINITIALIZE_BOOTSTRAP;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-        <PreprocessorDefinitions Condition="'$(WindowsAppSdkDeploymentManagerInitialize)'=='true'">MICROSOFT_WINDOWSAPPSDK_AUTOINITIALIZE_DEPLOYMENTMANAGER;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-        <PreprocessorDefinitions Condition="'$(WindowsAppSdkUndockedRegFreeWinRTInitialize)'=='true'">MICROSOFT_WINDOWSAPPSDK_AUTOINITIALIZE_UNDOCKEDREGFREEWINRT;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-        <PreprocessorDefinitions Condition="'$(WindowsAppSdkCompatibilityInitialize)'=='true'">MICROSOFT_WINDOWSAPPSDK_AUTOINITIALIZE_COMPATIBILITY;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+        <PreprocessorDefinitions>$(AutoInitializerPreprocessorDefinitions)</PreprocessorDefinitions>
       </ClCompile>
     </ItemGroup>
   </Target>

--- a/build/NuSpecs/WindowsAppSDK-Nuget-Native.AutoInitializer.targets
+++ b/build/NuSpecs/WindowsAppSDK-Nuget-Native.AutoInitializer.targets
@@ -11,10 +11,7 @@
       <AutoInitializerPreprocessorDefinitions Condition="'$(WindowsAppSdkUndockedRegFreeWinRTInitialize)'=='true'">$(AutoInitializerPreprocessorDefinitions);MICROSOFT_WINDOWSAPPSDK_AUTOINITIALIZE_UNDOCKEDREGFREEWINRT</AutoInitializerPreprocessorDefinitions>
       <AutoInitializerPreprocessorDefinitions Condition="'$(WindowsAppSdkCompatibilityInitialize)'=='true'">$(AutoInitializerPreprocessorDefinitions);MICROSOFT_WINDOWSAPPSDK_AUTOINITIALIZE_COMPATIBILITY</AutoInitializerPreprocessorDefinitions>
       <!-- Inherit the previous definitions based on condition -->
-      <AutoInitializerPreprocessorDefinitions Condition="'$(PreProcessorDefinitionsInheritance)'!='true'">$(AutoInitializerPreprocessorDefinitions);%(ClCompile.PreprocessorDefinitions)</AutoInitializerPreprocessorDefinitions>
-      <PreProcessorDefinitionsInheritance Condition="'$(PreProcessorDefinitionsInheritance)'!='true'">true</PreProcessorDefinitionsInheritance>
-      <!-- Set PreprocessorDefinitions final value for following target -->
-      <PreprocessorDefinitions>$(AutoInitializerPreprocessorDefinitions);$(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <AutoInitializerPreprocessorDefinitions>$(AutoInitializerPreprocessorDefinitions);%(ClCompile.PreprocessorDefinitions)</AutoInitializerPreprocessorDefinitions>
     </PropertyGroup>
   </Target>
 
@@ -22,7 +19,7 @@
     <ItemGroup>
       <ClCompile Include="$(MSBuildThisFileDirectory)..\..\include\WindowsAppRuntimeAutoInitializer.cpp">
         <PrecompiledHeader>NotUsing</PrecompiledHeader>
-        <PreprocessorDefinitions>$(PreprocessorDefinitions)</PreprocessorDefinitions>
+        <PreprocessorDefinitions>$(AutoInitializerPreprocessorDefinitions)</PreprocessorDefinitions>
       </ClCompile>
     </ItemGroup>
   </Target>

--- a/build/NuSpecs/WindowsAppSDK-Nuget-Native.Bootstrap.targets
+++ b/build/NuSpecs/WindowsAppSDK-Nuget-Native.Bootstrap.targets
@@ -12,10 +12,7 @@
             <BootstrapPreprocessorDefinitions Condition="'$(WindowsAppSDKBootstrapAutoInitializeOptions_OnNoMatch_ShowUI)'=='true'">$(BootstrapPreprocessorDefinitions);MICROSOFT_WINDOWSAPPSDK_BOOTSTRAP_AUTO_INITIALIZE_OPTIONS_ONNOMATCH_SHOWUI</BootstrapPreprocessorDefinitions>
             <BootstrapPreprocessorDefinitions Condition="'$(WindowsAppSDKBootstrapAutoInitializeOptions_OnPackageIdentity_NoOp)'=='true'">$(BootstrapPreprocessorDefinitions);MICROSOFT_WINDOWSAPPSDK_BOOTSTRAP_AUTO_INITIALIZE_OPTIONS_ONPACKAGEIDENTITY_NOOP</BootstrapPreprocessorDefinitions>
             <!-- Inherit the previous definitions based on condition -->
-            <BootstrapPreprocessorDefinitions Condition="'$(PreProcessorDefinitionsInheritance)'!='true'">$(BootstrapPreprocessorDefinitions);%(ClCompile.PreprocessorDefinitions)</BootstrapPreprocessorDefinitions>
-            <PreProcessorDefinitionsInheritance Condition="'$(PreProcessorDefinitionsInheritance)'!='true'">true</PreProcessorDefinitionsInheritance>
-            <!-- Set PreprocessorDefinitions final value for following target -->
-            <PreprocessorDefinitions>$(BootstrapPreprocessorDefinitions);$(PreprocessorDefinitions)</PreprocessorDefinitions>
+            <BootstrapPreprocessorDefinitions>$(BootstrapPreprocessorDefinitions);%(ClCompile.PreprocessorDefinitions)</BootstrapPreprocessorDefinitions>
         </PropertyGroup>
     </Target>
 
@@ -23,7 +20,7 @@
         <ItemGroup>
             <ClCompile Include="$(MSBuildThisFileDirectory)..\..\include\MddBootstrapAutoInitializer.cpp">
                 <PrecompiledHeader>NotUsing</PrecompiledHeader>
-                <PreprocessorDefinitions>$(PreprocessorDefinitions)</PreprocessorDefinitions>
+                <PreprocessorDefinitions>$(BootstrapPreprocessorDefinitions)</PreprocessorDefinitions>
             </ClCompile>
         </ItemGroup>
     </Target>

--- a/build/NuSpecs/WindowsAppSDK-Nuget-Native.Bootstrap.targets
+++ b/build/NuSpecs/WindowsAppSDK-Nuget-Native.Bootstrap.targets
@@ -16,7 +16,7 @@
         <ItemGroup>
             <ClCompile Include="$(MSBuildThisFileDirectory)..\..\include\MddBootstrapAutoInitializer.cpp">
                 <PrecompiledHeader>NotUsing</PrecompiledHeader>
-                <PreprocessorDefinitions>$(BootstrapPreprocessorDefinitions)</PreprocessorDefinitions>
+                <PreprocessorDefinitions>$(BootstrapPreprocessorDefinitions);%(PreprocessorDefinitions)</PreprocessorDefinitions>
             </ClCompile>
         </ItemGroup>
     </Target>

--- a/build/NuSpecs/WindowsAppSDK-Nuget-Native.Bootstrap.targets
+++ b/build/NuSpecs/WindowsAppSDK-Nuget-Native.Bootstrap.targets
@@ -1,8 +1,8 @@
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 
-    <Target Name="GenerateBootstrapCpp">
-        <!-- Build the preprocessor definitions based on conditions -->
+    <Target Name="SetBootstrapPreprocessorDefinitions" BeforeTargets="BeforeClCompile" >
         <PropertyGroup>
+            <!-- Build the Bootstrap preprocessor definitions based on conditions -->
             <BootstrapPreprocessorDefinitions>MICROSOFT_WINDOWSAPPSDK_BOOTSTRAP_AUTO_INITIALIZE=1</BootstrapPreprocessorDefinitions>
             <BootstrapPreprocessorDefinitions Condition="'$(WindowsAppSDKBootstrapAutoInitializeOptions_Default)'=='true'">$(BootstrapPreprocessorDefinitions);MICROSOFT_WINDOWSAPPSDK_BOOTSTRAP_AUTO_INITIALIZE_OPTIONS_DEFAULT</BootstrapPreprocessorDefinitions>
             <BootstrapPreprocessorDefinitions Condition="'$(WindowsAppSDKBootstrapAutoInitializeOptions_None)'=='true'">$(BootstrapPreprocessorDefinitions);MICROSOFT_WINDOWSAPPSDK_BOOTSTRAP_AUTO_INITIALIZE_OPTIONS_NONE</BootstrapPreprocessorDefinitions>
@@ -11,12 +11,19 @@
             <BootstrapPreprocessorDefinitions Condition="'$(WindowsAppSDKBootstrapAutoInitializeOptions_OnError_FailFast)'=='true'">$(BootstrapPreprocessorDefinitions);MICROSOFT_WINDOWSAPPSDK_BOOTSTRAP_AUTO_INITIALIZE_OPTIONS_ONERROR_FAILFAST</BootstrapPreprocessorDefinitions>
             <BootstrapPreprocessorDefinitions Condition="'$(WindowsAppSDKBootstrapAutoInitializeOptions_OnNoMatch_ShowUI)'=='true'">$(BootstrapPreprocessorDefinitions);MICROSOFT_WINDOWSAPPSDK_BOOTSTRAP_AUTO_INITIALIZE_OPTIONS_ONNOMATCH_SHOWUI</BootstrapPreprocessorDefinitions>
             <BootstrapPreprocessorDefinitions Condition="'$(WindowsAppSDKBootstrapAutoInitializeOptions_OnPackageIdentity_NoOp)'=='true'">$(BootstrapPreprocessorDefinitions);MICROSOFT_WINDOWSAPPSDK_BOOTSTRAP_AUTO_INITIALIZE_OPTIONS_ONPACKAGEIDENTITY_NOOP</BootstrapPreprocessorDefinitions>
+            <!-- Inherit the previous definitions based on condition -->
+            <BootstrapPreprocessorDefinitions Condition="'$(PreProcessorDefinitionsInheritance)'!='true'">$(BootstrapPreprocessorDefinitions);%(ClCompile.PreprocessorDefinitions)</BootstrapPreprocessorDefinitions>
+            <PreProcessorDefinitionsInheritance Condition="'$(PreProcessorDefinitionsInheritance)'!='true'">true</PreProcessorDefinitionsInheritance>
+            <!-- Set PreprocessorDefinitions final value for following target -->
+            <PreprocessorDefinitions>$(BootstrapPreprocessorDefinitions);$(PreprocessorDefinitions)</PreprocessorDefinitions>
         </PropertyGroup>
-        
+    </Target>
+
+    <Target Name="GenerateBootstrapCpp">
         <ItemGroup>
             <ClCompile Include="$(MSBuildThisFileDirectory)..\..\include\MddBootstrapAutoInitializer.cpp">
                 <PrecompiledHeader>NotUsing</PrecompiledHeader>
-                <PreprocessorDefinitions>$(BootstrapPreprocessorDefinitions);%(PreprocessorDefinitions)</PreprocessorDefinitions>
+                <PreprocessorDefinitions>$(PreprocessorDefinitions)</PreprocessorDefinitions>
             </ClCompile>
         </ItemGroup>
     </Target>
@@ -26,5 +33,4 @@
             $(BeforeClCompileTargets); GenerateBootstrapCpp;
         </BeforeClCompileTargets>
     </PropertyGroup>
-
 </Project>

--- a/build/NuSpecs/WindowsAppSDK-Nuget-Native.Bootstrap.targets
+++ b/build/NuSpecs/WindowsAppSDK-Nuget-Native.Bootstrap.targets
@@ -1,17 +1,22 @@
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 
     <Target Name="GenerateBootstrapCpp">
+        <!-- Build the preprocessor definitions based on conditions -->
+        <PropertyGroup>
+            <BootstrapPreprocessorDefinitions>MICROSOFT_WINDOWSAPPSDK_BOOTSTRAP_AUTO_INITIALIZE=1</BootstrapPreprocessorDefinitions>
+            <BootstrapPreprocessorDefinitions Condition="'$(WindowsAppSDKBootstrapAutoInitializeOptions_Default)'=='true'">$(BootstrapPreprocessorDefinitions);MICROSOFT_WINDOWSAPPSDK_BOOTSTRAP_AUTO_INITIALIZE_OPTIONS_DEFAULT</BootstrapPreprocessorDefinitions>
+            <BootstrapPreprocessorDefinitions Condition="'$(WindowsAppSDKBootstrapAutoInitializeOptions_None)'=='true'">$(BootstrapPreprocessorDefinitions);MICROSOFT_WINDOWSAPPSDK_BOOTSTRAP_AUTO_INITIALIZE_OPTIONS_NONE</BootstrapPreprocessorDefinitions>
+            <BootstrapPreprocessorDefinitions Condition="'$(WindowsAppSDKBootstrapAutoInitializeOptions_OnError_DebugBreak)'=='true'">$(BootstrapPreprocessorDefinitions);MICROSOFT_WINDOWSAPPSDK_BOOTSTRAP_AUTO_INITIALIZE_OPTIONS_ONERROR_DEBUGBREAK</BootstrapPreprocessorDefinitions>
+            <BootstrapPreprocessorDefinitions Condition="'$(WindowsAppSDKBootstrapAutoInitializeOptions_OnError_DebugBreak_IfDebuggerAttached)'=='true'">$(BootstrapPreprocessorDefinitions);MICROSOFT_WINDOWSAPPSDK_BOOTSTRAP_AUTO_INITIALIZE_OPTIONS_ONERROR_DEBUGBREAK_IFDEBUGGERATTACHED</BootstrapPreprocessorDefinitions>
+            <BootstrapPreprocessorDefinitions Condition="'$(WindowsAppSDKBootstrapAutoInitializeOptions_OnError_FailFast)'=='true'">$(BootstrapPreprocessorDefinitions);MICROSOFT_WINDOWSAPPSDK_BOOTSTRAP_AUTO_INITIALIZE_OPTIONS_ONERROR_FAILFAST</BootstrapPreprocessorDefinitions>
+            <BootstrapPreprocessorDefinitions Condition="'$(WindowsAppSDKBootstrapAutoInitializeOptions_OnNoMatch_ShowUI)'=='true'">$(BootstrapPreprocessorDefinitions);MICROSOFT_WINDOWSAPPSDK_BOOTSTRAP_AUTO_INITIALIZE_OPTIONS_ONNOMATCH_SHOWUI</BootstrapPreprocessorDefinitions>
+            <BootstrapPreprocessorDefinitions Condition="'$(WindowsAppSDKBootstrapAutoInitializeOptions_OnPackageIdentity_NoOp)'=='true'">$(BootstrapPreprocessorDefinitions);MICROSOFT_WINDOWSAPPSDK_BOOTSTRAP_AUTO_INITIALIZE_OPTIONS_ONPACKAGEIDENTITY_NOOP</BootstrapPreprocessorDefinitions>
+        </PropertyGroup>
+        
         <ItemGroup>
             <ClCompile Include="$(MSBuildThisFileDirectory)..\..\include\MddBootstrapAutoInitializer.cpp">
                 <PrecompiledHeader>NotUsing</PrecompiledHeader>
-                <PreprocessorDefinitions Condition="'$(WindowsAppSDKBootstrapAutoInitializeOptions_Default)'=='true'">MICROSOFT_WINDOWSAPPSDK_BOOTSTRAP_AUTO_INITIALIZE_OPTIONS_DEFAULT;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-                <PreprocessorDefinitions Condition="'$(WindowsAppSDKBootstrapAutoInitializeOptions_None)'=='true'">MICROSOFT_WINDOWSAPPSDK_BOOTSTRAP_AUTO_INITIALIZE_OPTIONS_NONE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-                <PreprocessorDefinitions Condition="'$(WindowsAppSDKBootstrapAutoInitializeOptions_OnError_DebugBreak)'=='true'">MICROSOFT_WINDOWSAPPSDK_BOOTSTRAP_AUTO_INITIALIZE_OPTIONS_ONERROR_DEBUGBREAK;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-                <PreprocessorDefinitions Condition="'$(WindowsAppSDKBootstrapAutoInitializeOptions_OnError_DebugBreak_IfDebuggerAttached)'=='true'">MICROSOFT_WINDOWSAPPSDK_BOOTSTRAP_AUTO_INITIALIZE_OPTIONS_ONERROR_DEBUGBREAK_IFDEBUGGERATTACHED;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-                <PreprocessorDefinitions Condition="'$(WindowsAppSDKBootstrapAutoInitializeOptions_OnError_FailFast)'=='true'">MICROSOFT_WINDOWSAPPSDK_BOOTSTRAP_AUTO_INITIALIZE_OPTIONS_ONERROR_FAILFAST;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-                <PreprocessorDefinitions Condition="'$(WindowsAppSDKBootstrapAutoInitializeOptions_OnNoMatch_ShowUI)'=='true'">MICROSOFT_WINDOWSAPPSDK_BOOTSTRAP_AUTO_INITIALIZE_OPTIONS_ONNOMATCH_SHOWUI;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-                <PreprocessorDefinitions Condition="'$(WindowsAppSDKBootstrapAutoInitializeOptions_OnPackageIdentity_NoOp)'=='true'">MICROSOFT_WINDOWSAPPSDK_BOOTSTRAP_AUTO_INITIALIZE_OPTIONS_ONPACKAGEIDENTITY_NOOP;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-                <PreprocessorDefinitions>%(PreprocessorDefinitions);MICROSOFT_WINDOWSAPPSDK_BOOTSTRAP_AUTO_INITIALIZE=1</PreprocessorDefinitions>
+                <PreprocessorDefinitions>$(BootstrapPreprocessorDefinitions)</PreprocessorDefinitions>
             </ClCompile>
         </ItemGroup>
     </Target>


### PR DESCRIPTION
**Fix MSB4120 and MSB8027 warnings in MSBuild targets files

Problem:
MSBuild was generating multiple warnings when building the project:

1. MSB4120: "Item 'ClCompile' definition within target references itself via (qualified or unqualified) metadatum 'PreprocessorDefinitions'. This can lead to unintended expansion and cross-applying of pre-existing items."

2. MSB8027: Multiple targets were being executed repeatedly due to cross-target interference caused by the self-referencing item definitions.

Root Cause:
The issue occurred because multiple PreprocessorDefinitions were being set conditionally within ClCompile items inside targets, each referencing %(PreprocessorDefinitions) to append to existing definitions. This created several problems:

1. **Self-reference pattern**: MSBuild flags this as potentially problematic due to unexpected behavior during item evaluation and expansion
2. **Cross-target interference**: The repeated references to %(PreprocessorDefinitions) caused targets to influence each other, leading MSBuild to re-execute the same target multiple times
3. **Build performance impact**: Redundant target execution slowed down the build process
**


A microsoft employee must use /azp run to validate using the pipelines below.

WARNING:
Comments made by azure-pipelines bot maybe inaccurate.
Please see pipeline link to verify that the build is being ran.

For status checks on the main branch, please use TransportPackage-Foundation-PR
(https://microsoft.visualstudio.com/ProjectReunion/_build?definitionId=81063&_a=summary)
and run the build against your PR branch with the default parameters.
