### PR TITLE
DevCheck: Creating nuget directory if it does not exist

### DIFF
--- a/tools/DevCheck/DevCheck.ps1
+++ b/tools/DevCheck/DevCheck.ps1
@@ -166,7 +166,7 @@ Param(
 
     [Switch]$NoInteractive=$false,
 
-    [String]$NugetExe=[IO.Path]::GetFullPath("$PSScriptRoot\..\..\.user\nuget.exe"),
+    [String]$NugetExe=[IO.Path]::GetFullPath((Join-Path $PSScriptRoot "..\..\.user\nuget.exe")),
 
     [String]$NugetMinVersion="6.14.0.116",
 


### PR DESCRIPTION
If I don't have the nuget.exe directory created, running `DevCheck.ps1 -NugetExeUpdate` fails as the curl command cannot create the file in the download process (by default, if I don't have the `.user` directory).

This change makes the script create the directory in case of a first download of the nuget in the computer.

A microsoft employee must use /azp run to validate using the pipelines below.

WARNING:
Comments made by azure-pipelines bot maybe inaccurate.
Please see pipeline link to verify that the build is being ran.

For status checks on the main branch, please use TransportPackage-Foundation-PR
(https://microsoft.visualstudio.com/ProjectReunion/_build?definitionId=81063&_a=summary)
and run the build against your PR branch with the default parameters.
