### PR TITLE
Add longPathAware declaration to app.manifest for C# project templates

### DIFF
--- a/dev/VSIX/ProjectTemplates/Desktop/CSharp/PackagedApp/BlankApp/app.manifest
+++ b/dev/VSIX/ProjectTemplates/Desktop/CSharp/PackagedApp/BlankApp/app.manifest
@@ -14,6 +14,7 @@
   <application xmlns="urn:schemas-microsoft-com:asm.v3">
     <windowsSettings>
       <dpiAwareness xmlns="http://schemas.microsoft.com/SMI/2016/WindowsSettings">PerMonitorV2</dpiAwareness>
+      <longPathAware xmlns="http://schemas.microsoft.com/SMI/2016/WindowsSettings">true</longPathAware>
     </windowsSettings>
   </application>
 </assembly>

--- a/dev/VSIX/ProjectTemplates/Desktop/CSharp/SingleProjectPackagedApp/app.manifest
+++ b/dev/VSIX/ProjectTemplates/Desktop/CSharp/SingleProjectPackagedApp/app.manifest
@@ -14,6 +14,7 @@
   <application xmlns="urn:schemas-microsoft-com:asm.v3">
     <windowsSettings>
       <dpiAwareness xmlns="http://schemas.microsoft.com/SMI/2016/WindowsSettings">PerMonitorV2</dpiAwareness>
+      <longPathAware xmlns="http://schemas.microsoft.com/SMI/2016/WindowsSettings">true</longPathAware>
     </windowsSettings>
   </application>
 </assembly>

--- a/dev/VSIX/ProjectTemplates/Desktop/CSharp/UnitTestApp/app.manifest
+++ b/dev/VSIX/ProjectTemplates/Desktop/CSharp/UnitTestApp/app.manifest
@@ -14,6 +14,7 @@
   <application xmlns="urn:schemas-microsoft-com:asm.v3">
     <windowsSettings>
       <dpiAwareness xmlns="http://schemas.microsoft.com/SMI/2016/WindowsSettings">PerMonitorV2</dpiAwareness>
+      <longPathAware xmlns="http://schemas.microsoft.com/SMI/2016/WindowsSettings">true</longPathAware>
     </windowsSettings>
   </application>
 </assembly>


### PR DESCRIPTION
Since Windows 10 1607, developers can declare a flag in their app.manifest to remove the MAX_PATH limitation. This enables support for file paths longer than 260 characters. 

Modern versions of .NET support this well and most .NET libraries also support this as well due to their cross-platform design. Other platforms do not impose the same limitation.

For new C# applications in 2025 and beyond, the recommended default value for longPathAware should be true. This PR enables that setting in the C# project templates.

This change does not force WinAppSDK apps to be longPathAware. If incompatibilities arise, developers can remove the line, or set the value to false explicitly.

I have not updated the C++ templates in this PR.

----

A microsoft employee must use /azp run to validate using the pipelines below.

WARNING:
Comments made by azure-pipelines bot maybe inaccurate.
Please see pipeline link to verify that the build is being ran.

For status checks on the main branch, please use TransportPackage-Foundation-PR
(https://microsoft.visualstudio.com/ProjectReunion/_build?definitionId=81063&_a=summary)
and run the build against your PR branch with the default parameters.
