### PR TITLE
Avoid non-fatal BinSkim errors in Post* job inject by OneBranch

### DIFF
--- a/build/AzurePipelinesTemplates/WindowsAppSDK-Build-Per-Platform-Stage.yml
+++ b/build/AzurePipelinesTemplates/WindowsAppSDK-Build-Per-Platform-Stage.yml
@@ -193,25 +193,27 @@ stages:
         runPREfast : ${{ parameters.runPREfast }}
         runApiScan : ${{ parameters.runApiScan }}
 
-  - job: ExtractMatrix
-    pool:
-      type: windows
-      isCustom: true
-      name: 'ProjectReunionESPool-2022'
-    steps:
-    - powershell: |
-        $testMatrix = "${{ parameters.testMatrix }}" | ConvertFrom-Json
-        $targetPlatform = "${{ parameters.buildPlatform }}"
-        $filteredMatrix = @{}
-        foreach ($entry in $testMatrix.PSObject.Properties) {
-          if ($entry.Value.buildPlatform -eq $targetPlatform) {
-              $filteredMatrix[$entry.Name] = $entry.Value
+  # Only run the test matrix extraction job in Build_{buildPlatform} job. The PREfast_{buildPlatform} job don't have the following test stages, don't need this job.
+  - ${{ if not(parameters.runPREfast) }}:
+    - job: ExtractMatrix
+      pool:
+        type: windows
+        isCustom: true
+        name: 'ProjectReunionESPool-2022'
+      steps:
+      - powershell: |
+          $testMatrix = "${{ parameters.testMatrix }}" | ConvertFrom-Json
+          $targetPlatform = "${{ parameters.buildPlatform }}"
+          $filteredMatrix = @{}
+          foreach ($entry in $testMatrix.PSObject.Properties) {
+            if ($entry.Value.buildPlatform -eq $targetPlatform) {
+                $filteredMatrix[$entry.Name] = $entry.Value
+            }
           }
-        }
-        $matrixJson = $filteredMatrix | ConvertTo-Json -Compress
-        Write-Host "##vso[task.setvariable variable=filteredTestMatrix;isOutput=true]$matrixJson"
-      name: filterByPlatformStep
-      displayName: "Extract matrix as json value filtering by build platform"
-    - script: echo $(filterByPlatformStep.filteredTestMatrix)
-      name: echoMatrix
-      displayName: "Echo filtered matrix"
+          $matrixJson = $filteredMatrix | ConvertTo-Json -Compress
+          Write-Host "##vso[task.setvariable variable=filteredTestMatrix;isOutput=true]$matrixJson"
+        name: filterByPlatformStep
+        displayName: "Extract matrix as json value filtering by build platform"
+      - script: echo $(filterByPlatformStep.filteredTestMatrix)
+        name: echoMatrix
+        displayName: "Echo filtered matrix"

--- a/build/AzurePipelinesTemplates/WindowsAppSDK-RunTestsInPipeline-Job.yml
+++ b/build/AzurePipelinesTemplates/WindowsAppSDK-RunTestsInPipeline-Job.yml
@@ -34,6 +34,16 @@ jobs:
     artifactAttempt: ''
     ob_artifactSuffix: '_$(buildConfiguration)$(buildPlatform)_$(Agent.JobStatus)$(artifactAttempt)'
     ob_artifactBaseName: '$(System.StageName)_$(imageName)'
+    # As the name of this job suggests, we currently don't build any code here, but only run tests; therefore, not bothering to enable BinSkim scans
+    # here. OTOH, if we leave BinSkim enabled, then the "Guardian: BinSkim" task in the Post* jobs injected into our pipeline by OneBranch 
+    # for this job would hit the following non-fatal, but noisy AnalyzeArgumentNoValuesException error:
+    #
+    # ##[error]Error running binskim job: 1 of 1
+    # ##[error]AnalyzeArgumentNoValuesException: Argument Target has no values. Check your configuration. -- Additional arguments:Microsoft.Guardian.InvalidResponseFileContentsException: InvalidResponseFileContentsException: Cannot create a response file with zero arguments. Ensure that your arguments are correctly set up.
+    # at Microsoft.Guardian.ResponseFileFormatterPlaintext.Format(IList`1 arguments, ResponseFileOptions Options)
+    # at Microsoft.Guardian.ResponseFileManager.CreateResponseFile(IList`1 arguments, String formatterName, ResponseFileOptions options, String outputPathOverride)
+    # at Microsoft.Guardian.CliAnalyzerResponseFileManager.SetupResponseFile(CliAnalyzerConfig analyzeConfig, ToolConfig toolConfig)
+    ob_sdl_binskim_enabled: false
   steps:
     - template: WindowsAppSDK-RunTests-Steps.yml
       parameters:


### PR DESCRIPTION
A microsoft employee must use /azp run to validate using the pipelines below.

WARNING:
Comments made by azure-pipelines bot maybe inaccurate.
Please see pipeline link to verify that the build is being ran.

For status checks on the main branch, please use TransportPackage-Foundation-PR
(https://microsoft.visualstudio.com/ProjectReunion/_build?definitionId=81063&_a=summary)
and run the build against your PR branch with the default parameters.
