### PR TITLE
[CP to 1.8] Bug 58790285: [WinAppSDK] Adding 1 more DynDep test to BypassTests.json for Win10_Ent_LTSC_2021

### DIFF
--- a/test/BypassTests.json
+++ b/test/BypassTests.json
@@ -1535,5 +1535,6 @@
   "release_x64_Windows.10.Enterprise.LTSC.2021.Test::DynamicDependency::Test_WinRT::Add_Rank_B0prepend_A0",
   "release_x64_Windows.10.Enterprise.LTSC.2021.Test::DynamicDependency::Test_WinRT::Add_Rank_Bneg10_A0",
   "release_x64_Windows.10.Enterprise.LTSC.2021.Test::DynamicDependency::Test_WinRT::Create_DoNotVerifyDependencyResolution",
+  "release_x64_Windows.10.Enterprise.LTSC.2021.Test::DynamicDependency::Test_WinRT::Create_Add_Architectures_Explicit",
   "release_x64_Windows.10.Enterprise.LTSC.2021.Test::DynamicDependency::Test_WinRT::Create_Add_Architectures_Current"
 ]


### PR DESCRIPTION
Testing on Win10_Ent_LTSC_2021 v85.0.0 revealed that we need to add 1 more DynDep test to BypassTests.json for Win10_Ent_LTSC_2021.

////
A microsoft employee must use /azp run to validate using the pipelines below.

WARNING:
Comments made by azure-pipelines bot maybe inaccurate.
Please see pipeline link to verify that the build is being ran.

For status checks on the main branch, please use TransportPackage-Foundation-PR
(https://microsoft.visualstudio.com/ProjectReunion/_build?definitionId=81063&_a=summary)
and run the build against your PR branch with the default parameters.
