### PR TITLE
PackageDeployment API Progress status bug #5532

### DIFF
--- a/dev/PackageManager/API/M.W.M.D.PackageDeploymentManager.cpp
+++ b/dev/PackageManager/API/M.W.M.D.PackageDeploymentManager.cpp
@@ -1966,6 +1966,7 @@ namespace winrt::Microsoft::Windows::Management::Deployment::implementation
                                             winrt::Windows::Management::Deployment::DeploymentProgress> const& /*sender*/,
                                          winrt::Windows::Management::Deployment::DeploymentProgress const& progressInfo)
         {
+            packageDeploymentProgress.Status = PackageDeploymentProgressStatus::InProgress;
             const auto progressAfter{ progressBefore + PercentageToProgress(progressInfo.percentage, progressMaxPerPackageSetItem) };
             if (packageDeploymentProgress.Progress < progressAfter)
             {
@@ -2050,6 +2051,7 @@ namespace winrt::Microsoft::Windows::Management::Deployment::implementation
                                             winrt::Windows::Management::Deployment::DeploymentProgress> const& /*sender*/,
                                          winrt::Windows::Management::Deployment::DeploymentProgress const& progressInfo)
         {
+            packageDeploymentProgress.Status = PackageDeploymentProgressStatus::InProgress;
             const auto progressAfter{ progressBefore + PercentageToProgress(progressInfo.percentage, progressMaxPerPackage) };
             if (packageDeploymentProgress.Progress < progressAfter)
             {
@@ -2144,6 +2146,7 @@ namespace winrt::Microsoft::Windows::Management::Deployment::implementation
                                             winrt::Windows::Management::Deployment::DeploymentProgress> const& /*sender*/,
                                          winrt::Windows::Management::Deployment::DeploymentProgress const& progressInfo)
         {
+            packageDeploymentProgress.Status = PackageDeploymentProgressStatus::InProgress;
             const auto progressAfter{ progressBefore + PercentageToProgress(progressInfo.percentage, progressMaxPerPackage) };
             if (packageDeploymentProgress.Progress < progressAfter)
             {
@@ -2238,6 +2241,7 @@ namespace winrt::Microsoft::Windows::Management::Deployment::implementation
                                             winrt::Windows::Management::Deployment::DeploymentProgress> const& /*sender*/,
                                          winrt::Windows::Management::Deployment::DeploymentProgress const& progressInfo)
         {
+            packageDeploymentProgress.Status = PackageDeploymentProgressStatus::InProgress;
             const auto progressAfter{ progressBefore + PercentageToProgress(progressInfo.percentage, progressMaxPerPackage) };
             if (packageDeploymentProgress.Progress < progressAfter)
             {
@@ -2316,6 +2320,7 @@ namespace winrt::Microsoft::Windows::Management::Deployment::implementation
                                             winrt::Windows::Management::Deployment::DeploymentProgress> const& /*sender*/,
                                          winrt::Windows::Management::Deployment::DeploymentProgress const& progressInfo)
         {
+            packageDeploymentProgress.Status = PackageDeploymentProgressStatus::InProgress;
             const auto progressAfter{ progressBefore + PercentageToProgress(progressInfo.percentage, progressMaxPerPackage) };
             if (packageDeploymentProgress.Progress < progressAfter)
             {
@@ -2391,6 +2396,7 @@ namespace winrt::Microsoft::Windows::Management::Deployment::implementation
                                             winrt::Windows::Management::Deployment::DeploymentProgress> const& /*sender*/,
                                          winrt::Windows::Management::Deployment::DeploymentProgress const& progressInfo)
         {
+            packageDeploymentProgress.Status = PackageDeploymentProgressStatus::InProgress;
             const double progressMaxPerPackage{ 1.0 };
             packageDeploymentProgress.Progress = PercentageToProgress(progressInfo.percentage, progressMaxPerPackage);
             progress(packageDeploymentProgress);
@@ -2496,6 +2502,7 @@ namespace winrt::Microsoft::Windows::Management::Deployment::implementation
                                             winrt::Windows::Management::Deployment::DeploymentProgress> const& /*sender*/,
                                          winrt::Windows::Management::Deployment::DeploymentProgress const& progressInfo)
         {
+            packageDeploymentProgress.Status = PackageDeploymentProgressStatus::InProgress;
             packageDeploymentProgress.Progress = PercentageToProgress(progressInfo.percentage, progressMaxPerPackage);
             progress(packageDeploymentProgress);
         });
@@ -2815,6 +2822,7 @@ namespace winrt::Microsoft::Windows::Management::Deployment::implementation
                                             winrt::Windows::Management::Deployment::DeploymentProgress> const& /*sender*/,
                                          winrt::Windows::Management::Deployment::DeploymentProgress const& progressInfo)
         {
+            packageDeploymentProgress.Status = PackageDeploymentProgressStatus::InProgress;
             packageDeploymentProgress.Progress = PercentageToProgress(progressInfo.percentage, progressMaxPerPackage);
             progress(packageDeploymentProgress);
         });
@@ -3049,6 +3057,7 @@ namespace winrt::Microsoft::Windows::Management::Deployment::implementation
                                             winrt::Windows::Management::Deployment::DeploymentProgress> const& /*sender*/,
                                          winrt::Windows::Management::Deployment::DeploymentProgress const& progressInfo)
         {
+            packageDeploymentProgress.Status = PackageDeploymentProgressStatus::InProgress;
             packageDeploymentProgress.Progress = PercentageToProgress(progressInfo.percentage, progressMaxPerPackage);
             progress(packageDeploymentProgress);
         });
