### PR TITLE
Adding comparator to map and removing lowercasing process names from …

### DIFF
--- a/dev/PushNotifications/PushNotificationsLongRunningTask/ToastRegistrationManager.h
+++ b/dev/PushNotifications/PushNotificationsLongRunningTask/ToastRegistrationManager.h
@@ -1,9 +1,28 @@
-﻿// Copyright (c) Microsoft Corporation and Contributors.
+// Copyright (c) Microsoft Corporation and Contributors.
 // Licensed under the MIT License.
 
 #include <unordered_map>
 #include <algorithm>
 #include <vector>
+
+// Custom case-insensitive hash and equality for std::wstring
+struct CaseInsensitiveWStringHash
+{
+    size_t operator()(const std::wstring& str) const
+    {
+        std::wstring lowerStr = str;
+        std::transform(lowerStr.begin(), lowerStr.end(), lowerStr.begin(), ::towlower);
+        return std::hash<std::wstring>{}(lowerStr);
+    }
+};
+
+struct CaseInsensitiveWStringEqual
+{
+    bool operator()(const std::wstring& left, const std::wstring& right) const
+    {
+        return _wcsicmp(left.c_str(), right.c_str()) == 0;
+    }
+};
 
 class ToastRegistrationManager
 {
@@ -19,6 +38,6 @@ public:
 private:
     winrt::Windows::Storage::ApplicationDataContainer m_toastStorage{ nullptr };
 
-    std::unordered_map<std::wstring, std::wstring> m_registrationMap = {};
+    std::unordered_map<std::wstring, std::wstring, CaseInsensitiveWStringHash, CaseInsensitiveWStringEqual> m_registrationMap = {};
     wil::srwlock m_lock;
 };

--- a/dev/PushNotifications/externs.h
+++ b/dev/PushNotifications/externs.h
@@ -37,6 +37,6 @@ inline std::wstring GetCurrentProcessPath()
 {
     std::wstring processPath{};
     THROW_IF_FAILED(wil::GetModuleFileNameExW(GetCurrentProcess(), nullptr, processPath));
-    std::transform(processPath.begin(), processPath.end(), processPath.begin(), ::towlower);
+    // std::transform(processPath.begin(), processPath.end(), processPath.begin(), ::towlower);
     return processPath;
 };


### PR DESCRIPTION
…externs.h

A microsoft employee must use /azp run to validate using the pipelines below.

WARNING:
Comments made by azure-pipelines bot maybe inaccurate.
Please see pipeline link to verify that the build is being ran.

For status checks on the main branch, please use TransportPackage-Foundation-PR
(https://microsoft.visualstudio.com/ProjectReunion/_build?definitionId=81063&_a=summary)
and run the build against your PR branch with the default parameters.
