### PR TITLE
Using lowercase seed so hash gets case insensitive on AppLificycle Association class

### DIFF
--- a/dev/AppLifecycle/Association.cpp
+++ b/dev/AppLifecycle/Association.cpp
@@ -27,7 +27,7 @@ namespace winrt::Microsoft::Windows::AppLifecycle::implementation
         }
 
         // Convert seed to lowercase for case-insensitive hashing
-        std::transform(seed.begin(), seed.end(), seed.begin(), [](wchar_t c) { return std::towlower(c); });
+        std::transform(seed.begin(), seed.end(), seed.begin(), ::towlower);
 
         std::hash<std::wstring> hasher;
         auto hash = hasher(seed);

--- a/dev/AppLifecycle/Association.cpp
+++ b/dev/AppLifecycle/Association.cpp
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft Corporation and Contributors.
+// Copyright (c) Microsoft Corporation and Contributors.
 // Licensed under the MIT License.
 #include <pch.h>
 #include "Association.h"
@@ -25,6 +25,9 @@ namespace winrt::Microsoft::Windows::AppLifecycle::implementation
         {
             seed = wil::GetModuleFileNameW<std::wstring>(nullptr);
         }
+
+        // Convert seed to lowercase for case-insensitive hashing
+        std::transform(seed.begin(), seed.end(), seed.begin(), [](wchar_t c) { return std::towlower(c); });
 
         std::hash<std::wstring> hasher;
         auto hash = hasher(seed);


### PR DESCRIPTION
A microsoft employee must use /azp run to validate using the pipelines below.
Fixes #3521 

WARNING:
Comments made by azure-pipelines bot maybe inaccurate.
Please see pipeline link to verify that the build is being ran.

For status checks on the main branch, please use TransportPackage-Foundation-PR
(https://microsoft.visualstudio.com/ProjectReunion/_build?definitionId=81063&_a=summary)
and run the build against your PR branch with the default parameters.
