### PR TITLE
DynamicDependency: Expanded powershell cmdlets

### DIFF
--- a/dev/DynamicDependency/Powershell/Get-PackageDependency.ps1
+++ b/dev/DynamicDependency/Powershell/Get-PackageDependency.ps1
@@ -1,0 +1,191 @@
+# Copyright (c) Microsoft Corporation and Contributors.
+# Licensed under the MIT License.
+
+<#
+.SYNOPSIS
+    Return the process ids of processes using the package dependency.
+
+.DESCRIPTION
+    Return the process ids of processes using the package dependency.
+
+    This does not add the package to the invoking process' package graph.
+
+    NOTE: -All, -PackageDependencyId and -PackageFamilyName are mutually exclusive.
+
+.PARAMETER PackageDependencyId
+    The id of the resolved package dependency.
+
+.PARAMETER PackageFamilyName
+    Find package dependencies with this package family.
+
+.LINK
+    https://learn.microsoft.com/windows/win32/api/appmodel/nf-appmodel-findpackagedependency
+    https://learn.microsoft.com/windows/win32/api/appmodel/nf-appmodel-getpackagedependencyinformation
+    https://learn.microsoft.com/windows/win32/api/appmodel/nf-appmodel-getprocessesusingpackagedependency
+#>
+[CmdletBinding(SupportsShouldProcess=$true)]
+param(
+    [Parameter(ParameterSetName='All')]
+    [switch]$All,
+
+    [Parameter(ParameterSetName='Id')]
+    [string]$PackageDependencyId,
+
+    [Parameter(ParameterSetName='Package')]
+    [string]$PackageFamilyName,
+
+    [switch]$ScopeIsSystem
+)
+
+Set-StrictMode -Version 3.0
+
+$ErrorActionPreference = "Stop"
+
+$ERROR_SUCCESS = 0
+
+function Is-PackageDependencyId
+{
+    param(
+        [string]$id
+    )
+
+    if (($id -ne $null) -and ($id.Length -ge 3))
+    {
+        $prefix = $id.Substring(0, 2)
+        return (($prefix -eq 'T:') -or ($prefix -eq 'P:'))
+    }
+    return $false
+}
+
+function Is-PackageFamilyName
+{
+    param(
+        [string]$packageFamilyName
+    )
+
+    $rc = [Microsoft.Windows.ApplicationModel.PackageFamilyName]::Verify($packageFamilyName)
+    return $rc == $ERROR_SUCCESS
+}
+
+function Get-Processes
+{
+    param(
+        [string]$id
+    )
+
+    [uint32]$processIdsCount = 0
+    [uint32[]]$processIds = $null
+    $hr = [Microsoft.Windows.ApplicationModel.DynamicDependency.PackageDependency]::GetProcesses(
+            $id, $ScopeIsSystem, [ref] $processIdsCount, [ref] $processIds)
+    if ($hr -lt 0)
+    {
+        $win32ex = [System.ComponentModel.Win32Exception]::new($hr)
+        Write-Error "Error 0x$($hr.ToString('X')): $($win32ex.Message)" -ErrorAction Stop
+    }
+    else
+    {
+        Write-Host "Processes: $processIdsCount"
+    }
+    return $processIds
+}
+
+# Import the MSIX Dynamic Dependency module
+if (-not (Get-Module | Where-Object {$_.Name -eq 'MsixDynamicDependency'}))
+{
+    $module = Join-Path $PSScriptRoot 'MsixDynamicDependency.psm1'
+    Import-Module -Name $module -ErrorAction Stop
+}
+
+$ids = [ordered]@{}
+if ($PSCmdlet.ParameterSetName -eq 'None')
+{
+    if ([string]::IsNullOrWhiteSpace($PackageDependencyId))
+    {
+        $All = $true
+    }
+    elseif (Is-PackageFamilyName $PackageDependencyId)
+    {
+        $PackageFamilyName = $PackageDependencyId
+        $PackageDependencyId = $null
+        $PSCmdlet.ParameterSetName = 'Package'
+    }
+    else
+    {
+        $PSCmdlet.ParameterSetName = 'Id'
+    }
+}
+
+
+
+if (-not [string]::IsNullOrWhiteSpace($PackageDependencyId))
+{
+    $ids.Add($PackageDependencyId, $null)
+}
+else #if ($PSCmdlet.ParameterSetName -eq 'Package')
+{
+    $findPackageDependencyCriteria = New-Object Microsoft.Windows.ApplicationModel.DynamicDependency.FindPackageDependencyCriteria
+    $findPackageDependencyCriteria.User = [IntPtr]::Zero
+    $findPackageDependencyCriteria.ScopeIsSystem = $ScopeIsSystem
+    if ($PSCmdlet.ParameterSetName -eq 'Package')
+    {
+        $findPackageDependencyCriteria.PackageFamilyName = $PackageFamilyName
+    }
+    else # -All
+    {
+        $findPackageDependencyCriteria.PackageFamilyName = "" #$null
+    }
+    [uint]$packageDependencyIdsCount = 0
+    [string[]]$packageDependencyIds = $null
+    $hr = [Microsoft.Windows.ApplicationModel.DynamicDependency.PackageDependency]::Find(
+            $findPackageDependencyCriteria, [ref] $packageDependencyIdsCount, [ref] $packageDependencyIds);
+    if ($hr -lt 0)
+    {
+        $win32ex = [System.ComponentModel.Win32Exception]::new($hr)
+        Write-Error "Error 0x$($hr.ToString('X')): $($win32ex.Message)" -ErrorAction Stop
+    }
+    else
+    {
+        Write-Host "Package Dependencies: $packageDependencyIdsCount"
+    }
+    ForEach ($pdi in $packageDependencyIds)
+    {
+        $ids.Add($pdi, $null)
+    }
+}
+
+ForEach ($pdi in $ids.Keys)
+{
+    $pids = Get-Processes $pdi
+
+    [string]$familyName = $null
+    [ulong]$minVersion = 0
+    $processorArchitectures = 0
+    $lifetimeKind = 0
+    [string]$lifetimeArtifact = $null
+    $options = 0
+    $lifetimeExpiration = New-Object DateTime
+    $hr = [Microsoft.Windows.ApplicationModel.DynamicDependency.PackageDependency]::GetInfo(
+            $pdi, [ref] $familyName, [ref] $minVersion, [ref] $processorArchitectures,
+            [ref] $lifetimeKind, [ref] $lifetimeArtifact, [ref] $options, [ref] $lifetimeExpiration)
+    if ($hr -lt 0)
+    {
+        $win32ex = [System.ComponentModel.Win32Exception]::new($hr)
+        Write-Error "Error 0x$($hr.ToString('X')): $($win32ex.Message)" -ErrorAction Stop
+    }
+    if ($lifetimeExpiration.Ticks -eq 0)
+    {
+        $lifetimeExpiration = $null
+    }
+    $pd = [PSCustomObject]@{
+        PackageDependencyId     = $pdi
+        PackageFamilyName       = $familyName
+        MinVersion              = $minVersion
+        ProcessorArchitectures  = $processorArchitectures
+        LifetimeKind            = $lifetimeKind
+        LifetimeArtifact        = $lifetimeArtifact
+        Options                 = $options
+        LifetimeExpiration      = $lifetimeExpiration
+        ProcessIDs              = $pids
+    }
+    $pd | Format-List
+}

