### PR TITLE
DevCheck: LongPath support, verify nuget.exe, fix ExitCode, fix InstallWindowsSDK, add/fix SettingsFile, update Getting Started docs

### DIFF
--- a/build/AzurePipelinesTemplates/WindowsAppSDK-RunTests-Steps.yml
+++ b/build/AzurePipelinesTemplates/WindowsAppSDK-RunTests-Steps.yml
@@ -8,11 +8,11 @@ parameters:
 
 steps:
   - task: powershell@2
-    displayName: 'DevCheck: Setup/Verify development environment'
+    displayName: 'DevCheck: Setup/Verify test environment'
     inputs:
       targetType: filePath
       filePath: tools\DevCheck\DevCheck.ps1
-      arguments: -NoInteractive -Offline -Verbose -CheckTestPfx -Clean -CheckDependencies -CheckVisualStudio -ShowSystemInfo
+      arguments: -NoInteractive -Offline -Verbose -CheckTestPfx -Clean -ShowSystemInfo
       workingDirectory: '$(Build.SourcesDirectory)'
 
   - task: DownloadPipelineArtifact@2
@@ -150,7 +150,7 @@ steps:
         Get-Service | Out-Host
         sc.exe queryex te.service | Write-Host
         sc.exe qc te.service | Write-Host
-  
+
   - task: PowerShell@2
     displayName: 'Run TAEF Tests'
     inputs:

--- a/docs/Coding-Guidelines/GettingStarted.md
+++ b/docs/Coding-Guidelines/GettingStarted.md
@@ -2,61 +2,23 @@
 
 # Tooling Prerequisites
 
-Development requires the following installed tools...
+Development requires the following installation:
 
-1. Windows 10 SDK 10.0.17763.0 (RS5)
+1. Install Visual Studio 2022
 
-The SDK can be installed via winget:
+   Select the following workloads:
+     * .NET desktop development
+     * Desktop development with C++
+     * Universal Windows Platform development
 
-    winget install Microsoft.WindowsSDK.10.0.17736
+   Additional components are quired. To add them via the Visual Studio Installer...
+     * select `More` / `Import configuration`
+     * select the file `docs\Coding-Guidelines\VisualStudio2022.vsconfig` in the repository
+     * select `Review details`
+     * select `Modify`
+   and wait for the install to complete.
 
