### PR TITLE
Move matrix extraction to Build stage

### DIFF
--- a/build/AzurePipelinesTemplates/WindowsAppSDK-Build-Per-Platform-Stage.yml
+++ b/build/AzurePipelinesTemplates/WindowsAppSDK-Build-Per-Platform-Stage.yml
@@ -197,6 +197,7 @@ stages:
     steps:
     - powershell: |
         Write-Host "${{ parameters.testMatrix }}"
+        Write-Host "${{ parameters.buildPlatform }}"
         $testMatrix = "${{ parameters.testMatrix }}" | ConvertFrom-Json
         $targetPlatform = "${{ parameters.buildPlatform }}"
         $filteredMatrix = @{}

--- a/build/AzurePipelinesTemplates/WindowsAppSDK-Build-Per-Platform-Stage.yml
+++ b/build/AzurePipelinesTemplates/WindowsAppSDK-Build-Per-Platform-Stage.yml
@@ -196,8 +196,6 @@ stages:
       name: 'ProjectReunionESPool-2022'
     steps:
     - powershell: |
-        Write-Host "${{ parameters.testMatrix }}"
-        Write-Host "${{ parameters.buildPlatform }}"
         $testMatrix = "${{ parameters.testMatrix }}" | ConvertFrom-Json
         $targetPlatform = "${{ parameters.buildPlatform }}"
         $filteredMatrix = @{}

--- a/build/AzurePipelinesTemplates/WindowsAppSDK-Build-Per-Platform-Stage.yml
+++ b/build/AzurePipelinesTemplates/WindowsAppSDK-Build-Per-Platform-Stage.yml
@@ -15,7 +15,7 @@ parameters:
   type: string
   default: x64
 - name: testMatrix
-  type: object
+  type: string
   default: ''
 
 stages:

--- a/build/AzurePipelinesTemplates/WindowsAppSDK-Build-Per-Platform-Stage.yml
+++ b/build/AzurePipelinesTemplates/WindowsAppSDK-Build-Per-Platform-Stage.yml
@@ -196,6 +196,7 @@ stages:
       name: 'ProjectReunionESPool-2022'
     steps:
     - powershell: |
+        Write-Host "${{ parameters.testMatrix }}"
         $testMatrix = "${{ parameters.testMatrix }}" | ConvertFrom-Json
         $targetPlatform = "${{ parameters.buildPlatform }}"
         $filteredMatrix = @{}

--- a/build/AzurePipelinesTemplates/WindowsAppSDK-Build-Per-Platform-Stage.yml
+++ b/build/AzurePipelinesTemplates/WindowsAppSDK-Build-Per-Platform-Stage.yml
@@ -208,7 +208,7 @@ stages:
         $matrixJson = $filteredMatrix | ConvertTo-Json -Compress
         Write-Host "##vso[task.setvariable variable=filteredTestMatrix;isOutput=true]$matrixJson"
       name: filterByPlatformStep
-      displayName: "Extract matrix as json value filtering by build platform and pass the extracted matrix to next job"
+      displayName: "Extract matrix as json value filtering by build platform"
     - script: echo $(filterByPlatformStep.filteredTestMatrix)
       name: echoMatrix
       displayName: "Echo filtered matrix"

--- a/build/AzurePipelinesTemplates/WindowsAppSDK-Build-Per-Platform-Stage.yml
+++ b/build/AzurePipelinesTemplates/WindowsAppSDK-Build-Per-Platform-Stage.yml
@@ -14,6 +14,9 @@ parameters:
 - name: buildPlatform
   type: string
   default: x64
+- name: testMatrix
+  type: object
+  default: ''
 
 stages:
 - stage: ${{ format(iif(parameters.runPREfast, 'PREfast_{0}', 'Build_{0}'), parameters.buildPlatform) }}
@@ -185,3 +188,26 @@ stages:
     - script: |
         md "C:\__t\NativeCompilerPrefast"
       displayName: 'Creating C:\__t\NativeCompilerPrefast to prevent errors from Guardian PREfast'