--- a/dev/DynamicDependency/Powershell/Get-PackageDependency.ps1
+++ b/dev/DynamicDependency/Powershell/Get-PackageDependency.ps1
@@ -13,10 +13,16 @@
     NOTE: -All, -PackageDependencyId and -PackageFamilyName are mutually exclusive.
 
 .PARAMETER PackageDependencyId
-    The id of the resolved package dependency.
+    Find package dependencies with this id.
+
+.PARAMETER All
+    Find all package dependencies.
 
 .PARAMETER PackageFamilyName
     Find package dependencies with this package family.
+
+.PARAMETER ScopeIsSystem
+    Find package dependencies created with CreatePackageDependencyOptions_ScopeIsSystem.
 
 .LINK
     https://learn.microsoft.com/windows/win32/api/appmodel/nf-appmodel-findpackagedependency

--- a/dev/DynamicDependency/Powershell/Get-PackageDependency.ps1
+++ b/dev/DynamicDependency/Powershell/Get-PackageDependency.ps1
@@ -88,10 +88,6 @@ function Get-Processes
         $win32ex = [System.ComponentModel.Win32Exception]::new($hr)
         Write-Error "Error 0x$($hr.ToString('X')): $($win32ex.Message)" -ErrorAction Stop
     }
-    else
-    {
-        Write-Host "Processes: $processIdsCount"
-    }
     return $processIds
 }
 

--- a/dev/DynamicDependency/Powershell/Get-PackageDependency.ps1
+++ b/dev/DynamicDependency/Powershell/Get-PackageDependency.ps1
@@ -178,9 +178,13 @@ ForEach ($pdi in $ids.Keys)
     {
         $lifetimeExpiration = $null
     }
+
+    $packageFullName = .\Get-PackageDependencyResolved.ps1 $pdi
+
     $pd = [PSCustomObject]@{
         PackageDependencyId     = $pdi
         PackageFamilyName       = $familyName
+        ResolvedPackage         = $packageFullName
         MinVersion              = $minVersion
         ProcessorArchitectures  = $processorArchitectures
         LifetimeKind            = $lifetimeKind

--- a/dev/DynamicDependency/Powershell/Get-PackageDependencyProcesses.ps1
+++ b/dev/DynamicDependency/Powershell/Get-PackageDependencyProcesses.ps1
@@ -1,0 +1,52 @@
+# Copyright (c) Microsoft Corporation and Contributors.
+# Licensed under the MIT License.
+
+<#
+.SYNOPSIS
+    Return the process ids of processes using the package dependency.
+
+.DESCRIPTION
+    Return the process ids of processes using the package dependency.
+
+    This does not add the package to the invoking process' package graph.
+
+.PARAMETER PackageDependencyId
+    The ID of the resolved package dependency.
+
+.LINK
+    https://learn.microsoft.com/windows/win32/api/appmodel/nf-appmodel-getprocessesusingpackagedependency
+#>
+[CmdletBinding(SupportsShouldProcess=$true)]
+param(
+    [Parameter(Mandatory=$true)]
+    [string]$PackageDependencyId,
+
+    [switch]$ScopeIsSystem
+)
+
+Set-StrictMode -Version 3.0
+
+$ErrorActionPreference = "Stop"
+
+# Import the MSIX Dynamic Dependency module
+if (-not (Get-Module | Where-Object {$_.Name -eq 'MsixDynamicDependency'}))
+{
+    $module = Join-Path $PSScriptRoot 'MsixDynamicDependency.psm1'
+    Import-Module -Name $module -ErrorAction Stop
+}
+
+$processIdsCount = 0
+$processIds = $null
+$hr = [Microsoft.Windows.ApplicationModel.DynamicDependency.PackageDependency]::GetProcesses(
+        $PackageDependencyId, $ScopeIsSystem, [ref] $processIdsCount, [ref] $processIds)
+if ($hr -lt 0)
+{
+    $win32ex = [System.ComponentModel.Win32Exception]::new($hr)
+    Write-Error "Error 0x$($hr.ToString('X')): $($win32ex.Message)" -ErrorAction Stop
+}
+else
+{
+    Write-Host "Processes: $processIdsCount"
+}
+
+$processIds

--- a/dev/DynamicDependency/Powershell/Get-PackageDependencyProcesses.ps1
+++ b/dev/DynamicDependency/Powershell/Get-PackageDependencyProcesses.ps1
@@ -35,8 +35,8 @@ if (-not (Get-Module | Where-Object {$_.Name -eq 'MsixDynamicDependency'}))
     Import-Module -Name $module -ErrorAction Stop
 }
 
