### PR TITLE
Revert "fix: MSB8027, two or more files with the same name (#5597)" (…

### DIFF
--- a/build/NuSpecs/WindowsAppSDK-Nuget-Native.AutoInitializer.targets
+++ b/build/NuSpecs/WindowsAppSDK-Nuget-Native.AutoInitializer.targets
@@ -1,25 +1,15 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT License. See LICENSE in the project root for license information. -->
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  
-  <Target Name="SetAutoInitializerPreprocessorDefinitions" BeforeTargets="BeforeClCompile" >
-    <!-- Build the AutoInitializer preprocessor definitions based on conditions -->
-    <PropertyGroup>
-      <AutoInitializerPreprocessorDefinitions></AutoInitializerPreprocessorDefinitions>
-      <AutoInitializerPreprocessorDefinitions Condition="'$(WindowsAppSdkBootstrapInitialize)'=='true'">$(AutoInitializerPreprocessorDefinitions);MICROSOFT_WINDOWSAPPSDK_AUTOINITIALIZE_BOOTSTRAP</AutoInitializerPreprocessorDefinitions>
-      <AutoInitializerPreprocessorDefinitions Condition="'$(WindowsAppSdkDeploymentManagerInitialize)'=='true'">$(AutoInitializerPreprocessorDefinitions);MICROSOFT_WINDOWSAPPSDK_AUTOINITIALIZE_DEPLOYMENTMANAGER</AutoInitializerPreprocessorDefinitions>
-      <AutoInitializerPreprocessorDefinitions Condition="'$(WindowsAppSdkUndockedRegFreeWinRTInitialize)'=='true'">$(AutoInitializerPreprocessorDefinitions);MICROSOFT_WINDOWSAPPSDK_AUTOINITIALIZE_UNDOCKEDREGFREEWINRT</AutoInitializerPreprocessorDefinitions>
-      <AutoInitializerPreprocessorDefinitions Condition="'$(WindowsAppSdkCompatibilityInitialize)'=='true'">$(AutoInitializerPreprocessorDefinitions);MICROSOFT_WINDOWSAPPSDK_AUTOINITIALIZE_COMPATIBILITY</AutoInitializerPreprocessorDefinitions>
-      <!-- Inherit the previous definitions based on condition -->
-      <AutoInitializerPreprocessorDefinitions>$(AutoInitializerPreprocessorDefinitions);%(ClCompile.PreprocessorDefinitions)</AutoInitializerPreprocessorDefinitions>
-    </PropertyGroup>
-  </Target>
 
   <Target Name="WindowsAppRuntimeAutoInitializer">
     <ItemGroup>
       <ClCompile Include="$(MSBuildThisFileDirectory)..\..\include\WindowsAppRuntimeAutoInitializer.cpp">
         <PrecompiledHeader>NotUsing</PrecompiledHeader>
-        <PreprocessorDefinitions>$(AutoInitializerPreprocessorDefinitions)</PreprocessorDefinitions>
+        <PreprocessorDefinitions Condition="'$(WindowsAppSdkBootstrapInitialize)'=='true'">MICROSOFT_WINDOWSAPPSDK_AUTOINITIALIZE_BOOTSTRAP;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+        <PreprocessorDefinitions Condition="'$(WindowsAppSdkDeploymentManagerInitialize)'=='true'">MICROSOFT_WINDOWSAPPSDK_AUTOINITIALIZE_DEPLOYMENTMANAGER;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+        <PreprocessorDefinitions Condition="'$(WindowsAppSdkUndockedRegFreeWinRTInitialize)'=='true'">MICROSOFT_WINDOWSAPPSDK_AUTOINITIALIZE_UNDOCKEDREGFREEWINRT;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+        <PreprocessorDefinitions Condition="'$(WindowsAppSdkCompatibilityInitialize)'=='true'">MICROSOFT_WINDOWSAPPSDK_AUTOINITIALIZE_COMPATIBILITY;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       </ClCompile>
     </ItemGroup>
   </Target>

--- a/build/NuSpecs/WindowsAppSDK-Nuget-Native.Bootstrap.targets
+++ b/build/NuSpecs/WindowsAppSDK-Nuget-Native.Bootstrap.targets
@@ -1,26 +1,17 @@
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 
-    <Target Name="SetBootstrapPreprocessorDefinitions" BeforeTargets="BeforeClCompile" >
-        <PropertyGroup>
-            <!-- Build the Bootstrap preprocessor definitions based on conditions -->
-            <BootstrapPreprocessorDefinitions>MICROSOFT_WINDOWSAPPSDK_BOOTSTRAP_AUTO_INITIALIZE=1</BootstrapPreprocessorDefinitions>
-            <BootstrapPreprocessorDefinitions Condition="'$(WindowsAppSDKBootstrapAutoInitializeOptions_Default)'=='true'">$(BootstrapPreprocessorDefinitions);MICROSOFT_WINDOWSAPPSDK_BOOTSTRAP_AUTO_INITIALIZE_OPTIONS_DEFAULT</BootstrapPreprocessorDefinitions>
-            <BootstrapPreprocessorDefinitions Condition="'$(WindowsAppSDKBootstrapAutoInitializeOptions_None)'=='true'">$(BootstrapPreprocessorDefinitions);MICROSOFT_WINDOWSAPPSDK_BOOTSTRAP_AUTO_INITIALIZE_OPTIONS_NONE</BootstrapPreprocessorDefinitions>
-            <BootstrapPreprocessorDefinitions Condition="'$(WindowsAppSDKBootstrapAutoInitializeOptions_OnError_DebugBreak)'=='true'">$(BootstrapPreprocessorDefinitions);MICROSOFT_WINDOWSAPPSDK_BOOTSTRAP_AUTO_INITIALIZE_OPTIONS_ONERROR_DEBUGBREAK</BootstrapPreprocessorDefinitions>
-            <BootstrapPreprocessorDefinitions Condition="'$(WindowsAppSDKBootstrapAutoInitializeOptions_OnError_DebugBreak_IfDebuggerAttached)'=='true'">$(BootstrapPreprocessorDefinitions);MICROSOFT_WINDOWSAPPSDK_BOOTSTRAP_AUTO_INITIALIZE_OPTIONS_ONERROR_DEBUGBREAK_IFDEBUGGERATTACHED</BootstrapPreprocessorDefinitions>
-            <BootstrapPreprocessorDefinitions Condition="'$(WindowsAppSDKBootstrapAutoInitializeOptions_OnError_FailFast)'=='true'">$(BootstrapPreprocessorDefinitions);MICROSOFT_WINDOWSAPPSDK_BOOTSTRAP_AUTO_INITIALIZE_OPTIONS_ONERROR_FAILFAST</BootstrapPreprocessorDefinitions>
-            <BootstrapPreprocessorDefinitions Condition="'$(WindowsAppSDKBootstrapAutoInitializeOptions_OnNoMatch_ShowUI)'=='true'">$(BootstrapPreprocessorDefinitions);MICROSOFT_WINDOWSAPPSDK_BOOTSTRAP_AUTO_INITIALIZE_OPTIONS_ONNOMATCH_SHOWUI</BootstrapPreprocessorDefinitions>
-            <BootstrapPreprocessorDefinitions Condition="'$(WindowsAppSDKBootstrapAutoInitializeOptions_OnPackageIdentity_NoOp)'=='true'">$(BootstrapPreprocessorDefinitions);MICROSOFT_WINDOWSAPPSDK_BOOTSTRAP_AUTO_INITIALIZE_OPTIONS_ONPACKAGEIDENTITY_NOOP</BootstrapPreprocessorDefinitions>
-            <!-- Inherit the previous definitions based on condition -->
-            <BootstrapPreprocessorDefinitions>$(BootstrapPreprocessorDefinitions);%(ClCompile.PreprocessorDefinitions)</BootstrapPreprocessorDefinitions>
-        </PropertyGroup>
-    </Target>
-
     <Target Name="GenerateBootstrapCpp">
         <ItemGroup>
             <ClCompile Include="$(MSBuildThisFileDirectory)..\..\include\MddBootstrapAutoInitializer.cpp">
                 <PrecompiledHeader>NotUsing</PrecompiledHeader>
-                <PreprocessorDefinitions>$(BootstrapPreprocessorDefinitions)</PreprocessorDefinitions>
+                <PreprocessorDefinitions Condition="'$(WindowsAppSDKBootstrapAutoInitializeOptions_Default)'=='true'">MICROSOFT_WINDOWSAPPSDK_BOOTSTRAP_AUTO_INITIALIZE_OPTIONS_DEFAULT;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+                <PreprocessorDefinitions Condition="'$(WindowsAppSDKBootstrapAutoInitializeOptions_None)'=='true'">MICROSOFT_WINDOWSAPPSDK_BOOTSTRAP_AUTO_INITIALIZE_OPTIONS_NONE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+                <PreprocessorDefinitions Condition="'$(WindowsAppSDKBootstrapAutoInitializeOptions_OnError_DebugBreak)'=='true'">MICROSOFT_WINDOWSAPPSDK_BOOTSTRAP_AUTO_INITIALIZE_OPTIONS_ONERROR_DEBUGBREAK;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+                <PreprocessorDefinitions Condition="'$(WindowsAppSDKBootstrapAutoInitializeOptions_OnError_DebugBreak_IfDebuggerAttached)'=='true'">MICROSOFT_WINDOWSAPPSDK_BOOTSTRAP_AUTO_INITIALIZE_OPTIONS_ONERROR_DEBUGBREAK_IFDEBUGGERATTACHED;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+                <PreprocessorDefinitions Condition="'$(WindowsAppSDKBootstrapAutoInitializeOptions_OnError_FailFast)'=='true'">MICROSOFT_WINDOWSAPPSDK_BOOTSTRAP_AUTO_INITIALIZE_OPTIONS_ONERROR_FAILFAST;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+                <PreprocessorDefinitions Condition="'$(WindowsAppSDKBootstrapAutoInitializeOptions_OnNoMatch_ShowUI)'=='true'">MICROSOFT_WINDOWSAPPSDK_BOOTSTRAP_AUTO_INITIALIZE_OPTIONS_ONNOMATCH_SHOWUI;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+                <PreprocessorDefinitions Condition="'$(WindowsAppSDKBootstrapAutoInitializeOptions_OnPackageIdentity_NoOp)'=='true'">MICROSOFT_WINDOWSAPPSDK_BOOTSTRAP_AUTO_INITIALIZE_OPTIONS_ONPACKAGEIDENTITY_NOOP;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+                <PreprocessorDefinitions>%(PreprocessorDefinitions);MICROSOFT_WINDOWSAPPSDK_BOOTSTRAP_AUTO_INITIALIZE=1</PreprocessorDefinitions>
             </ClCompile>
         </ItemGroup>
     </Target>
@@ -30,4 +21,5 @@
             $(BeforeClCompileTargets); GenerateBootstrapCpp;
         </BeforeClCompileTargets>
     </PropertyGroup>
+
 </Project>


### PR DESCRIPTION
Cherrypick #5658

This reverts commit 6549492b11a86ae54bd4b86daceb753beb53e410, which is causing some internal compiler errors in some builds.

A microsoft employee must use /azp run to validate using the pipelines below.

WARNING:
Comments made by azure-pipelines bot maybe inaccurate.
Please see pipeline link to verify that the build is being ran.

For status checks on the main branch, please use TransportPackage-Foundation-PR
(https://microsoft.visualstudio.com/ProjectReunion/_build?definitionId=81063&_a=summary)
and run the build against your PR branch with the default parameters.
