### PR TITLE
Changing include on deployment/PackageDefinitions.h

### DIFF
--- a/dev/Deployment/PackageDefinitions.h
+++ b/dev/Deployment/PackageDefinitions.h
@@ -1,6 +1,11 @@
-﻿// Copyright (c) Microsoft Corporation and Contributors.
+// Copyright (c) Microsoft Corporation and Contributors.
 // Licensed under the MIT License.
-#include <pch.h>
+
+#pragma once
+
+#include <map>
+#include <string>
+
 #define WINDOWSAPPRUNTIME_PACKAGE_NAME_PREFIX                       L"Microsoft.WindowsAppRuntime"
 #define WINDOWSAPPRUNTIME_PACKAGE_NAME_DDLMPREFIX                   L"Microsoft.WinAppRuntime"
 #define WINDOWSAPPRUNTIME_PACKAGE_NAME_MAINPREFIX                   L"MicrosoftCorporationII.WinAppRuntime"


### PR DESCRIPTION
This pull request introduces some minor improvements to the `dev/Deployment/PackageDefinitions.h` header file, removing the `pch.h` include and explicitly including `<string>` and `<map>`, both of which are used in this file.

This change is good because when we include this header on different contexts (for example, for building the unit tests), the `pch.h` file will not be [the one intended](https://github.com/microsoft/WindowsAppSDK/blob/main/dev/WindowsAppRuntime_DLL/pch.h) to be. This will be mistaken by the test's `pch.h` file which can create conflicts.

A good practice would be for header files not to depend on `pch.h` files, and only let the `.cpp` files to depend on them.

A microsoft employee must use /azp run to validate using the pipelines below.

WARNING:
Comments made by azure-pipelines bot maybe inaccurate.
Please see pipeline link to verify that the build is being ran.

For status checks on the main branch, please use TransportPackage-Foundation-PR
(https://microsoft.visualstudio.com/ProjectReunion/_build?definitionId=81063&_a=summary)
and run the build against your PR branch with the default parameters.
