### PR TITLE
[CP to 1.8] Bug 58790285: [WinAppSDK] The "PipelineTests Win10_Ent_LTSC_2021_x64chk" test job in the Foundation nightly pipeline has been failing since Aug 13

### DIFF
--- a/test/BypassTests.json
+++ b/test/BypassTests.json
@@ -1525,5 +1525,15 @@
   "release_x86_Windows.Server.2019.DataCenter.zh-CN.Test::Decimal::Tests::DecimalTests::from_zstring_view_localename_system",
   "release_x86_Windows.Server.2019.DataCenter.zh-CN.Test::Decimal::Tests::DecimalTests::from_zwstring_view",
   "release_x86_Windows.Server.2019.DataCenter.zh-CN.Test::Decimal::Tests::DecimalTests::from_zwstring_view_invariant",
-  "release_x86_Windows.Server.2019.DataCenter.zh-CN.Test::Decimal::Tests::DecimalTests::from_zwstring_view_localename_system"
+  "release_x86_Windows.Server.2019.DataCenter.zh-CN.Test::Decimal::Tests::DecimalTests::from_zwstring_view_localename_system",
+  "release_x64_Windows.10.Enterprise.LTSC.2021.Test::DynamicDependency::Test_WinRT::Create_Delete",
+  "release_x64_Windows.10.Enterprise.LTSC.2021.Test::DynamicDependency::Test_WinRT::FullLifecycle_ProcessLifetime_Framework_WindowsAppRuntime",
+  "release_x64_Windows.10.Enterprise.LTSC.2021.Test::DynamicDependency::Test_WinRT::FullLifecycle_ProcessLifetime_Frameworks_WindowsAppRuntime_MathAdd",
+  "release_x64_Windows.10.Enterprise.LTSC.2021.Test::DynamicDependency::Test_WinRT::FullLifecycle_FilePathLifetime_Frameworks_WindowsAppRuntime_MathAdd",
+  "release_x64_Windows.10.Enterprise.LTSC.2021.Test::DynamicDependency::Test_WinRT::FullLifecycle_RegistryLifetime_Frameworks_WindowsAppRuntime_MathAdd",
+  "release_x64_Windows.10.Enterprise.LTSC.2021.Test::DynamicDependency::Test_WinRT::Add_Rank_A0_B10",
+  "release_x64_Windows.10.Enterprise.LTSC.2021.Test::DynamicDependency::Test_WinRT::Add_Rank_B0prepend_A0",
+  "release_x64_Windows.10.Enterprise.LTSC.2021.Test::DynamicDependency::Test_WinRT::Add_Rank_Bneg10_A0",
+  "release_x64_Windows.10.Enterprise.LTSC.2021.Test::DynamicDependency::Test_WinRT::Create_DoNotVerifyDependencyResolution",
+  "release_x64_Windows.10.Enterprise.LTSC.2021.Test::DynamicDependency::Test_WinRT::Create_Add_Architectures_Current"
 ]


### PR DESCRIPTION
Due to merge conflict, manually cherry picking the following to 1.8:
- [https://github.com/microsoft/WindowsAppSDK/pull/5735](https://github.com/microsoft/WindowsAppSDK/pull/5735)

////

A microsoft employee must use /azp run to validate using the pipelines below.

WARNING:
Comments made by azure-pipelines bot maybe inaccurate.
Please see pipeline link to verify that the build is being ran.

For status checks on the main branch, please use TransportPackage-Foundation-PR
(https://microsoft.visualstudio.com/ProjectReunion/_build?definitionId=81063&_a=summary)
and run the build against your PR branch with the default parameters.
