### PR TITLE
Update Pack stage's condition

### DIFF
--- a/build/AzurePipelinesTemplates/WindowsAppSDK-PackTransportPackage-Stage.yml
+++ b/build/AzurePipelinesTemplates/WindowsAppSDK-PackTransportPackage-Stage.yml
@@ -23,7 +23,7 @@ stages:
     - Build_x64
     - Build_arm64
   condition:
-    eq(variables['useBuildOutputFromBuildId'],'')
+    and(succeeded(), eq(variables['useBuildOutputFromBuildId'],''))
   jobs:
   - job: NugetPackage
     pool:


### PR DESCRIPTION
According to Bug 59105489, Pack stage should not run if the build stage has failed

A microsoft employee must use /azp run to validate using the pipelines below.

WARNING:
Comments made by azure-pipelines bot maybe inaccurate.
Please see pipeline link to verify that the build is being ran.

For status checks on the main branch, please use TransportPackage-Foundation-PR
(https://microsoft.visualstudio.com/ProjectReunion/_build?definitionId=81063&_a=summary)
and run the build against your PR branch with the default parameters.