-$processIdsCount = 0
-$processIds = $null
+[uint32]$processIdsCount = 0
+[uint32[]]$processIds = $null
 $hr = [Microsoft.Windows.ApplicationModel.DynamicDependency.PackageDependency]::GetProcesses(
         $PackageDependencyId, $ScopeIsSystem, [ref] $processIdsCount, [ref] $processIds)
 if ($hr -lt 0)

--- a/dev/DynamicDependency/Powershell/MsixDynamicDependency.psm1
+++ b/dev/DynamicDependency/Powershell/MsixDynamicDependency.psm1
@@ -21,6 +21,7 @@ None
 Add-Type -TypeDefinition @"
 using System;
 using System.Runtime.InteropServices;
+using FILETIME = System.Runtime.InteropServices.ComTypes.FILETIME;
 
 namespace Microsoft.Windows.ApplicationModel.DynamicDependency
 {
@@ -59,6 +60,13 @@ namespace Microsoft.Windows.ApplicationModel.DynamicDependency
         PrependIfRankCollision = 0x00000001,
     };
 
+    public enum AddPackageDependencyOptions2
+    {
+        None                       = 0,
+        PrependIfRankCollision     = 0x00000001,
+        SpecifiedPackageFamilyOnly = 0x00000002,
+    };
+
     public class Rank
     {
         public const int Default = 0;
@@ -88,38 +96,82 @@ namespace Microsoft.Windows.ApplicationModel.DynamicDependency
             return kernel32_HeapFree(kernel32_GetProcessHeap(), 0, p);
         }
 
-        // Define a package dependency. The criteria for a PackageDependency
-        // (package family name, minimum version, etc)
-        // may match multiple packages, but ensures Deployment won't remove
-        // a package if it's the only one satisfying the PackageDependency.
-        //
-        // @note A package matching a PackageDependency pin can still be removed
-        //       as long as there's another package that satisfies the PackageDependency.
-        //       For example, if Fwk-v1 is installed and a PackageDependency specifies
-        //       MinVersion=1 and then Fwk-v2 is installed, Deployment could remove
-        //       Fwk-v1 because Fwk-v2 will satisfy the PackageDependency. After Fwk-v1
-        //       is removed Deployment won't remove Fwk-v2 because it's the only package
-        //       satisfying the PackageDependency. Thus Fwk-v1 and Fwk-v2 (and any other
-        //       package matching the PackageDependency) are 'loosely pinned'. Deployment
-        //       guarantees it won't remove a package if it would make a PackageDependency
-        //       unsatisfied.
-        //
-        // A PackageDependency specifies criteria (package family, minimum version, etc)
-        // and not a specific package. Deployment reserves the right to use a different
-        // package (e.g. higher version) to satisfy the PackageDependency if/when
-        // one becomes available.
-        //
-        // @param user the user scope of the package dependency. If NULL the caller's
-        //        user context is used. MUST be NULL if CreatePackageDependencyOptions_ScopeIsSystem
-        //        is specified
-        // @param lifetimeArtifact MUST be NULL if lifetimeKind=Process
-        // @param packageDependencyId allocated via HeapAlloc; use HeapFree to deallocate
-        //
-        // @note TryCreatePackageDependency() fails if the PackageDependency cannot be resolved to a specific
-        //       package. This package resolution check is skipped if
-        //       CreatePackageDependencyOptions_DoNotVerifyDependencyResolution is specified. This is useful
-        //       for installers running as user contexts other than the target user (e.g. installers
-        //       running as LocalSystem).
+        [System.Flags]
+        enum LoadLibraryFlags : uint
+        {
+              DONT_RESOLVE_DLL_REFERENCES = 0x00000001,
+              LOAD_IGNORE_CODE_AUTHZ_LEVEL = 0x00000010,
+              LOAD_LIBRARY_AS_DATAFILE = 0x00000002,
+              LOAD_LIBRARY_AS_DATAFILE_EXCLUSIVE = 0x00000040,
+              LOAD_LIBRARY_AS_IMAGE_RESOURCE = 0x00000020,
+              LOAD_LIBRARY_SEARCH_APPLICATION_DIR = 0x00000200,
+              LOAD_LIBRARY_SEARCH_DEFAULT_DIRS = 0x00001000,
+              LOAD_LIBRARY_SEARCH_DLL_LOAD_DIR = 0x00000100,
+              LOAD_LIBRARY_SEARCH_SYSTEM32 = 0x00000800,
+              LOAD_LIBRARY_SEARCH_USER_DIRS = 0x00000400,
+              LOAD_WITH_ALTERED_SEARCH_PATH = 0x00000008
+        }
+
+        [DllImport("kernel32.dll", EntryPoint="LoadLibraryExW", ExactSpelling=true, SetLastError=true)]
+        static extern IntPtr LoadLibraryExW(string lpFileName, IntPtr hReservedNull, LoadLibraryFlags dwFlags);
+
+        [DllImport("kernel32.dll", EntryPoint="FreeLibrary", ExactSpelling=true, SetLastError=true)]
+        [return: MarshalAs(UnmanagedType.Bool)]
+        static extern bool FreeLibrary(IntPtr hModule);
+
+        [DllImport("kernel32", CharSet=CharSet.Ansi, ExactSpelling=true, SetLastError=true)]
+        static extern IntPtr GetProcAddress(IntPtr hModule, string procName);
+
+        private static bool IsExport(string feature)
+        {
+            IntPtr hmodule = LoadLibraryExW("kernelbase.dll", IntPtr.Zero, 0);
+            IntPtr fn = GetProcAddress(hmodule, "AddPackageDependency2");
+            FreeLibrary(hmodule);
+            return fn != IntPtr.Zero;
+        }
+
+        private static bool IsSupported(string feature)
+        {
+            switch (feature)
+            {
+                case "AddPackageDependency2": return IsExport(feature);
+                default: return false;
+            }
+        }
+
+        /// Define a package dependency. The criteria for a PackageDependency
+        /// (package family name, minimum version, etc)
+        /// may match multiple packages, but ensures Deployment won't remove
+        /// a package if it's the only one satisfying the PackageDependency.
+        ///
+        /// @note A package matching a PackageDependency pin can still be removed
+        ///       as long as there's another package that satisfies the PackageDependency.
+        ///       For example, if Fwk-v1 is installed and a PackageDependency specifies
+        ///       MinVersion=1 and then Fwk-v2 is installed, Deployment could remove
+        ///       Fwk-v1 because Fwk-v2 will satisfy the PackageDependency. After Fwk-v1
+        ///       is removed Deployment won't remove Fwk-v2 because it's the only package
+        ///       satisfying the PackageDependency. Thus Fwk-v1 and Fwk-v2 (and any other
+        ///       package matching the PackageDependency) are 'loosely pinned'. Deployment
+        ///       guarantees it won't remove a package if it would make a PackageDependency
+        ///       unsatisfied.
+        ///
+        /// A PackageDependency specifies criteria (package family, minimum version, etc)
+        /// and not a specific package. Deployment reserves the right to use a different
+        /// package (e.g. higher version) to satisfy the PackageDependency if/when
+        /// one becomes available.
+        ///
+        /// @param user the user scope of the package dependency. If NULL the caller's
+        ///        user context is used. MUST be NULL if CreatePackageDependencyOptions_ScopeIsSystem
+        ///        is specified
+        /// @param lifetimeArtifact MUST be NULL if lifetimeKind=PackageDependencyLifetimeKind_Process
+        /// @param packageDependencyId allocated via HeapAlloc; use HeapFree to deallocate
+        ///
+        /// @note TryCreatePackageDependency() fails if the PackageDependency cannot be resolved to a specific
+        ///       package. This package resolution check is skipped if
+        ///       CreatePackageDependencyOptions_DoNotVerifyDependencyResolution is specified. This is useful
+        ///       for installers running as user contexts other than the target user (e.g. installers
+        ///       running as LocalSystem).
+        /// @see TryCreatePackageDependency2
         [DllImport("kernelbase.dll", ExactSpelling=true, CharSet=CharSet.Unicode)]
         private static extern int TryCreatePackageDependency(
             /*PSID*/ IntPtr user,
@@ -156,6 +208,92 @@ namespace Microsoft.Windows.ApplicationModel.DynamicDependency
             return hr;
         }
 