+
+  - job: ExtractMatrix
+    pool:
+      type: windows
+      isCustom: true
+      name: 'ProjectReunionESPool-2022'
+    steps:
+    - powershell: |
+        $testMatrix = "${{ parameters.testMatrix }}" | ConvertFrom-Json
+        $targetPlatform = "${{ parameters.buildPlatform }}"
+        $filteredMatrix = @{}
+        foreach ($entry in $testMatrix.PSObject.Properties) {
+          if ($entry.Value.buildPlatform -eq $targetPlatform) {
+              $filteredMatrix[$entry.Name] = $entry.Value
+          }
+        }
+        $matrixJson = $filteredMatrix | ConvertTo-Json -Compress
+        Write-Host "##vso[task.setvariable variable=filteredTestMatrix;isOutput=true]$matrixJson"
+      name: filterByPlatformStep
+      displayName: "Extract matrix as json value filtering by build platform and pass the extracted matrix to next job"
+    - script: echo $(filterByPlatformStep.filteredTestMatrix)
+      name: echoMatrix
+      displayName: "Echo filtered matrix"

--- a/build/AzurePipelinesTemplates/WindowsAppSDK-Build-Stage.yml
+++ b/build/AzurePipelinesTemplates/WindowsAppSDK-Build-Stage.yml
@@ -82,7 +82,7 @@ stages:
     runPREfast : ${{ parameters.runPREfast }}
     runApiScan : ${{ parameters.runApiScan }}
     BuildPlatform: x64
-    testMatrix: ${{ parameters.PipelineTests }}
+    testMatrix: ${{ parameters.testMatrix }}
 
 - ${{ if not(parameters.runPREfast) }}:
   - template: WindowsAppSDK-Build-Per-Platform-Stage.yml@self
@@ -92,7 +92,7 @@ stages:
       runPREfast : ${{ parameters.runPREfast }}
       runApiScan : ${{ parameters.runApiScan }}
       BuildPlatform: x86
-      testMatrix: ${{ parameters.PipelineTests }}
+      testMatrix: ${{ parameters.testMatrix }}
 
   - template: WindowsAppSDK-Build-Per-Platform-Stage.yml@self
     parameters:
@@ -101,4 +101,4 @@ stages:
       runPREfast : ${{ parameters.runPREfast }}
       runApiScan : ${{ parameters.runApiScan }}
       BuildPlatform: arm64
-      testMatrix: ${{ parameters.PipelineTests }}
+      testMatrix: ${{ parameters.testMatrix }}

--- a/build/AzurePipelinesTemplates/WindowsAppSDK-Build-Stage.yml
+++ b/build/AzurePipelinesTemplates/WindowsAppSDK-Build-Stage.yml
@@ -75,7 +75,8 @@ stages:
 
 # extract BuildFoundation and BuildMRT into WindowsAppSDK-Build-Stage-Per-Platform.yml. Separate the build stage per platform
 
-- stage: "echoStage"
+- stage: echoStage
+  displayName: "Echo Stage"
   jobs:
   - job: echo
     steps:

--- a/build/AzurePipelinesTemplates/WindowsAppSDK-Build-Stage.yml
+++ b/build/AzurePipelinesTemplates/WindowsAppSDK-Build-Stage.yml
@@ -75,6 +75,19 @@ stages:
 
 # extract BuildFoundation and BuildMRT into WindowsAppSDK-Build-Stage-Per-Platform.yml. Separate the build stage per platform
 
+- stage: test
+  jobs:
+    - job: echo
+      steps:
+      - script: |
+          echo "This is a test job to ensure the pipeline runs correctly."
+          echo "Parameters:"
+          echo "SignOutput: ${{ parameters.SignOutput }}"
+          echo "IsOneBranch: ${{ parameters.IsOneBranch }}"
+          echo "runApiScan: ${{ parameters.runApiScan }}"
+          echo "runPREfast: ${{ parameters.runPREfast }}"
+          echo "testMatrix: ${{ parameters.testMatrix }}"
+
 - template: WindowsAppSDK-Build-Per-Platform-Stage.yml@self
   parameters:
     SignOutput: ${{ parameters.SignOutput }}

--- a/build/AzurePipelinesTemplates/WindowsAppSDK-Build-Stage.yml
+++ b/build/AzurePipelinesTemplates/WindowsAppSDK-Build-Stage.yml
@@ -11,6 +11,9 @@ parameters:
 - name: runPREfast
   type: boolean
   default: false
+- name: testMatrix
+  type: object
+  default: ''
 
 stages:
 - stage: ${{ iif(parameters.runPREfast, 'PREfast_AnyCPU', 'Build_AnyCPU') }}
@@ -79,6 +82,7 @@ stages:
     runPREfast : ${{ parameters.runPREfast }}
     runApiScan : ${{ parameters.runApiScan }}
     BuildPlatform: x64
