### PR TITLE
Undocked Reg-Free WinRT Activation isn’t enabled for Packaged Self-Contained apps on < 19H1 devices

### DIFF
--- a/dev/WindowsAppRuntime_DLL/dllmain.cpp
+++ b/dev/WindowsAppRuntime_DLL/dllmain.cpp
@@ -62,9 +62,12 @@ static HRESULT DetoursShutdown()
     // Stop Detour'ing APIs to our implementation
     FAIL_FAST_IF_WIN32_ERROR(DetourTransactionBegin());
     FAIL_FAST_IF_WIN32_ERROR(DetourUpdateThread(GetCurrentThread()));
-    if (!isPackaged && !is19H1OrGreater)
+    if (!is19H1OrGreater)
     {
         UrfwShutdown();
+    }
+    if (!isPackaged)
+    {
         MddDetourPackageGraphShutdown();
     }
     FAIL_FAST_IF_WIN32_ERROR(DetourTransactionCommit());


### PR DESCRIPTION
Bug fix for  #3133 

A microsoft employee must use /azp run to validate using the pipelines below.

WARNING:
Comments made by azure-pipelines bot maybe inaccurate.
Please see pipeline link to verify that the build is being ran.

For status checks on the main branch, please use TransportPackage-Foundation-PR
(https://microsoft.visualstudio.com/ProjectReunion/_build?definitionId=81063&_a=summary)
and run the build against your PR branch with the default parameters.
