### PR TITLE
Update VS Template for C# and WinRT to enable calling AI API by default

### DIFF
--- a/dev/VSIX/ProjectTemplates/Desktop/CSharp/PackagedApp/WapProj/Package-managed.appxmanifest
+++ b/dev/VSIX/ProjectTemplates/Desktop/CSharp/PackagedApp/WapProj/Package-managed.appxmanifest
@@ -5,7 +5,8 @@
   xmlns:mp="http://schemas.microsoft.com/appx/2014/phone/manifest"
   xmlns:uap="http://schemas.microsoft.com/appx/manifest/uap/windows10"
   xmlns:rescap="http://schemas.microsoft.com/appx/manifest/foundation/windows10/restrictedcapabilities"
-  IgnorableNamespaces="uap rescap">
+  xmlns:systemai="http://schemas.microsoft.com/appx/manifest/systemai/windows10"
+  IgnorableNamespaces="uap rescap systemai">
 
   <Identity
     Name="$guid9$"
@@ -21,8 +22,8 @@
   </Properties>
 
   <Dependencies>
-    <TargetDeviceFamily Name="Windows.Universal" MinVersion="10.0.17763.0" MaxVersionTested="10.0.19041.0" />
-    <TargetDeviceFamily Name="Windows.Desktop" MinVersion="10.0.17763.0" MaxVersionTested="10.0.19041.0" />
+    <TargetDeviceFamily Name="Windows.Universal" MinVersion="10.0.17763.0" MaxVersionTested="10.0.26226.0" />
+    <TargetDeviceFamily Name="Windows.Desktop" MinVersion="10.0.17763.0" MaxVersionTested="10.0.26226.0" />
   </Dependencies>
 
   <Resources>
@@ -47,5 +48,6 @@
 
   <Capabilities>
     <rescap:Capability Name="runFullTrust" />
+    <systemai:Capability Name="systemAIModels"/>
   </Capabilities>
 </Package>

--- a/dev/VSIX/ProjectTemplates/Desktop/CSharp/SingleProjectPackagedApp/Package-managed.appxmanifest
+++ b/dev/VSIX/ProjectTemplates/Desktop/CSharp/SingleProjectPackagedApp/Package-managed.appxmanifest
@@ -5,7 +5,8 @@
   xmlns:mp="http://schemas.microsoft.com/appx/2014/phone/manifest"
   xmlns:uap="http://schemas.microsoft.com/appx/manifest/uap/windows10"
   xmlns:rescap="http://schemas.microsoft.com/appx/manifest/foundation/windows10/restrictedcapabilities"
-  IgnorableNamespaces="uap rescap">
+  xmlns:systemai="http://schemas.microsoft.com/appx/manifest/systemai/windows10"
+  IgnorableNamespaces="uap rescap systemai">
 
   <Identity
     Name="$guid9$"
@@ -21,8 +22,8 @@
   </Properties>
 
   <Dependencies>
-    <TargetDeviceFamily Name="Windows.Universal" MinVersion="10.0.17763.0" MaxVersionTested="10.0.19041.0" />
-    <TargetDeviceFamily Name="Windows.Desktop" MinVersion="10.0.17763.0" MaxVersionTested="10.0.19041.0" />
+    <TargetDeviceFamily Name="Windows.Universal" MinVersion="10.0.17763.0" MaxVersionTested="10.0.26226.0" />
+    <TargetDeviceFamily Name="Windows.Desktop" MinVersion="10.0.17763.0" MaxVersionTested="10.0.26226.0" />
   </Dependencies>
 
   <Resources>
@@ -47,5 +48,6 @@
 
   <Capabilities>
     <rescap:Capability Name="runFullTrust" />
+    <systemai:Capability Name="systemAIModels"/>
   </Capabilities>
 </Package>

--- a/dev/VSIX/ProjectTemplates/Desktop/CSharp/UnitTestApp/Package-managed.appxmanifest
+++ b/dev/VSIX/ProjectTemplates/Desktop/CSharp/UnitTestApp/Package-managed.appxmanifest
@@ -5,7 +5,8 @@
   xmlns:mp="http://schemas.microsoft.com/appx/2014/phone/manifest"
   xmlns:uap="http://schemas.microsoft.com/appx/manifest/uap/windows10"
   xmlns:rescap="http://schemas.microsoft.com/appx/manifest/foundation/windows10/restrictedcapabilities"
-  IgnorableNamespaces="uap rescap">
+  xmlns:systemai="http://schemas.microsoft.com/appx/manifest/systemai/windows10"
+  IgnorableNamespaces="uap rescap systemai">
 
   <Identity
     Name="$guid9$"
@@ -21,8 +22,8 @@
   </Properties>
 
   <Dependencies>
-    <TargetDeviceFamily Name="Windows.Universal" MinVersion="10.0.17763.0" MaxVersionTested="10.0.19041.0" />
-    <TargetDeviceFamily Name="Windows.Desktop" MinVersion="10.0.17763.0" MaxVersionTested="10.0.19041.0" />
+    <TargetDeviceFamily Name="Windows.Universal" MinVersion="10.0.17763.0" MaxVersionTested="10.0.26226.0" />
+    <TargetDeviceFamily Name="Windows.Desktop" MinVersion="10.0.17763.0" MaxVersionTested="10.0.26226.0" />
   </Dependencies>
 
   <Resources>
