### PR TITLE
Fix: getting activity context by reference on deployment method

### DIFF
--- a/dev/Deployment/DeploymentManager.cpp
+++ b/dev/Deployment/DeploymentManager.cpp
@@ -574,7 +574,7 @@ namespace winrt::Microsoft::Windows::ApplicationModel::WindowsAppRuntime::implem
 
     HRESULT DeploymentManager::DeployPackages(const std::wstring& frameworkPackageFullName, const bool forceDeployment)
     {
-        auto initializeActivity{ ::WindowsAppRuntime::Deployment::Activity::Context::Get() };
+        auto& initializeActivity{ ::WindowsAppRuntime::Deployment::Activity::Context::Get() };
         initializeActivity.Reset();
 
         initializeActivity.SetInstallStage(::WindowsAppRuntime::Deployment::Activity::DeploymentStage::GetPackagePath);


### PR DESCRIPTION
The activity context global variable was not being get by reference, we were getting a copy of it instead. This creates an issue in telemetry collection as in the deployment stage, it was never actually setting the data on the global variable, but into a local copy of it inside the method's scope.

This makes any error originated inside the deployment method to be reported as an error in the installation phase with the singleton license, making it hard to track down the possible error origin.

TO-DO: Add unit tests to check the activity behavior after the refactoring of the deployment manager flow.

A microsoft employee must use /azp run to validate using the pipelines below.

WARNING:
Comments made by azure-pipelines bot maybe inaccurate.
Please see pipeline link to verify that the build is being ran.

For status checks on the main branch, please use TransportPackage-Foundation-PR
(https://microsoft.visualstudio.com/ProjectReunion/_build?definitionId=81063&_a=summary)
and run the build against your PR branch with the default parameters.