+    testMatrix: ${{ parameters.PipelineTests }}
 
 - ${{ if not(parameters.runPREfast) }}:
   - template: WindowsAppSDK-Build-Per-Platform-Stage.yml@self
@@ -88,6 +92,7 @@ stages:
       runPREfast : ${{ parameters.runPREfast }}
       runApiScan : ${{ parameters.runApiScan }}
       BuildPlatform: x86
+      testMatrix: ${{ parameters.PipelineTests }}
 
   - template: WindowsAppSDK-Build-Per-Platform-Stage.yml@self
     parameters:
@@ -96,3 +101,4 @@ stages:
       runPREfast : ${{ parameters.runPREfast }}
       runApiScan : ${{ parameters.runApiScan }}
       BuildPlatform: arm64
+      testMatrix: ${{ parameters.PipelineTests }}

--- a/build/AzurePipelinesTemplates/WindowsAppSDK-Build-Stage.yml
+++ b/build/AzurePipelinesTemplates/WindowsAppSDK-Build-Stage.yml
@@ -75,8 +75,8 @@ stages:
 
 # extract BuildFoundation and BuildMRT into WindowsAppSDK-Build-Stage-Per-Platform.yml. Separate the build stage per platform
 
-- stage: echoStage
-  displayName: "Echo Stage"
+- stage: EchoParameters
+  displayName: "Echo Parameters Stage"
   jobs:
   - job: echo
     steps:

--- a/build/AzurePipelinesTemplates/WindowsAppSDK-Build-Stage.yml
+++ b/build/AzurePipelinesTemplates/WindowsAppSDK-Build-Stage.yml
@@ -75,7 +75,7 @@ stages:
 
 # extract BuildFoundation and BuildMRT into WindowsAppSDK-Build-Stage-Per-Platform.yml. Separate the build stage per platform
 
-- stage: testStageBuild
+- stage: "echoStage"
   jobs:
     - job: echo
       steps:

--- a/build/AzurePipelinesTemplates/WindowsAppSDK-Build-Stage.yml
+++ b/build/AzurePipelinesTemplates/WindowsAppSDK-Build-Stage.yml
@@ -11,9 +11,6 @@ parameters:
 - name: runPREfast
   type: boolean
   default: false
-- name: testMatrix
-  type: object
-  default: ''
 
 stages:
 - stage: ${{ iif(parameters.runPREfast, 'PREfast_AnyCPU', 'Build_AnyCPU') }}

--- a/build/AzurePipelinesTemplates/WindowsAppSDK-Build-Stage.yml
+++ b/build/AzurePipelinesTemplates/WindowsAppSDK-Build-Stage.yml
@@ -11,6 +11,9 @@ parameters:
 - name: runPREfast
   type: boolean
   default: false
+- name: testMatrix
+  type: string
+  default: ''
 
 stages:
 - stage: ${{ iif(parameters.runPREfast, 'PREfast_AnyCPU', 'Build_AnyCPU') }}

--- a/build/AzurePipelinesTemplates/WindowsAppSDK-Build-Stage.yml
+++ b/build/AzurePipelinesTemplates/WindowsAppSDK-Build-Stage.yml
@@ -23,6 +23,17 @@ stages:
     eq(variables['useBuildOutputFromBuildId'],'')
   dependsOn: []
   jobs:
+  - job: echo
+    steps:
+    - script: |
+        echo "This is a test job to ensure the pipeline runs correctly."
+        echo "Parameters:"
+        echo "SignOutput: ${{ parameters.SignOutput }}"
+        echo "IsOneBranch: ${{ parameters.IsOneBranch }}"
+        echo "runApiScan: ${{ parameters.runApiScan }}"
+        echo "runPREfast: ${{ parameters.runPREfast }}"
+        echo "testMatrix: ${{ parameters.testMatrix }}"
+
   - job: VerifyCopyrightHeaders
     dependsOn: []
     pool:
@@ -74,20 +85,6 @@ stages:
       displayName: 'Creating C:\__t\NativeCompilerPrefast to prevent errors from Guardian PREfast'
 
 # extract BuildFoundation and BuildMRT into WindowsAppSDK-Build-Stage-Per-Platform.yml. Separate the build stage per platform