-or via the browser:
-
-* Browse to https://go.microsoft.com/fwlink/p/?LinkID=2033908
-* Save the offered download `winsdksetup.exe`
-* Run winsdksetup.exe
-
-**NOTE:** Visual Studio 2022 doesn't include this SDK but will use it if installed on the machine.
-
-2. Windows 11 SDK 10.0.26100.2454 (24H2)
-   a. Browse to https://go.microsoft.com/fwlink/?linkid=2300556
-   b. Save the offered download `winsdksetup.exe`
-   c. Run winsdksetup.exe
-
-**NOTE:** Visual Studio 2022 doesn't include this SDK but will use it if installed on the machine.
-
-3. Visual Studio 2022 with...
-   * Workloads
-      * .NET desktop development
-      * Desktop development with C++
-      * Universal Windows Platform development
-   * Individual components including
-      * .NET 6.0 Runtime (LTS)
-      * .NET 7.0 Runtime
-      * .NET SDK
-      * Git for Windows
-      * NuGet package manager
-      * NuGet targets and build tasks
-      * C# and Visual Basic Roslyn compilers
-      * MSBuild
-      * MSVC v143 - VS 2022 C++ ARM64 build tools (Latest)
-      * MSVC v143 - VS 2022 C++ x64/x86 build tools (Latest)
-      * MSVC v143 - VS 2022 C++ ARM64 Spectre-mitigated libs (Latest)
-      * MSVC v143 - VS 2022 C++ x64/x86 Spectre-mitigated libs (Latest)
-      * Windows Universal CRT SDK
-      * C# and Visual Basic
-      * C++ core features
-      * C++/WinRT
-      * Windows 10 SDK (10.0.18362.0)
-      * Windows 10 SDK (10.0.19041.0)
-      * Windows 10 SDK (10.0.20348.0)
-      * Windows 10 SDK (10.0.22000.0)
-      * Windows 10 SDK (10.0.22621.0)
-      * Windows Universal C Runtime
-      * and more! See [VisualStudio2022.vsconfig](https://github.com/microsoft/WindowsAppSDK/blob/develop/docs/Coding-Guidelines/VisualStudio2022.vsconfig) for the complete list
-
-**NOTE:** You can tell the Visual Studio Installer to do the heavy lifting for you
-via `More` / `Import configuration` and select `docs\Coding-Guidelines\VisualStudio2022.vsconfig`.
+2. Run `DevCheck -CheckAll -FixAll` to verify your configuration and perform additional installation and configuration updates.
 
 4. Run NuGet Restore
    * Download nuget.exe version >= 6.2.1 from https://www.nuget.org/downloads
@@ -71,8 +33,11 @@ Run the `DevCheck.cmd` from an elevated command prompt (e.g. right-click on "Com
 in the Start Menu and select `Run as Administrator`) to update your development environment. The script will:
 
 * Verify Windows' Developer Mode is enabled.
+* Verify LongPath support (and enable if necessary).
 * Verify Visual Studio is installed with the required components.
-* Create a test certificate and add it to the certificate store. Used to sign test packages for inner-loop development and testing.
+* Verify Windows 10 SDK 10.0.17763.0 is installed (and install if necessary).
+* Verify Windows 11 SDK 10.0.26100.4654+ is installed (and install if necessary).
+* Verify a password-protected test certificate exists and add it to the certificate store (or create if necessary). Used to sign test packages for inner-loop development and testing.
 * Install the TAEF service (TE.Service). Used by TAEF to enable test functionality (e.g. RunAs).
 * Verify the project's dependencies are sanctioned and using the correct version(s).
 

--- a/docs/Coding-Guidelines/GettingStarted.md
+++ b/docs/Coding-Guidelines/GettingStarted.md
@@ -19,7 +19,7 @@ Development requires the following installation:
    and wait for the install to complete.
 
 2. Run `DevCheck -CheckAll -FixAll` from an admin prompt to verify your configuration and perform
-   additional installation and configuration updates. See `One-Time Setup` for more details.
+   additional installation and configuration updates (if necessary). See `One-Time Setup` for more details.
 
 # One-Time Setup
 
@@ -28,10 +28,10 @@ in the Start Menu and select `Run as Administrator`) to update your development 
 
 * Verify Windows' Developer Mode is enabled.
 * Verify LongPath support (and enable if necessary).
+* Verify nuget.exe is available (and download if necessary).
 * Verify Visual Studio is installed with the required components.
 * Verify Windows 10 SDK 10.0.17763.0 is installed (and install if necessary).
 * Verify Windows 11 SDK 10.0.26100.4654+ is installed (and install if necessary).
-* Verify nuget.exe is available (and download if necessary).
 * Verify a password-protected test certificate exists and add it to the certificate store (or create if necessary). Used to sign test packages for inner-loop development and testing.
 * Install the TAEF service (TE.Service). Used by TAEF to enable test functionality (e.g. RunAs).
 * Verify the project's dependencies are sanctioned and using the correct version(s).

--- a/docs/Coding-Guidelines/GettingStarted.md
+++ b/docs/Coding-Guidelines/GettingStarted.md
@@ -18,14 +18,8 @@ Development requires the following installation:
      * select `Modify`
    and wait for the install to complete.
 
-2. Run `DevCheck -CheckAll -FixAll` to verify your configuration and perform additional installation and configuration updates.
-
-4. Run NuGet Restore
-   * Download nuget.exe version >= 6.2.1 from https://www.nuget.org/downloads
-     e.g. https://dist.nuget.org/win-x86-commandline/v6.2.1/nuget.exe
-   * Open a command prompt
-   * CD to the project root e.g. `cd c:\source\repos\windowsappsdk`
-   * Run `nuget.exe restore`
+2. Run `DevCheck -CheckAll -FixAll` from an admin prompt to verify your configuration and perform
+   additional installation and configuration updates. See `One-Time Setup` for more details.
 
 # One-Time Setup
 