+        private static DateTime FiletimeToDateTime(FILETIME fileTime)
+        {
+            long hFT2 = (((long) fileTime.dwHighDateTime) << 32) | ((uint) fileTime.dwLowDateTime);
+            return DateTime.FromFileTimeUtc(hFT2);
+        }
+
+        private static FILETIME DateTimeToFiletime(DateTime time)
+        {
+            FILETIME ft;
+            long hFT1 = time.ToFileTimeUtc();
+            ft.dwLowDateTime = (int) (hFT1 & 0xFFFFFFFF);
+            ft.dwHighDateTime = (int) (hFT1 >> 32);
+            return ft;
+        }
+
+        /// Define a package dependency. The criteria for a PackageDependency
+        /// (package family name, minimum version, etc)
+        /// may match multiple packages, but ensures Deployment won't remove
+        /// a package if it's the only one satisfying the PackageDependency.
+        ///
+        /// @note A package matching a PackageDependency pin can still be removed
+        ///       as long as there's another package that satisfies the PackageDependency.
+        ///       For example, if Fwk-v1 is installed and a PackageDependency specifies
+        ///       MinVersion=1 and then Fwk-v2 is installed, Deployment could remove
+        ///       Fwk-v1 because Fwk-v2 will satisfy the PackageDependency. After Fwk-v1
+        ///       is removed Deployment won't remove Fwk-v2 because it's the only package
+        ///       satisfying the PackageDependency. Thus Fwk-v1 and Fwk-v2 (and any other
+        ///       package matching the PackageDependency) are 'loosely pinned'. Deployment
+        ///       guarantees it won't remove a package if it would make a PackageDependency
+        ///       unsatisfied.
+        ///
+        /// A PackageDependency specifies criteria (package family, minimum version, etc)
+        /// and not a specific package. Deployment reserves the right to use a different
+        /// package (e.g. higher version) to satisfy the PackageDependency if/when
+        /// one becomes available.
+        ///
+        /// @param user the user scope of the package dependency. If NULL the caller's
+        ///        user context is used. MUST be NULL if CreatePackageDependencyOptions_ScopeIsSystem
+        ///        is specified
+        /// @param lifetimeArtifact MUST be NULL if lifetimeKind=PackageDependencyLifetimeKind_Process
+        /// @param packageDependencyId allocated via HeapAlloc; use HeapFree to deallocate
+        ///
+        /// @note TryCreatePackageDependency2() fails if the PackageDependency cannot be resolved to a specific
+        ///       package. This package resolution check is skipped if
+        ///       CreatePackageDependencyOptions_DoNotVerifyDependencyResolution is specified. This is useful
+        ///       for installers running as user contexts other than the target user (e.g. installers
+        ///       running as LocalSystem).
+        /// @see TryCreatePackageDependency
+        [DllImport("kernelbase.dll", ExactSpelling=true, CharSet=CharSet.Unicode)]
+        private static extern int TryCreatePackageDependency2(
+            /*PSID*/ IntPtr user,
+            string packageFamilyName,
+            /*PACKAGE_VERSION*/ long minVersion,
+            /*PackageDependencyProcessorArchitectures*/ int packageDependencyProcessorArchitectures,
+            /*PackageDependencyLifetimeKind*/ int lifetimeKind,
+            string lifetimeArtifact,
+            /*CreatePackageDependencyOptions*/ int options,
+            /*const FILETIME* */ ref FILETIME lifetimeExpiration,
+            /*_Outptr_result_maybenull_ PWSTR* */ out IntPtr packageDependencyId);
+
+        public static int TryCreate2(
+            string packageFamilyName,
+            long minVersion,
+            /*PackageDependencyProcessorArchitectures*/ int packageDependencyProcessorArchitectures,
+            /*PackageDependencyLifetimeKind*/ int lifetimeKind,
+            string lifetimeArtifact,
+            /*CreatePackageDependencyOptions*/ int options,
+            /*const FILETIME* */ FILETIME lifetimeExpiration,
+            /*_Outptr_result_maybenull_ PWSTR* */ out string packageDependencyId)
+        {
+            packageDependencyId = null;
+
+            IntPtr pdi = IntPtr.Zero;
+            int hr = TryCreatePackageDependency2(IntPtr.Zero, packageFamilyName, minVersion, packageDependencyProcessorArchitectures,
+                                                 lifetimeKind, lifetimeArtifact, options, ref lifetimeExpiration, out pdi);
+            if (hr >= 0)
+            {
+                packageDependencyId = Marshal.PtrToStringUni(pdi);
+            }
+            if (pdi != IntPtr.Zero)
+            {
+                HeapFree(pdi);
+            }
+            return hr;
+        }
+
         // Undefine a package dependency. Removing a pin on a PackageDependency is typically done at uninstall-time.
         // This implicitly occurs if the package dependency's 'lifetime artifact' (specified via TryCreatePackageDependency)
         // is deleted. Packages that are not referenced by other packages and have no pins are elegible to be removed.
