### PR TITLE
Set WinUISDKReferences=false in Templates

### DIFF
--- a/dev/VSIX/ProjectTemplates/Desktop/CSharp/ClassLibrary/ProjectTemplate.csproj
+++ b/dev/VSIX/ProjectTemplates/Desktop/CSharp/ClassLibrary/ProjectTemplate.csproj
@@ -5,6 +5,7 @@
     <RootNamespace>$safeprojectname$</RootNamespace>
     <RuntimeIdentifiers>win-x86;win-x64;win-arm64</RuntimeIdentifiers>
     <UseWinUI>true</UseWinUI>
+    <WinUISDKReferences>false</WinUISDKReferences>
   </PropertyGroup>
   
 </Project>

--- a/dev/VSIX/ProjectTemplates/Desktop/CSharp/PackagedApp/BlankApp/ProjectTemplate.csproj
+++ b/dev/VSIX/ProjectTemplates/Desktop/CSharp/PackagedApp/BlankApp/ProjectTemplate.csproj
@@ -8,6 +8,7 @@
     <Platforms>x86;x64;ARM64</Platforms>
     <RuntimeIdentifiers>win-x86;win-x64;win-arm64</RuntimeIdentifiers>
     <UseWinUI>true</UseWinUI>
+    <WinUISDKReferences>false</WinUISDKReferences>
     <Nullable>enable</Nullable>
   </PropertyGroup>
 

--- a/dev/VSIX/ProjectTemplates/Desktop/CSharp/PackagedApp/WapProj/WapProjTemplate.wapproj
+++ b/dev/VSIX/ProjectTemplates/Desktop/CSharp/PackagedApp/WapProj/WapProjTemplate.wapproj
@@ -35,6 +35,7 @@
   <PropertyGroup>
     <WapProjPath Condition="'$(WapProjPath)'==''">$(MSBuildExtensionsPath)\Microsoft\DesktopBridge\</WapProjPath>
     <PathToXAMLWinRTImplementations>$ext_projectname$\</PathToXAMLWinRTImplementations>
+    <WinUISDKReferences>false</WinUISDKReferences>
   </PropertyGroup>
 
   <Import Project="$(WapProjPath)\Microsoft.DesktopBridge.props" />

--- a/dev/VSIX/ProjectTemplates/Desktop/CSharp/SingleProjectPackagedApp/ProjectTemplate.csproj
+++ b/dev/VSIX/ProjectTemplates/Desktop/CSharp/SingleProjectPackagedApp/ProjectTemplate.csproj
@@ -9,6 +9,7 @@
     <RuntimeIdentifiers>win-x86;win-x64;win-arm64</RuntimeIdentifiers>
     <PublishProfile>win-$(Platform).pubxml</PublishProfile>
     <UseWinUI>true</UseWinUI>
+    <WinUISDKReferences>false</WinUISDKReferences>
     <EnableMsixTooling>true</EnableMsixTooling>
     <Nullable>enable</Nullable>
   </PropertyGroup>

--- a/dev/VSIX/ProjectTemplates/Desktop/CSharp/UnitTestApp/ProjectTemplate.csproj
+++ b/dev/VSIX/ProjectTemplates/Desktop/CSharp/UnitTestApp/ProjectTemplate.csproj
@@ -9,6 +9,7 @@
     <RuntimeIdentifiers>win-x86;win-x64;win-arm64</RuntimeIdentifiers>
     <PublishProfile>win-$(Platform).pubxml</PublishProfile>
     <UseWinUI>true</UseWinUI>
+    <WinUIDSKReferences>false</WinUIDSKReferences>
     <EnableMsixTooling>true</EnableMsixTooling>
     <Nullable>enable</Nullable>
   </PropertyGroup>

--- a/dev/VSIX/ProjectTemplates/Desktop/CppWinRT/PackagedApp/BlankApp/ProjectTemplate.vcxproj
+++ b/dev/VSIX/ProjectTemplates/Desktop/CppWinRT/PackagedApp/BlankApp/ProjectTemplate.vcxproj
@@ -21,6 +21,7 @@
     <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
     <WindowsTargetPlatformMinVersion>10.0.17763.0</WindowsTargetPlatformMinVersion>
     <UseWinUI>true</UseWinUI>
