### PR TITLE
Official API Review for new functionalities of Storage.Pickers: SettingsIdentifier; InitialFileTypeIndex; Title; PickMultipleFoldersAsync; ShowOverwritePrompt

### DIFF
--- a/specs/Storage.Pickers/FileOpenPicker.md
+++ b/specs/Storage.Pickers/FileOpenPicker.md
@@ -158,11 +158,16 @@ Allow customizing the title of file dialog. It's based on the
 
 The SettingsIdentifier property allows the picker object to remember its own states.
 
+If the picker cannot determine the app identity (package identity or executable path), it will
+fail to launch and throw an error.
+
 See the examples in [Note 2: The use case and implementation of SettingsIdentifier (Microsoft.Windows.Storage.Pickers.md)](./Microsoft.Windows.Storage.Pickers.md#note-2-the-use-case-and-implementation-of-settingsidentifier)
 
 ### FileOpenPicker.InitialFileTypeIndex
 
 The InitialFileTypeIndex is a 0-based value deciding the auto-selected file type on dialog launch. 
+
+Values smaller than `-1` or outside the available range will cause the picker to fail to launch.
 
 See the examples in [Note 3: Properties for File Types and The Initial Index (Microsoft.Windows.Storage.Pickers.md)](./Microsoft.Windows.Storage.Pickers.md#note-3-properties-for-file-types-and-its-auto-selection-on-launch)
 

--- a/specs/Storage.Pickers/FileSavePicker.md
+++ b/specs/Storage.Pickers/FileSavePicker.md
@@ -176,11 +176,16 @@ Allow customizing the title of file dialog. It's based on the
 
 The `SettingsIdentifier` property allows the picker object to remember its own states.
 
+If the picker cannot determine the app identity (package identity or executable path), it will
+fail to launch and throw an error.
+
 See the examples in [Note 2: The use case and implementation of SettingsIdentifier (Microsoft.Windows.Storage.Pickers.md)](./Microsoft.Windows.Storage.Pickers.md#note-2-the-use-case-and-implementation-of-settingsidentifier)
 
 ### FileSavePicker.InitialFileTypeIndex
 
 The `InitialFileTypeIndex` property is 0-based. It decides the auto-selected file type on dialog launch.
+
+Values smaller than `-1` or outside the available range will cause the picker to fail to launch.
 
 See the examples in [Note 3: Properties for File Types and The Initial Index (Microsoft.Windows.Storage.Pickers.md)](./Microsoft.Windows.Storage.Pickers.md#note-3-properties-for-file-types-and-its-auto-selection-on-launch)
 

--- a/specs/Storage.Pickers/FolderPicker.md
+++ b/specs/Storage.Pickers/FolderPicker.md
@@ -136,6 +136,9 @@ Allow customizing the title of file dialog. It's based on the
 
 The SettingsIdentifier property allows the picker object to remember its own states.
 
+If the picker cannot determine the app identity (package identity or executable path), it will
+fail to launch and throw an error.
+
 See the examples in [Note 2: The use case and implementation of SettingsIdentifier (Microsoft.Windows.Storage.Pickers.md)](./Microsoft.Windows.Storage.Pickers.md#note-2-the-use-case-and-implementation-of-settingsidentifier)
 
 ## Methods

--- a/specs/Storage.Pickers/Microsoft.Windows.Storage.Pickers.md
+++ b/specs/Storage.Pickers/Microsoft.Windows.Storage.Pickers.md
@@ -274,6 +274,9 @@ API. The implementation derives that `ClientGuid` as follows:
     and coerced into a GUID.
 - The calculated GUID will be passed to set the `ClientGuid`.
 
+If the picker cannot determine either the package identity or the process executable path, it will
+fail to launch and throw an error.
+
 This means the feature works for both packaged and unpackaged apps. Packaged apps remain distinct by
 their package identity, while unpackaged apps are differentiated by the absolute path of their
 executable. As long as an app uses a stable combination of package identity (or executable path) and
@@ -343,5 +346,5 @@ defined,
     (which is its first) category, as `FileTypeChoices` takes precedence over the `FileTypeFilter`.
 
 Additionally,
-- `InitialFileTypeIndex` cannot be set to a value smaller than `-1`;
-- if the index falls outside the available range, we treat it as `-1` (not specified).
+- `InitialFileTypeIndex` cannot be set to a value smaller than `-1` or out of range;
+- if the index falls outside the available range, the dialog will fail to launch.


### PR DESCRIPTION
This pull request updates the Storage.Pickers API specifications to add new customization and usability features to the `FileOpenPicker`, `FileSavePicker`, and `FolderPicker` classes. The changes introduce properties for dialog title and instance-specific settings, allow specifying the default file type filter by 0-based index, and add support for picking multiple folders. These enhancements are reflected in both the API definitions and usage examples.

## Adds properties:

### Title

* Adds `Title` properties to `FileOpenPicker`, `FileSavePicker`, and `FolderPicker`, enabling custom dialog titles. ([[1]](diffhunk://#diff-5cfa035ddfdddfd5f0ea035dc2e78ac86e1b55c323ed0dd06dc9c8bcbf3b5869R22-R27), [[2]](diffhunk://#diff-bcc29af476dc86f30a02d3d5b1dd7590c05e0c8bbae63e7c8bdc9a10feb6f3ecR20-R27), [[3]](diffhunk://#diff-e80bc34d75ca387aa052733c5c44bf7a036fe36ada3021dbb0f3371bcdb4f181R22-R23), [[4]](diffhunk://#diff-bba148e5db9446f11863ced91e43406bb3c998bf5475e491d7086a5ed47b9fe0R131-R136), [[5]](diffhunk://#diff-bba148e5db9446f11863ced91e43406bb3c998bf5475e491d7086a5ed47b9fe0R153-R160), [[6]](diffhunk://#diff-bba148e5db9446f11863ced91e43406bb3c998bf5475e491d7086a5ed47b9fe0R174-R175))

Related:
- #5879

### SettingsIdentifier
* Adds `SettingsIdentifier` properties to `FileOpenPicker`, `FileSavePicker`, and `FolderPicker`, enabling picker instance-specific state across sessions. ([[1]](diffhunk://#diff-5cfa035ddfdddfd5f0ea035dc2e78ac86e1b55c323ed0dd06dc9c8bcbf3b5869R22-R27), [[2]](diffhunk://#diff-bcc29af476dc86f30a02d3d5b1dd7590c05e0c8bbae63e7c8bdc9a10feb6f3ecR20-R27), [[3]](diffhunk://#diff-e80bc34d75ca387aa052733c5c44bf7a036fe36ada3021dbb0f3371bcdb4f181R22-R23), [[4]](diffhunk://#diff-bba148e5db9446f11863ced91e43406bb3c998bf5475e491d7086a5ed47b9fe0R131-R136), [[5]](diffhunk://#diff-bba148e5db9446f11863ced91e43406bb3c998bf5475e491d7086a5ed47b9fe0R153-R160), [[6]](diffhunk://#diff-bba148e5db9446f11863ced91e43406bb3c998bf5475e491d7086a5ed47b9fe0R174-R175))

Related:
- #5847
- https://github.com/microsoft/microsoft-ui-xaml/issues/10904

### InitialFileTypeIndex

* Adds `InitialFileTypeIndex` property to `FileOpenPicker` and `FileSavePicker`, allowing developers to set the default selected file type filter by index (0-based). This is documented and shown in usage examples. ([[1]](diffhunk://#diff-5cfa035ddfdddfd5f0ea035dc2e78ac86e1b55c323ed0dd06dc9c8bcbf3b5869R22-R27), [[2]](diffhunk://#diff-5cfa035ddfdddfd5f0ea035dc2e78ac86e1b55c323ed0dd06dc9c8bcbf3b5869R89-R94), [[3]](diffhunk://#diff-5cfa035ddfdddfd5f0ea035dc2e78ac86e1b55c323ed0dd06dc9c8bcbf3b5869R146-R151), [[4]](diffhunk://#diff-bcc29af476dc86f30a02d3d5b1dd7590c05e0c8bbae63e7c8bdc9a10feb6f3ecR20-R27), [[5]](diffhunk://#diff-bcc29af476dc86f30a02d3d5b1dd7590c05e0c8bbae63e7c8bdc9a10feb6f3ecR71-R88), [[6]](diffhunk://#diff-bcc29af476dc86f30a02d3d5b1dd7590c05e0c8bbae63e7c8bdc9a10feb6f3ecR127-R142), [[7]](diffhunk://#diff-bba148e5db9446f11863ced91e43406bb3c998bf5475e491d7086a5ed47b9fe0R131-R136), [[8]](diffhunk://#diff-bba148e5db9446f11863ced91e43406bb3c998bf5475e491d7086a5ed47b9fe0R153-R160))

Related:
- #5975

### Changes in FileSavePicker
* Adds a new properties for `FileSavePicker`: `ShowOverwritePrompt`:
  `ShowOverwritePrompt` default to `true` and control whether the picker warns about overwriting when user picked an existing file via FileSavePicker.

* Changing the default behavior - when the user picked a not-existing file via FileSavePicker, the picker will NOT create an empty file there - allowing developer to decide when to make this file.

Related:
- #5976

## Adds method:

### FolderPicker.PickMultipleFoldersAsync

* Adds `PickMultipleFoldersAsync` method to `FolderPicker`, enabling selection of multiple folders in a single operation. API definitions, documentation, and code samples have been updated to reflect this feature. ([[1]](diffhunk://#diff-e80bc34d75ca387aa052733c5c44bf7a036fe36ada3021dbb0f3371bcdb4f181R32), [[2]](diffhunk://#diff-e80bc34d75ca387aa052733c5c44bf7a036fe36ada3021dbb0f3371bcdb4f181R170-R221), [[3]](diffhunk://#diff-bba148e5db9446f11863ced91e43406bb3c998bf5475e491d7086a5ed47b9fe0R184)`)

Related:
- #5848
