### PR TITLE
Modify checkout task to job level

### DIFF
--- a/build/AzurePipelinesTemplates/WindowsAppSDK-RunTests-Steps.yml
+++ b/build/AzurePipelinesTemplates/WindowsAppSDK-RunTests-Steps.yml
@@ -7,9 +7,6 @@ parameters:
   testLocale: ''
 
 steps:
-  - checkout: self
-    path: s
-
   - task: powershell@2
     displayName: 'DevCheck: Setup/Verify development environment'
     inputs:
@@ -162,8 +159,6 @@ steps:
         sc.exe queryex te.service | Write-Host
         sc.exe qc te.service | Write-Host
   
-  - checkout: WindowsAppSDKConfig
-
   - task: PowerShell@2
     displayName: 'Run TAEF Tests'
     inputs:

--- a/build/AzurePipelinesTemplates/WindowsAppSDK-RunTestsInPipeline-Job.yml
+++ b/build/AzurePipelinesTemplates/WindowsAppSDK-RunTestsInPipeline-Job.yml
@@ -45,6 +45,10 @@ jobs:
     # at Microsoft.Guardian.CliAnalyzerResponseFileManager.SetupResponseFile(CliAnalyzerConfig analyzeConfig, ToolConfig toolConfig)
     ob_sdl_binskim_enabled: false
   steps:
+    - checkout: self
+      path: s
+    - checkout: WindowsAppSDKConfig
+
     - template: WindowsAppSDK-RunTests-Steps.yml
       parameters:
         buildPlatform: $(buildPlatform)

--- a/build/ProjectReunion-CI.yml
+++ b/build/ProjectReunion-CI.yml
@@ -186,6 +186,10 @@ jobs:
     ob_artifactSuffix: '_$(buildConfiguration)$(buildPlatform)_$(Agent.JobStatus)$(artifactAttempt)'
     ob_artifactBaseName: '$(System.StageName)_$(imageName)'
   steps:
+  - checkout: self
+    path: s
+  - checkout: WindowsAppSDKConfig
+  
   - template: AzurePipelinesTemplates\WindowsAppSDK-RunTests-Steps.yml
     parameters:
       buildPlatform: $(buildPlatform)


### PR DESCRIPTION
In https://github.com/microsoft/WindowsAppSDK/pull/5498, the `checkout` task is added to `WindowsAppSDK-RunTests-Steps.yml`. This PR moves the `checkout` task to the beginning of the job


A microsoft employee must use /azp run to validate using the pipelines below.

WARNING:
Comments made by azure-pipelines bot maybe inaccurate.
Please see pipeline link to verify that the build is being ran.

For status checks on the main branch, please use TransportPackage-Foundation-PR
(https://microsoft.visualstudio.com/ProjectReunion/_build?definitionId=81063&_a=summary)
and run the build against your PR branch with the default parameters.