@@ -172,45 +310,46 @@ namespace Microsoft.Windows.ApplicationModel.DynamicDependency
             return DeletePackageDependency(packageDependencyId);
         }
 
-        // Resolve a previously-pinned PackageDependency to a specific package and
-        // add it to the invoking process' package graph. Once the dependency has
-        // been added other code-loading methods (LoadLibrary, CoCreateInstance, etc)
-        // can find the binaries in the resolved package.
-        //
-        // Package resolution is specific to a user and can return different values
-        // for different users on a system.
-        //
-        // Each successful AddPackageDependency() adds the resolve packaged to the
-        // calling process' package graph, even if already present. There is no
-        // duplicate 'detection' or 'filtering' applied by the API (multiple
-        // references from a package is not harmful). Once resolution is complete
-        // the package dependency stays resolved for that user until the last reference across
-        // all processes for that user is removed via RemovePackageDependency (or
-        // process termination).
-        //
-        // AddPackageDependency() adds the resolved package to the caller's package graph,
-        // per the rank specified. A process' package graph is a list of packages sorted by
-        // rank in ascending order (-infinity...0...+infinity). If package(s) are present in the
-        // package graph with the same rank as the call to AddPackageDependency the resolved
-        // package is (by default) added after others of the same rank. To add a package
-        // before others of the same rank, specify AddPackageDependencyOptions_PrependIfRankCollision.
-        //
-        // Every AddPackageDependency can be balanced by a RemovePackageDependency
-        // to remove the entry from the package graph. If the process terminates all package
-        // references are removed, but any pins stay behind.
-        //
-        // AddPackageDependency adds the resolved package to the process' package
-        // graph, per the rank and options parameters. The process' package
-        // graph is used to search for DLLs (per Dynamic-Link Library Search Order),
-        // WinRT objects and other resources; the caller can now load DLLs, activate
-        // WinRT objects and use other resources from the framework package until
-        // RemovePackageDependency is called. The packageDependencyId parameter
-        // must match a package dependency defined for the calling user or the
-        // system (i.e. pinned with CreatePackageDependencyOptions_ScopeIsSystem) else
-        // an error is returned.
-        //
-        // @param packageDependencyContext valid until passed to RemovePackageDependency()
-        // @param packageFullName allocated via HeapAlloc; use HeapFree to deallocate
+        /// Resolve a previously-pinned PackageDependency to a specific package and
+        /// add it to the invoking process' package graph. Once the dependency has
+        /// been added other code-loading methods (LoadLibrary, CoCreateInstance, etc)
+        /// can find the binaries in the resolved package.
+        ///
+        /// Package resolution is specific to a user and can return different values
+        /// for different users on a system.
+        ///
+        /// Each successful AddPackageDependency() adds the resolve packaged to the
+        /// calling process' package graph, even if already present. There is no
+        /// duplicate 'detection' or 'filtering' applied by the API (multiple
+        /// references from a package is not harmful). Once resolution is complete
+        /// the package dependency stays resolved for that user until the last reference across
+        /// all processes for that user is removed via RemovePackageDependency (or
+        /// process termination).
+        ///
+        /// AddPackageDependency() adds the resolved package to the caller's package graph,
+        /// per the rank specified. A process' package graph is a list of packages sorted by
+        /// rank in ascending order (-infinity...0...+infinity). If package(s) are present in the
+        /// package graph with the same rank as the call to AddPackageDependency the resolved
+        /// package is (by default) added after others of the same rank. To add a package
+        /// before others o the same rank, specify AddPackageDependencyOptions_PrependIfRankCollision.
+        ///
+        /// Every AddPackageDependency can be balanced by a RemovePackageDependency
+        /// to remove the entry from the package graph. If the process terminates all package
+        /// references are removed, but any pins stay behind.
+        ///
+        /// AddPackageDependency adds the resolved package to the process' package
+        /// graph, per the rank and options parameters. The process' package
+        /// graph is used to search for DLLs (per Dynamic-Link Library Search Order),
+        /// WinRT objects and other resources; the caller can now load DLLs, activate
+        /// WinRT objects and use other resources from the framework package until
+        /// RemovePackageDependency is called. The packageDependencyId parameter
+        /// must match a package dependency defined for the calling user or the
+        /// system (i.e. pinned with CreatePackageDependencyOptions_ScopeIsSystem) else
+        /// an error is returned.
+        ///
+        /// @param packageDependencyContext valid until passed to RemovePackageDependency()
+        /// @param packageFullName allocated via HeapAlloc; use HeapFree to deallocate
+        /// @see AddPackageDependency2()
         [DllImport("kernelbase.dll", ExactSpelling=true, CharSet=CharSet.Unicode)]
         private static extern int AddPackageDependency(
             string packageDependencyId,
@@ -244,6 +383,79 @@ namespace Microsoft.Windows.ApplicationModel.DynamicDependency
             return hr;
         }
 
