### PR TITLE
Bug 58790285: [WinAppSDK] The "PipelineTests Win10_Ent_LTSC_2021_x64chk" test job in the Foundation nightly pipeline has been failing since Aug 13

### DIFF
--- a/test/BypassTests.json
+++ b/test/BypassTests.json
@@ -1538,5 +1538,15 @@
   "release_x64_Win10_rs5_DC.Test::AppLifecycle::FunctionalTests::SingleInstanceTest_Win32",
   "release_x64_Win10_rs5_DC.Test::AppLifecycle::FunctionalTests::SingleInstanceTest_PackagedWin32",
   "release_x64_Win10_rs5_DC.Test::AppLifecycle::FunctionalTests::RequestRestart_Win32",
-  "release_x64_Win10_rs5_DC.Test::AppLifecycle::FunctionalTests::RequestRestart_PackagedWin32"
+  "release_x64_Win10_rs5_DC.Test::AppLifecycle::FunctionalTests::RequestRestart_PackagedWin32",
+  "release_x64_Windows.10.Enterprise.LTSC.2021.Test::DynamicDependency::Test_WinRT::Create_Delete",
+  "release_x64_Windows.10.Enterprise.LTSC.2021.Test::DynamicDependency::Test_WinRT::FullLifecycle_ProcessLifetime_Framework_WindowsAppRuntime",
+  "release_x64_Windows.10.Enterprise.LTSC.2021.Test::DynamicDependency::Test_WinRT::FullLifecycle_ProcessLifetime_Frameworks_WindowsAppRuntime_MathAdd",
+  "release_x64_Windows.10.Enterprise.LTSC.2021.Test::DynamicDependency::Test_WinRT::FullLifecycle_FilePathLifetime_Frameworks_WindowsAppRuntime_MathAdd",
+  "release_x64_Windows.10.Enterprise.LTSC.2021.Test::DynamicDependency::Test_WinRT::FullLifecycle_RegistryLifetime_Frameworks_WindowsAppRuntime_MathAdd",
+  "release_x64_Windows.10.Enterprise.LTSC.2021.Test::DynamicDependency::Test_WinRT::Add_Rank_A0_B10",
+  "release_x64_Windows.10.Enterprise.LTSC.2021.Test::DynamicDependency::Test_WinRT::Add_Rank_B0prepend_A0",
+  "release_x64_Windows.10.Enterprise.LTSC.2021.Test::DynamicDependency::Test_WinRT::Add_Rank_Bneg10_A0",
+  "release_x64_Windows.10.Enterprise.LTSC.2021.Test::DynamicDependency::Test_WinRT::Create_DoNotVerifyDependencyResolution",
+  "release_x64_Windows.10.Enterprise.LTSC.2021.Test::DynamicDependency::Test_WinRT::Create_Add_Architectures_Current"
 ]


### PR DESCRIPTION
The current workaround for this this problem is to revert to the last known version of the Win10_Ent_LTSC_2021 image (in use before Aug 13). This is undesirable for various reasons. 
Given that the set of new test cases that are failing after the image update is relatively small, 11 to be specific, and they are all DynamicDependency tests, and they all seem to fail in the same  manner, a more targeted workaround is to add these test cases to the BypassTests.json list, which already contains the 11 failed DynDep test cases, but for RS5 instead.
Once these changes are merged, we can try to resume testing with the latest version of the Win10_Ent_LTSC_2021 image.

////
A microsoft employee must use /azp run to validate using the pipelines below.

WARNING:
Comments made by azure-pipelines bot maybe inaccurate.
Please see pipeline link to verify that the build is being ran.

For status checks on the main branch, please use TransportPackage-Foundation-PR
(https://microsoft.visualstudio.com/ProjectReunion/_build?definitionId=81063&_a=summary)
and run the build against your PR branch with the default parameters.
