### PR TITLE
Fix race with /external github trigger

### DIFF
--- a/.github/policies/resourceManagement.yml
+++ b/.github/policies/resourceManagement.yml
@@ -296,6 +296,9 @@ configuration:
       - hasLabel:
           label: area-External
       - isOpen
+      - commentContains:
+          pattern: '\/[E|e]xternal'
+          isRegex: True
       then:
       - closeIssue
 


### PR DESCRIPTION
A microsoft employee must use /azp run to validate using the pipelines below.

WARNING:
Comments made by azure-pipelines bot maybe inaccurate.
Please see pipeline link to verify that the build is being ran.

For status checks on the main branch, please use TransportPackage-Foundation-PR
(https://microsoft.visualstudio.com/ProjectReunion/_build?definitionId=81063&_a=summary)
and run the build against your PR branch with the default parameters.