+        /// Resolve a previously-pinned PackageDependency to a specific package and
+        /// add it to the invoking process' package graph. Once the dependency has
+        /// been added other code-loading methods (LoadLibrary, CoCreateInstance, etc)
+        /// can find the binaries in the resolved package.
+        ///
+        /// Package resolution is specific to a user and can return different values
+        /// for different users on a system.
+        ///
+        /// Each successful AddPackageDependency2() adds the resolve packaged to the
+        /// calling process' package graph, even if already present. There is no
+        /// duplicate 'detection' or 'filtering' applied by the API (multiple
+        /// references from a package is not harmful). Once resolution is complete
+        /// the package dependency stays resolved for that user until the last reference across
+        /// all processes for that user is removed via RemovePackageDependency (or
+        /// process termination).
+        ///
+        /// AddPackageDependency2() adds the resolved package to the caller's package graph,
+        /// per the rank specified. A process' package graph is a list of packages sorted by
+        /// rank in ascending order (-infinity...0...+infinity). If package(s) are present in the
+        /// package graph with the same rank as the call to AddPackageDependency2 the resolved
+        /// package is (by default) added after others of the same rank. To add a package
+        /// before others o the same rank, specify AddPackageDependencyOptions2_PrependIfRankCollision.
+        ///
+        /// Every AddPackageDependency2 can be balanced by a RemovePackageDependency
+        /// to remove the entry from the package graph. If the process terminates all package
+        /// references are removed, but any pins stay behind.
+        ///
+        /// AddPackageDependency2 adds the resolved package to the process' package
+        /// graph, per the rank and options parameters. The process' package
+        /// graph is used to search for DLLs (per Dynamic-Link Library Search Order),
+        /// WinRT objects and other resources; the caller can now load DLLs, activate
+        /// WinRT objects and use other resources from the framework package until
+        /// RemovePackageDependency is called. The packageDependencyId parameter
+        /// must match a package dependency defined for the calling user or the
+        /// system (i.e. pinned with CreatePackageDependencyOptions_ScopeIsSystem) else
+        /// an error is returned.
+        ///
+        /// @param packageDependencyContext valid until passed to RemovePackageDependency()
+        /// @param packageFullName allocated via HeapAlloc; use HeapFree to deallocate
+        /// @see AddPackageDependency()
+        [DllImport("kernelbase.dll", ExactSpelling=true, CharSet=CharSet.Unicode)]
+        private static extern int AddPackageDependency2(
+            string packageDependencyId,
+            int rank,
+            /*AddPackageDependencyOptions2*/ int options,
+            /*_Out_ PACKAGEDEPENDENCY_CONTEXT* */ out IntPtr packageDependencyContext,
+            /*_Outptr_opt_result_maybenull_ PWSTR* */ out IntPtr packageFullName);
+
+        public static int Add2(
+            string packageDependencyId,
+            int rank,
+            /*AddPackageDependencyOptions2*/ int options,
+            /*_Out_ PACKAGEDEPENDENCY_CONTEXT* */ out IntPtr packageDependencyContext,
+            out string packageFullName)
+        {
+            packageDependencyContext = IntPtr.Zero;
+            packageFullName = null;
+
+            IntPtr pdc = IntPtr.Zero;
+            IntPtr pfn = IntPtr.Zero;
+            int hr = AddPackageDependency2(packageDependencyId, rank, options, out pdc, out pfn);
+            if (hr >= 0)
+            {
+                packageDependencyContext = pdc;
+                packageFullName = Marshal.PtrToStringUni(pfn);
+            }
+            if (pfn != IntPtr.Zero)
+            {
+                HeapFree(pfn);
+            }
+            return hr;
+        }
+
         // Remove a resolved PackageDependency from the current process' package graph
         // (i.e. undo AddPackageDependency). Used at runtime (i.e. the moral equivalent
         // of Windows' RemoveDllDirectory()).
@@ -262,19 +474,51 @@ namespace Microsoft.Windows.ApplicationModel.DynamicDependency
             return RemovePackageDependency(packageDependencyContext);
         }
 