-
-- stage: EchoParameters
-  displayName: "Echo Parameters Stage"
-  jobs:
-  - job: echo
-    steps:
-    - script: |
-        echo "This is a test job to ensure the pipeline runs correctly."
-        echo "Parameters:"
-        echo "SignOutput: ${{ parameters.SignOutput }}"
-        echo "IsOneBranch: ${{ parameters.IsOneBranch }}"
-        echo "runApiScan: ${{ parameters.runApiScan }}"
-        echo "runPREfast: ${{ parameters.runPREfast }}"
-        echo "testMatrix: ${{ parameters.testMatrix }}"
 
 - template: WindowsAppSDK-Build-Per-Platform-Stage.yml@self
   parameters:

--- a/build/AzurePipelinesTemplates/WindowsAppSDK-Build-Stage.yml
+++ b/build/AzurePipelinesTemplates/WindowsAppSDK-Build-Stage.yml
@@ -75,7 +75,7 @@ stages:
 
 # extract BuildFoundation and BuildMRT into WindowsAppSDK-Build-Stage-Per-Platform.yml. Separate the build stage per platform
 
-- stage: test
+- stage: testStageBuild
   jobs:
     - job: echo
       steps:

--- a/build/AzurePipelinesTemplates/WindowsAppSDK-Build-Stage.yml
+++ b/build/AzurePipelinesTemplates/WindowsAppSDK-Build-Stage.yml
@@ -77,16 +77,16 @@ stages:
 
 - stage: "echoStage"
   jobs:
-    - job: echo
-      steps:
-      - script: |
-          echo "This is a test job to ensure the pipeline runs correctly."
-          echo "Parameters:"
-          echo "SignOutput: ${{ parameters.SignOutput }}"
-          echo "IsOneBranch: ${{ parameters.IsOneBranch }}"
-          echo "runApiScan: ${{ parameters.runApiScan }}"
-          echo "runPREfast: ${{ parameters.runPREfast }}"
-          echo "testMatrix: ${{ parameters.testMatrix }}"
+  - job: echo
+    steps:
+    - script: |
+        echo "This is a test job to ensure the pipeline runs correctly."
+        echo "Parameters:"
+        echo "SignOutput: ${{ parameters.SignOutput }}"
+        echo "IsOneBranch: ${{ parameters.IsOneBranch }}"
+        echo "runApiScan: ${{ parameters.runApiScan }}"
+        echo "runPREfast: ${{ parameters.runPREfast }}"
+        echo "testMatrix: ${{ parameters.testMatrix }}"
 
 - template: WindowsAppSDK-Build-Per-Platform-Stage.yml@self
   parameters:

--- a/build/AzurePipelinesTemplates/WindowsAppSDK-Build-Stage.yml
+++ b/build/AzurePipelinesTemplates/WindowsAppSDK-Build-Stage.yml
@@ -23,17 +23,6 @@ stages:
     eq(variables['useBuildOutputFromBuildId'],'')
   dependsOn: []
   jobs:
-  - job: echo
-    steps:
-    - script: |
-        echo "This is a test job to ensure the pipeline runs correctly."
-        echo "Parameters:"
-        echo "SignOutput: ${{ parameters.SignOutput }}"
-        echo "IsOneBranch: ${{ parameters.IsOneBranch }}"
-        echo "runApiScan: ${{ parameters.runApiScan }}"
-        echo "runPREfast: ${{ parameters.runPREfast }}"
-        echo "testMatrix: ${{ parameters.testMatrix }}"
-
   - job: VerifyCopyrightHeaders
     dependsOn: []
     pool:

--- a/build/AzurePipelinesTemplates/WindowsAppSDK-RunTestsInPipeline-Job.yml
+++ b/build/AzurePipelinesTemplates/WindowsAppSDK-RunTestsInPipeline-Job.yml
@@ -19,34 +19,9 @@ parameters:
   default: x64
 
 jobs:
-- job: ExtractMatrix
-  pool:
-    type: windows
-    isCustom: true
-    name: 'ProjectReunionESPool-2022'
-  steps:
-  - powershell: |
-      $testMatrix = "${{ parameters.testMatrix }}" | ConvertFrom-Json
-      $targetPlatform = "${{ parameters.buildPlatform }}"
-      $filteredMatrix = @{}
-      foreach ($entry in $testMatrix.PSObject.Properties) {
-        if ($entry.Value.buildPlatform -eq $targetPlatform) {
-            $filteredMatrix[$entry.Name] = $entry.Value
-        }
-      }
-      $matrixJson = $filteredMatrix | ConvertTo-Json -Compress
-      Write-Host "##vso[task.setvariable variable=matrixJson;isOutput=true]$matrixJson"
-    name: filterByPlatformStep
-    displayName: "Extract matrix as json value filtering by build platform and pass the extracted matrix to next job"
-  - script: echo $(filterByPlatformStep.matrixJson)
-    name: echoMatrix
-    displayName: "Echo filtered matrix"
-
-
 - job: ${{ parameters.jobName }}
