### PR TITLE
Update StaticValidationTests to use 26100 (#5791)

### DIFF
--- a/build/AzurePipelinesTemplates/WindowsAppSDK-StaticValidationTest-Stage.yml
+++ b/build/AzurePipelinesTemplates/WindowsAppSDK-StaticValidationTest-Stage.yml
@@ -99,7 +99,7 @@ stages:
         ignoreLASTEXITCODE: true
         script: |
           $KitsRoot10 = (Get-ItemProperty "HKLM:\SOFTWARE\Microsoft\Windows Kits\Installed Roots" -Name KitsRoot10).KitsRoot10
-          $WindowsSdkBinDir = Join-Path $KitsRoot10 "bin\10.0.22000.0\x86"
+          $WindowsSdkBinDir = Join-Path $KitsRoot10 "bin\10.0.26100.0\x86"
 
           $path = "$(Build.SourcesDirectory)\Packages\Microsoft.WindowsAppSDK.Foundation.TransportPackage\$(FoundationVersion)"
           $buildtype = '$(channel)'


### PR DESCRIPTION
A microsoft employee must use /azp run to validate using the pipelines below.

WARNING:
Comments made by azure-pipelines bot maybe inaccurate.
Please see pipeline link to verify that the build is being ran.

For status checks on the main branch, please use TransportPackage-Foundation-PR
(https://microsoft.visualstudio.com/ProjectReunion/_build?definitionId=81063&_a=summary)
and run the build against your PR branch with the default parameters.
