### PR TITLE
Allow ApplicationLanguages.PrimaryLanguageOverride to be unset

### DIFF
--- a/dev/MRTCore/mrt/Microsoft.Windows.ApplicationModel.Resources/TestCommon/CommonTestCode.cs
+++ b/dev/MRTCore/mrt/Microsoft.Windows.ApplicationModel.Resources/TestCommon/CommonTestCode.cs
@@ -585,4 +585,23 @@ namespace CommonTestCode
             Verify.IsNull(resourceCandidate);
         }
     }
+
+    public class ApplicationLanguagesTest
+    {
+        public static void PrimaryLanguageOverrideAcceptsEmptyStringTest()
+        {
+            ApplicationLanguages.PrimaryLanguageOverride = "fr-FR";
+            ApplicationLanguages.PrimaryLanguageOverride = "";
+
+            Verify.AreEqual(ApplicationLanguages.PrimaryLanguageOverride, "");
+        }
+
+        public static void PrimaryLanguageOverrideAcceptsNullStringTest()
+        {
+            ApplicationLanguages.PrimaryLanguageOverride = "fr-FR";
+            ApplicationLanguages.PrimaryLanguageOverride = null;
+
+            Verify.AreEqual(ApplicationLanguages.PrimaryLanguageOverride, ""); // C# projection of null HSTRING is empty string
+        }
+    }
 }

--- a/dev/MRTCore/mrt/Microsoft.Windows.ApplicationModel.Resources/src/ApplicationLanguages.cpp
+++ b/dev/MRTCore/mrt/Microsoft.Windows.ApplicationModel.Resources/src/ApplicationLanguages.cpp
@@ -41,7 +41,7 @@ namespace winrt::Microsoft::Windows::Globalization::implementation
 
     void ApplicationLanguages::PrimaryLanguageOverride(hstring const& language)
     {
-        bool isValidLanguageTag = IsWellFormedTag(language.c_str());
+        bool isValidLanguageTag = language.empty() || IsWellFormedTag(language.c_str());
 
         THROW_HR_IF_MSG(E_INVALIDARG, !isValidLanguageTag, "The parameter is incorrect");
 

--- a/dev/MRTCore/mrt/Microsoft.Windows.ApplicationModel.Resources/unittests/UnitTest.cs
+++ b/dev/MRTCore/mrt/Microsoft.Windows.ApplicationModel.Resources/unittests/UnitTest.cs
@@ -165,4 +165,20 @@ namespace ManagedTest
             CommonTestCode.ResourceContextTest.NoResourceFileWithContextTest();
         }
     }
+
+    [TestClass]
+    public class ApplicationLanguagesTest
+    {
+        [TestMethod]
+        public void PrimaryLanguageOverrideAcceptsEmptyStringTest()
+        {
+            CommonTestCode.ApplicationLanguagesTest.PrimaryLanguageOverrideAcceptsEmptyStringTest();
+        }
+
+        [TestMethod]
+        public void PrimaryLanguageOverrideAcceptsNullStringTest()
+        {
+            CommonTestCode.ApplicationLanguagesTest.PrimaryLanguageOverrideAcceptsNullStringTest();
+        }
+    }
 }


### PR DESCRIPTION
Fixes https://github.com/microsoft/WindowsAppSDK/issues/5335

A microsoft employee must use /azp run to validate using the pipelines below.

WARNING:
Comments made by azure-pipelines bot maybe inaccurate.
Please see pipeline link to verify that the build is being ran.

For status checks on the main branch, please use TransportPackage-Foundation-PR
(https://microsoft.visualstudio.com/ProjectReunion/_build?definitionId=81063&_a=summary)
and run the build against your PR branch with the default parameters.
