### PR TITLE
Adding tests to the bypass list of the newly added images

### DIFF
--- a/test/BypassTests.json
+++ b/test/BypassTests.json
@@ -1701,5 +1701,19 @@
   "release_x64_Windows11.Enterprise.25h2.Test::ABForward::FunctionalTests::PackageManager",
   "release_x64_Windows11.Enterprise.25h2.Test::ABForward::FunctionalTests::RuntimeVersion",
   "release_x64_Windows11.Enterprise.25h2.Test::ABForward::FunctionalTests::RuntimeCompatibilityOptions",
-  "release_x64_Windows11.Enterprise.25h2.Test::ABForward::FunctionalTests::SecurityAccessControl"
+  "release_x64_Windows11.Enterprise.25h2.Test::ABForward::FunctionalTests::SecurityAccessControl",
+  "release_arm64_Windows11.Professional.25h2.arm64.PackagedTests#metadataSet0::VerifyBadgeNotificationManagerCurrent",
+  "release_arm64_Windows11.Professional.25h2.arm64.PackagedTests#metadataSet1::VerifyBadgeNotificationManagerCurrent",
+  "release_arm64_Windows11.Professional.25h2.arm64.Test::ABForward::FunctionalTests::ApplicationData",
+  "release_arm64_Windows11.Professional.25h2.arm64.Test::ABForward::FunctionalTests::AppNotificationsManager",
+  "release_arm64_Windows11.Professional.25h2.arm64.Test::ABForward::FunctionalTests::AppNotificationsBuilder",
+  "release_arm64_Windows11.Professional.25h2.arm64.Test::ABForward::FunctionalTests::BackgroundTaskBuilder",
+  "release_arm64_Windows11.Professional.25h2.arm64.Test::ABForward::FunctionalTests::BadgeNotifications",
+  "release_arm64_Windows11.Professional.25h2.arm64.Test::ABForward::FunctionalTests::BatteryStatus",
+  "release_arm64_Windows11.Professional.25h2.arm64.Test::ABForward::FunctionalTests::DeploymentManager",
+  "release_arm64_Windows11.Professional.25h2.arm64.Test::ABForward::FunctionalTests::EnvironmentManager",
+  "release_arm64_Windows11.Professional.25h2.arm64.Test::ABForward::FunctionalTests::PackageManager",
+  "release_arm64_Windows11.Professional.25h2.arm64.Test::ABForward::FunctionalTests::RuntimeVersion",
+  "release_arm64_Windows11.Professional.25h2.arm64.Test::ABForward::FunctionalTests::RuntimeCompatibilityOptions",
+  "release_arm64_Windows11.Professional.25h2.arm64.Test::ABForward::FunctionalTests::SecurityAccessControl"
 ]


### PR DESCRIPTION
For the two newest images on our test pipeline (Win11 25H2 x64/arm64), we need to add the tests for their bypass lists.
All these tests are already added to other images in the same architecture and it is not reducing the current test coverage by any means.

This will unblock the pipeline from failing on tests.
 
A microsoft employee must use /azp run to validate using the pipelines below.

WARNING:
Comments made by azure-pipelines bot maybe inaccurate.
Please see pipeline link to verify that the build is being ran.

For status checks on the main branch, please use TransportPackage-Foundation-PR
(https://microsoft.visualstudio.com/ProjectReunion/_build?definitionId=81063&_a=summary)
and run the build against your PR branch with the default parameters.
