### PR TITLE
[Cherry-pick] [1.8-stable] add 'All Files' label for the summarizing filter

### DIFF
--- a/dev/Interop/StoragePickers/PickerCommon.cpp
+++ b/dev/Interop/StoragePickers/PickerCommon.cpp
@@ -320,7 +320,7 @@ namespace PickerCommon {
         }
         else
         {
-            FileTypeFilterData.push_back(L"");
+            FileTypeFilterData.push_back(AllFilesText);
             FileTypeFilterData.push_back(allFilesExtensionList.c_str());
         }
 


### PR DESCRIPTION
Cherry-pick from #5699

### Description
This PR is a minor fix - adding the "All Files" label for the summarizing filter of FileOpenPicker.

This label was removed before due to the lack of localization (#5434 ), but didn't add back when the localization is achieved (#5495 ).

### Before fix
<img width="354" height="141" alt="image" src="https://github.com/user-attachments/assets/7e4b942e-bb8b-4601-8dfd-679450f6c0f4" />


### After fix
<img width="400" height="188" alt="image" src="https://github.com/user-attachments/assets/735a1abf-9f16-4416-93a3-9eb19e0fb44a" />
