### PR TITLE
Migrate net6 to net8 for the Test Sample app

### DIFF
--- a/test/WindowsAppSDK.Test.SampleTests/WindowsAppSDKSampleAppTests.cs
+++ b/test/WindowsAppSDK.Test.SampleTests/WindowsAppSDKSampleAppTests.cs
@@ -702,7 +702,7 @@ namespace WindowsAppSDK.Test.SampleTests
                 return;
             }
 
-            var exePath = GetFullFilePathFromRelativePath("SelfContainedDeployment\\cs\\cs-console-unpackaged\\bin\\[BuildArch]\\[BuildConfig]\\net8.0-windows10.0.19041.0\\win10-[BuildArch]\\SelfContainedDeployment.exe");
+            var exePath = GetFullFilePathFromRelativePath("SelfContainedDeployment\\cs\\cs-console-unpackaged\\bin\\[BuildArch]\\[BuildConfig]\\net8.0-windows10.0.19041.0\\win-[BuildArch]\\SelfContainedDeployment.exe");
             LaunchUnpackagedConsoleApp(exePath);
             return;
         }
@@ -717,7 +717,7 @@ namespace WindowsAppSDK.Test.SampleTests
                 return;
             }
 
-            var exePath = GetFullFilePathFromRelativePath("SelfContainedDeployment\\cs\\cs-wpf-unpackaged\\bin\\[BuildArch]\\[BuildConfig]\\net8.0-windows10.0.17763.0\\win10-[BuildArch]\\SelfContainedDeployment.exe");
+            var exePath = GetFullFilePathFromRelativePath("SelfContainedDeployment\\cs\\cs-wpf-unpackaged\\bin\\[BuildArch]\\[BuildConfig]\\net8.0-windows10.0.17763.0\\win-[BuildArch]\\SelfContainedDeployment.exe");
             LaunchAndCloseUnpackagedApp(exePath, "MainWindow", "SelfContainedDeployment.exe");
             return;
         }


### PR DESCRIPTION
This pull request updates the test project and related test cases to target .NET 8 instead of .NET 6. The changes ensure that all sample test applications and their paths are compatible with .NET 8, improving future compatibility and aligning with newer framework standards.
This pull request depends on this PR to be completed first on WinAppSDK-Samples: https://github.com/microsoft/WindowsAppSDK-Samples/pull/574

Test case updates for .NET 8 compatibility:

* Modified all references in `WindowsAppSDKSampleAppTests.cs` to use `net8.0-windows10.0.19041.0` or `net8.0-windows10.0.17763.0` in the sample app paths, replacing previous `net6.0` references to ensure the correct binaries are targeted for tests. [[1]](diffhunk://#diff-9909d6725488eda3e54e0b4eade70737f22f59c858cc24c218d522769157475bL705-R705) [[2]](diffhunk://#diff-9909d6725488eda3e54e0b4eade70737f22f59c858cc24c218d522769157475bL720-R720) [[3]](diffhunk://#diff-9909d6725488eda3e54e0b4eade70737f22f59c858cc24c218d522769157475bL755-R755) [[4]](diffhunk://#diff-9909d6725488eda3e54e0b4eade70737f22f59c858cc24c218d522769157475bL783-R783) [[5]](diffhunk://#diff-9909d6725488eda3e54e0b4eade70737f22f59c858cc24c218d522769157475bL797-R797) [[6]](diffhunk://#diff-9909d6725488eda3e54e0b4eade70737f22f59c858cc24c218d522769157475bL852-R852) [[7]](diffhunk://#diff-9909d6725488eda3e54e0b4eade70737f22f59c858cc24c218d522769157475bL880-R880) [[8]](diffhunk://#diff-9909d6725488eda3e54e0b4eade70737f22f59c858cc24c218d522769157475bL910-R910) [[9]](diffhunk://#diff-9909d6725488eda3e54e0b4eade70737f22f59c858cc24c218d522769157475bL926-R926) [[10]](diffhunk://#diff-9909d6725488eda3e54e0b4eade70737f22f59c858cc24c218d522769157475bL956-R956) [[11]](diffhunk://#diff-9909d6725488eda3e54e0b4eade70737f22f59c858cc24c218d522769157475bL986-R986) [[12]](diffhunk://#diff-9909d6725488eda3e54e0b4eade70737f22f59c858cc24c218d522769157475bL1002-R1002) [[13]](diffhunk://#diff-9909d6725488eda3e54e0b4eade70737f22f59c858cc24c218d522769157475bL1164-R1164) [[14]](diffhunk://#diff-9909d6725488eda3e54e0b4eade70737f22f59c858cc24c218d522769157475bL1208-R1208) [[15]](diffhunk://#diff-9909d6725488eda3e54e0b4eade70737f22f59c858cc24c218d522769157475bL1268-R1268)
