### PR TITLE
Zero Detours if Detours isn't needed

### DIFF
--- a/dev/DynamicDependency/API/MddDetourPackageGraph.cpp
+++ b/dev/DynamicDependency/API/MddDetourPackageGraph.cpp
@@ -110,10 +110,22 @@ HRESULT WINAPI DynamicGetPackageGraphRevisionId();
 
 typedef UINT32 (WINAPI* GetPackageGraphRevisionIdFunction)();
 
+static bool MddUseOSImplementation()
+{
+    // Use the Win11 APIs if available (instead of Detour'ing to our own implementation)
+    return MddCore::Win11::IsSupported();
+}
+
+bool MddNeedsDetours() noexcept
+{
+    // Detour to our own implementation if Windows doesn't provide a sufficient implementation
+    return !MddUseOSImplementation();
+}
+
 HRESULT WINAPI MddDetourPackageGraphInitialize() noexcept
 {
     // Use the Win11 APIs if available (instead of Detour'ing to our own implementation)
-    if (MddCore::Win11::IsSupported())
+    if (MddUseOSImplementation())
     {
         RETURN_IF_FAILED(MddWin11Initialize());
         return S_OK;

--- a/dev/DynamicDependency/API/MddDetourPackageGraph.h
+++ b/dev/DynamicDependency/API/MddDetourPackageGraph.h
@@ -6,6 +6,8 @@
 
 #include "appmodel_msixdynamicdependency.h"
 
+bool MddNeedsDetours() noexcept;
+
 HRESULT WINAPI MddDetourPackageGraphInitialize() noexcept;
 
 void WINAPI MddDetourPackageGraphShutdown() noexcept;

--- a/dev/UndockedRegFreeWinRT/urfw.cpp
+++ b/dev/UndockedRegFreeWinRT/urfw.cpp
@@ -405,29 +405,25 @@ HRESULT ExtRoLoadCatalog()
     return S_OK;
 }
 
+static bool UrfwUseOSImplementation() noexcept
+{
+    // Delegate to the OS' implementation on >= Windows 11 24H1
+    return WindowsVersion::IsWindows11_24H1OrGreater();
+}
+
+bool UrfwNeedsDetours() noexcept
+{
+    // Detour to our own implementation if Windows doesn't provide a sufficient implementation
+    return !UrfwUseOSImplementation();
+}
+
 HRESULT UrfwInitialize() noexcept
 {
-#if defined(TODO_URFW_DELEGATE_TO_OS_19H1PLUS)
-    // Windows' Reg-Free WinRT first appeared in Windows 10 Version 1903, May 2019 Update (aka 19H1)
-    // https://blogs.windows.com/windowsdeveloper/2019/04/30/enhancing-non-packaged-desktop-apps-using-windows-runtime-components/
-    // Delegate to the OS' implementation when available
-    if (WindowsVersion::IsWindows10_19H1OrGreater())
+    // Delegate to the OS' implementation if we can
+    if (UrfwUseOSImplementation())
     {
         return S_OK;
     }
-#elif defined(TODO_SEEME_PRODUCT_TARGET)
-    // Delegate to the OS' implementation on >= Windows 11 24H1
-    if (WindowsVersion::IsWindows11_22H2OrGreater())
-    {
-        return S_OK;
-    }
-#else
-    // Delegate to the OS' implementation on >= Windows 11 24H1
-    if (WindowsVersion::IsWindows11_24H1OrGreater())
-    {
-        return S_OK;
-    }
-#endif
 
     // OS Reg-Free WinRT isn't available so let's do it ourselves...
     DetourAttach(&(PVOID&)TrueRoActivateInstance, RoActivateInstanceDetour);

--- a/dev/UndockedRegFreeWinRT/urfw.h
+++ b/dev/UndockedRegFreeWinRT/urfw.h
@@ -4,6 +4,8 @@
 #if !defined(URFW_H)
 #define URFW_H
 
+bool UrfwNeedsDetours() noexcept;
+
 HRESULT UrfwInitialize() noexcept;
 
 void UrfwShutdown() noexcept;

--- a/dev/WindowsAppRuntime_DLL/dllmain.cpp
+++ b/dev/WindowsAppRuntime_DLL/dllmain.cpp
@@ -22,6 +22,12 @@ static HRESULT DetoursInitialize()
     }
 
     // Do we need to detour APIs?
+    if (!MddNeedsDetours() && !UrfwNeedsDetours())
+    {
+        return S_OK;
+    }
+
+    // No detours needed in a 'detours helper process'
     if (DetourIsHelperProcess())
     {
         return S_OK;


### PR DESCRIPTION
If Detours isn't needed (no functions hooked) we'd still call `DetourRestoreAfterWith()`, `DetourTransactionBegin()` and `DetourTransactionCommit()`. Omit these unnecessary calls if Detours isn't needed.