@@ -37,6 +31,7 @@ in the Start Menu and select `Run as Administrator`) to update your development 
 * Verify Visual Studio is installed with the required components.
 * Verify Windows 10 SDK 10.0.17763.0 is installed (and install if necessary).
 * Verify Windows 11 SDK 10.0.26100.4654+ is installed (and install if necessary).
+* Verify nuget.exe is available (and download if necessary).
 * Verify a password-protected test certificate exists and add it to the certificate store (or create if necessary). Used to sign test packages for inner-loop development and testing.
 * Install the TAEF service (TE.Service). Used by TAEF to enable test functionality (e.g. RunAs).
 * Verify the project's dependencies are sanctioned and using the correct version(s).

--- a/tools/DevCheck/DevCheck-Settings.ps1
+++ b/tools/DevCheck/DevCheck-Settings.ps1
@@ -1,0 +1,20 @@
+﻿# Copyright (c) Microsoft Corporation and Contributors.
+# Licensed under the MIT License.
+
+# DevCheck Settings
+
+# Do not alter contents except in the Customization block
+# Everything else is owned by DevCheck and subject to change without warning
+
+$me = (Get-Item $PSScriptRoot).FullName
+Write-Verbose "$me BEGIN Customization"
+#-----------------------------------------------------------------------
+# BEGIN Customization
+
+# Set paths to scan by -CheckDependencies and -SyncDependencies
+$global:dependency_paths = ('dev', 'test', 'installer', 'tools')
+
+# END   Customization
+#-----------------------------------------------------------------------
+$me = (Get-Item $PSScriptRoot).FullName
+Write-Verbose "$me END Customization"

--- a/tools/DevCheck/DevCheck-Settings.ps1
+++ b/tools/DevCheck/DevCheck-Settings.ps1
@@ -18,6 +18,9 @@ $global:dependency_paths = ('dev', 'test', 'installer', 'tools')
 $global:windows_sdks = (('10.0.17763.0', 'https://go.microsoft.com/fwlink/p/?LinkID=2033908'),
                         ('10.0.26100.4654', 'https://go.microsoft.com/fwlink/p/?LinkID=2327008'))
 
+# Set Nuget Restore paths/filenames (relative to project root directory)
+$global:nuget_restore_filenames = ('WindowsAppRuntime.sln')
+
 # END   Customization
 #-----------------------------------------------------------------------
 $me = (Get-Item $PSScriptRoot).FullName

--- a/tools/DevCheck/DevCheck-Settings.ps1
+++ b/tools/DevCheck/DevCheck-Settings.ps1
@@ -14,6 +14,10 @@ Write-Verbose "$me BEGIN Customization"
 # Set paths to scan by -CheckDependencies and -SyncDependencies
 $global:dependency_paths = ('dev', 'test', 'installer', 'tools')
 
+# Set Windows SDKs to check/install by -CheckWindowsSDK and -InstallWindowsSDK
+$global:windows_sdks = (('10.0.17763.0', 'https://go.microsoft.com/fwlink/p/?LinkID=2033908'),
+                        ('10.0.26100.4654', 'https://go.microsoft.com/fwlink/p/?LinkID=2327008'))
+
 # END   Customization
 #-----------------------------------------------------------------------
 $me = (Get-Item $PSScriptRoot).FullName

--- a/tools/DevCheck/DevCheck.ps1
+++ b/tools/DevCheck/DevCheck.ps1
@@ -203,6 +203,7 @@ $ErrorActionPreference = "Stop"
 
 $global:issues = 0
 $global:issues_test_certificate_thumbprint_not_found = 0
+$global:issues_nuget_exe_not_found = 0
 
 $global:isadmin = $null
 
@@ -213,7 +214,7 @@ $global:dependency_paths = ('dev', 'test', 'installer', 'tools')
 
 function Get-Issues
 {
-    return $global:issues + $global:issues_test_certificate_thumbprint_not_found
+    return $global:issues + $global:issues_test_certificate_thumbprint_not_found + $global:issues_nuget_exe_not_found
 }
 
 function Get-SettingsFileDefault
@@ -912,6 +913,7 @@ function Repair-DevTestPfx
     # Save the thumbprint
     $thumbprint = $cert.Thumbprint
     Set-Content -Path $cert_thumbprint -Value $thumbprint -Force
