### PR TITLE
Fix the Sample Tests failure caused by ModifySampleAppsReferences.ps1

### DIFF
--- a/build/AzurePipelinesTemplates/WindowsAppSDK-BuildSamplesCompat-Job.yml
+++ b/build/AzurePipelinesTemplates/WindowsAppSDK-BuildSamplesCompat-Job.yml
@@ -177,7 +177,7 @@ jobs:
     inputs:
       filePath: '$(Build.SourcesDirectory)\$(SelfRepoName)\test\ModifySampleAppsReferences.ps1'
       arguments: >
-        -SampleRepoRoot "$(Build.SourcesDirectory)\$(SamplesRepoName)"
+        -SampleRepoRoot "$(Build.SourcesDirectory)\$(SamplesRepoName)\Samples"
         -FoundationVersion "$(FoundationVersion)"
         -FoundationPackagesFolder "$(Build.SourcesDirectory)\$(SamplesRepoName)\Samples\localpackages"
         -WASDKNugetDependencies $(wasdkDependencies)

--- a/build/AzurePipelinesTemplates/WindowsAppSDK-BuildSamplesCompat-Job.yml
+++ b/build/AzurePipelinesTemplates/WindowsAppSDK-BuildSamplesCompat-Job.yml
@@ -180,7 +180,7 @@ jobs:
         -SampleRepoRoot "$(Build.SourcesDirectory)\$(SamplesRepoName)"
         -FoundationVersion "$(FoundationVersion)"
         -FoundationPackagesFolder "$(Build.SourcesDirectory)\$(SamplesRepoName)\Samples\localpackages"
-        -WASDKNugetDependencies variables['wasdkDependencies']
+        -WASDKNugetDependencies $(wasdkDependencies)
   
   # update the nuget.config file to point to the internal feed
   - powershell: |

--- a/build/AzurePipelinesTemplates/WindowsAppSDK-BuildSamplesCompat-Job.yml
+++ b/build/AzurePipelinesTemplates/WindowsAppSDK-BuildSamplesCompat-Job.yml
@@ -180,7 +180,7 @@ jobs:
         -SampleRepoRoot "$(Build.SourcesDirectory)\$(SamplesRepoName)\Samples"
         -FoundationVersion "$(FoundationVersion)"
         -FoundationPackagesFolder "$(Build.SourcesDirectory)\$(SamplesRepoName)\Samples\localpackages"
-        -WASDKNugetDependencies $(wasdkDependencies)
+        -WASDKNugetDependencies "$(wasdkDependencies)"
   
   # update the nuget.config file to point to the internal feed
   - powershell: |

--- a/test/ModifySampleAppsReferences.ps1
+++ b/test/ModifySampleAppsReferences.ps1
@@ -33,6 +33,7 @@ if (!($FoundationPackagesFolder -eq ""))
     }
 }
 Write-Host "NuGet packages to version table: $($packagesToUpdateTable | Out-String)"
+Write-Host "NuGet packages to remove: $($packagesToRemoveList | Out-String)"
 
 Get-ChildItem -Recurse packages.config -Path $SampleRepoRoot | foreach-object {
     $content = Get-Content $_.FullName -Raw

--- a/test/ModifySampleAppsReferences.ps1
+++ b/test/ModifySampleAppsReferences.ps1
@@ -10,6 +10,7 @@ Set-StrictMode -Version 3.0
 $ErrorActionPreference = 'Stop'
 
 $packagesToRemoveList = $WASDKNugetDependencies -split ';'
+$packagesToRemoveList += @("Microsoft.WindowsAppSDK")
 
 $packagesToUpdateTable = @{"Microsoft.WindowsAppSDK.Foundation" = $FoundationVersion}
 
@@ -46,7 +47,6 @@ Get-ChildItem -Recurse packages.config -Path $SampleRepoRoot | foreach-object {
     }
     foreach ($package in $packagesToRemoveList)
     {
-        Write-Host "removing $package from $($_.FullName)"
         $packageReferenceString = '(?m)^\s*<package id="' + $package + '" version="[-.0-9a-zA-Z]*"[^>]*?/>\s*$\r?\n?'
         $content = $content -replace $packageReferenceString, ''
     }
@@ -66,7 +66,6 @@ Get-ChildItem -Recurse *.vcxproj -Path $SampleRepoRoot | foreach-object {
     }
     foreach ($package in $packagesToRemoveList)
     {
-        Write-Host "removing $package from $($_.FullName)"
         $packageReferenceString = "(?m)^.*\\$package\.[0-9][-.0-9a-zA-Z]*\\.*\r?\n?"
         $content = $content -replace $packageReferenceString, ''
     }

--- a/test/ModifySampleAppsReferences.ps1
+++ b/test/ModifySampleAppsReferences.ps1
@@ -46,6 +46,7 @@ Get-ChildItem -Recurse packages.config -Path $SampleRepoRoot | foreach-object {
     }
     foreach ($package in $packagesToRemoveList)
     {
+        Write-Host "removing $package from $($_.FullName)"
         $packageReferenceString = '(?m)^\s*<package id="' + $package + '" version="[-.0-9a-zA-Z]*"[^>]*?/>\s*$\r?\n?'
         $content = $content -replace $packageReferenceString, ''
     }
@@ -65,6 +66,7 @@ Get-ChildItem -Recurse *.vcxproj -Path $SampleRepoRoot | foreach-object {
     }
     foreach ($package in $packagesToRemoveList)
     {
+        Write-Host "removing $package from $($_.FullName)"
         $packageReferenceString = "(?m)^.*\\$package\.[0-9][-.0-9a-zA-Z]*\\.*\r?\n?"
         $content = $content -replace $packageReferenceString, ''
     }


### PR DESCRIPTION
A microsoft employee must use /azp run to validate using the pipelines below.

WARNING:
Comments made by azure-pipelines bot maybe inaccurate.
Please see pipeline link to verify that the build is being ran.

For status checks on the main branch, please use TransportPackage-Foundation-PR
(https://microsoft.visualstudio.com/ProjectReunion/_build?definitionId=81063&_a=summary)
and run the build against your PR branch with the default parameters.
