### PR TITLE
Bugfix: the filter name for FileOpenPicker.FileTypeFilters

### DIFF
--- a/dev/Interop/StoragePickers/PickerCommon.cpp
+++ b/dev/Interop/StoragePickers/PickerCommon.cpp
@@ -318,7 +318,7 @@ namespace PickerCommon {
         for (const auto& filter : filters)
         {
             auto ext = FormatExtensionWithWildcard(filter);
-            FileTypeFilterData.push_back(L"");
+            FileTypeFilterData.push_back(ext);
             FileTypeFilterData.push_back(ext);
 
             allFilesExtensionList += ext;

--- a/test/StoragePickersTests/PickerCommonTests.cpp
+++ b/test/StoragePickersTests/PickerCommonTests.cpp
@@ -158,13 +158,22 @@ namespace Test::PickerCommonTests
             VERIFY_ARE_EQUAL(parameters.FileTypeFilterPara.size(), 3);
 
             VERIFY_ARE_EQUAL(
+                std::wstring(parameters.FileTypeFilterPara[0].pszName),
+                L"*.txt");
+            VERIFY_ARE_EQUAL(
                 std::wstring(parameters.FileTypeFilterPara[0].pszSpec),
                 L"*.txt");
 
             VERIFY_ARE_EQUAL(
+                std::wstring(parameters.FileTypeFilterPara[1].pszName),
+                L"*.doc");
+            VERIFY_ARE_EQUAL(
                 std::wstring(parameters.FileTypeFilterPara[1].pszSpec),
                 L"*.doc");
 
+            VERIFY_ARE_EQUAL(
+                std::wstring(parameters.FileTypeFilterPara[2].pszName),
+                L"All Files");
             VERIFY_ARE_EQUAL(
                 std::wstring(parameters.FileTypeFilterPara[2].pszSpec),
                 L"*.txt;*.doc");


### PR DESCRIPTION
**Issue description**
This PR is the fix for Issue
- #5837 

The single FileTypeFilters are not displayed when the system's file extension is not enabled.

**Cause and Fix**

The cause was filter spec name is not declared when creating filter specs for the open file dialog. And the fix adds spec name back.

**Comparing with/without fix**

1. When the system is set to hide file extension (the default setting):

With fix:
<img width="470" height="218" alt="image" src="https://github.com/user-attachments/assets/f7e23174-5518-4959-a497-de3d0b1fce87" />



Without fix:
<img width="391" height="147" alt="image" src="https://github.com/user-attachments/assets/044f01e3-7380-4e0e-a539-535207b302d7" />

2. When the system is set to display file extensions.

With fix:
<img width="488" height="199" alt="image" src="https://github.com/user-attachments/assets/265d7149-4bba-4931-9e89-a8069053a83f" />

Without fix:
<img width="489" height="210" alt="image" src="https://github.com/user-attachments/assets/32e02dca-78a6-4d73-a2ab-c886f2becfc1" />




