### PR TITLE
Fixing configuration for MRT

### DIFF
--- a/BuildAll.ps1
+++ b/BuildAll.ps1
@@ -220,9 +220,9 @@ Try {
             {
                 foreach($platformToRun in $platform.Split(","))
                 {
-                    write-host "Building MrtCore.sln for configuration $configurationToRun and platform:$platformToRun"
+                    write-host "Building MrtCore.sln for configuration $configurationForMrtAndAnyCPU and platform:$platformToRun"
                     & $msBuildPath /restore "$MRTSourcesDirectory\mrt\MrtCore.sln" `
-                                    /p:Configuration=$configurationToRun `
+                                    /p:Configuration=$configurationForMrtAndAnyCPU `
                                     /p:Platform=$platformToRun `
                                     /p:PGOBuildMode=$PGOBuildMode `
                                     /binaryLogger:"BuildOutput/binlogs/MrtCore.$platformToRun.$configurationToRun.binlog"


### PR DESCRIPTION
Fixes #5034 

A microsoft employee must use /azp run to validate using the pipelines below.

WARNING:
Comments made by azure-pipelines bot maybe inaccurate.
Please see pipeline link to verify that the build is being ran.

For status checks on the main branch, please use TransportPackage-Foundation-PR
(https://microsoft.visualstudio.com/ProjectReunion/_build?definitionId=81063&_a=summary)
and run the build against your PR branch with the default parameters.
