### PR TITLE
change dev package suffix

### DIFF
--- a/build/AzurePipelinesTemplates/WindowsAppSDK-PackTransportPackage-Stage.yml
+++ b/build/AzurePipelinesTemplates/WindowsAppSDK-PackTransportPackage-Stage.yml
@@ -187,6 +187,13 @@ stages:
           $buildType = '$(channel)'
           $majorMinorPatchRev = '$(MajorVersion).$(MinorVersion).$(versionMinDate)'
           $majorMinorPatchRev = $majorMinorPatchRev + $paddedRevision
+          
+          if ($env:ComponentType)
+          {
+            Write-Host "componentType " $env:ComponentType
+            $majorMinorPatchRev = $majorMinorPatchRev + $env:ComponentType
+          }
+          
           $version = $majorMinorPatchRev + '-' + $buildType
 
           # If using release versioning, drop the version suffix, which includes a tag & build stamp.


### PR DESCRIPTION
<img width="568" height="482" alt="image" src="https://github.com/user-attachments/assets/15a4c694-c608-4bc1-8237-0f1342b7bbdb" />

Use ComponentType as a suffix for dev pipeline, to make sure the component package version won't conflict with nightly build.
And with the config in -dev pipeline, we could get 2 packages like this
<img width="788" height="175" alt="image" src="https://github.com/user-attachments/assets/0cd1ea67-1cbc-40e5-b9d3-e2c4bf9a47c3" />

A microsoft employee must use /azp run to validate using the pipelines below.

WARNING:
Comments made by azure-pipelines bot maybe inaccurate.
Please see pipeline link to verify that the build is being ran.

For status checks on the main branch, please use TransportPackage-Foundation-PR
(https://microsoft.visualstudio.com/ProjectReunion/_build?definitionId=81063&_a=summary)
and run the build against your PR branch with the default parameters.
