### PR TITLE
Add ManualValidation step for RuntimeCompatibilityChange in servicing builds

### DIFF
--- a/build/WindowsAppSDK-Foundation-Official.yml
+++ b/build/WindowsAppSDK-Foundation-Official.yml
@@ -49,6 +49,10 @@ parameters:
   displayName: "Whether Maestro publishing should depend on successful Sample tests"
   type: boolean
   default: false
+- name: "validateRuntimeCompatibility"
+  displayName: "Validate Runtime Compatibility Enums (Servicing builds only)"
+  type: boolean
+  default: true
 
 variables:
 - template: WindowsAppSDK-Foundation-TestConfig.yml@WindowsAppSDKConfig
@@ -121,8 +125,8 @@ extends:
 
     - stage: ManualValidation_RuntimeCompatibility
       displayName: 'Manual Validation - RuntimeCompatibilityChange Enums'
-      # Only run this validation for servicing builds (release branches)
-      condition: contains(variables['Build.SourceBranch'], 'release/')
+      # Only run this validation for release branches
+      condition: and(contains(variables['Build.SourceBranch'], 'release/'), eq(parameters.validateRuntimeCompatibility, true))
       dependsOn: []
       jobs:
       - job: waitForValidation


### PR DESCRIPTION
Update the Foundation Official pipeline to require a ManualValidation step when kicking off a servicing build. The person starting the build should confirm that RuntimeCompatibilityChange enum values are added before the pipeline continues.

A microsoft employee must use /azp run to validate using the pipelines below.

WARNING:
Comments made by azure-pipelines bot maybe inaccurate.
Please see pipeline link to verify that the build is being ran.

For status checks on the main branch, please use TransportPackage-Foundation-PR
(https://microsoft.visualstudio.com/ProjectReunion/_build?definitionId=81063&_a=summary)
and run the build against your PR branch with the default parameters.
