### PR TITLE
[FixBuildBreak][1.6] Adding explicit install of Windows SDK 22000 to the BuildInstaller stage

### DIFF
--- a/build/AzurePipelinesTemplates/WindowsAppSDK-BuildInstaller-Stage.yml
+++ b/build/AzurePipelinesTemplates/WindowsAppSDK-BuildInstaller-Stage.yml
@@ -31,4 +31,16 @@ stages:
       foundationRepoPath: ""
     condition: ne(variables.LatestOfficialBuildID, '')
     steps:
+    # The MMS2022 image used to come with Windows SDK 10.0.22000, but not any more.
+    - task: PowerShell@2
+      displayName: 'Add Windows SDK 10.0.22000'
+      env:
+        SYSTEM_ACCESSTOKEN: $(System.AccessToken)
+      inputs:
+        targetType: filePath
+        filePath: $(Build.SourcesDirectory)\build\scripts\windows-sdk.ps1
+        # TODO: the SdkVersion parameter does not yet support arbitrary versions.
+        arguments: >
+          -SdkVersion "10.0.22000"
+
     - template: WindowsAppSDK-BuildInstaller-Steps.yml@self

--- a/build/scripts/windows-sdk.ps1
+++ b/build/scripts/windows-sdk.ps1
@@ -3,7 +3,7 @@
 #
 
 param(
-    # TODO: Use version
+    # TODO: Use version, currently hardwire to only support 2 specific versions.
     [string]$SdkVersion = $null
 )
 
@@ -51,8 +51,6 @@ function Install-EXE
     }
 }
 
-
-
 $ErrorCodes = Data {
     ConvertFrom-StringData @'
     Success = 0
@@ -83,26 +81,48 @@ function PrintMessageAndExit($Message, $ReturnCode)
 # Main execution sequence
 #
 
-# Requires Windows SDK with the same version number as the WDK
-$winSdkUrl = "https://go.microsoft.com/fwlink/p/?LinkID=2023014"
-$wdkUrl = "https://go.microsoft.com/fwlink/?linkid=2026156"
-
-# `winsdksetup.exe /features + /quiet` installs all features without showing the GUI
-$sdkExitCode = Install-EXE -Url $winSdkUrl -Name "winsdksetup.exe" -ArgumentList ("/features", "+", "/quiet")
-
-if ($sdkExitCode -ne 0)
+if ($SdkVersion -eq "10.1.17763")
 {
-    Write-Host "Failed to install the Windows SDK."
-    exit $sdkExitCode
+    # Requires Windows SDK with the same version number as the WDK
+    $winSdkUrl = "https://go.microsoft.com/fwlink/p/?LinkID=2023014"
+    $wdkUrl = "https://go.microsoft.com/fwlink/?linkid=2026156"
+    
+    # `winsdksetup.exe /features + /quiet` installs all features without showing the GUI
+    $sdkExitCode = Install-EXE -Url $winSdkUrl -Name "winsdksetup.exe" -ArgumentList ("/features", "+", "/quiet")
+    
+    if ($sdkExitCode -ne 0)
+    {
+        Write-Host "Failed to install the Windows SDK."
+        exit $sdkExitCode
+    }
+    
+    # `wdksetup.exe /features + /quiet` installs all features without showing the GUI
+    $wdkExitCode = Install-EXE -Url $wdkUrl -Name "wdksetup.exe" -ArgumentList ("/features", "+", "/quiet")
+    
+    if ($wdkExitCode -ne 0)
+    {
+        Write-Host "Failed to install the Windows Driver Kit."
+        exit $wdkExitCode
+    }
 }
-
-# `wdksetup.exe /features + /quiet` installs all features without showing the GUI
-$wdkExitCode = Install-EXE -Url $wdkUrl -Name "wdksetup.exe" -ArgumentList ("/features", "+", "/quiet")
-
-if ($wdkExitCode -ne 0)
+elseif ($SdkVersion -eq "10.0.22000")
 {
-    Write-Host "Failed to install the Windows Driver Kit."
-    exit $wdkExitCode
+    # Install Windows SDK for Windows 11 (10.0.22000.194).
+    # Link came from https://developer.microsoft.com/en-us/windows/downloads/sdk-archive/index-legacy.
+    $winSdk22000Url = "https://go.microsoft.com/fwlink/?linkid=2173743"
+
+    # `winsdksetup.exe /features + /quiet` installs all features without showing the GUI
+    $sdkExitCode = Install-EXE -Url $winSdk22000Url -Name "winsdksetup.exe" -ArgumentList ("/features", "+", "/quiet")
+
+    if ($sdkExitCode -ne 0)
+    {
+        Write-Host "Failed to install the Windows SDK."
+        exit $sdkExitCode
+    }
+}
+else
+{
+    Write-Host -Object "WARNING: The supplied SdkVersion is current unsupported : $SdkVersion."
 }
 
 Write-Host "Done"


### PR DESCRIPTION
Updating 1.6-stable's BuildInstaller stage to explicitly install Windows SDK 22000 in a pipeline run, because this version is no longer included in VS 2022. 
The script windows-sdk.ps1, which already installs another version of the Windows SDK, is now upgraded to support installing 2 different version of the Windows SDK.

////////
A microsoft employee must use /azp run to validate using the pipelines below.

WARNING:
Comments made by azure-pipelines bot maybe inaccurate.
Please see pipeline link to verify that the build is being ran.

For status checks on the main branch, please use TransportPackage-Foundation-PR
(https://microsoft.visualstudio.com/ProjectReunion/_build?definitionId=81063&_a=summary)
and run the build against your PR branch with the default parameters.