-  dependsOn: ExtractMatrix
   strategy:
-    matrix: $[ dependencies.ExtractMatrix.outputs['filterByPlatformStep.matrixJson'] ]
+    matrix: ${{ parameters.TestMatrix }}
   pool:
     type: windows
     isCustom: true

--- a/build/AzurePipelinesTemplates/WindowsAppSDK-Test-Stage.yml
+++ b/build/AzurePipelinesTemplates/WindowsAppSDK-Test-Stage.yml
@@ -6,7 +6,7 @@ stages:
   - template: WindowsAppSDK-RunTestsInPipeline-Job.yml@self
     parameters:
       jobName: PipelineTests
-      testMatrix: ${{ parameters.testMatrix }} # testMatrix is supplied by WindowsAppSDKConfig/WindowsAppSDK-Foundation-TestConfig.yml
+      testMatrix: $[ stageDependencies.Build_x86.ExtractMatrix.outputs['filterByPlatformStep.filteredTestMatrix'] ] # testMatrix is supplied by WindowsAppSDKConfig/WindowsAppSDK-Foundation-TestConfig.yml
       buildPlatform: x86
 
 - stage: Test_x64
@@ -16,7 +16,7 @@ stages:
   - template: WindowsAppSDK-RunTestsInPipeline-Job.yml@self
     parameters:
       jobName: PipelineTests
-      testMatrix: ${{ parameters.testMatrix }} # testMatrix is supplied by WindowsAppSDKConfig/WindowsAppSDK-Foundation-TestConfig.yml
+      testMatrix: $[ stageDependencies.Build_x64.ExtractMatrix.outputs['filterByPlatformStep.filteredTestMatrix'] ] # testMatrix is supplied by WindowsAppSDKConfig/WindowsAppSDK-Foundation-TestConfig.yml
       buildPlatform: x64
 
 - stage: Test_arm64
@@ -26,5 +26,5 @@ stages:
   - template: WindowsAppSDK-RunTestsInPipeline-Job.yml@self
     parameters:
       jobName: PipelineTests
-      testMatrix: ${{ parameters.testMatrix }} # testMatrix is supplied by WindowsAppSDKConfig/WindowsAppSDK-Foundation-TestConfig.yml
+      testMatrix: $[ stageDependencies.Build_arm64.ExtractMatrix.outputs['filterByPlatformStep.filteredTestMatrix'] ] # testMatrix is supplied by WindowsAppSDKConfig/WindowsAppSDK-Foundation-TestConfig.yml
       buildPlatform: arm64

--- a/build/ProjectReunion-BuildFoundation.yml
+++ b/build/ProjectReunion-BuildFoundation.yml
@@ -32,6 +32,7 @@ stages:
     IsOneBranch: false
     runApiScan: true
     runPREFast: false
+    testMatrix: ${{ variables.PipelineTests }}
 
 - template: AzurePipelinesTemplates\WindowsAppSDK-Build-Stage.yml@self
   parameters:

--- a/build/ProjectReunion-BuildFoundation.yml
+++ b/build/ProjectReunion-BuildFoundation.yml
@@ -39,10 +39,9 @@ stages:
     IsOneBranch: false
     runApiScan: false
     runPREFast: true
+    testMatrix: ${{ variables.PipelineTests }}
 
 - template: AzurePipelinesTemplates\WindowsAppSDK-Test-Stage.yml@self
-  parameters:
-    testMatrix: ${{ variables.PipelineTests }}
 
 - template: AzurePipelinesTemplates\WindowsAppSDK-PackTransportPackage-Stage.yml@self
   parameters:


### PR DESCRIPTION
A microsoft employee must use /azp run to validate using the pipelines below.

WARNING:
Comments made by azure-pipelines bot maybe inaccurate.
Please see pipeline link to verify that the build is being ran.

For status checks on the main branch, please use TransportPackage-Foundation-PR
(https://microsoft.visualstudio.com/ProjectReunion/_build?definitionId=81063&_a=summary)
and run the build against your PR branch with the default parameters.
