### PR TITLE
Fix bug caused by PublishPipelineArtifact

### DIFF
--- a/build/AzurePipelinesTemplates/WindowsAppSDK-RunTestsInPipeline-Job.yml
+++ b/build/AzurePipelinesTemplates/WindowsAppSDK-RunTestsInPipeline-Job.yml
@@ -57,6 +57,8 @@ jobs:
     testPayloadArtifactDir: $(Build.SourcesDirectory)\BuildOutput\$(buildConfiguration)\$(buildPlatform)
     AZURE_PIPELINES_DEDUP_PARALLELISM: 16
     artifactAttempt: ''
+    ob_artifactSuffix: '_$(buildConfiguration)$(buildPlatform)_$(Agent.JobStatus)$(artifactAttempt)'
+    ob_artifactBaseName: '$(System.StageName)_$(imageName)'
   steps:
     - template: WindowsAppSDK-RunTests-Steps.yml
       parameters:

--- a/build/ProjectReunion-CI.yml
+++ b/build/ProjectReunion-CI.yml
@@ -182,9 +182,13 @@ jobs:
   - BuildMRT
   variables:
     testPayloadArtifactDir: $(Build.SourcesDirectory)\BuildOutput\$(buildConfiguration)\$(buildPlatform)
+    artifactAttempt: ''
+    ob_artifactSuffix: '_$(buildConfiguration)$(buildPlatform)_$(Agent.JobStatus)$(artifactAttempt)'
+    ob_artifactBaseName: '$(System.StageName)_$(imageName)'
   steps:
   - template: AzurePipelinesTemplates\WindowsAppSDK-RunTests-Steps.yml
     parameters:
       buildPlatform: $(buildPlatform)
       buildConfiguration: $(buildConfiguration)
       testLocale: $(testLocale)
+      ImageName: $(imageName)


### PR DESCRIPTION
A microsoft employee must use /azp run to validate using the pipelines below.

WARNING:
Comments made by azure-pipelines bot maybe inaccurate.
Please see pipeline link to verify that the build is being ran.

For status checks on the main branch, please use TransportPackage-Foundation-PR
(https://microsoft.visualstudio.com/ProjectReunion/_build?definitionId=81063&_a=summary)
and run the build against your PR branch with the default parameters.
