### PR TITLE
Bugfix: FileSavePicker.PickSaveFileAsync() should not truncate file when the picked file exists.

### DIFF
--- a/dev/Interop/StoragePickers/FileSavePicker.cpp
+++ b/dev/Interop/StoragePickers/FileSavePicker.cpp
@@ -171,10 +171,9 @@ namespace winrt::Microsoft::Windows::Storage::Pickers::implementation
         check_hresult(shellItem->GetDisplayName(SIGDN_NORMALDISPLAY, fileName.put()));
         std::wstring fileNameStr(fileName.get());
 
-        // Create a file. If the file already exists,
-        // since common item dialog prompts to let user select cancel or override, thus we can safely truncate here.
-        // Due to our design spec to align with UWP pickers, we need ensure existance of picked file.
-        auto [handle, _] = wil::try_open_or_truncate_existing_file(pathStr.c_str(), GENERIC_WRITE);
+        // Create an empty file if the file doesn't exist,
+        // If the file already exists, do nothing.
+        auto [handle, _] = wil::try_open_or_create_file(pathStr.c_str(), GENERIC_WRITE);
 
         if (cancellationToken())
         {


### PR DESCRIPTION
**Description**

This PR is part of the solution of issue
- #5976 

In `PickSaveFileAsync`, if the picked file exists, user will see a warning prompt re-confirming if the picked file can be overwrite. 
<img width="1100" height="574" alt="image" src="https://github.com/user-attachments/assets/d956dd69-d4e0-4b11-85e6-b6a79e732418" />

**Then, if user selected "Yes", the FileSavePicker directly truncate the picked file to be empty.**

This is not an expected behavior, and it can block some scenarios, such as:
- Developers may need to read original content after the file is picked.
- Developers may want to add some extra confirmation step before actually overwriting the file (as described in the issue).

Additionally, the UWP FileSavePicker won't directly truncate an existing picked save file in method PickSaveFileAsync().


**Fix**

Updating the file creation method to be:
- If the picked file doesn't exist, create an empty file.
- if the picked file already exist, do nothing, do not truncate it.