+    <WinUISDKReferences>false</WinUISDKReferences>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <ItemGroup Label="ProjectConfigurations">

--- a/dev/VSIX/ProjectTemplates/Desktop/CppWinRT/PackagedApp/WapProj/WapProjTemplate.wapproj
+++ b/dev/VSIX/ProjectTemplates/Desktop/CppWinRT/PackagedApp/WapProj/WapProjTemplate.wapproj
@@ -36,6 +36,7 @@
     <WapProjPath Condition="'$(WapProjPath)'==''">$(MSBuildExtensionsPath)\Microsoft\DesktopBridge\</WapProjPath>
     <DebuggerType>NativeOnly</DebuggerType>
     <BackgroundTaskDebugEngines>NativeOnly</BackgroundTaskDebugEngines>
+    <WinUISDKReferences>false</WinUISDKReferences>
   </PropertyGroup>
 
   <Import Project="$(WapProjPath)\Microsoft.DesktopBridge.props" />

--- a/dev/VSIX/ProjectTemplates/Desktop/CppWinRT/SingleProjectPackagedApp/ProjectTemplate.vcxproj
+++ b/dev/VSIX/ProjectTemplates/Desktop/CppWinRT/SingleProjectPackagedApp/ProjectTemplate.vcxproj
@@ -21,6 +21,7 @@
     <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
     <WindowsTargetPlatformMinVersion>10.0.17763.0</WindowsTargetPlatformMinVersion>
     <UseWinUI>true</UseWinUI>
+    <WinUISDKReferences>false</WinUISDKReferences>
     <EnableMsixTooling>true</EnableMsixTooling>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />

--- a/dev/VSIX/ProjectTemplates/Desktop/CppWinRT/UnitTestApp/ProjectTemplate.vcxproj
+++ b/dev/VSIX/ProjectTemplates/Desktop/CppWinRT/UnitTestApp/ProjectTemplate.vcxproj
@@ -21,6 +21,7 @@
     <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
     <WindowsTargetPlatformMinVersion>10.0.17763.0</WindowsTargetPlatformMinVersion>
     <UseWinUI>true</UseWinUI>
+    <WinUISDKReferences>false</WinUISDKReferences>
     <EnableMsixTooling>true</EnableMsixTooling>
     <ProjectSubType>NativeUnitTestProject</ProjectSubType>
   </PropertyGroup>

--- a/dev/VSIX/ProjectTemplates/Neutral/CppWinRT/RuntimeComponent/ProjectTemplate.vcxproj
+++ b/dev/VSIX/ProjectTemplates/Neutral/CppWinRT/RuntimeComponent/ProjectTemplate.vcxproj
@@ -16,6 +16,7 @@
     <WindowsTargetPlatformMinVersion>$targetplatformminversion$</WindowsTargetPlatformMinVersion>
     <DesktopCompatible>true</DesktopCompatible>
     <UseWinUI>true</UseWinUI>
+    <WinUISDKReferences>false</WinUISDKReferences>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <ItemGroup Label="ProjectConfigurations">


### PR DESCRIPTION
### Resolves: #2425

### Motivation for the change:
* The `WinUISDKReferences` property was added to allow developers with pre-existing projects to opt-in to Hybrid CRT. New projects can use Hybrid CRT (`WinUISDKReferences=false`) by default.

### Changes description:
Sets `WinUISDKReferences` to `false` in the template files. See diff for more details.

### Verification Steps:
Manually verified by:
* Building the VsixExtension solution
* Removing the component template vsixes from the Visual Studio Installer
* Double clicking the Standalone vsix file for each project (which installs them on Visual Studio)
* Built a sample project with each template
* Verified that the C# project `AppxManifest.xml` does not have a reference to `Microsoft.VCLibs.140.00.Debug.UWPDesktop`, while the C++ project does

WARNING:
Comments made by azure-pipelines bot maybe inaccurate.
Please see pipeline link to verify that the build is being ran.

For status checks on the main branch, please use TransportPackage-Foundation-PR
(https://microsoft.visualstudio.com/ProjectReunion/_build?definitionId=81063&_a=summary)
and run the build against your PR branch with the default parameters.
