### PR TITLE
Hide FileSavePicker.SuggestedSaveFilePath

### DIFF
--- a/dev/Interop/StoragePickers/Microsoft.Windows.Storage.Pickers.idl
+++ b/dev/Interop/StoragePickers/Microsoft.Windows.Storage.Pickers.idl
@@ -57,7 +57,6 @@ namespace Microsoft.Windows.Storage.Pickers
         Windows.Foundation.Collections.IMap<String, Windows.Foundation.Collections.IVector<String> > FileTypeChoices{ get; };
         String DefaultFileExtension;
         String SuggestedFileName;
-        String SuggestedSaveFilePath;
 
         [remote_sync] Windows.Foundation.IAsyncOperation<PickFileResult> PickSaveFileAsync();
     }

--- a/test/StoragePickersTests/PickerCommonTests.cpp
+++ b/test/StoragePickersTests/PickerCommonTests.cpp
@@ -79,6 +79,7 @@ namespace Test::PickerCommonTests
 
         }
 
+        /*
         TEST_METHOD(VerifyConfigureFileSaveDialog_WhenSuggestedSaveFilePathFolderDeleted_ExpectItsFileNameStillWork)
         {
             // Arrange.
@@ -124,6 +125,7 @@ namespace Test::PickerCommonTests
             // Even the empty file name of SuggestedSaveFilePath takes precedence over SuggestedFileName.
             VERIFY_IS_NULL(dialogFileName, L"The save dialog's file name should be empty.");
         }
+        */
 
         TEST_METHOD(VerifyFilters_FileOpenPickerWhenFileTypeFiltersDefinedExpectAddingUnionedType)
         {
@@ -277,6 +279,7 @@ namespace Test::PickerCommonTests
             VERIFY_ARE_EQUAL(L"MyFile1.txt", std::wstring(fileName.get()));
         }
 
+        /*
         TEST_METHOD(VerifyFileSaveDialog_SuggestedSaveFilePathTakesPrecedenceOverSuggestedFileName)
         {
             // Arrange.
@@ -299,6 +302,7 @@ namespace Test::PickerCommonTests
             dialog->GetFileName(fileName.put());
             VERIFY_ARE_EQUAL(L"MyFile2.txt", std::wstring(fileName.get()));
         }
+            */
 
         TEST_METHOD(VerifyParseFolderItemAndFileName)
         {
@@ -601,6 +605,7 @@ namespace Test::PickerCommonTests
             }
         }
 
+        /*
         TEST_METHOD(VerifyValidateSuggestedSaveFilePath)
         {
             // Arrange.
@@ -644,6 +649,7 @@ namespace Test::PickerCommonTests
                 }
             }
         }
+            */
 
         std::vector<std::tuple<winrt::hstring, bool>> file_extension_validation_test_cases{
             {L".txt", true},

--- a/test/StoragePickersTests/StoragePickersTests.cpp
+++ b/test/StoragePickersTests/StoragePickersTests.cpp
@@ -163,9 +163,9 @@ namespace Test::StoragePickersTests
             picker.SuggestedStartLocation(winrt::Microsoft::Windows::Storage::Pickers::PickerLocationId::DocumentsLibrary);
             VERIFY_ARE_EQUAL(picker.SuggestedStartLocation(), winrt::Microsoft::Windows::Storage::Pickers::PickerLocationId::DocumentsLibrary);
 
-            std::filesystem::remove_all(L"C:\\temp_filesavepicker_ut_temp");
-            picker.SuggestedSaveFilePath(L"C:\\temp_filesavepicker_ut_temp\\MyFile.txt");
-            VERIFY_ARE_EQUAL(picker.SuggestedSaveFilePath(), L"C:\\temp_filesavepicker_ut_temp\\MyFile.txt");
+            // std::filesystem::remove_all(L"C:\\temp_filesavepicker_ut_temp");
+            // picker.SuggestedSaveFilePath(L"C:\\temp_filesavepicker_ut_temp\\MyFile.txt");
+            // VERIFY_ARE_EQUAL(picker.SuggestedSaveFilePath(), L"C:\\temp_filesavepicker_ut_temp\\MyFile.txt");
 
             picker.CommitButtonText(L"commit");
             VERIFY_ARE_EQUAL(picker.CommitButtonText(), L"commit");


### PR DESCRIPTION
There's an open question regarding the design of SuggestedSaveFilePath during the official API review #5634

Hence hiding this property from preview release.

Related PR on preview-1: #5664 