### PR TITLE
Revert "Fix: getting activity context by reference on deployment method"

### DIFF
--- a/dev/Deployment/DeploymentManager.cpp
+++ b/dev/Deployment/DeploymentManager.cpp
@@ -574,7 +574,7 @@ namespace winrt::Microsoft::Windows::ApplicationModel::WindowsAppRuntime::implem
 
     HRESULT DeploymentManager::DeployPackages(const std::wstring& frameworkPackageFullName, const bool forceDeployment)
     {
-        auto& initializeActivity{ ::WindowsAppRuntime::Deployment::Activity::Context::Get() };
+        auto initializeActivity{ ::WindowsAppRuntime::Deployment::Activity::Context::Get() };
         initializeActivity.Reset();
 
         initializeActivity.SetInstallStage(::WindowsAppRuntime::Deployment::Activity::DeploymentStage::GetPackagePath);


### PR DESCRIPTION
Reverts microsoft/WindowsAppSDK#6000