### PR TITLE
Updating storage pickers resources

### DIFF
--- a/dev/Interop/StoragePickers/Strings/StoragePickers.resw
+++ b/dev/Interop/StoragePickers/Strings/StoragePickers.resw
@@ -121,10 +121,10 @@
     <value>All Files</value>
   </data>
   <data name="IDS_APIERROR_INVALIDVIEWMODEVALUE" xml:space="preserve">
-    <value>The specified 'ViewMode' is invalid.</value>
+    <value>The specified ViewMode is invalid.</value>
   </data>
   <data name="IDS_APIERROR_INVALIDSUGGESTEDSTARTLOCATIONVALUE" xml:space="preserve">
-    <value>The specified 'SuggestedStartLocation' is invalid.</value>
+    <value>The specified SuggestedStartLocation is invalid.</value>
   </data>
   <data name="IDS_APIERROR_IMPROPERFILEEXTENSION" xml:space="preserve">
     <value>File extensions must begin with '.' and contain no wildcards.</value>


### PR DESCRIPTION
Updating storage pickers resources

The existing resources failed to generate localized messages for `IDS_APIERROR_INVALIDVIEWMODEVALUE` and `IDS_APIERROR_INVALIDSUGGESTEDSTARTLOCATIONVALUE` in the touch down pipeline.