@@ -3192,6 +3201,7 @@ namespace winrt::Microsoft::Windows::Management::Deployment::implementation
                                             winrt::Windows::Management::Deployment::DeploymentProgress> const& /*sender*/,
                                          winrt::Windows::Management::Deployment::DeploymentProgress const& progressInfo)
         {
+            packageDeploymentProgress.Status = PackageDeploymentProgressStatus::InProgress;
             const double progressMaxPerPackage{ 1.0 };
             packageDeploymentProgress.Progress = PercentageToProgress(progressInfo.percentage, progressMaxPerPackage);
             progress(packageDeploymentProgress);
@@ -3296,6 +3306,7 @@ namespace winrt::Microsoft::Windows::Management::Deployment::implementation
                                             winrt::Windows::Management::Deployment::DeploymentProgress> const& /*sender*/,
                                          winrt::Windows::Management::Deployment::DeploymentProgress const& progressInfo)
         {
+            packageDeploymentProgress.Status = PackageDeploymentProgressStatus::InProgress;
             const double progressMaxPerPackage{ 1.0 };
             packageDeploymentProgress.Progress = PercentageToProgress(progressInfo.percentage, progressMaxPerPackage);
             progress(packageDeploymentProgress);

--- a/test/PackageManager/API/PackageDeploymentManagerTests.h
+++ b/test/PackageManager/API/PackageDeploymentManagerTests.h
@@ -154,6 +154,10 @@ namespace Test::PackageManager::Tests
                 [&](const IAsyncOperationWithProgress<PackageDeploymentResult, PackageDeploymentProgress>&, PackageDeploymentProgress progress)
             {
                     WEX::Logging::Log::Comment(WEX::Common::String().Format(L"...State:%d Percentage:%lf", static_cast<int>(progress.Status), progress.Progress));
+                    if (progress.Progress != 0)
+                    {
+                        VERIFY_ARE_EQUAL(PackageDeploymentProgressStatus::InProgress, progress.Status);
+                    }
                 }
             );
             deploymentOperation.Progress(progressCallback);


### PR DESCRIPTION
Set the ProgressStatus to InProgress once we have started making progress, and make sure that the Test validates this for all things that use the Async code in the future.

fixes #5532 