### PR TITLE
BugFix: fix the null reference error of FolderPicker

### DIFF
--- a/dev/Interop/StoragePickers/PickerCommon.cpp
+++ b/dev/Interop/StoragePickers/PickerCommon.cpp
@@ -285,7 +285,10 @@ namespace PickerCommon {
             check_hresult(dialog->SetDefaultFolder(defaultFolder.get()));
         }
 
-        check_hresult(dialog->SetFileTypes((UINT)FileTypeFilterPara.size(), FileTypeFilterPara.data()));
+        if (FileTypeFilterPara.size() > 0)
+        {
+            check_hresult(dialog->SetFileTypes((UINT)FileTypeFilterPara.size(), FileTypeFilterPara.data()));
+        }
     }
 
     /// <summary>

--- a/test/StoragePickersTests/PickerCommonTests.cpp
+++ b/test/StoragePickersTests/PickerCommonTests.cpp
@@ -62,6 +62,23 @@ namespace Test::PickerCommonTests
             return true;
         }
 
+        TEST_METHOD(VerifyConfigureDialog_WhenPickerParameters_FileTypeFilterNotSpecified_ExpectSuccess)
+        {
+            // Arrange.
+            winrt::Microsoft::UI::WindowId windowId{};
+            winrt::Microsoft::Windows::Storage::Pickers::FolderPicker picker(windowId);
+
+            PickerParameters parameters{};
+
+            // Act.
+            auto dialog = winrt::create_instance<IFileOpenDialog>(CLSID_FileOpenDialog, CLSCTX_INPROC_SERVER);
+            parameters.ConfigureDialog(dialog);
+
+            // Assert.
+            // Expect the action's successful.
+
+        }
+
         TEST_METHOD(VerifyFilters_FileOpenPickerWhenFileTypeFiltersDefinedExpectAddingUnionedType)
         {
             // Arrange.


### PR DESCRIPTION
In #5547 we removed the FileTypeFilter attribute of FolderPicker. While in `PickerParameters::ConfigureDialog`, it was assumed there's always the file type filter initialized, which is a wrong and will cause `null reference` error when configuring dialog for FolderPicker, who doesn't have the FileTypeFilter attribute any more.

This PR fixes above issue, and adds a unit test to ensure the no values passed by PickerParameters are required to configure dialog.