-        // Return the package full name that would be used if the
-        // PackageDependency were to be resolved. Does not add the
-        // package to the process graph.
-        //
-        // @param packageFullName allocated via HeapAlloc; use HeapFree to deallocate.
-        //                        If the package dependency cannot be resolved the function
-        //                        succeeds but packageFullName is nullptr.
+        /// Return the package full name that would be used if the
+        /// PackageDependency were to be resolved. Does not add the
+        /// package to the process graph.
+        ///
+        /// @param packageFullName allocated via HeapAlloc; use HeapFree to deallocate.
+        ///                        If the package dependency cannot be resolved the function
+        ///                        succeeds but packageFullName is NULL.
+        /// @see GetResolvedPackageFullNameForPackageDependency2
         [DllImport("kernelbase.dll", ExactSpelling=true, CharSet=CharSet.Unicode)]
         private static extern int GetResolvedPackageFullNameForPackageDependency(
             string packageDependencyId,
             /*_Outptr_result_maybenull_ PWSTR* */ out IntPtr packageFullName);
 
         public static int GetResolvedPackageFullName(
+            string packageDependencyId,
+            out string packageFullName)
+        {
+            packageFullName = null;
+
+            IntPtr pfn = IntPtr.Zero;
+            int hr = GetResolvedPackageFullNameForPackageDependency(packageDependencyId, out pfn);
+            if (hr >= 0)
+            {
+                packageFullName = Marshal.PtrToStringUni(pfn);
+            }
+            if (pfn != IntPtr.Zero)
+            {
+                HeapFree(pfn);
+            }
+            return hr;
+        }
+
+        /// Return the package full name that would be used if the
+        /// PackageDependency were to be resolved. Does not add the
+        /// package to the process graph.
+        ///
+        /// @param packageFullName allocated via HeapAlloc; use HeapFree to deallocate.
+        /// @return E_INVALIDARG if packageDependencyId is not a valid package dependency.
+        /// @see GetResolvedPackageFullNameForPackageDependency
+        [DllImport("kernelbase.dll", ExactSpelling=true, CharSet=CharSet.Unicode)]
+        private static extern int GetResolvedPackageFullNameForPackageDependency2(
+            string packageDependencyId,
+            /*_Outptr_result_maybenull_ PWSTR* */ out IntPtr packageFullName);
+
+        public static int GetResolvedPackageFullName2(
             string packageDependencyId,
             out string packageFullName)
         {
@@ -318,6 +562,176 @@ namespace Microsoft.Windows.ApplicationModel.DynamicDependency
             if (pdi != IntPtr.Zero)
             {
                 HeapFree(pdi);
+            }
+            return hr;
+        }
+
+        [StructLayout(LayoutKind.Sequential)]
+        public struct FindPackageDependencyCriteria
+        {
+            /// Match package dependencies for this user if not NULL.
+            /// Match package dependencies for the current user if NULL (and ScopeIsSystem=FALSE).
+            /// @note This MUST be NULL if ScopeIsSystem=TRUE.
+            /// @note Admin privilege is required if User is not NULL and not the current user.
+            public /*PSID*/ IntPtr User;
+
+            /// Match package dependencies created with CreatePackageDependencyOptions_ScopeIsSystem this is TRUE.
+            /// @note Admin privilege is required if ScopeIsSystem is TRUE.
+            public bool ScopeIsSystem;
+
+            /// Match package dependencies with this package family. Ignore if NULL or empty ("").
+            public string PackageFamilyName;
+        }
+
+        /// Retrieve package dependencies.
+        /// @param packageDependencyIds allocated via HeapAlloc; use HeapFree to deallocate
+        ///
+        /// @see FindPackageDependencyCriteria
+        /// @see TryCreatePackageDependency2
+        [DllImport("kernelbase.dll", ExactSpelling=true, CharSet=CharSet.Unicode)]
+        private static extern int FindPackageDependency(
+            /*const FindPackageDependencyCriteria* */ ref FindPackageDependencyCriteria findPackageDependencyCriteria,
+            /*_Out_ UINT32* */ out /*ref*/ ulong packageDependencyIdsCount,
+            /*_Outptr_result_buffer_maybenull_(*packageDependencyIdsCount) PWSTR** */ out IntPtr packageDependencyIds);
+
+        public static int Find(
+            FindPackageDependencyCriteria findPackageDependencyCriteria,
+            out ulong packageDependencyIdsCount,
+            out string[] packageDependencyIds)
+        {
+            packageDependencyIdsCount = 0;
+            packageDependencyIds = null;
+
+            IntPtr pdis = IntPtr.Zero;
+            int hr = FindPackageDependency(ref findPackageDependencyCriteria, out packageDependencyIdsCount, out pdis);
+            if (hr >= 0)
+            {
+                if (packageDependencyIdsCount > 0)
+                {
+                    string[] ids = new string[packageDependencyIdsCount];
+                    int ptrSize = IntPtr.Size;
+                    for (uint index=0; index < packageDependencyIdsCount; ++index)
+                    {
+                        IntPtr stringPtr = Marshal.ReadIntPtr(pdis, (int)(index * ptrSize));
+                        ids[index] = Marshal.PtrToStringUni(stringPtr);
+                    }
+                    packageDependencyIds = ids;
+                }
+            }
+            if (pdis != IntPtr.Zero)
+            {
+                HeapFree(pdis);
+            }
+            return hr;
+        }
+
+        /// Retrieve information about a package dependency.
+        ///
+        /// @param user allocated via HeapAlloc; use HeapFree to deallocate
+        /// @param packageFamilyName allocated via HeapAlloc; use HeapFree to deallocate
+        /// @param lifetimeArtifact allocated via HeapAlloc; use HeapFree to deallocate
+        /// @param lifetimeExpiration if specified, the value is zero if expiration date is not set.
+        /// @note Admin privilege is required the package dependency was created with CreatePackageDependencyOptions_ScopeIsSystem or user is not NULL and not the current user.
+        /// @see FindPackageDependency
+        [DllImport("kernelbase.dll", ExactSpelling=true, CharSet=CharSet.Unicode)]
+        private static extern int GetPackageDependencyInformation(
+            /*PCWSTR*/ string packageDependencyId,
+            /*_Outptr_opt_result_maybenull_ PSID* */ out /*ref*/ IntPtr user,
+            /*_Outptr_opt_result_maybenull_ PWSTR* */ out IntPtr packageFamilyName,
+            /*_Out_opt_ PACKAGE_VERSION* */ out /*ref*/ long minVersion,
+            /*_Out_opt_ PackageDependencyProcessorArchitectures* */ out /*ref*/ int packageDependencyProcessorArchitectures,
+            /*_Out_opt_ PackageDependencyLifetimeKind* */ out /*ref*/ int lifetimeKind,
+            /*_Outptr_opt_result_maybenull_ PWSTR* */ out /*ref*/ IntPtr lifetimeArtifact,
+            /*_Out_opt_ CreatePackageDependencyOptions* */ out /*ref*/ int options,
+            /*_Out_opt_ FILETIME* */ out /*ref*/ FILETIME lifetimeExpiration);
+
+        public static int GetInfo(
+            string packageDependencyId,
+            out string packageFamilyName,
+            out long minVersion,
+            out int packageDependencyProcessorArchitectures,
+            out int lifetimeKind,
+            out string lifetimeArtifact,
+            out int options,
+            out DateTime lifetimeExpiration)
+        {
+            packageFamilyName = null;
+            minVersion = 0;
+            packageDependencyProcessorArchitectures = 0;
+            lifetimeKind = 0;
+            lifetimeArtifact = null;
+            options = 0;
+            lifetimeExpiration = DateTime.MinValue;
+
+            IntPtr u = IntPtr.Zero;
+            IntPtr pfn = IntPtr.Zero;
+            IntPtr la = IntPtr.Zero;
+            FILETIME le;
+            int hr = GetPackageDependencyInformation(packageDependencyId, out u, out pfn, out minVersion,
+                                                     out packageDependencyProcessorArchitectures,
+                                                     out lifetimeKind, out la, out options, out le);
+            if (hr >= 0)
+            {
+                packageFamilyName = Marshal.PtrToStringUni(pfn);
+                if (la != IntPtr.Zero)
+                {
+                    lifetimeArtifact = Marshal.PtrToStringUni(la);
+                }
+                if ((le.dwHighDateTime != 0) || (le.dwLowDateTime != 0))
+                {
+                    lifetimeExpiration = FiletimeToDateTime(le);
+                }
+            }
+            if (pfn != IntPtr.Zero)
+            {
+                HeapFree(pfn);
+            }
+            if (la != IntPtr.Zero)
+            {
+                HeapFree(la);
+            }
+            return hr;
+        }
+
+        /// Retrieve the list of processes using a package dependency.
+        ///
+        /// @param user the user scope of the package dependency. If NULL the caller's
+        ///        user context is used. MUST be NULL if scopeIsSystem=TRUE.
+        /// @param processIdsCount allocated via HeapAlloc; use HeapFree to deallocate
+        /// @param processIds allocated via HeapAlloc; use HeapFree to deallocate
+        /// @note Admin privilege is required if scopeIsSystem=TRUE or user is not NULL and not the current user.
+        /// @see FindPackageDependency
+        [DllImport("kernelbase.dll", ExactSpelling=true, CharSet=CharSet.Unicode)]
+        private static extern int GetProcessesUsingPackageDependency(
+            /*PCWSTR*/ string packageDependencyId,
+            /*PSID*/ IntPtr user,
+            /*BOOL*/ bool scopeIsSystem,
+            /*_Out_ UINT32* */ out /*ref*/ uint processIdsCount,
+            /*_Outptr_result_buffer_maybenull_(*processIdsCount) DWORD** */ out IntPtr processIds);
+
+        public static int GetProcesses(
+            string packageDependencyId,
+            bool scopeIsSystem,
+            out uint processIdsCount,
+            out uint[] processIds)
+        {
+            processIdsCount = 0;
+            processIds = null;
+
+            IntPtr pis = IntPtr.Zero;
+            int hr = GetProcessesUsingPackageDependency(packageDependencyId, IntPtr.Zero, scopeIsSystem, out processIdsCount, out pis);
+            if (hr >= 0)
+            {
+                uint[] pids = new uint[processIdsCount];
+                int pidSize = sizeof(uint);
+                for (uint index=0; index < processIdsCount; ++index)
+                {
+                    pids[index] = (uint)Marshal.ReadInt32(pis, (int)(index * pidSize));
+                }
+            }
+            if (pis != IntPtr.Zero)
+            {
+                HeapFree(pis);
             }
             return hr;
         }


### PR DESCRIPTION
`Get-PackageDependency.ps1` dumps information about dynamic dependencies. For example
```
pwsh -c .\Get-PackageDependency.ps1 -PackageDependencyId T:1BB73916-AB6B-4281-A97B-0672ED4497CF
pwsh -c .\Get-PackageDependency.ps1 -PackageFamilyName Microsoft.WindowsAppRuntime.1.8_8wekyb3d8bbwe
pwsh -c .\Get-PackageDependency.ps1 -All
```

`pwsh -c .\Get-PackageDependency.ps1 -?` for more details.

NOTE: This only works for OS Dynamic Dependencies (like everything else in `dev\dynamicdependency\powershell`)

P.S. I'd like to add support to make the `-PackageDependencyId/-PackageFamilyName/-All` optional and (pardon the pun) dynamically figure it out given the input string but so far all attempts don't work, break explicit scenarios or introduced undesired side effects. This is deferred to a future PR; for today, specify the type of input.

P.P.S. `Get-PackageDependencyProcesses.ps1` dumps the process ids dynamically using a specified package dependency id. This is an earlier testing ground for a subset of functionality now in `Get-PackageDependency.ps1` so it's more of an intellectual curiosity than anything else right now, and will probably be removed in the future.