### PR TITLE
Pipeline fix to unblock official.

### DIFF
--- a/build/AzurePipelinesTemplates/WindowsAppSDK-Publish-Stage.yml
+++ b/build/AzurePipelinesTemplates/WindowsAppSDK-Publish-Stage.yml
@@ -12,7 +12,7 @@ parameters:
 - name: "TestOnArm64"
   displayName: "Enable running of sample tests on arm64 platform (Default: false)"
   type: boolean
-  default: false
+  default: true
 - name: "MaestroDependOnTestSamples"
   displayName: "Whether Maestro publishing should depend on successful Sample tests"
   type: boolean

--- a/build/WindowsAppSDK-Foundation-PR.yml
+++ b/build/WindowsAppSDK-Foundation-PR.yml
@@ -29,9 +29,9 @@ parameters: # parameters are shown up in ADO UI in a build queue time
   type: boolean
   default: false
 - name: "TestOnArm64"
-  displayName: "Enable running of tests on arm64 platform (Default: false)"
+  displayName: "Enable running of tests on arm64 platform (Default: true)"
   type: boolean
-  default: false
+  default: true
 - name: runStaticAnalysis
   displayName: "Run Static Analysis (e.g., PREFast, APIScan)"
   type: boolean


### PR DESCRIPTION
2.0 already went in: https://github.com/microsoft/WindowsAppSDK/pull/5932

A microsoft employee must use /azp run to validate using the pipelines below.

WARNING:
Comments made by azure-pipelines bot maybe inaccurate.
Please see pipeline link to verify that the build is being ran.

For status checks on the main branch, please use TransportPackage-Foundation-PR
(https://microsoft.visualstudio.com/ProjectReunion/_build?definitionId=81063&_a=summary)
and run the build against your PR branch with the default parameters.