@@ -47,5 +48,6 @@
 
   <Capabilities>
     <rescap:Capability Name="runFullTrust" />
+    <systemai:Capability Name="systemAIModels"/>
   </Capabilities>
 </Package>

--- a/dev/VSIX/ProjectTemplates/Desktop/CppWinRT/PackagedApp/WapProj/Package-managed.appxmanifest
+++ b/dev/VSIX/ProjectTemplates/Desktop/CppWinRT/PackagedApp/WapProj/Package-managed.appxmanifest
@@ -5,7 +5,8 @@
   xmlns:mp="http://schemas.microsoft.com/appx/2014/phone/manifest"
   xmlns:uap="http://schemas.microsoft.com/appx/manifest/uap/windows10"
   xmlns:rescap="http://schemas.microsoft.com/appx/manifest/foundation/windows10/restrictedcapabilities"
-  IgnorableNamespaces="uap rescap">
+  xmlns:systemai="http://schemas.microsoft.com/appx/manifest/systemai/windows10"
+  IgnorableNamespaces="uap rescap systemai">
 
   <Identity
     Name="$guid9$"
@@ -21,8 +22,8 @@
   </Properties>
 
   <Dependencies>
-    <TargetDeviceFamily Name="Windows.Universal" MinVersion="10.0.17763.0" MaxVersionTested="10.0.19041.0" />
-    <TargetDeviceFamily Name="Windows.Desktop" MinVersion="10.0.17763.0" MaxVersionTested="10.0.19041.0" />
+    <TargetDeviceFamily Name="Windows.Universal" MinVersion="10.0.17763.0" MaxVersionTested="10.0.26226.0" />
+    <TargetDeviceFamily Name="Windows.Desktop" MinVersion="10.0.17763.0" MaxVersionTested="10.0.26226.0" />
   </Dependencies>
 
   <Resources>
@@ -47,5 +48,6 @@
 
   <Capabilities>
     <rescap:Capability Name="runFullTrust" />
+    <systemai:Capability Name="systemAIModels"/>
   </Capabilities>
 </Package>

--- a/dev/VSIX/ProjectTemplates/Desktop/CppWinRT/SingleProjectPackagedApp/Package-native.appxmanifest
+++ b/dev/VSIX/ProjectTemplates/Desktop/CppWinRT/SingleProjectPackagedApp/Package-native.appxmanifest
@@ -5,7 +5,8 @@
   xmlns:mp="http://schemas.microsoft.com/appx/2014/phone/manifest"
   xmlns:uap="http://schemas.microsoft.com/appx/manifest/uap/windows10"
   xmlns:rescap="http://schemas.microsoft.com/appx/manifest/foundation/windows10/restrictedcapabilities"
-  IgnorableNamespaces="uap rescap">
+  xmlns:systemai="http://schemas.microsoft.com/appx/manifest/systemai/windows10"
+  IgnorableNamespaces="uap rescap systemai">
 
   <Identity
     Name="$guid9$"
@@ -21,8 +22,8 @@
   </Properties>
 
   <Dependencies>
-    <TargetDeviceFamily Name="Windows.Universal" MinVersion="10.0.17763.0" MaxVersionTested="10.0.19041.0" />
-    <TargetDeviceFamily Name="Windows.Desktop" MinVersion="10.0.17763.0" MaxVersionTested="10.0.19041.0" />
+    <TargetDeviceFamily Name="Windows.Universal" MinVersion="10.0.17763.0" MaxVersionTested="10.0.26226.0" />
+    <TargetDeviceFamily Name="Windows.Desktop" MinVersion="10.0.17763.0" MaxVersionTested="10.0.26226.0" />
   </Dependencies>
 
   <Resources>
@@ -47,5 +48,6 @@
 
   <Capabilities>
     <rescap:Capability Name="runFullTrust" />
+    <systemai:Capability Name="systemAIModels"/>
   </Capabilities>
 </Package>

--- a/dev/VSIX/ProjectTemplates/Desktop/CppWinRT/UnitTestApp/Package-native.appxmanifest
+++ b/dev/VSIX/ProjectTemplates/Desktop/CppWinRT/UnitTestApp/Package-native.appxmanifest
@@ -5,7 +5,8 @@
   xmlns:mp="http://schemas.microsoft.com/appx/2014/phone/manifest"
   xmlns:uap="http://schemas.microsoft.com/appx/manifest/uap/windows10"
   xmlns:rescap="http://schemas.microsoft.com/appx/manifest/foundation/windows10/restrictedcapabilities"
-  IgnorableNamespaces="uap rescap">
+  xmlns:systemai="http://schemas.microsoft.com/appx/manifest/systemai/windows10"
+  IgnorableNamespaces="uap rescap systemai">
 
   <Identity
     Name="$guid9$"
@@ -21,8 +22,8 @@
   </Properties>
 
   <Dependencies>
