### PR TITLE
Cherry-pick [stable] Microsoft.Windows.Storage.Pickers APIs (#5649)

### DIFF
--- a/dev/Common/TerminalVelocityFeatures-StoragePickers.xml
+++ b/dev/Common/TerminalVelocityFeatures-StoragePickers.xml
@@ -12,9 +12,5 @@
     <name>Feature_StoragePickers</name>
     <description>StoragePickers for the WindowsAppRuntime</description>
     <state>AlwaysEnabled</state>
-    <alwaysDisabledChannelTokens>
-      <channelToken>Preview</channelToken>
-      <channelToken>Stable</channelToken>
-    </alwaysDisabledChannelTokens>
   </feature>
 </features>

--- a/dev/Interop/StoragePickers/FileOpenPicker.cpp
+++ b/dev/Interop/StoragePickers/FileOpenPicker.cpp
@@ -31,15 +31,6 @@ namespace winrt::Microsoft::Windows::Storage::Pickers::implementation
         PickerCommon::ValidateViewMode(value);
         m_viewMode = value;
     }
-    hstring FileOpenPicker::SettingsIdentifier()
-    {
-        return m_settingsIdentifier;
-    }
-    void FileOpenPicker::SettingsIdentifier(hstring const& value)
-    {
-        PickerCommon::ValidateStringNoEmbeddedNulls(value);
-        m_settingsIdentifier = value;
-    }
     winrt::Microsoft::Windows::Storage::Pickers::PickerLocationId FileOpenPicker::SuggestedStartLocation()
     {
         return m_suggestedStartLocation;
@@ -67,7 +58,6 @@ namespace winrt::Microsoft::Windows::Storage::Pickers::implementation
     {
         parameters.HWnd = winrt::Microsoft::UI::GetWindowFromWindowId(m_windowId);
         parameters.CommitButtonText = m_commitButtonText;
-        parameters.SettingsIdentifierId = m_settingsIdentifier;
         parameters.PickerLocationId = m_suggestedStartLocation;
         parameters.CaptureFilterSpec(m_fileTypeFilter.GetView());
     }

--- a/dev/Interop/StoragePickers/FileOpenPicker.h
+++ b/dev/Interop/StoragePickers/FileOpenPicker.h
@@ -17,9 +17,6 @@ namespace winrt::Microsoft::Windows::Storage::Pickers::implementation
         winrt::Microsoft::Windows::Storage::Pickers::PickerViewMode ViewMode();
         void ViewMode(winrt::Microsoft::Windows::Storage::Pickers::PickerViewMode const& value);
 
-        hstring SettingsIdentifier();
-        void SettingsIdentifier(hstring const& value);
-
         winrt::Microsoft::Windows::Storage::Pickers::PickerLocationId SuggestedStartLocation();
         void SuggestedStartLocation(winrt::Microsoft::Windows::Storage::Pickers::PickerLocationId const& value);
 
@@ -34,7 +31,6 @@ namespace winrt::Microsoft::Windows::Storage::Pickers::implementation
     private:
         winrt::Microsoft::UI::WindowId m_windowId{};
         PickerViewMode m_viewMode{ PickerViewMode::List };
-        winrt::hstring m_settingsIdentifier{};
         PickerLocationId m_suggestedStartLocation{ PickerLocationId::Unspecified };
         winrt::hstring m_commitButtonText{};
 

--- a/dev/Interop/StoragePickers/FileSavePicker.cpp
+++ b/dev/Interop/StoragePickers/FileSavePicker.cpp
@@ -27,15 +27,6 @@ namespace winrt::Microsoft::Windows::Storage::Pickers::implementation
     {
         THROW_HR_IF(E_NOTIMPL, !::Microsoft::Windows::Storage::Pickers::Feature_StoragePickers::IsEnabled());
     }
-    hstring FileSavePicker::SettingsIdentifier()
-    {
-        return m_settingsIdentifier;
-    }
-    void FileSavePicker::SettingsIdentifier(hstring const& value)
-    {
-        PickerCommon::ValidateStringNoEmbeddedNulls(value);
-        m_settingsIdentifier = value;
-    }
     winrt::Microsoft::Windows::Storage::Pickers::PickerLocationId FileSavePicker::SuggestedStartLocation()
     {
         return m_suggestedStartLocation;
@@ -70,19 +61,10 @@ namespace winrt::Microsoft::Windows::Storage::Pickers::implementation
     {
         return m_suggestedSaveFilePath;
     }
-
-    bool FileSavePicker::TrySetSuggestedSaveFilePath(hstring const& filePath)
+    void FileSavePicker::SuggestedSaveFilePath(hstring const& value)
     {
-        auto parseResult = PickerCommon::ParseFolderItemAndFileName(filePath);
-        winrt::com_ptr<IShellItem> folderItem = parseResult.first;
-
-        if (!folderItem)
-        {
-            return false;
-        }
-
-        m_suggestedSaveFilePath = filePath;
-        return true;
+        PickerCommon::ValidateSuggestedSaveFilePath(value);
+        m_suggestedSaveFilePath = value;
     }
 
     hstring FileSavePicker::SuggestedFileName()
@@ -100,7 +82,6 @@ namespace winrt::Microsoft::Windows::Storage::Pickers::implementation
     {
         parameters.HWnd = winrt::Microsoft::UI::GetWindowFromWindowId(m_windowId);
         parameters.CommitButtonText = m_commitButtonText;
-        parameters.SettingsIdentifierId = m_settingsIdentifier;
         parameters.PickerLocationId = m_suggestedStartLocation;
         parameters.SuggestedFileName = m_suggestedFileName;
         parameters.SuggestedSaveFilePath = m_suggestedSaveFilePath;

--- a/dev/Interop/StoragePickers/FileSavePicker.h
+++ b/dev/Interop/StoragePickers/FileSavePicker.h
@@ -15,9 +15,6 @@ namespace winrt::Microsoft::Windows::Storage::Pickers::implementation
     {
         FileSavePicker(winrt::Microsoft::UI::WindowId const& windowId);
 
-        hstring SettingsIdentifier();
-        void SettingsIdentifier(hstring const& value);
-
         winrt::Microsoft::Windows::Storage::Pickers::PickerLocationId SuggestedStartLocation();
         void SuggestedStartLocation(winrt::Microsoft::Windows::Storage::Pickers::PickerLocationId const& value);
 
@@ -30,7 +27,7 @@ namespace winrt::Microsoft::Windows::Storage::Pickers::implementation
         void DefaultFileExtension(hstring const& value);
 
         hstring SuggestedSaveFilePath();
-        bool TrySetSuggestedSaveFilePath(hstring const& filePath);
+        void SuggestedSaveFilePath(hstring const& value);
 
         hstring SuggestedFileName();
         void SuggestedFileName(hstring const& value);
@@ -39,7 +36,6 @@ namespace winrt::Microsoft::Windows::Storage::Pickers::implementation
 
     private:
         winrt::Microsoft::UI::WindowId m_windowId{};
-        hstring m_settingsIdentifier{};
         PickerLocationId m_suggestedStartLocation{ PickerLocationId::Unspecified };
         hstring m_commitButtonText{};
         winrt::Windows::Foundation::Collections::IMap<hstring, winrt::Windows::Foundation::Collections::IVector<hstring>> m_fileTypeChoices{ make<FileTypeChoicesMap>() };

--- a/dev/Interop/StoragePickers/FolderPicker.cpp
+++ b/dev/Interop/StoragePickers/FolderPicker.cpp
@@ -29,15 +29,6 @@ namespace winrt::Microsoft::Windows::Storage::Pickers::implementation
         PickerCommon::ValidateViewMode(value);
         m_viewMode = value;
     }
-    hstring FolderPicker::SettingsIdentifier()
-    {
-        return m_settingsIdentifier;
-    }
-    void FolderPicker::SettingsIdentifier(hstring const& value)
-    {
-        PickerCommon::ValidateStringNoEmbeddedNulls(value);
-        m_settingsIdentifier = value;
-    }
     winrt::Microsoft::Windows::Storage::Pickers::PickerLocationId FolderPicker::SuggestedStartLocation()
     {
         return m_suggestedStartLocation;
@@ -61,7 +52,6 @@ namespace winrt::Microsoft::Windows::Storage::Pickers::implementation
     {
         parameters.HWnd = winrt::Microsoft::UI::GetWindowFromWindowId(m_windowId);
         parameters.CommitButtonText = m_commitButtonText;
-        parameters.SettingsIdentifierId = m_settingsIdentifier;
         parameters.PickerLocationId = m_suggestedStartLocation;
     }
 

--- a/dev/Interop/StoragePickers/FolderPicker.h
+++ b/dev/Interop/StoragePickers/FolderPicker.h
@@ -15,9 +15,6 @@ namespace winrt::Microsoft::Windows::Storage::Pickers::implementation
         winrt::Microsoft::Windows::Storage::Pickers::PickerViewMode ViewMode();
         void ViewMode(winrt::Microsoft::Windows::Storage::Pickers::PickerViewMode const& value);
 
-        hstring SettingsIdentifier();
-        void SettingsIdentifier(hstring const& value);
-
         winrt::Microsoft::Windows::Storage::Pickers::PickerLocationId SuggestedStartLocation();
         void SuggestedStartLocation(winrt::Microsoft::Windows::Storage::Pickers::PickerLocationId const& value);
 
@@ -30,7 +27,6 @@ namespace winrt::Microsoft::Windows::Storage::Pickers::implementation
         winrt::Microsoft::UI::WindowId m_windowId{};
 
         PickerViewMode m_viewMode{ PickerViewMode::List };
-        hstring m_settingsIdentifier{};
         PickerLocationId m_suggestedStartLocation{ PickerLocationId::Unspecified };
         hstring m_commitButtonText{};
         StoragePickersTelemetryHelper m_telemetryHelper{};

--- a/dev/Interop/StoragePickers/Microsoft.Windows.Storage.Pickers.idl
+++ b/dev/Interop/StoragePickers/Microsoft.Windows.Storage.Pickers.idl
@@ -1,14 +1,12 @@
 // Copyright (c) Microsoft Corporation and Contributors.
 // Licensed under the MIT License.
 
-#include <TerminalVelocityFeatures-StoragePickers.h>
 namespace Microsoft.Windows.Storage.Pickers
 {
     [contractversion(1.8)]
     apicontract StoragePickersContract {};
     
     [contract(StoragePickersContract, 1.8)]
-    [feature(Feature_StoragePickers)]
     enum PickerViewMode
     {
         List,
@@ -16,7 +14,6 @@ namespace Microsoft.Windows.Storage.Pickers
     };
 
     [contract(StoragePickersContract, 1.8)]
-    [feature(Feature_StoragePickers)]
     enum PickerLocationId
     {
         DocumentsLibrary,
@@ -31,20 +28,17 @@ namespace Microsoft.Windows.Storage.Pickers
     };
 
     [contract(StoragePickersContract, 1.8)]
-    [feature(Feature_StoragePickers)]
     runtimeclass PickFileResult
     {
         String Path { get; };
     }
 
     [contract(StoragePickersContract, 1.8)]
-    [feature(Feature_StoragePickers)]
     runtimeclass FileOpenPicker
     {
         FileOpenPicker(Microsoft.UI.WindowId windowId);
 
         Microsoft.Windows.Storage.Pickers.PickerViewMode ViewMode;
-        String SettingsIdentifier;
         Microsoft.Windows.Storage.Pickers.PickerLocationId SuggestedStartLocation;
         String CommitButtonText;
         Windows.Foundation.Collections.IVector<String> FileTypeFilter{ get; };
@@ -54,39 +48,32 @@ namespace Microsoft.Windows.Storage.Pickers
     }
 
     [contract(StoragePickersContract, 1.8)]
-    [feature(Feature_StoragePickers)]
     runtimeclass FileSavePicker
     {
         FileSavePicker(Microsoft.UI.WindowId windowId);
 
-        String SettingsIdentifier;
         Microsoft.Windows.Storage.Pickers.PickerLocationId SuggestedStartLocation;
         String CommitButtonText;
         Windows.Foundation.Collections.IMap<String, Windows.Foundation.Collections.IVector<String> > FileTypeChoices{ get; };
         String DefaultFileExtension;
         String SuggestedFileName;
-
-        String SuggestedSaveFilePath{ get; };
-        Boolean TrySetSuggestedSaveFilePath(String filePath);
+        String SuggestedSaveFilePath;
 
         [remote_sync] Windows.Foundation.IAsyncOperation<PickFileResult> PickSaveFileAsync();
     }
 
     [contract(StoragePickersContract, 1.8)]
-    [feature(Feature_StoragePickers)]
     runtimeclass PickFolderResult
     {
         String Path { get; };
     }
 
     [contract(StoragePickersContract, 1.8)]
-    [feature(Feature_StoragePickers)]
     runtimeclass FolderPicker
     {
         FolderPicker(Microsoft.UI.WindowId windowId);
 
         Microsoft.Windows.Storage.Pickers.PickerViewMode ViewMode;
-        String SettingsIdentifier;
         Microsoft.Windows.Storage.Pickers.PickerLocationId SuggestedStartLocation;
         String CommitButtonText;
 

--- a/dev/Interop/StoragePickers/PickerCommon.h
+++ b/dev/Interop/StoragePickers/PickerCommon.h
@@ -28,11 +28,11 @@ namespace PickerCommon {
     void ValidateSuggestedStartLocation(winrt::Microsoft::Windows::Storage::Pickers::PickerLocationId const& value);
     void ValidateSingleFileTypeFilterElement(winrt::hstring const& filter);
     void ValidateSuggestedFileName(winrt::hstring const& suggestedFileName);
+    void ValidateSuggestedSaveFilePath(winrt::hstring const& path);
 
     struct PickerParameters {
         HWND HWnd{};
         winrt::hstring CommitButtonText;
-        winrt::hstring SettingsIdentifierId;
         winrt::Microsoft::Windows::Storage::Pickers::PickerLocationId PickerLocationId;
         std::vector<winrt::hstring> FileTypeFilterData{};
         std::vector<COMDLG_FILTERSPEC> FileTypeFilterPara{};

--- a/test/StoragePickersTests/StoragePickersTests.cpp
+++ b/test/StoragePickersTests/StoragePickersTests.cpp
@@ -145,9 +145,6 @@ namespace Test::StoragePickersTests
             picker.ViewMode(winrt::Microsoft::Windows::Storage::Pickers::PickerViewMode::Thumbnail);
             VERIFY_ARE_EQUAL(picker.ViewMode(), winrt::Microsoft::Windows::Storage::Pickers::PickerViewMode::Thumbnail);
 
-            picker.SettingsIdentifier(L"id");
-            VERIFY_ARE_EQUAL(picker.SettingsIdentifier(), L"id");
-
             picker.SuggestedStartLocation(winrt::Microsoft::Windows::Storage::Pickers::PickerLocationId::DocumentsLibrary);
             VERIFY_ARE_EQUAL(picker.SuggestedStartLocation(), winrt::Microsoft::Windows::Storage::Pickers::PickerLocationId::DocumentsLibrary);
 
@@ -163,15 +160,12 @@ namespace Test::StoragePickersTests
             winrt::Microsoft::UI::WindowId windowId{};
             winrt::Microsoft::Windows::Storage::Pickers::FileSavePicker picker(windowId);
 
-            picker.SettingsIdentifier(L"id");
-            VERIFY_ARE_EQUAL(picker.SettingsIdentifier(), L"id");
-
             picker.SuggestedStartLocation(winrt::Microsoft::Windows::Storage::Pickers::PickerLocationId::DocumentsLibrary);
             VERIFY_ARE_EQUAL(picker.SuggestedStartLocation(), winrt::Microsoft::Windows::Storage::Pickers::PickerLocationId::DocumentsLibrary);
 
-            bool isSuccess = picker.TrySetSuggestedSaveFilePath(L"C:\\MyFile.txt");
-            VERIFY_ARE_EQUAL(isSuccess, true);
-            VERIFY_ARE_EQUAL(picker.SuggestedSaveFilePath(), L"C:\\MyFile.txt");
+            std::filesystem::remove_all(L"C:\\temp_filesavepicker_ut_temp");
+            picker.SuggestedSaveFilePath(L"C:\\temp_filesavepicker_ut_temp\\MyFile.txt");
+            VERIFY_ARE_EQUAL(picker.SuggestedSaveFilePath(), L"C:\\temp_filesavepicker_ut_temp\\MyFile.txt");
 
             picker.CommitButtonText(L"commit");
             VERIFY_ARE_EQUAL(picker.CommitButtonText(), L"commit");
@@ -193,9 +187,6 @@ namespace Test::StoragePickersTests
 
             picker.ViewMode(winrt::Microsoft::Windows::Storage::Pickers::PickerViewMode::Thumbnail);
             VERIFY_ARE_EQUAL(picker.ViewMode(), winrt::Microsoft::Windows::Storage::Pickers::PickerViewMode::Thumbnail);
-
-            picker.SettingsIdentifier(L"id");
-            VERIFY_ARE_EQUAL(picker.SettingsIdentifier(), L"id");
 
             picker.SuggestedStartLocation(winrt::Microsoft::Windows::Storage::Pickers::PickerLocationId::DocumentsLibrary);
             VERIFY_ARE_EQUAL(picker.SuggestedStartLocation(), winrt::Microsoft::Windows::Storage::Pickers::PickerLocationId::DocumentsLibrary);


### PR DESCRIPTION
This PR implements suggestions raised in the official API review of `Microsoft.Windows.Storage.Pickers` APIs (#5634 ).

1. Removal of `SettingsIdentifier` Property.
2. Replace method `TrySetSuggestedSaveFilePath` with the property's own setter.
3. For FileSavePicker, updated underlying logic to ensure that the file name in `SuggestedSaveFilePath` takes precedence over the `SuggestedFileName`, even if the folder of `SuggestedSaveFilePath` does not exists. This is also the existing behavior of UWP pickers ( the `Windows.Storage.Pickers`)
4. Test Additions and Updates.
5. XML and Feature Flag Cleanup.