+    $global:issues_test_certificate_thumbprint_not_found = 0
 
     # Export the certificate
     $cer = Join-Path $user 'winappsdk.certificate.test.cer'
@@ -1742,6 +1744,7 @@ function Test-NugetExe
     if (-not(Test-Path -Path $file -PathType Leaf))
     {
         Write-Host "ERROR: Nuget.exe ($file)...Not Found" -ForegroundColor Red -BackgroundColor Black
+        $global:issues_nuget_exe_not_found = 1
         return $false
     }
     $versioninfo = (Get-Item $file).VersionInfo
@@ -1761,10 +1764,12 @@ function Test-NugetExe
     if ($version_uint64 -lt $minversion_uint64)
     {
         Write-Host "ERROR: Nuget.exe ($file)...Version {$($versioninfo.FileVersion)} doesn't meet required minversion v{$NugetMinVersion}" -ForegroundColor Red -BackgroundColor Black
+        $global:issues_nuget_exe_not_found = 1
         return $false
     }
 
     Write-Host "Nuget.exe v$($versioninfo.FileVersion) detected...$file"
+    $global:issues_nuget_exe_not_found = 0
     return $true
 }
 

--- a/tools/DevCheck/DevCheck.ps1
+++ b/tools/DevCheck/DevCheck.ps1
@@ -8,9 +8,11 @@
 .DESCRIPTION
     Review the current environment and fix or warn if anything is amiss. This includes...
     * Developer mode is enabled
+    * LongPath support is enabled
     * Test certificate to sign test MSIX packages is installed
     * TAEF service is installed and running
     * Visual Studio 2022 is installed and properly configured
+    * Windows SDK(s) are installed
     * Dependencies in use are in the approved list of packages and versions
 
 .PARAMETER CertPassword
@@ -670,6 +672,13 @@ function Install-WindowsSDK
         [String]$version,
         [uri]$url
     )
+
+    if ($Offline -eq $true)
+    {
+        Write-Host "ERROR: Windows SDK(s) cannot be downloaded with -Offline" -ForegroundColor Red -BackgroundColor Black
+        $global:issues++
+        return $false
+    }
 
     $path = Join-Path $env:TEMP "winsdksetup-$($version).exe"
     if ($Clean -eq $true -And (Test-Path -Path $path -PathType Leaf))

--- a/tools/DevCheck/DevCheck.ps1
+++ b/tools/DevCheck/DevCheck.ps1
@@ -1032,6 +1032,7 @@ function Repair-DevTestCert
     $cert_path = "cert:\LocalMachine\TrustedPeople"
     $x509certificates = Import-Certificate -FilePath $cer -CertStoreLocation $cert_path
     Write-Host "Install test certificate $cer...OK"
+    $global:issues_test_certificate_thumbprint_not_found = 0
 }
 
 function Remove-DevTestCert

--- a/tools/DevCheck/DevCheck.ps1
+++ b/tools/DevCheck/DevCheck.ps1
@@ -32,7 +32,7 @@
     Check developer mode
 
 .PARAMETER CheckNugetExe
-    Check nuget.exe
+    Verify nuget.exe is present
 
 .PARAMETER CheckTAEFService
     Check the TAEF service

--- a/tools/DevCheck/DevCheck.ps1
+++ b/tools/DevCheck/DevCheck.ps1
@@ -212,6 +212,9 @@ $global:vswhere_url = ''
 
 $global:dependency_paths = ('dev', 'test', 'installer', 'tools')
 