-    <TargetDeviceFamily Name="Windows.Universal" MinVersion="10.0.17763.0" MaxVersionTested="10.0.19041.0" />
-    <TargetDeviceFamily Name="Windows.Desktop" MinVersion="10.0.17763.0" MaxVersionTested="10.0.19041.0" />
+    <TargetDeviceFamily Name="Windows.Universal" MinVersion="10.0.17763.0" MaxVersionTested="10.0.26226.0" />
+    <TargetDeviceFamily Name="Windows.Desktop" MinVersion="10.0.17763.0" MaxVersionTested="10.0.26226.0" />
     <PackageDependency Name="Microsoft.VCLibs.140.00" MinVersion="14.0.33519.0" Publisher="CN=Microsoft Corporation, O=Microsoft Corporation, L=Redmond, S=Washington, C=US" />
   </Dependencies>
 
@@ -48,6 +49,7 @@
 
   <Capabilities>
     <rescap:Capability Name="runFullTrust" />
+    <systemai:Capability Name="systemAIModels"/>
   </Capabilities>
 
   <Extensions>


### PR DESCRIPTION
# Background
According to this public doc:
https://learn.microsoft.com/en-us/windows/ai/apis/get-started?tabs=winget%2Cwinui%2Cwinui2
Every dev need to do 3 extra steps before calling AI APIs:
<img width="639" height="674" alt="image" src="https://github.com/user-attachments/assets/4a46227e-bfe2-4322-9c68-0c1d0f23449f" />
I am not sure if anyone will read this "get-started" step 3 carefully, but at least I don't aware that at all a month ago, and not sure spend me how much time to figure it out on my project.

# Fix
In minimal, let's fix the template first. Other Vibe coding Troubleshooting is TBD for existing projects in the world.
This pull request updates several packaged app manifest templates for both C# and C++ desktop projects to support new system AI model capabilities. The changes ensure that new projects created from these templates can declare and use system AI models and are compatible with the most recent Windows features.
Fore sure, there are other circumstance, e.g. what platform SDK VS has, does it run on NPU machine etc which it doesn't mean this change can help for everything, but at least our template update is a good start for less fraction.

**Manifest capability and compatibility updates:**

* Added the `systemai` XML namespace and included `systemai:Capability Name="systemAIModels"` in the `<Capabilities>` section to enable packaged apps to declare usage of system AI models. [[1]](diffhunk://#diff-59f8083ebc7c13ad3159e39653a7dfbe3dbdbf535be7917819bba67b93a601dbL8-R9) [[2]](diffhunk://#diff-11c1ff806763fd92a6c84407238ec24f5493fb113f1246981c7483873f685f3eL8-R9) [[3]](diffhunk://#diff-c8522c0152e7df90d005d82cb9c4c4c362e7f330e1b86d6ef4af13d1714e2d3eL8-R9) [[4]](diffhunk://#diff-59f8083ebc7c13ad3159e39653a7dfbe3dbdbf535be7917819bba67b93a601dbR51) [[5]](diffhunk://#diff-11c1ff806763fd92a6c84407238ec24f5493fb113f1246981c7483873f685f3eR51) [[6]](diffhunk://#diff-c8522c0152e7df90d005d82cb9c4c4c362e7f330e1b86d6ef4af13d1714e2d3eR52)
* Updated the `IgnorableNamespaces` attribute to include `systemai`, ensuring the new namespace is recognized and ignored where appropriate. [[1]](diffhunk://#diff-59f8083ebc7c13ad3159e39653a7dfbe3dbdbf535be7917819bba67b93a601dbL8-R9) [[2]](diffhunk://#diff-11c1ff806763fd92a6c84407238ec24f5493fb113f1246981c7483873f685f3eL8-R9) [[3]](diffhunk://#diff-c8522c0152e7df90d005d82cb9c4c4c362e7f330e1b86d6ef4af13d1714e2d3eL8-R9)
* Increased the `MaxVersionTested` for `TargetDeviceFamily` entries from `10.0.19041.0` to `10.0.26226.0` to target the latest Windows 10 SDK, improving compatibility with newer Windows releases. [[1]](diffhunk://#diff-59f8083ebc7c13ad3159e39653a7dfbe3dbdbf535be7917819bba67b93a601dbL24-R26) [[2]](diffhunk://#diff-11c1ff806763fd92a6c84407238ec24f5493fb113f1246981c7483873f685f3eL24-R26) [[3]](diffhunk://#diff-c8522c0152e7df90d005d82cb9c4c4c362e7f330e1b86d6ef4af13d1714e2d3eL24-R26)
* Applied these changes consistently across all relevant manifest templates for C# and C++ desktop project types, including packaged apps, single project packaged apps, and unit test apps. [[1]](diffhunk://#diff-59f8083ebc7c13ad3159e39653a7dfbe3dbdbf535be7917819bba67b93a601dbL8-R9) [[2]](diffhunk://#diff-11c1ff806763fd92a6c84407238ec24f5493fb113f1246981c7483873f685f3eL8-R9) [[3]](diffhunk://#diff-c8522c0152e7df90d005d82cb9c4c4c362e7f330e1b86d6ef4af13d1714e2d3eL8-R9)
