### PR TITLE
Bug Fix #5605 - 1.8 exp4: App crashes at DeploymentManager.Initialize();

### DIFF
--- a/dev/Deployment/DeploymentManager.cpp
+++ b/dev/Deployment/DeploymentManager.cpp
@@ -169,7 +169,7 @@ namespace winrt::Microsoft::Windows::ApplicationModel::WindowsAppRuntime::implem
         {
             HRESULT hr = HRESULT_FROM_WIN32(E_UNEXPECTED);
             winrt::hstring message = L"DeploymentManager can only be initialized once and has already been initialized by default. "
-                L"If you would like to explicitly initialize, add <WindowsAppSdkDeploymentManagerInitialize>false</WindowsAppSdkDeploymentManagerInitialize> to your .csproj file.";
+                L"Please either remove your explicit initialization call, or disable auto-initialization by adding <WindowsAppSdkDeploymentManagerInitialize>false</WindowsAppSdkDeploymentManagerInitialize> to your .csproj file.";
             throw winrt::hresult_error(hr, message);
         }
 

--- a/dev/Deployment/DeploymentManager.cpp
+++ b/dev/Deployment/DeploymentManager.cpp
@@ -48,6 +48,7 @@ inline void Initialize_StopSuccessActivity(
 
 namespace winrt::Microsoft::Windows::ApplicationModel::WindowsAppRuntime::implementation
 {
+    static bool isInitializedByDefault{ false };
 
     winrt::Microsoft::Windows::ApplicationModel::WindowsAppRuntime::DeploymentResult DeploymentManager::GetStatus()
     {
@@ -164,6 +165,14 @@ namespace winrt::Microsoft::Windows::ApplicationModel::WindowsAppRuntime::implem
         winrt::Microsoft::Windows::ApplicationModel::WindowsAppRuntime::DeploymentInitializeOptions const& deploymentInitializeOptions,
         bool isRepair)
     {
+        if (isInitializedByDefault)
+        {
+            HRESULT hr = HRESULT_FROM_WIN32(E_UNEXPECTED);
+            winrt::hstring message = L"DeploymentManager can only be initialized once and has already been initialized by default. "
+                L"If you would like to explicitly initialize, add <WindowsAppSdkDeploymentManagerInitialize>false</WindowsAppSdkDeploymentManagerInitialize> to your .csproj file.";
+            throw winrt::hresult_error(hr, message);
+        }
+
         auto& initializeActivityContext{ ::WindowsAppRuntime::Deployment::Activity::Context::Get() };
         const bool isPackagedProcess{ AppModel::Identity::IsPackagedProcess() };
         const int integrityLevel = Security::IntegrityLevel::GetIntegrityLevel();
@@ -231,6 +240,7 @@ namespace winrt::Microsoft::Windows::ApplicationModel::WindowsAppRuntime::implem
         }
 
         // Success!
+        isInitializedByDefault = true;
         return deploymentResult;
     }
 

--- a/dev/Deployment/DeploymentManager.cpp
+++ b/dev/Deployment/DeploymentManager.cpp
@@ -48,7 +48,7 @@ inline void Initialize_StopSuccessActivity(
 
 namespace winrt::Microsoft::Windows::ApplicationModel::WindowsAppRuntime::implementation
 {
-    static bool isInitializedByDefault{ false };
+    static bool isAutoInitialized{ false };
 
     winrt::Microsoft::Windows::ApplicationModel::WindowsAppRuntime::DeploymentResult DeploymentManager::GetStatus()
     {
@@ -165,7 +165,7 @@ namespace winrt::Microsoft::Windows::ApplicationModel::WindowsAppRuntime::implem
         winrt::Microsoft::Windows::ApplicationModel::WindowsAppRuntime::DeploymentInitializeOptions const& deploymentInitializeOptions,
         bool isRepair)
     {
-        if (isInitializedByDefault)
+        if (isAutoInitialized)
         {
             HRESULT hr = HRESULT_FROM_WIN32(E_UNEXPECTED);
             winrt::hstring message = L"DeploymentManager can only be initialized once and has already been initialized by default. "
@@ -240,7 +240,7 @@ namespace winrt::Microsoft::Windows::ApplicationModel::WindowsAppRuntime::implem
         }
 
         // Success!
-        isInitializedByDefault = true;
+        isAutoInitialized = true;
         return deploymentResult;
     }
 


### PR DESCRIPTION
## Summary
This pull request resolves an application crash/fail fast occurring during the call to `DeploymentManager.Initialize()`, as reported in issue #5605. The DeploymentManager initialize is expected to only be called once, but in the case of the issue repro, it is getting called twice. This is because of the explicit call to initialize in the constructor and the default property value for WindowsAppSdkDeploymentManagerInitialize being set to true.

The change corrects error handling in `DeploymentManager.Initialize()` to prevent crash scenarios/fail fast. Instead an exception is thrown that is explanatory on the issue and can be handled by the application. 

## Testing
- The change was tested manually in the repro scenario to observe the new exception being thrown
<img width="789" height="452" alt="image" src="https://github.com/user-attachments/assets/dc8b7e24-924d-4bbf-922a-199ef2b30a03" />
- Pipeline Runs 



-----------------------------------------------------------------------------------------------------------------------------------------
A microsoft employee must use /azp run to validate using the pipelines below.

WARNING:
Comments made by azure-pipelines bot maybe inaccurate.
Please see pipeline link to verify that the build is being ran.

For status checks on the main branch, please use TransportPackage-Foundation-PR
(https://microsoft.visualstudio.com/ProjectReunion/_build?definitionId=81063&_a=summary)
and run the build against your PR branch with the default parameters.
