### PR TITLE
Task 47803694: Fix psscriptanalyzer: MissingStatementBlock warning in Foundation pipeline

### DIFF
--- a/dev/MRTCore/build/DownloadDotNetCoreSdk.ps1
+++ b/dev/MRTCore/build/DownloadDotNetCoreSdk.ps1
@@ -13,7 +13,7 @@ $repoInstallDir  = [System.IO.Path]::GetFullPath("$PSScriptRoot\..\.dotnet")
 $filename = "$PSScriptRoot\..\..\..\eng\Versions.Dependencies.props"
 $xml = [xml](Get-Content $filename -EA:Stop)
 $dotNotSdkVersion = $xml.SelectSingleNode("/Dependencies/ToolsetDependencies/Dependency[@Name='CsWinRT.Dependency.DotNetCoreSdk']").Version
-$dotNotSdkVersionLkg = if (-not $skipLKG) $dotNotSdkVersion
+$dotNotSdkVersionLkg = if (-not $skipLKG) { $dotNotSdkVersion }
 
 if ($version -ne "")
 {


### PR DESCRIPTION
Fixed a psscriptanalyzer: MissingStatementBlock issue.
How verified:
- A private pipeline run confirmed that the issue is fixed with the changes in this PR

////
A microsoft employee must use /azp run to validate using the pipelines below.

WARNING:
Comments made by azure-pipelines bot maybe inaccurate.
Please see pipeline link to verify that the build is being ran.

For status checks on the main branch, please use TransportPackage-Foundation-PR
(https://microsoft.visualstudio.com/ProjectReunion/_build?definitionId=81063&_a=summary)
and run the build against your PR branch with the default parameters.
