### PR TITLE
Shorten VSIX DisplayName to fit 50 char limit when Experimental prefix is added

### DIFF
--- a/dev/VSIX/Extension/Cpp/Dev17/Component/source.extension.vsixmanifest
+++ b/dev/VSIX/Extension/Cpp/Dev17/Component/source.extension.vsixmanifest
@@ -2,7 +2,7 @@
 <PackageManifest Version="2.0.0" xmlns="http://schemas.microsoft.com/developer/vsx-schema/2011" xmlns:d="http://schemas.microsoft.com/developer/vsx-schema-design/2011">
   <Metadata>
     <Identity Id="Microsoft.WindowsAppSDK.Cpp.Dev17" Version="|%CurrentProject%;GetVSIXVersion|" Language="en-US" Publisher="Microsoft" />
-    <DisplayName>Windows App SDK C++ VS 2022-2026 Templates</DisplayName>
+    <DisplayName>Windows App SDK C++ VS Templates</DisplayName>
     <Description xml:space="preserve">The Microsoft Windows App SDK Visual Studio extension adds C++ project and item templates to support building Windows apps and components in VS 2022-2026.</Description>
     <MoreInfo>https://github.com/microsoft/WindowsAppSDK/</MoreInfo>
     <License>LICENSE</License>

--- a/dev/VSIX/Extension/Cpp/Dev17/Standalone/source.extension.vsixmanifest
+++ b/dev/VSIX/Extension/Cpp/Dev17/Standalone/source.extension.vsixmanifest
@@ -2,7 +2,7 @@
 <PackageManifest Version="2.0.0" xmlns="http://schemas.microsoft.com/developer/vsx-schema/2011" xmlns:d="http://schemas.microsoft.com/developer/vsx-schema-design/2011">
   <Metadata>
     <Identity Id="Microsoft.WindowsAppSDK.Cpp.Dev17" Version="|%CurrentProject%;GetVSIXVersion|" Language="en-US" Publisher="Microsoft" />
-    <DisplayName>Windows App SDK C++ VS 2022-2026 Templates</DisplayName>
+    <DisplayName>Windows App SDK C++ VS Templates</DisplayName>
     <Description xml:space="preserve">The Microsoft Windows App SDK Visual Studio extension adds C++ project and item templates to support building Windows apps and components in VS 2022-2026.</Description>
     <MoreInfo>https://github.com/microsoft/WindowsAppSDK/</MoreInfo>
     <License>LICENSE</License>

--- a/dev/VSIX/Extension/Cs/Dev17/Component/source.extension.vsixmanifest
+++ b/dev/VSIX/Extension/Cs/Dev17/Component/source.extension.vsixmanifest
@@ -2,7 +2,7 @@
 <PackageManifest Version="2.0.0" xmlns="http://schemas.microsoft.com/developer/vsx-schema/2011" xmlns:d="http://schemas.microsoft.com/developer/vsx-schema-design/2011">
   <Metadata>
     <Identity Id="Microsoft.WindowsAppSDK.Cs.Dev17" Version="|%CurrentProject%;GetVSIXVersion|" Language="en-US" Publisher="Microsoft" />
-    <DisplayName>Windows App SDK C# VS 2022-2026 Templates</DisplayName>
+    <DisplayName>Windows App SDK C# VS Templates</DisplayName>
     <Description xml:space="preserve">The Microsoft Windows App SDK Visual Studio extension adds C# project and item templates to support building Windows apps and components in VS 2022-2026.</Description>
     <MoreInfo>https://github.com/microsoft/WindowsAppSDK/</MoreInfo>
     <License>LICENSE</License>

--- a/dev/VSIX/Extension/Cs/Dev17/Standalone/source.extension.vsixmanifest
+++ b/dev/VSIX/Extension/Cs/Dev17/Standalone/source.extension.vsixmanifest
@@ -2,7 +2,7 @@
 <PackageManifest Version="2.0.0" xmlns="http://schemas.microsoft.com/developer/vsx-schema/2011" xmlns:d="http://schemas.microsoft.com/developer/vsx-schema-design/2011">
   <Metadata>
     <Identity Id="Microsoft.WindowsAppSDK.Cs.Dev17" Version="|%CurrentProject%;GetVSIXVersion|" Language="en-US" Publisher="Microsoft" />
-    <DisplayName>Windows App SDK C# VS 2022-2026 Templates</DisplayName>
+    <DisplayName>Windows App SDK C# VS Templates</DisplayName>
     <Description xml:space="preserve">The Microsoft Windows App SDK Visual Studio extension adds C# project and item templates to support building Windows apps and components in VS 2022-2026.</Description>
     <MoreInfo>https://github.com/microsoft/WindowsAppSDK/</MoreInfo>
     <License>LICENSE</License>


### PR DESCRIPTION
[Nightly pipeline validation - stable](https://microsoft.visualstudio.com/ProjectReunion/_build/results?buildId=132796826&view=results)
[Nightly pipeline validation - experimental](https://microsoft.visualstudio.com/ProjectReunion/_build/results?buildId=132802970&view=results)

## Summary

Shortens VSIX DisplayName to fix schema validation error when experimental features are enabled.

## Problem

The VSIX schema has a 50-character limit for DisplayName. When `EnableExperimentalVSIXFeatures=true`, the build prepends "Experimental " to the DisplayName, causing the following error:

```Error VSSDK1062: The 'DisplayName' element is invalid - The actual length is greater than the MaxLength value.```

## Solution

Removed the year range from DisplayNames since it's redundant (already specified in `<InstallationTarget>` elements).

**New DisplayNames:**
- `Windows App SDK C# VS Templates` (35 chars) → `Experimental ...` (48 chars) ✅
- `Windows App SDK C++ VS Templates` (36 chars) → `Experimental ...` (49 chars) ✅

## Files Changed

- `dev/VSIX/Extension/Cs/Dev17/Standalone/source.extension.vsixmanifest`
- `dev/VSIX/Extension/Cs/Dev17/Component/source.extension.vsixmanifest`
- `dev/VSIX/Extension/Cpp/Dev17/Standalone/source.extension.vsixmanifest`
- `dev/VSIX/Extension/Cpp/Dev17/Component/source.extension.vsixmanifest`

A microsoft employee must use /azp run to validate using the pipelines below.

WARNING:
Comments made by azure-pipelines bot maybe inaccurate.
Please see pipeline link to verify that the build is being ran.

For status checks on the main branch, please use TransportPackage-Foundation-PR
(https://microsoft.visualstudio.com/ProjectReunion/_build?definitionId=81063&_a=summary)
and run the build against your PR branch with the default parameters.
