### PR TITLE
Enabling AppNotification builder tests

### DIFF
--- a/test/AppNotificationBuilderTests/APITests.cpp
+++ b/test/AppNotificationBuilderTests/APITests.cpp
@@ -2,6 +2,7 @@
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
 #include "pch.h"
+#include "MddWin11.h"
 
 namespace winrt
 {
@@ -37,8 +38,17 @@ namespace Test::AppNotification::Builder
         {
 
             ::Test::Bootstrap::SetupBootstrap();
-            ::WindowsAppRuntime::VersionInfo::TestInitialize(::Test::Bootstrap::TP::WindowsAppRuntimeFramework::c_PackageFamilyName,
-                ::Test::Bootstrap::TP::WindowsAppRuntimeMain::c_PackageFamilyName);
+            
+            PCWSTR testFrameworkPackageFamilyName{ ::Test::Bootstrap::TP::WindowsAppRuntimeFramework::c_PackageFamilyName };
+            PCWSTR testMainPackageFamilyName{ ::Test::Bootstrap::TP::WindowsAppRuntimeMain::c_PackageFamilyName };
+
+            // For Windows 11 newer versions, the TestInitialize will fail fast if we pass a non null package family name.
+            if (MddCore::Win11::IsSupported())
+            {
+                testMainPackageFamilyName = nullptr;
+            }
+
+            ::WindowsAppRuntime::VersionInfo::TestInitialize(testFrameworkPackageFamilyName, testMainPackageFamilyName);
             return true;
         }
 

--- a/test/AppNotificationBuilderTests/APITests.cpp
+++ b/test/AppNotificationBuilderTests/APITests.cpp
@@ -43,6 +43,7 @@ namespace Test::AppNotification::Builder
             PCWSTR testMainPackageFamilyName{ ::Test::Bootstrap::TP::WindowsAppRuntimeMain::c_PackageFamilyName };
 
             // For Windows 11 newer versions, the TestInitialize will fail fast if we pass a non null package family name.
+            // https://github.com/microsoft/WindowsAppSDK/blob/main/dev/Common/WindowsAppRuntime.VersionInfo.cpp#L123-L133
             if (MddCore::Win11::IsSupported())
             {
                 testMainPackageFamilyName = nullptr;

--- a/test/AppNotificationBuilderTests/AppNotificationBuilderTests.testdef
+++ b/test/AppNotificationBuilderTests/AppNotificationBuilderTests.testdef
@@ -1,0 +1,11 @@
+{
+    "Tests": [
+        {
+            "Description": "App Notification Builder Tests",
+            "Filename": "AppNotificationBuilderTests.dll",
+            "Parameters": "",
+            "Architectures": ["x64", "x86", "arm64"],
+            "Status": "Enabled"
+        }
+    ]
+}

--- a/test/AppNotificationBuilderTests/AppNotificationBuilderTests.vcxproj
+++ b/test/AppNotificationBuilderTests/AppNotificationBuilderTests.vcxproj
@@ -143,6 +143,7 @@
   <Target Name="CopyFiles" AfterTargets="AfterBuild">
     <Copy SkipUnchangedFiles="true" SourceFiles="$(OutDir)\..\WindowsAppRuntime_BootstrapDLL\Microsoft.WindowsAppRuntime.Bootstrap.dll" DestinationFolder="$(OutDir)" />
     <Copy SkipUnchangedFiles="true" SourceFiles="$(OutDir)\..\WindowsAppRuntime_DLL\Microsoft.Internal.FrameworkUdk.dll" DestinationFolder="$(OutDir)" />
+    <Copy SkipUnchangedFiles="true" SourceFiles="AppNotificationBuilderTests.testdef" DestinationFolder="$(OutDir)" />
   </Target>
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>


### PR DESCRIPTION
This PR enables the App Notification Builder tests, with a small fix for adapting to the Win11 TestInitialize requirements.

A microsoft employee must use /azp run to validate using the pipelines below.

WARNING:
Comments made by azure-pipelines bot maybe inaccurate.
Please see pipeline link to verify that the build is being ran.

For status checks on the main branch, please use TransportPackage-Foundation-PR
(https://microsoft.visualstudio.com/ProjectReunion/_build?definitionId=81063&_a=summary)
and run the build against your PR branch with the default parameters.
