### PR TITLE
CP: Update BuildTool.MSIX reference to pick up missing task build error

### DIFF
--- a/dev/WindowsAppRuntime_DLL/packages.config
+++ b/dev/WindowsAppRuntime_DLL/packages.config
@@ -5,5 +5,5 @@
   <package id="Microsoft.SourceLink.GitHub" version="1.1.1" targetFramework="native" developmentDependency="true" />
   <package id="Microsoft.Windows.CppWinRT" version="2.0.230706.1" targetFramework="native" />
   <package id="Microsoft.Windows.ImplementationLibrary" version="1.0.240803.1" targetFramework="native" />
-  <package id="Microsoft.Windows.SDK.BuildTools.MSIX" version="1.7.20250728.1" targetFramework="native" developmentDependency="true" />
+  <package id="Microsoft.Windows.SDK.BuildTools.MSIX" version="1.7.20250806.1" targetFramework="native" developmentDependency="true" />
 </packages>

--- a/eng/Version.Dependencies.xml
+++ b/eng/Version.Dependencies.xml
@@ -35,7 +35,7 @@
   <Dependency Name="Microsoft.Windows.CppWinRT"               Version="2.0.230706.1"/>
   <Dependency Name="Microsoft.Windows.ImplementationLibrary"  Version="1.0.240803.1"/>
   <Dependency Name="Microsoft.Windows.SDK.BuildTools"         Version="10.0.26100.4654"/>
-  <Dependency Name="Microsoft.Windows.SDK.BuildTools.MSIX"    Version="1.7.20250728.1"/>
+  <Dependency Name="Microsoft.Windows.SDK.BuildTools.MSIX"    Version="1.7.20250806.1"/>
   <Dependency Name="Microsoft.WindowsAppSDK"                  Version="1.6.250408002"/>
   <Dependency Name="Microsoft.WindowsAppSDK.Protobuf"         Version="3.21.12"/>
 </Dependencies>


### PR DESCRIPTION
A microsoft employee must use /azp run to validate using the pipelines below.

WARNING:
Comments made by azure-pipelines bot maybe inaccurate.
Please see pipeline link to verify that the build is being ran.

For status checks on the main branch, please use TransportPackage-Foundation-PR
(https://microsoft.visualstudio.com/ProjectReunion/_build?definitionId=81063&_a=summary)
and run the build against your PR branch with the default parameters.