+$global:windows_sdks = (('10.0.17763.0', 'https://go.microsoft.com/fwlink/p/?LinkID=2033908'),
+                        ('10.0.26100.4654', 'https://go.microsoft.com/fwlink/p/?LinkID=2327008'))
+
 function Get-Issues
 {
     return $global:issues + $global:issues_test_certificate_thumbprint_not_found + $global:issues_nuget_exe_not_found
@@ -1838,8 +1841,12 @@ if (($CheckAll -ne $false) -Or ($ShowSystemInfo -ne $false))
 
 if (($CheckAll -ne $false) -Or ($CheckWindowsSDK -ne $false))
 {
-    $null = Test-WindowsSDKInstall '10.0.17763.0' 'https://go.microsoft.com/fwlink/p/?LinkID=2033908'
-    $null = Test-WindowsSDKInstall '10.0.26100.4654' 'https://go.microsoft.com/fwlink/p/?LinkID=2327008'
+    ForEach ($sdk in $global:windows_sdks)
+    {
+        $version = $sdk[0]
+        $url = $sdk[1]
+        $null = Test-WindowsSDKInstall $version $url
+    }
 }
 
 if (($CheckAll -ne $false) -Or ($CheckVisualStudio -ne $false))

--- a/tools/DevCheck/DevCheck.ps1
+++ b/tools/DevCheck/DevCheck.ps1
@@ -530,14 +530,27 @@ function Get-TAEFPackageVersion
 
 function Get-VSWhereOffline
 {
-    # Absolute Path = "%ProgramFiles(x86)%\Microsoft Visual Studio\Installer\vswhere.exe"
+    # Default absolute Path = "%ProgramFiles(x86)%\Microsoft Visual Studio\Installer\vswhere.exe"
+    # Unless it's installed in a non-default location
 
+    # Check default path
     $programfilesx86 = [Environment]::GetFolderPath([Environment+SpecialFolder]::ProgramFilesX86)
     $path = Join-Path $programfilesx86 "Microsoft Visual Studio\Installer\vswhere.exe"
     if (-not(Test-Path -Path $path -PathType Leaf))
     {
-        return $null
+        # Check if Windows can find it (e.g. via PATH)
+        $file = Get-Command 'vswhere.exe' -ErrorAction Ignore
+        if ($file)
+        {
+            $path = $file.Path
+        }
+        else
+        {
+            Write-Verbose "...vswhere.exe not found offline"
+            return $null
+        }
     }
+    Write-Verbose "...vswhere.exe found offline...$path"
     return $path
 }
 
@@ -564,6 +577,7 @@ function Get-VSWhereOnline
     {
         return $null
     }
+    Write-Verbose "...vswhere.exe found online...$path"
     return $path
 }
 
@@ -878,7 +892,7 @@ function Repair-DevTestPfx
 
     if (Test-Path -Path $pwd_file -PathType Leaf)
     {
-        Write-Warning "A pre-existing password file is found. A new password will be generated, please rebuild the tests to ensure the new password is used."
+        Write-Warning "A pre-existing password file is found. A new password will be generated, please rebuild tests to ensure the new password is used."
     }
 
     $password = ''


### PR DESCRIPTION
* New options:
  * -CheckNugetExe - Verify nuget.exe is present
  * -FixAll - Enable all -Fix* options plus -NugetRestore
  * -FixLongPath - Enable LongPath support if necessary
  * -InstallWindowsSDK - Download and install Windows Platform SDKs (if necessary)
  * -NugetExe <path> - Location of nuget.exe (default=".user\nuget.exe")
  * -NugetMinVersion <version> - Minimum required version of nuget.exe (default="6.14.0.116")
  * -NugetExeUpdate - Download nuget.exe to the -NugetExe path
  * -NugetRestore - Restore nuget packages
* Fixed error reporting. ExitCode=0 if successful, ExitCode=1 if 1+ issue(s) occurred
* Added LongPath detection/enablement
* Enhanced -CheckVisualStudio to detect `vswhere.exe` in PATH if not found at default install location
* Fixed Install-WindowsSDK to respect -Offline
* Changed SettingsFile handling:
  * -SaveSettingsFile is now a boolean
  * Default filename is DevCheck-Settings.ps1 next to DevCheck.ps1
  * Removed fallback to look for SettingsFile in root\.user
  * Added a default settings file for this repo
    * paths to check/update dependencies (-CheckDependencies, -SyncDependencies)
    * Windows SDK versions/URLs to check/install (-CheckWindowsSDK, -InstallWindowsSDK)
    * paths/files to check to restore Nuget packages (-NugetRestore)
* Updated Getting Started documentation (`docs\Coding-Guidelines\GettingStarted.md`)

Ubersimplified usage to check everything is ready to rock and if not, fix it:
```
DevCheck -FixAll
```
See Getting Started documentation for more details.