### PR TITLE
2.0-exp3 Update Patch to 3; Fix to revision causing runaway patch number

### DIFF
--- a/build/AzurePipelinesTemplates/WindowsAppSDK-PackTransportPackage-Stage.yml
+++ b/build/AzurePipelinesTemplates/WindowsAppSDK-PackTransportPackage-Stage.yml
@@ -167,12 +167,6 @@ stages:
       inputs:
         targetType: 'inline'
         script: |
-          if ([int]$(versionCounter) -gt 999)
-          {
-            Write-Host "Revision Number limit reach. Please try again the next day"
-            Write-Host "##vso[task.complete result=Failed;]DONE"
-          }
-
           $buildType = '$(channel)'
           $majorMinorPatchRev = '$(MajorVersion).$(MinorVersion).3'
           


### PR DESCRIPTION
A microsoft employee must use /azp run to validate using the pipelines below.

WARNING:
Comments made by azure-pipelines bot maybe inaccurate.
Please see pipeline link to verify that the build is being ran.

For status checks on the main branch, please use TransportPackage-Foundation-PR
(https://microsoft.visualstudio.com/ProjectReunion/_build?definitionId=81063&_a=summary)
and run the build against your PR branch with the default parameters.
