### PR TITLE
Update VSIX resource files to include NuGet wizard strings

### DIFF
--- a/dev/VSIX/Extension/Cpp/Common/cs-CZ/VSPackage.cs-CZ.resx
+++ b/dev/VSIX/Extension/Cpp/Common/cs-CZ/VSPackage.cs-CZ.resx
@@ -118,31 +118,31 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="1001" xml:space="preserve">
-    <value>Prázdné okno (WinUI 3 na ploše)</value>
+    <value>Prázdné okno</value>
   </data>
   <data name="1002" xml:space="preserve">
-    <value>[Experimentální] Prázdné okno (WinUI 3 na ploše)</value>
+    <value>[Experimentální] Prázdné okno</value>
   </data>
   <data name="1003" xml:space="preserve">
-    <value>Prázdné okno pro desktopové aplikace založené na Knihovně uživatelského rozhraní Windows (WinUI 3)</value>
+    <value>Prázdné okno (WinUI).</value>
   </data>
   <data name="1005" xml:space="preserve">
-    <value>Prázdná stránka (WinUI 3)</value>
+    <value>Prázdná stránka</value>
   </data>
   <data name="1006" xml:space="preserve">
-    <value>[Experimentální] Prázdná stránka (WinUI 3)</value>
+    <value>[Experimentální] Prázdná stránka</value>
   </data>
   <data name="1007" xml:space="preserve">
-    <value>Prázdná stránka pro aplikace založené na Knihovně uživatelského rozhraní Windows (WinUI 3)</value>
+    <value>Prázdná stránka (WinUI).</value>
   </data>
   <data name="1009" xml:space="preserve">
-    <value>Slovník prostředků (WinUI 3)</value>
+    <value>Slovník prostředků</value>
   </data>
   <data name="1010" xml:space="preserve">
-    <value>[Experimentální] Slovník prostředků (WinUI 3)</value>
+    <value>[Experimentální] Slovník prostředků</value>
   </data>
   <data name="1011" xml:space="preserve">
-    <value>Prázdná kolekce prostředků XAML s klíči pro aplikace založené na Knihovně uživatelského rozhraní Windows (WinUI 3).</value>
+    <value>Prázdná kolekce prostředků XAML (WinUI) s klíči</value>
   </data>
   <data name="1013" xml:space="preserve">
     <value>Soubor prostředků (.resw)</value>
@@ -151,60 +151,109 @@
     <value>[Experimental] Soubor prostředků (.resw)</value>
   </data>
   <data name="1015" xml:space="preserve">
-    <value>Soubor pro ukládání řetězců a podmíněných prostředků pro aplikace založené na Knihovně uživatelského rozhraní Windows (WinUI 3)</value>
+    <value>Soubor pro ukládání řetězce a podmíněných prostředků (WinUI)</value>
   </data>
   <data name="1017" xml:space="preserve">
-    <value>Vlastní ovládací prvek (WinUI 3)</value>
+    <value>Ovládací prvek v šabloně</value>
   </data>
   <data name="1018" xml:space="preserve">
-    <value>[Experimentální] Vlastní ovládací prvek (WinUI 3)</value>
+    <value>[Experimentální] Ovládací prvek v šabloně</value>
   </data>
   <data name="1019" xml:space="preserve">
-    <value>Vlastní ovládací prvek pro aplikace založené na Knihovně uživatelského rozhraní Windows (WinUI 3).</value>
+    <value>Prázdný vlastní ovládací prvek s odpovídajícím výchozím stylem (WinUI)</value>
   </data>
   <data name="1021" xml:space="preserve">
-    <value>Uživatelský ovládací prvek (WinUI 3)</value>
+    <value>Uživatelský ovládací prvek</value>
   </data>
   <data name="1022" xml:space="preserve">
-    <value>[Experimentální] Uživatelský ovládací prvek (WinUI 3)</value>
+    <value>[Experimentální] Uživatelský ovládací prvek</value>
   </data>
   <data name="1023" xml:space="preserve">
-    <value>Uživatelský ovládací prvek pro aplikace založené na Knihovně uživatelského rozhraní Windows (WinUI 3)</value>
+    <value>Prázdný uživatelský ovládací prvek (WinUI).</value>
   </data>
   <data name="1025" xml:space="preserve">
-    <value>Prázdná aplikace zabalená s Projekt vytváření balíčku aplikace Windows (WinUI 3 v desktopové verzi)</value>
+    <value>Prázdná aplikace WinUI (zabalená s projektem vytváření balíčku aplikace Windows)</value>
   </data>
   <data name="1026" xml:space="preserve">
-    <value>[Experimentální] Prázdná aplikace zabalená s Projekt vytváření balíčku aplikace Windows (WinUI 3 v desktopu)</value>
+    <value>[Experimentální] Prázdná aplikace WinUI (zabalená s projektem vytváření balíčku aplikace Windows)</value>
   </data>
   <data name="1027" xml:space="preserve">
-    <value>Šablona projektu pro vytvoření desktopové aplikace založené na Knihovně uživatelského rozhraní Windows (WinUI 3). K vytvoření balíčku MSIX pro instalaci bokem nebo distribuci prostřednictvím Microsoft Store je zahrnutý projekt WAP (vytváření balíčku aplikace Windows).</value>
+    <value>Šablona projektu pro vytvoření aplikace WinUI. Součástí je projekt vytváření balíčku aplikace Windows (WAP), který vytvoří balíček MSIX pro zkušební načtení před prodejem nebo distribuci prostřednictvím obchodu Microsoft Store.</value>
   </data>
   <data name="1029" xml:space="preserve">
-    <value>Prázdná aplikace, zabalená (WinUI 3 v desktopové verzi)</value>
+    <value>Prázdná aplikace WinUI (zabalená)</value>
   </data>
   <data name="1030" xml:space="preserve">
-    <value>[Experimentální] Prázdná aplikace, zabalená (WinUI 3 v desktopové verzi)</value>
+    <value>[Experimentální] Prázdná aplikace WinUI (zabalená)</value>
   </data>
   <data name="1031" xml:space="preserve">
-    <value>Šablona projektu pro vytvoření desktopové aplikace založené na Knihovně uživatelského rozhraní Windows (WinUI 3) spolu s balíčkem MSIX pro zkušební načtení nebo distribuci prostřednictvím Microsoft Store.</value>
+    <value>Šablona projektu pro vytvoření aplikace WinUI spolu s balíčkem MSIX pro zkušební načtení před prodejem nebo distribuci prostřednictvím obchodu Microsoft Store.</value>
   </data>
   <data name="1033" xml:space="preserve">
-    <value>Součást prostředí Windows Runtime (WinUI 3)</value>
+    <value>Součást prostředí Windows Runtime WinUI</value>
   </data>
   <data name="1034" xml:space="preserve">
-    <value>[Experimentální] Součást prostředí Windows Runtime (WinUI 3)</value>
+    <value>[Experimentální] Součást prostředí Windows Runtime WinUI (C++/WinRT)</value>
   </data>
   <data name="1035" xml:space="preserve">
-    <value>Projekt pro vytvoření součásti prostředí Windows Runtime C++/WinRT (.winmd) pro desktopovou i Univerzální platformu Windows (UPW) založené na Knihovně uživatelského rozhraní Windows (WinUI 3).</value>
+    <value>Projekt pro vytvoření součásti prostředí Windows Runtime C++/WinRT (.winmd) pro aplikace pro desktopovou i Univerzální platformu Windows (UPW) založené na WinUI.</value>
   </data>
   <data name="1037" xml:space="preserve">
-    <value>Aplikace pro testování jednotek (WinUI 3)</value>
+    <value>Testovací aplikace jednotek WinUI</value>
   </data>
   <data name="1038" xml:space="preserve">
-    <value>[Experimentální] Testovací Aplikace Jednotky (WinUI 3)</value>
+    <value>[Experimentální] Testovací aplikace jednotek WinUI</value>
   </data>
   <data name="1039" xml:space="preserve">
-    <value>Projekt pro vytvoření aplikace pro testování jednotek C++/WinRT pro WinUI 3 pomocí MSTestu</value>
+    <value>Projekt pro vytvoření aplikace pro testování jednotek C++/WinRT pro WinUI pomocí MSTestu</value>
+  </data>
+  <data name="1040" xml:space="preserve">
+    <value>Prázdná aplikace WinUI</value>
+  </data>
+  <data name="1041" xml:space="preserve">
+    <value>Projekt pro vytvoření prázdné aplikace WinUI.</value>
+  </data>
+  <data name="1042" xml:space="preserve">
+    <value>Projekt vytváření balíčku aplikace Windows pro WinUI</value>
+  </data>
+  <data name="1043" xml:space="preserve">
+    <value>Šablona projektu, která vytváří balíčky MSIX obsahující aplikace WinUI pro instalaci bokem nebo distribuci prostřednictvím Microsoft Store</value>
+  </data>
+  <data name="1044" xml:space="preserve">
+    <value>Instalují se balíčky NuGet do projektu...</value>
+  </data>
+  <data name="1045" xml:space="preserve">
+    <value>Probíhá operace...</value>
+  </data>
+  <data name="1046" xml:space="preserve">
+    <value>Chybějící odkaz(y) na balíček</value>
+  </data>
+  <data name="1047" xml:space="preserve">
+    <value>Nelze přidat odkazy na následující balíčky pro {0}: {1}. Před sestavením prosím přidejte odkazy na balíček.</value>
+  </data>
+  <data name="1048" xml:space="preserve">
+    <value>[{0}] Nelze přidat odkazy na následující balíčky: {1}.
+
+Toto je chyba prostředí. Před sestavením projektu prosím přidejte odkazy na balíček.
+
+Další podrobnosti o chybě najdete na kartě Obecné v okně Výstup.</value>
+  </data>
+  <data name="1049" xml:space="preserve">
+    <value>Správa balíčků NuGet</value>
+  </data>
+  <data name="1050" xml:space="preserve">
+    <value>Zobrazit podrobnosti chyby</value>
+  </data>
+  <data name="1051" xml:space="preserve">
+    <value>Chybějící odkazy na balíčky pro {0}:</value>
+  </data>
+  <data name="1052" xml:space="preserve">
+    <value>Před sestavením ručně přidejte odkazy na balíček.</value>
+  </data>
+  <data name="1053" xml:space="preserve">
+    <value>Obecné</value>
+  </data>
+  <data name="1054" xml:space="preserve">
+    <value>Nejsou k dispozici žádné výstupní informace.</value>
   </data>
 </root>

--- a/dev/VSIX/Extension/Cpp/Common/de-DE/VSPackage.de-DE.resx
+++ b/dev/VSIX/Extension/Cpp/Common/de-DE/VSPackage.de-DE.resx
@@ -118,31 +118,31 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="1001" xml:space="preserve">
-    <value>Leeres Fenster (WinUI 3 in Desktop)</value>
+    <value>Leeres Fenster</value>
   </data>
   <data name="1002" xml:space="preserve">
-    <value>[Experimentell] Leeres Fenster (WinUI 3 in Desktop)</value>
+    <value>[Experimentell] Leeres Fenster</value>
   </data>
   <data name="1003" xml:space="preserve">
-    <value>Ein leeres Fenster für Desktop-Apps, die auf der Windows-UI-Bibliothek (WinUI 3) basieren.</value>
+    <value>Ein leeres Fenster (WinUI).</value>
   </data>
   <data name="1005" xml:space="preserve">
-    <value>Leere Seite (WinUI 3)</value>
+    <value>Leere Seite</value>
   </data>
   <data name="1006" xml:space="preserve">
-    <value>[Experimentell] Leere Seite (WinUI 3)</value>
+    <value>[Experimentell] Leere Seite</value>
   </data>
   <data name="1007" xml:space="preserve">
-    <value>Eine leere Seite für Apps, die auf der Windows-UI-Bibliothek (WinUI 3) basieren.</value>
+    <value>Eine leere Seite (WinUI).</value>
   </data>
   <data name="1009" xml:space="preserve">
-    <value>Ressourcenverzeichnis (WinUI 3)</value>
+    <value>Ressourcenverzeichnis</value>
   </data>
   <data name="1010" xml:space="preserve">
-    <value>[Experimentell] Ressourcenverzeichnis (WinUI 3)</value>
+    <value>[Experimentell] Ressourcenverzeichnis</value>
   </data>
   <data name="1011" xml:space="preserve">
-    <value>Eine leere, schlüsselgesteuerte Sammlung von XAML-Ressourcen für Apps, die auf der Windows-UI-Bibliothek (WinUI 3) basieren.</value>
+    <value>Eine leere, schlüsselierte Sammlung von XAML-Ressourcen (WinUI).</value>
   </data>
   <data name="1013" xml:space="preserve">
     <value>Ressourcendatei (.resw)</value>
@@ -151,60 +151,109 @@
     <value>[Experimentell] Ressourcendatei (.resw)</value>
   </data>
   <data name="1015" xml:space="preserve">
-    <value>Eine Datei zum Speichern von Zeichenfolgen und bedingten Ressourcen für Apps, die auf der Windows-UI-Bibliothek (WinUI 3) basieren.</value>
+    <value>Eine Datei zum Speichern von Zeichenfolgen- und bedingten Ressourcen (WinUI).</value>
   </data>
   <data name="1017" xml:space="preserve">
-    <value>Benutzerdefiniertes Steuerelement (WinUI 3)</value>
+    <value>Steuerelement mit Vorlagen</value>
   </data>
   <data name="1018" xml:space="preserve">
-    <value>[Experimentell] Benutzerdefiniertes Steuerelement (WinUI 3)</value>
+    <value>[Experimentell] Steuerelement mit Vorlagen</value>
   </data>
   <data name="1019" xml:space="preserve">
-    <value>Ein benutzerdefiniertes Steuerelement für Apps, die auf der Windows-UI-Bibliothek (WinUI 3) basieren.</value>
+    <value>Ein leeres benutzerdefiniertes Steuerelement mit der entsprechenden Standardformatierung (WinUI).</value>
   </data>
   <data name="1021" xml:space="preserve">
-    <value>Benutzersteuerelement (WinUI 3)</value>
+    <value>Benutzersteuerelement</value>
   </data>
   <data name="1022" xml:space="preserve">
-    <value>[Experimentell] Benutzersteuerelement (WinUI 3)</value>
+    <value>[Experimentell] Benutzerkontrolle</value>
   </data>
   <data name="1023" xml:space="preserve">
-    <value>Ein Benutzersteuerelement für Apps, die auf der Windows-UI-Bibliothek (WinUI 3) basieren.</value>
+    <value>Ein leeres Benutzersteuerelement (WinUI).</value>
   </data>
   <data name="1025" xml:space="preserve">
-    <value>Leere App, verpackt mit Paketerstellungsprojekt für Windows-Anwendungen (WinUI 3 in Desktop)</value>
+    <value>Leere WinUI-App (mit Paketerstellungsprojekt für Windows-Anwendungen verpackt)</value>
   </data>
   <data name="1026" xml:space="preserve">
-    <value>[Experimentell] Leere App, verpackt mit Paketerstellungsprojekt für Windows-Anwendungen (WinUI 3 in Desktop)</value>
+    <value>[Experimentell] Leere WinUI-App (mit Paketerstellungsprojekt für Windows-Anwendungen verpackt)</value>
   </data>
   <data name="1027" xml:space="preserve">
-    <value>Eine Projektvorlage zum Erstellen einer Desktop-App, die auf der Windows-UI-Bibliothek (WinUI 3) basiert. Ein WAP-Projekt (Paketerstellungsprojekt für Windows-Anwendungen) ist enthalten, um ein MSIX-Paket zum Querladen oder Verteilen über den Microsoft Store zu erstellen.</value>
+    <value>Eine Projektvorlage zum Erstellen einer WinUI-App. Ein WAP-Projekt (Paketerstellungsprojekt für Windows-Anwendungen) ist enthalten, um ein MSIX-Paket zum Querladen oder Verteilen über den Microsoft Store zu erstellen.</value>
   </data>
   <data name="1029" xml:space="preserve">
-    <value>Leere App, verpackt (WinUI 3 in Desktop)</value>
+    <value>Leere WinUI-App (verpackt)</value>
   </data>
   <data name="1030" xml:space="preserve">
-    <value>[Experimentell] Leere App, verpackt (WinUI 3 in Desktop)</value>
+    <value>[Experimentell] Leere WinUI-App (verpackt)</value>
   </data>
   <data name="1031" xml:space="preserve">
-    <value>Eine Projektvorlage zum Erstellen einer Desktop-App, die auf der Windows-UI-Bibliothek (WinUI 3) basiert, zusammen mit einem MSIX-Paket zum Querladen oder Verteilen über den Microsoft Store.</value>
+    <value>Eine Projektvorlage zum Erstellen einer WinUI-App zusammen mit einem MSIX-Paket zum Querladen oder Verteilen über den Microsoft Store.</value>
   </data>
   <data name="1033" xml:space="preserve">
-    <value>Komponente für Windows-Runtime (WinUI 3)</value>
+    <value>WinUI-Komponente für Windows-Runtime</value>
   </data>
   <data name="1034" xml:space="preserve">
-    <value>[Experimentell] Komponente für Windows-Runtime (WinUI 3)</value>
+    <value>[Experimentell] WinUI-Komponente für Windows-Runtime (C++/WinRT)</value>
   </data>
   <data name="1035" xml:space="preserve">
-    <value>Ein Projekt zum Erstellen einer C++/WinRT-Komponente für Windows-Runtime (WINMD) für Desktop- und UWP-Apps (Universelle Windows-Plattform), die auf der Windows-UI-Bibliothek (WinUI 3) basieren.</value>
+    <value>Ein Projekt zum Erstellen einer C++/WinRT-Komponente für Windows-Runtime (WINMD) für Desktop- und Universelle Windows-Plattform-Apps (UWP), basierend auf WinUI.</value>
   </data>
   <data name="1037" xml:space="preserve">
-    <value>Komponententest-App (WinUI 3)</value>
+    <value>WinUI-Komponententest-App</value>
   </data>
   <data name="1038" xml:space="preserve">
-    <value>[Experimentell] Komponententest-App (WinUI 3)</value>
+    <value>[Experimentell] WinUI-Komponententest-App</value>
   </data>
   <data name="1039" xml:space="preserve">
-    <value>Ein Projekt zum Erstellen einer C++-/WinRT-Komponententest-App für WinUI 3 mit MSTest.</value>
+    <value>Ein Projekt zum Erstellen einer C++/WinRT-Komponententest-App für WinUI mithilfe von MSTest.</value>
+  </data>
+  <data name="1040" xml:space="preserve">
+    <value>Leere WinUI-App</value>
+  </data>
+  <data name="1041" xml:space="preserve">
+    <value>Ein Projekt zum Erstellen einer leeren WinUI-App.</value>
+  </data>
+  <data name="1042" xml:space="preserve">
+    <value>Paketerstellungsprojekt für Windows-Anwendungen für WinUI</value>
+  </data>
+  <data name="1043" xml:space="preserve">
+    <value>Eine Projektvorlage, die MSIX-Pakete mit WinUI-Anwendungen zum Querladen oder Verteilen über den Microsoft Store erstellt.</value>
+  </data>
+  <data name="1044" xml:space="preserve">
+    <value>NuGet-Pakete werden in das Projekt installiert...</value>
+  </data>
+  <data name="1045" xml:space="preserve">
+    <value>Wird ausgeführt...</value>
+  </data>
+  <data name="1046" xml:space="preserve">
+    <value>Fehlende Paketverweise</value>
+  </data>
+  <data name="1047" xml:space="preserve">
+    <value>Für {0} können den folgenden Paketen keine Verweise hinzugefügt werden: {1}. Fügen Sie vor dem Erstellen Paketverweise hinzu.</value>
+  </data>
+  <data name="1048" xml:space="preserve">
+    <value>[{0}] Den folgenden Paketen können keine Verweise hinzugefügt werden: {1}.
+
+Dies ist ein Umgebungsfehler. Fügen Sie Vor dem Erstellen des Projekts Paketverweise hinzu.
+
+Weitere Informationen zum Fehler finden Sie auf der Registerkarte "Allgemein" im Ausgabefenster.</value>
+  </data>
+  <data name="1049" xml:space="preserve">
+    <value>NuGet-Pakete verwalten</value>
+  </data>
+  <data name="1050" xml:space="preserve">
+    <value>Fehlerdetails anzeigen</value>
+  </data>
+  <data name="1051" xml:space="preserve">
+    <value>Fehlende Paketverweise für {0}:</value>
+  </data>
+  <data name="1052" xml:space="preserve">
+    <value>Fügen Sie die Paketverweise manuell hinzu, bevor Sie mit dem Erstellen beginnen.</value>
+  </data>
+  <data name="1053" xml:space="preserve">
+    <value>Allgemein</value>
+  </data>
+  <data name="1054" xml:space="preserve">
+    <value>Keine Ausgabedaten verfügbar.</value>
   </data>
 </root>

--- a/dev/VSIX/Extension/Cpp/Common/es-ES/VSPackage.es-ES.resx
+++ b/dev/VSIX/Extension/Cpp/Common/es-ES/VSPackage.es-ES.resx
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <root>
   <!-- 
     Microsoft ResX Schema 
@@ -118,31 +118,31 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="1001" xml:space="preserve">
-    <value>Ventana en blanco (WinUI 3 en escritorio)</value>
+    <value>Ventana en blanco</value>
   </data>
   <data name="1002" xml:space="preserve">
-    <value>[Experimental] Ventana en blanco (WinUI 3 en escritorio)</value>
+    <value>[Experimental] Ventana en blanco</value>
   </data>
   <data name="1003" xml:space="preserve">
-    <value>Ventana en blanco para aplicaciones de escritorio basadas en la Biblioteca de interfaz de usuario de Windows (WinUI 3).</value>
+    <value>Una ventana en blanco (WinUI).</value>
   </data>
   <data name="1005" xml:space="preserve">
-    <value>Página en blanco (WinUI 3)</value>
+    <value>Página en blanco</value>
   </data>
   <data name="1006" xml:space="preserve">
-    <value>[Experimental] Página en blanco (WinUI 3)</value>
+    <value>[Experimental] Página en blanco</value>
   </data>
   <data name="1007" xml:space="preserve">
-    <value>Página en blanco para aplicaciones basadas en la Biblioteca de interfaz de usuario de Windows (WinUI 3).</value>
+    <value>Una página en blanco (WinUI).</value>
   </data>
   <data name="1009" xml:space="preserve">
-    <value>Diccionario de recursos (WinUI 3)</value>
+    <value>Diccionario de recursos</value>
   </data>
   <data name="1010" xml:space="preserve">
-    <value>[Experimental] Diccionario de recursos (WinUI 3)</value>
+    <value>[Experimental] Diccionario de recursos</value>
   </data>
   <data name="1011" xml:space="preserve">
-    <value>Colección vacía con clave de recursos XAML para aplicaciones basadas en la Biblioteca de interfaz de usuario de Windows (WinUI 3).</value>
+    <value>Colección vacía con clave de recursos XAML (WinUI).</value>
   </data>
   <data name="1013" xml:space="preserve">
     <value>Archivo de recursos (.resw)</value>
@@ -151,60 +151,109 @@
     <value>[Experimental] Archivo de recursos (.resw)</value>
   </data>
   <data name="1015" xml:space="preserve">
-    <value>Archivo para almacenar recursos condicionales y de cadena para aplicaciones basadas en la Biblioteca de interfaz de usuario de Windows (WinUI 3).</value>
+    <value>Un archivo para almacenar recursos condicionales y de cadena (WinUI).</value>
   </data>
   <data name="1017" xml:space="preserve">
-    <value>Control personalizado (WinUI 3)</value>
+    <value>Control con plantilla</value>
   </data>
   <data name="1018" xml:space="preserve">
-    <value>[Experimental] Control personalizado (WinUI 3)</value>
+    <value>[Experimental] Control con plantilla</value>
   </data>
   <data name="1019" xml:space="preserve">
-    <value>Control personalizado para aplicaciones basadas en la Biblioteca de interfaz de usuario de Windows (WinUI 3).</value>
+    <value>Control personalizado en blanco con el estilo predeterminado adecuado (WinUI).</value>
   </data>
   <data name="1021" xml:space="preserve">
-    <value>Control de usuario (WinUI 3)</value>
+    <value>Control de usuario</value>
   </data>
   <data name="1022" xml:space="preserve">
-    <value>[Experimental] Control de usuario (WinUI 3)</value>
+    <value>[Experimental] Control de usuario</value>
   </data>
   <data name="1023" xml:space="preserve">
-    <value>Control de usuario para aplicaciones basadas en la Biblioteca de interfaz de usuario de Windows (WinUI 3).</value>
+    <value>Un control de usuario en blanco (WinUI).</value>
   </data>
   <data name="1025" xml:space="preserve">
-    <value>Aplicación en blanco, empaquetada con Proyecto de paquete de aplicación de Windows (WinUI 3 en el escritorio)</value>
+    <value>Aplicación en blanco de WinUI (empaquetada con Proyecto de paquete de aplicación de Windows)</value>
   </data>
   <data name="1026" xml:space="preserve">
-    <value>[Experimental] Aplicación en blanco, empaquetada con Proyecto de paquete de aplicación de Windows (WinUI 3 en el escritorio)</value>
+    <value>[Experimental] Aplicación en blanco de WinUI (empaquetada con Proyecto de paquete de aplicación de Windows)</value>
   </data>
   <data name="1027" xml:space="preserve">
-    <value>Plantilla de proyecto para crear una aplicación de escritorio basada en la Biblioteca de interfaz de usuario de Windows (WinUI 3). Se incluye un proyecto de paquete de aplicación de Windows (WAP) para crear un paquete MSIX para la carga lateral o distribución mediante Microsoft Store.</value>
+    <value>Plantilla de proyecto para crear una aplicación WinUI. Se incluye un proyecto de empaquetado de aplicaciones de Windows (WAP) para crear un paquete MSIX para transferencia local o distribución a través de Microsoft Store.</value>
   </data>
   <data name="1029" xml:space="preserve">
-    <value>Aplicación en blanco, empaquetada (WinUI 3 en escritorio)</value>
+    <value>Aplicación en blanco de WinUI (empaquetada)</value>
   </data>
   <data name="1030" xml:space="preserve">
-    <value>[Experimental] Aplicación en blanco, empaquetada (WinUI 3 en escritorio)</value>
+    <value>[Experimental] Aplicación en blanco de WinUI (empaquetada)</value>
   </data>
   <data name="1031" xml:space="preserve">
-    <value>Plantilla de proyecto para crear una aplicación de escritorio basada en la Biblioteca de interfaz de usuario de Windows (WinUI 3) junto con un paquete MSIX para la carga lateral o distribución mediante Microsoft Store.</value>
+    <value>Una plantilla de proyecto para crear una aplicación de WinUI junto con un paquete MSIX para la transferencia local o la distribución a través de Microsoft Store.</value>
   </data>
   <data name="1033" xml:space="preserve">
-    <value>Componente de Windows Runtime (WinUI 3)</value>
+    <value>Componente de Windows Runtime WinUI</value>
   </data>
   <data name="1034" xml:space="preserve">
-    <value>[Experimental] Componente de Windows Runtime (WinUI 3)</value>
+    <value>[Experimental] Componente de Windows Runtime WinUI (C++/WinRT)</value>
   </data>
   <data name="1035" xml:space="preserve">
-    <value>Proyecto para crear un componente de Windows Runtime de C++/WinRT (.winmd) para aplicaciones de escritorio y de la Plataforma universal de Windows (UWP), basadas en la Biblioteca de interfaz de usuario de Windows (WinUI 3).</value>
+    <value>Un proyecto para crear un componente de tiempo de ejecución de Windows C++/WinRT (.winmd) tanto para aplicaciones de la Plataforma universal de Windows (UWP) como de escritorio, basado en WinUI.</value>
   </data>
   <data name="1037" xml:space="preserve">
-    <value>Aplicación de prueba unitaria (WinUI 3)</value>
+    <value>Aplicación de prueba unitaria de WinUI</value>
   </data>
   <data name="1038" xml:space="preserve">
-    <value>[Experimental] Aplicación de prueba unitaria (WinUI 3)</value>
+    <value>[Experimental] Aplicación de prueba unitaria de WinUI</value>
   </data>
   <data name="1039" xml:space="preserve">
-    <value>Proyecto para crear una aplicación de prueba unitaria de C++/WinRT para WinUI 3 con MSTest.</value>
+    <value>Proyecto para crear una aplicación de prueba unitaria de C++/WinRT para WinUI mediante MSTest.</value>
+  </data>
+  <data name="1040" xml:space="preserve">
+    <value>Aplicación en blanco de WinUI</value>
+  </data>
+  <data name="1041" xml:space="preserve">
+    <value>Proyecto para crear una aplicación WinUI vacía.</value>
+  </data>
+  <data name="1042" xml:space="preserve">
+    <value>Proyecto de paquete de aplicación de Windows para WinUI</value>
+  </data>
+  <data name="1043" xml:space="preserve">
+    <value>Plantilla de proyecto que crea paquetes MSIX que contienen aplicaciones WinUI para la carga o distribución de prueba mediante el Microsoft Store.</value>
+  </data>
+  <data name="1044" xml:space="preserve">
+    <value>Instalando paquetes NuGet en el proyecto...</value>
+  </data>
+  <data name="1045" xml:space="preserve">
+    <value>Operación en progreso...</value>
+  </data>
+  <data name="1046" xml:space="preserve">
+    <value>Faltan referencias de paquete</value>
+  </data>
+  <data name="1047" xml:space="preserve">
+    <value>No se pueden agregar referencias a los siguientes paquetes para {0}: {1}. Agregue referencias de paquete antes de compilar.</value>
+  </data>
+  <data name="1048" xml:space="preserve">
+    <value>[{0}] No se pueden agregar referencias a los siguientes paquetes: {1}.
+
+Se trata de un error de entorno. Agregue referencias de paquete antes de compilar el proyecto.
+
+Para obtener más detalles sobre el error, compruebe la pestaña General de la ventana De salida.</value>
+  </data>
+  <data name="1049" xml:space="preserve">
+    <value>Administrar paquetes NuGet</value>
+  </data>
+  <data name="1050" xml:space="preserve">
+    <value>Ver detalles del error</value>
+  </data>
+  <data name="1051" xml:space="preserve">
+    <value>Faltan referencias de paquete para {0}:</value>
+  </data>
+  <data name="1052" xml:space="preserve">
+    <value>Agregue manualmente las referencias de paquete antes de compilar.</value>
+  </data>
+  <data name="1053" xml:space="preserve">
+    <value>General</value>
+  </data>
+  <data name="1054" xml:space="preserve">
+    <value>No hay información de salida disponible.</value>
   </data>
 </root>

--- a/dev/VSIX/Extension/Cpp/Common/fr-FR/VSPackage.fr-FR.resx
+++ b/dev/VSIX/Extension/Cpp/Common/fr-FR/VSPackage.fr-FR.resx
@@ -118,31 +118,31 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="1001" xml:space="preserve">
-    <value>Fenêtre vierge (WinUI 3 dans le Bureau)</value>
+    <value>Fenêtre vierge</value>
   </data>
   <data name="1002" xml:space="preserve">
-    <value>Fenêtre vierge (WinUI 3 dans le Bureau)</value>
+    <value>[Expérimental] Fenêtre vierge</value>
   </data>
   <data name="1003" xml:space="preserve">
-    <value>Fenêtre vide pour les applications de bureau basées sur la Bibliothèque d’interface utilisateur Windows (WinUI 3).</value>
+    <value>Une fenêtre vierge (WinUI).</value>
   </data>
   <data name="1005" xml:space="preserve">
-    <value>Page vierge (WinUI 3)</value>
+    <value>Page vierge</value>
   </data>
   <data name="1006" xml:space="preserve">
-    <value>[Experimental] Page vierge (WinUI 3)</value>
+    <value>[Expérimental] Page vierge</value>
   </data>
   <data name="1007" xml:space="preserve">
-    <value>Page vide pour les applications basées sur la Bibliothèque d’interface utilisateur Windows (WinUI 3).</value>
+    <value>Une page vierge (WinUI).</value>
   </data>
   <data name="1009" xml:space="preserve">
-    <value>Dictionnaire de ressources (WinUI 3)</value>
+    <value>Dictionnaire de ressources</value>
   </data>
   <data name="1010" xml:space="preserve">
-    <value>[Expérimental] Dictionnaire de ressources (WinUI 3)</value>
+    <value>[Expérimental] Dictionnaire de ressources</value>
   </data>
   <data name="1011" xml:space="preserve">
-    <value>Collection vide et à clé de ressources XAML pour les applications basées sur la Bibliothèque d’interface utilisateur Windows (WinUI 3).</value>
+    <value>Une collection de ressources XAML (WinUI) vide à clé.</value>
   </data>
   <data name="1013" xml:space="preserve">
     <value>Fichier de ressources (.resw)</value>
@@ -151,60 +151,109 @@
     <value>[Experimental] Fichier de ressources (.resw)</value>
   </data>
   <data name="1015" xml:space="preserve">
-    <value>Fichier de stockage de ressources conditionnelles et de chaîne pour les applications basées sur la Bibliothèque d’interface utilisateur Windows (WinUI 3).</value>
+    <value>Fichier de stockage de la chaîne et des ressources conditionnelles (WinUI).</value>
   </data>
   <data name="1017" xml:space="preserve">
-    <value>Contrôle personnalisé (WinUI 3)</value>
+    <value>Contrôle avec modèle</value>
   </data>
   <data name="1018" xml:space="preserve">
-    <value>[Expérimental] Contrôle personnalisé (WinUI 3)</value>
+    <value>[Expérimental] Contrôle avec modèle</value>
   </data>
   <data name="1019" xml:space="preserve">
-    <value>Contrôle personnalisé pour les applications basé sur la Bibliothèque d’interface utilisateur Windows (WinUI 3).</value>
+    <value>Contrôle personnalisé vide avec le style par défaut approprié (WinUI).</value>
   </data>
   <data name="1021" xml:space="preserve">
-    <value>Contrôle utilisateur (WinUI 3)</value>
+    <value>Contrôle utilisateur</value>
   </data>
   <data name="1022" xml:space="preserve">
-    <value>[Expérimental] Contrôle utilisateur (WinUI 3)</value>
+    <value>[Expérimental] Contrôle utilisateur</value>
   </data>
   <data name="1023" xml:space="preserve">
-    <value>Contrôle utilisateur pour les applications basé sur la Bibliothèque d’interface utilisateur Windows (WinUI 3).</value>
+    <value>Contrôle utilisateur vierge (WinUI).</value>
   </data>
   <data name="1025" xml:space="preserve">
-    <value>Application vide, empaquetée avec Projet de création de packages d'applications Windows (WinUI 3 sur le Bureau)</value>
+    <value>Application vide WinUI, (Empaquetée avec Projet de création de packages d'applications Windows)</value>
   </data>
   <data name="1026" xml:space="preserve">
-    <value>[Expérimental] Application vide, empaquetée avec Projet de création de packages d'applications Windows (WinUI 3 sur le Bureau)</value>
+    <value>[Expérimental] Application vierge WinUI, (empaquetée avec Projet de création de packages d'applications Windows)</value>
   </data>
   <data name="1027" xml:space="preserve">
-    <value>Modèle de projet pour la création d’une application de bureau basée sur la bibliothèque d’interface utilisateur Windows (WinUI 3). Un projet d’empaquetage d’application Windows (WAP) est inclus pour créer un package MSIX pour le chargement indépendant ou la distribution via le Microsoft Store.</value>
+    <value>Modèle de projet pour la création d’une application WinUI. Un projet d’empaquetage d’application Windows (WAP) est inclus pour créer un package MSIX pour le chargement indépendant ou la distribution via le Microsoft Store.</value>
   </data>
   <data name="1029" xml:space="preserve">
-    <value>Application vide, empaquetée (WinUI 3 sur le Bureau)</value>
+    <value>Application WinUI vierge (Empaquetée)</value>
   </data>
   <data name="1030" xml:space="preserve">
-    <value>[Expérimental] Application vide, empaquetée (WinUI 3 sur le Bureau)</value>
+    <value>[Expérimental] Application WinUI vierge (Empaquetée)</value>
   </data>
   <data name="1031" xml:space="preserve">
-    <value>Modèle de projet pour la création d’une application de bureau basée sur la Bibliothèque d’interface utilisateur Windows (WinUI 3) ainsi qu’un package MSIX pour le chargement indépendant ou la distribution via le Microsoft Store.</value>
+    <value>Modèle de projet pour la création d’une application WinUI ainsi qu’un package MSIX pour le chargement indépendant ou la distribution via le Microsoft Store.</value>
   </data>
   <data name="1033" xml:space="preserve">
-    <value>Composant Windows Runtime (WinUI 3 dans UWP)</value>
+    <value>Composant Windows Runtime WinUI</value>
   </data>
   <data name="1034" xml:space="preserve">
-    <value>Composant Windows Runtime (WinUI 3 dans UWP)</value>
+    <value>[Expérimental] Composant Windows Runtime WinUI (C++/WinRT)</value>
   </data>
   <data name="1035" xml:space="preserve">
-    <value>Projet de création d’un composant de Windows Runtime C++/WinRT (.winmd) pour les applications de bureau et de plateforme Windows universelle (UWP), basé sur la bibliothèque d’interface utilisateur Windows (WinUI 3).</value>
+    <value>Un projet de création d’un composant Windows Runtime C++/WinRT (.winmd) pour les applications de bureau et de plateforme Windows universelle (UWP), basé sur WinUI.</value>
   </data>
   <data name="1037" xml:space="preserve">
-    <value>Application de test unitaire (WinUI 3)</value>
+    <value>Application de test unitaire WinUI</value>
   </data>
   <data name="1038" xml:space="preserve">
-    <value>[Expérimental] Application de test unitaire (WinUI 3)</value>
+    <value>[Expérimental] Application de test unitaire WinUI</value>
   </data>
   <data name="1039" xml:space="preserve">
-    <value>Projet de création d’une application de test unitaire C++/WinRT pour WinUI 3 à l’aide de MSTest.</value>
+    <value>Projet de création d’une application de test unitaire C++/WinRT pour WinUI à l’aide de MSTest.</value>
+  </data>
+  <data name="1040" xml:space="preserve">
+    <value>Application WinUI vierge</value>
+  </data>
+  <data name="1041" xml:space="preserve">
+    <value>Projet de création d’une application WinUI vide.</value>
+  </data>
+  <data name="1042" xml:space="preserve">
+    <value>Projet de création de packages d'applications Windows pour WinUI</value>
+  </data>
+  <data name="1043" xml:space="preserve">
+    <value>Modèle de projet qui crée des packages MSIX contenant des applications WinUI pour le chargement indépendant ou la distribution via le Microsoft Store.</value>
+  </data>
+  <data name="1044" xml:space="preserve">
+    <value>Installation des packages NuGet dans le projet...</value>
+  </data>
+  <data name="1045" xml:space="preserve">
+    <value>Opération en cours...</value>
+  </data>
+  <data name="1046" xml:space="preserve">
+    <value>Référence(s) de package manquante(s)</value>
+  </data>
+  <data name="1047" xml:space="preserve">
+    <value>Impossible d’ajouter des références aux packages suivants pour {0} : {1}. Ajoutez des références de package avant de générer.</value>
+  </data>
+  <data name="1048" xml:space="preserve">
+    <value>[{0}] Impossible d’ajouter des références aux packages suivants : {1}.
+
+Il s’agit d’une erreur d’environnement. Ajoutez des références de package avant de générer le projet.
+
+Pour plus d’informations sur l’erreur, case activée l’onglet Général dans la fenêtre Sortie.</value>
+  </data>
+  <data name="1049" xml:space="preserve">
+    <value>Gérer les packages NuGet</value>
+  </data>
+  <data name="1050" xml:space="preserve">
+    <value>Voir les détails des erreurs</value>
+  </data>
+  <data name="1051" xml:space="preserve">
+    <value>Références de package manquantes pour {0}:</value>
+  </data>
+  <data name="1052" xml:space="preserve">
+    <value>Ajoutez manuellement les références de package avant de compiler.</value>
+  </data>
+  <data name="1053" xml:space="preserve">
+    <value>Général</value>
+  </data>
+  <data name="1054" xml:space="preserve">
+    <value>Aucune information de résultat disponible.</value>
   </data>
 </root>

--- a/dev/VSIX/Extension/Cpp/Common/it-IT/VSPackage.it-IT.resx
+++ b/dev/VSIX/Extension/Cpp/Common/it-IT/VSPackage.it-IT.resx
@@ -118,31 +118,31 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="1001" xml:space="preserve">
-    <value>Finestra vuota (WinUI 3 su desktop)</value>
+    <value>Finestra vuota</value>
   </data>
   <data name="1002" xml:space="preserve">
-    <value>[Esperimento] Finestra vuota (WinUI 3 su desktop)</value>
+    <value>[Sperimentale] Finestra vuota</value>
   </data>
   <data name="1003" xml:space="preserve">
-    <value>Una finestra vuota per le app desktop basata sulla libreria dell'interfaccia utente di Windows (WinUI 3).</value>
+    <value>Una finestra vuota (WinUI).</value>
   </data>
   <data name="1005" xml:space="preserve">
-    <value>Pagina vuota (WinUI 3)</value>
+    <value>Pagina vuota</value>
   </data>
   <data name="1006" xml:space="preserve">
-    <value>[Esperimento] Pagina vuota (WinUI 3)</value>
+    <value>[Sperimentale] Pagina vuota</value>
   </data>
   <data name="1007" xml:space="preserve">
-    <value>Una pagina vuota per le app basata sulla libreria dell'interfaccia utente di Windows (WinUI 3).</value>
+    <value>Una pagina vuota (WinUI).</value>
   </data>
   <data name="1009" xml:space="preserve">
-    <value>Dizionario risorse (WinUI 3)</value>
+    <value>Dizionario risorse</value>
   </data>
   <data name="1010" xml:space="preserve">
-    <value>[Esperimento] Dizionario risorse (WinUI 3)</value>
+    <value>[Sperimentale] Dizionario risorse</value>
   </data>
   <data name="1011" xml:space="preserve">
-    <value>Una raccolta vuota con chiave di risorse XAML per le app basate sulla libreria dell'interfaccia utente di Windows (WinUI 3).</value>
+    <value>Raccolta con chiave vuota di risorse XAML (WinUI).</value>
   </data>
   <data name="1013" xml:space="preserve">
     <value>File di risorse (.resw)</value>
@@ -151,60 +151,109 @@
     <value>[Esperimento] File di risorse (.resw)</value>
   </data>
   <data name="1015" xml:space="preserve">
-    <value>Un file per l'archiviazione di risorse di tipo stringa e condizionale per le app basate sulla libreria dell'interfaccia utente di Windows (WinUI 3).</value>
+    <value>File per l'archiviazione di risorse stringa e condizionali (WinUI).</value>
   </data>
   <data name="1017" xml:space="preserve">
-    <value>Controllo personalizzato (WinUI 3)</value>
+    <value>Controllo con modello</value>
   </data>
   <data name="1018" xml:space="preserve">
-    <value>[Esperimento] Controllo personalizzato (WinUI 3)</value>
+    <value>[Sperimentale] Controllo con modello</value>
   </data>
   <data name="1019" xml:space="preserve">
-    <value>Un controllo personalizzato per le app basato sulla libreria dell'interfaccia utente di Windows (WinUI 3).</value>
+    <value>Controllo personalizzato vuoto con lo stile predefinito appropriato (WinUI).</value>
   </data>
   <data name="1021" xml:space="preserve">
-    <value>Controllo utente (WinUI 3)</value>
+    <value>Controllo utente</value>
   </data>
   <data name="1022" xml:space="preserve">
-    <value>[Esperimento] Controllo utente (WinUI 3)</value>
+    <value>[Sperimentale] Controllo utente</value>
   </data>
   <data name="1023" xml:space="preserve">
-    <value>Un controllo utente per le app basato sulla Libreria dell'interfaccia utente di Windows (WinUI 3).</value>
+    <value>Un controllo utente vuoto (WinUI).</value>
   </data>
   <data name="1025" xml:space="preserve">
-    <value>App vuota, in pacchetto con Progetto di creazione pacchetti per applicazioni Windows (WinUI 3 in desktop)</value>
+    <value>App vuota WinUI (in pacchetto con il Progetto di creazione pacchetti per applicazioni Windows)</value>
   </data>
   <data name="1026" xml:space="preserve">
-    <value>[Sperimentale] App vuota, in pacchetto con Progetto di creazione pacchetti per applicazioni Windows (WinUI 3 in desktop)</value>
+    <value>[Sperimentale] App vuota WinUI (in pacchetto con il Progetto di creazione pacchetti per applicazioni Windows)</value>
   </data>
   <data name="1027" xml:space="preserve">
-    <value>Modello di progetto per la creazione di un'app desktop basata sulla libreria dell'interfaccia utente di Windows (WinUI 3). È incluso un progetto WAP (Progetto di creazione pacchetti per applicazioni Windows) per la creazione di un pacchetto MSIX per il trasferimento locale o la distribuzione tramite il Microsoft Store.</value>
+    <value>Un modello di progetto per la creazione di un'app WinUI. È incluso un progetto WAP (Progetto di creazione pacchetti per applicazioni Windows) per la creazione di un pacchetto MSIX per il trasferimento locale o la distribuzione tramite Microsoft Store.</value>
   </data>
   <data name="1029" xml:space="preserve">
-    <value>App vuota, pacchetto (WinUI 3 su desktop)</value>
+    <value>App vuota WinUI (in pacchetto)</value>
   </data>
   <data name="1030" xml:space="preserve">
-    <value>[Sperimentale] App vuota, in pacchetto (WinUI 3 in desktop)</value>
+    <value>[Sperimentale] App vuota WinUI (in pacchetto)</value>
   </data>
   <data name="1031" xml:space="preserve">
-    <value>Modello di progetto per la creazione di un'app desktop basata sulla libreria dell'interfaccia utente di Windows (WinUI 3) insieme a un pacchetto MSIX per il trasferimento locale o la distribuzione tramite il Microsoft Store.</value>
+    <value>Un modello di progetto per la creazione di un'app WinUI insieme a un pacchetto MSIX per il trasferimento locale o la distribuzione tramite Microsoft Store.</value>
   </data>
   <data name="1033" xml:space="preserve">
-    <value>Componente Windows Runtime (WinUI 3)</value>
+    <value>Componente Windows Runtime WinUI</value>
   </data>
   <data name="1034" xml:space="preserve">
-    <value>[Esperimento] Componente Windows Runtime (WinUI 3)</value>
+    <value>[Sperimentale] Componente Windows Runtime WinUI (C++/WinRT)</value>
   </data>
   <data name="1035" xml:space="preserve">
-    <value>Un progetto per la creazione di un componente Windows Runtime C++/WinRT (.winmd) per app su desktop e piattaforma UWP (Universal Windows Platform) (UWP), basato sulla libreria dell'interfaccia utente di Windows (WinUI 3).</value>
+    <value>Un progetto per la creazione di un componente Windows Runtime C++/WinRT (.winmd) per app su desktop e piattaforma UWP (Universal Windows Platform), basato su WinUI.</value>
   </data>
   <data name="1037" xml:space="preserve">
-    <value>Test unitario app (WinUI 3)</value>
+    <value>App di test unità WinUI</value>
   </data>
   <data name="1038" xml:space="preserve">
-    <value>[Sperimentale] Test unitario app (WinUI 3)</value>
+    <value>[Sperimentale] App di test unità WinUI</value>
   </data>
   <data name="1039" xml:space="preserve">
-    <value>Progetto per la creazione di un'app di unit test C++/WinRT per WinUI 3 con MSTest.</value>
+    <value>Un progetto per la creazione di un'app di test unità C++/WinRT per WinUI usando MSTest.</value>
+  </data>
+  <data name="1040" xml:space="preserve">
+    <value>App vuota WinUI</value>
+  </data>
+  <data name="1041" xml:space="preserve">
+    <value>Progetto per la creazione di un'app WinUI vuota.</value>
+  </data>
+  <data name="1042" xml:space="preserve">
+    <value>Progetto di creazione pacchetti per applicazioni Windows per WinUI</value>
+  </data>
+  <data name="1043" xml:space="preserve">
+    <value>Modello di progetto che crea pacchetti MSIX contenenti applicazioni WinUI per il sideload o la distribuzione tramite il Microsoft Store.</value>
+  </data>
+  <data name="1044" xml:space="preserve">
+    <value>Installazione dei pacchetti NuGet nel progetto...</value>
+  </data>
+  <data name="1045" xml:space="preserve">
+    <value>Operazione in corso...</value>
+  </data>
+  <data name="1046" xml:space="preserve">
+    <value>Riferimenti ai pacchetti mancanti</value>
+  </data>
+  <data name="1047" xml:space="preserve">
+    <value>Non è possibile aggiungere riferimenti ai pacchetti seguenti per {0}: {1}. Aggiungere i riferimenti al pacchetto prima della compilazione.</value>
+  </data>
+  <data name="1048" xml:space="preserve">
+    <value>[{0}] Non è possibile aggiungere riferimenti ai pacchetti seguenti: {1}.
+
+Errore di ambiente. Aggiungere i riferimenti al pacchetto prima di compilare il progetto.
+
+Per ulteriori dettagli sull'errore, vedere la scheda Generale nella finestra di output.</value>
+  </data>
+  <data name="1049" xml:space="preserve">
+    <value>Gestisci pacchetti NuGet</value>
+  </data>
+  <data name="1050" xml:space="preserve">
+    <value>Visualizza dettagli errore</value>
+  </data>
+  <data name="1051" xml:space="preserve">
+    <value>Riferimenti ai pacchetti mancanti per {0}:</value>
+  </data>
+  <data name="1052" xml:space="preserve">
+    <value>Aggiungi manualmente i riferimenti ai pacchetti prima della compilazione.</value>
+  </data>
+  <data name="1053" xml:space="preserve">
+    <value>Generale</value>
+  </data>
+  <data name="1054" xml:space="preserve">
+    <value>Nessuna informazione sull'output disponibile.</value>
   </data>
 </root>

--- a/dev/VSIX/Extension/Cpp/Common/ja-JP/VSPackage.ja-JP.resx
+++ b/dev/VSIX/Extension/Cpp/Common/ja-JP/VSPackage.ja-JP.resx
@@ -118,31 +118,31 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="1001" xml:space="preserve">
-    <value>空白のウィンドウ (デスクトップの WinUI 3)</value>
+    <value>空白のウィンドウ</value>
   </data>
   <data name="1002" xml:space="preserve">
-    <value>[試験段階] 空白のウィンドウ (デスクトップの WinUI 3)</value>
+    <value>[試験段階] 空白のウィンドウ</value>
   </data>
   <data name="1003" xml:space="preserve">
-    <value>Windows UI ライブラリ (WinUI 3) に基づくデスクトップ アプリの空白のウィンドウです。</value>
+    <value>空白のウィンドウ (WinUI)。</value>
   </data>
   <data name="1005" xml:space="preserve">
-    <value>空白のページ (WinUI 3)</value>
+    <value>空白のページ</value>
   </data>
   <data name="1006" xml:space="preserve">
-    <value>[試験段階] 空白のページ (WinUI 3)</value>
+    <value>[試験段階] 空白のページ</value>
   </data>
   <data name="1007" xml:space="preserve">
-    <value>Windows UI ライブラリ (WinUI 3) に基づくアプリの空白のページ。</value>
+    <value>空白のページ (WinUI)。</value>
   </data>
   <data name="1009" xml:space="preserve">
-    <value>リソース ディクショナリ (WinUI 3)</value>
+    <value>リソース ディクショナリ</value>
   </data>
   <data name="1010" xml:space="preserve">
-    <value>[試験段階] リソース ディクショナリ (WinUI 3)</value>
+    <value>[試験段階] リソース ディクショナリ</value>
   </data>
   <data name="1011" xml:space="preserve">
-    <value>Windows UI ライブラリ (WinUI 3) に基づくアプリの XAML リソースの、空のキー付きコレクションです。</value>
+    <value>XAML リソースの、空のキー付きコレクション (WinUI)。</value>
   </data>
   <data name="1013" xml:space="preserve">
     <value>リソース ファイル (.resw)</value>
@@ -151,60 +151,109 @@
     <value>[試験段階] リソース ファイル (.resw)</value>
   </data>
   <data name="1015" xml:space="preserve">
-    <value>Windows UI ライブラリ (WinUI 3) に基づいてアプリの文字列と条件付きリソースを格納するためのファイルです。</value>
+    <value>文字列と条件付きリソース (WinUI) を格納するためのファイルです。</value>
   </data>
   <data name="1017" xml:space="preserve">
-    <value>カスタム コントロール (WinUI 3)</value>
+    <value>テンプレート化されたコントロール</value>
   </data>
   <data name="1018" xml:space="preserve">
-    <value>[試験段階] カスタム コントロール (WinUI 3)</value>
+    <value>[試験段階] テンプレート化されたコントロール</value>
   </data>
   <data name="1019" xml:space="preserve">
-    <value>Windows UI ライブラリ (WinUI 3) に基づくアプリのカスタム コントロール。</value>
+    <value>適切な既定のスタイルを持つ、空のカスタム コントロール (WinUI)。</value>
   </data>
   <data name="1021" xml:space="preserve">
-    <value>ユーザー コントロール (WinUI 3)</value>
+    <value>ユーザー コントロール</value>
   </data>
   <data name="1022" xml:space="preserve">
-    <value>[試験段階] ユーザー コントロール (WinUI 3)</value>
+    <value>[試験段階] ユーザー コントロール</value>
   </data>
   <data name="1023" xml:space="preserve">
-    <value>Windows UI ライブラリ (WinUI 3) に基づくアプリのユーザー コントロール。</value>
+    <value>空のユーザー コントロール (WinUI)。</value>
   </data>
   <data name="1025" xml:space="preserve">
-    <value>空白のアプリ、Windows アプリケーション パッケージ プロジェクトでパッケージ化 (デスクトップの WinUI 3)</value>
+    <value>WinUI 空のアプリ (Windows アプリケーション パッケージ プロジェクトでパッケージ化)</value>
   </data>
   <data name="1026" xml:space="preserve">
-    <value>[試験段階]空のアプリ、Windows アプリケーション パッケージ プロジェクトでパッケージ化 (デスクトップの WinUI 3)</value>
+    <value>[試験段階] WinUI 空のアプリ (Windows アプリケーション パッケージ プロジェクトでパッケージ化)</value>
   </data>
   <data name="1027" xml:space="preserve">
-    <value>Windows UI ライブラリ (WinUI 3) に基づいてデスクトップ アプリを作成するためのプロジェクト テンプレートです。Microsoft Store を介してサイドローディングまたは配布するための MSIX パッケージを作成するために Windows アプリケーション パッケージ (WAP) プロジェクトが含まれています。</value>
+    <value>WinUI アプリを作成するためのプロジェクト テンプレート。Microsoft Store を介したサイドローディングまたは配布用の MSIX パッケージを作成するために、Windows アプリケーション パッケージ (WAP) プロジェクトが含まれています。</value>
   </data>
   <data name="1029" xml:space="preserve">
-    <value>空のアプリ、パッケージ化 (デスクトップの WinUI 3)</value>
+    <value>WinUI 空のアプリ (パッケージ化)</value>
   </data>
   <data name="1030" xml:space="preserve">
-    <value>[試験段階]空のアプリ、パッケージ化 (デスクトップの WinUI 3)</value>
+    <value>[試験段階] WinUI 空のアプリ (パッケージ化)</value>
   </data>
   <data name="1031" xml:space="preserve">
-    <value>Windows UI ライブラリ (WinUI 3) に基づいてデスクトップ アプリを作成するためのプロジェクト テンプレートと、Microsoft Store を介したサイドローディングまたは配布用の MSIX パッケージです。</value>
+    <value>Microsoft Store を介したサイドローディングまたは配布用の MSIX パッケージとともに、WinUI アプリを作成するためのプロジェクト テンプレート。</value>
   </data>
   <data name="1033" xml:space="preserve">
-    <value>Windows ランタイム コンポーネント (WinUI 3)</value>
+    <value>WinUI Windows ランタイム コンポーネント</value>
   </data>
   <data name="1034" xml:space="preserve">
-    <value>[試験段階] Windows ランタイム コンポーネント (WinUI 3)</value>
+    <value>[試験段階] WinUI Windows ランタイム コンポーネント (C++/WinRT)</value>
   </data>
   <data name="1035" xml:space="preserve">
-    <value>Windows UI ライブラリ (WinUI 3) に基づいて、デスクトップ アプリとユニバーサル Windows プラットフォーム (UWP) アプリの両方の C++/WinRT Windows ランタイム コンポーネント (.winmd) を作成するためのプロジェクトです。</value>
+    <value>WinUI に基づいて、デスクトップおよびユニバーサル Windows プラットフォーム (UWP) アプリの両方の C++/WinRT Windows ランタイム コンポーネント (.winmd) を作成するためのプロジェクト。</value>
   </data>
   <data name="1037" xml:space="preserve">
-    <value>単体テスト アプリ (WinUI 3)</value>
+    <value>WinUI 単体テスト アプリ</value>
   </data>
   <data name="1038" xml:space="preserve">
-    <value>[試験段階]　単体テスト アプリ (WinUI 3)</value>
+    <value>[試験段階] WinUI 単体テスト アプリ</value>
   </data>
   <data name="1039" xml:space="preserve">
-    <value>MSTest を使用して WinUI 3 用 C++/WinRT 単体テスト アプリを作成するためのプロジェクトです。</value>
+    <value>MSTest を使用して WinUI 用 C++/WinRT 単体テスト アプリを作成するためのプロジェクト。</value>
+  </data>
+  <data name="1040" xml:space="preserve">
+    <value>WinUI 空のアプリ</value>
+  </data>
+  <data name="1041" xml:space="preserve">
+    <value>空の WinUI アプリを作成するためのプロジェクトです。</value>
+  </data>
+  <data name="1042" xml:space="preserve">
+    <value>WinUI 用の Windows アプリケーション パッケージ プロジェクト</value>
+  </data>
+  <data name="1043" xml:space="preserve">
+    <value>Microsoft Storeを使用してサイドローディングまたはディストリビューションを行う WinUI アプリケーションを含む MSIX パッケージを作成するプロジェクト テンプレートです。</value>
+  </data>
+  <data name="1044" xml:space="preserve">
+    <value>NuGet パッケージをプロジェクトにインストールしています...</value>
+  </data>
+  <data name="1045" xml:space="preserve">
+    <value>操作は実行中です...</value>
+  </data>
+  <data name="1046" xml:space="preserve">
+    <value>パッケージ参照がありません</value>
+  </data>
+  <data name="1047" xml:space="preserve">
+    <value>{0} の次のパッケージへの参照を追加できません: {1}。ビルドする前にパッケージ参照を追加してください。</value>
+  </data>
+  <data name="1048" xml:space="preserve">
+    <value>[{0}]次のパッケージへの参照を追加できません: {1}。
+
+これは環境エラーです。プロジェクトをビルドする前に、パッケージ参照を追加してください。
+
+エラーの詳細については、出力ウィンドウの [全般] タブをチェックしてください。</value>
+  </data>
+  <data name="1049" xml:space="preserve">
+    <value>NuGet パッケージの管理</value>
+  </data>
+  <data name="1050" xml:space="preserve">
+    <value>エラーの詳細を表示</value>
+  </data>
+  <data name="1051" xml:space="preserve">
+    <value>{0} のパッケージ参照がありません:</value>
+  </data>
+  <data name="1052" xml:space="preserve">
+    <value>ビルドする前に、パッケージ参照を手動で追加してください。</value>
+  </data>
+  <data name="1053" xml:space="preserve">
+    <value>全般</value>
+  </data>
+  <data name="1054" xml:space="preserve">
+    <value>使用できる出力情報がありません。</value>
   </data>
 </root>

--- a/dev/VSIX/Extension/Cpp/Common/ko-KR/VSPackage.ko-KR.resx
+++ b/dev/VSIX/Extension/Cpp/Common/ko-KR/VSPackage.ko-KR.resx
@@ -118,31 +118,31 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="1001" xml:space="preserve">
-    <value>빈 창(데스크탑의 WinUI 3)</value>
+    <value>빈 창</value>
   </data>
   <data name="1002" xml:space="preserve">
-    <value>[실험적] 빈 창(데스크톱의 WinUI 3)</value>
+    <value>[실험적] 빈 창</value>
   </data>
   <data name="1003" xml:space="preserve">
-    <value>Windows UI 라이브러리(WinUI 3)를 기반으로 하는 데스크톱 앱의 빈 창입니다.</value>
+    <value>빈 창(WinUI).</value>
   </data>
   <data name="1005" xml:space="preserve">
-    <value>빈 페이지(WinUI 3)</value>
+    <value>빈 페이지</value>
   </data>
   <data name="1006" xml:space="preserve">
-    <value>[실험적] 빈 페이지(WinUI 3)</value>
+    <value>[실험적] 빈 페이지</value>
   </data>
   <data name="1007" xml:space="preserve">
-    <value>Windows UI 라이브러리(WinUI 3)를 기반으로 하는 앱의 빈 페이지입니다.</value>
+    <value>빈 페이지(WinUI).</value>
   </data>
   <data name="1009" xml:space="preserve">
-    <value>리소스 사전(WinUI 3)</value>
+    <value>리소스 사전</value>
   </data>
   <data name="1010" xml:space="preserve">
-    <value>[실험적] 리소스 사전(WinUI 3)</value>
+    <value>[실험적] 리소스 사전</value>
   </data>
   <data name="1011" xml:space="preserve">
-    <value>Windows UI 라이브러리(WinUI 3)를 기반으로 하는 앱용 빈 키가 있는 XAML 리소스 컬렉션입니다.</value>
+    <value>비어 있는 키로 구성된 XAML 리소스 컬렉션입니다(WinUI).</value>
   </data>
   <data name="1013" xml:space="preserve">
     <value>리소스 파일(.resw)</value>
@@ -151,60 +151,109 @@
     <value>[실험] 리소스 파일(.resw)</value>
   </data>
   <data name="1015" xml:space="preserve">
-    <value>Windows UI 라이브러리(WinUI 3)를 기반으로 하는 앱용 문자열 및 조건부 리소스를 저장하기 위한 파일입니다.</value>
+    <value>WinUI(문자열 및 조건부 리소스)를 저장하는 파일입니다.</value>
   </data>
   <data name="1017" xml:space="preserve">
-    <value>사용자 지정 컨트롤(WinUI 3)</value>
+    <value>템플릿 제공 컨트롤</value>
   </data>
   <data name="1018" xml:space="preserve">
-    <value>[실험적] 사용자 지정 컨트롤(WinUI 3)</value>
+    <value>[실험적] 템플릿 제공 컨트롤</value>
   </data>
   <data name="1019" xml:space="preserve">
-    <value>Windows UI 라이브러리(WinUI 3)를 기반으로 하는 앱용 사용자 지정 컨트롤입니다.</value>
+    <value>적절한 기본 스타일(WinUI)을 사용하는 빈 사용자 지정 컨트롤입니다.</value>
   </data>
   <data name="1021" xml:space="preserve">
-    <value>사용자 정의 컨트롤(WinUI 3)</value>
+    <value>사용자 정의 컨트롤</value>
   </data>
   <data name="1022" xml:space="preserve">
-    <value>[실험적] 사용자 정의 컨트롤(WinUI 3)</value>
+    <value>[실험적] 사용자 정의 컨트롤</value>
   </data>
   <data name="1023" xml:space="preserve">
-    <value>Windows UI 라이브러리(WinUI 3)를 기반으로 하는 앱용 사용자 정의 컨트롤입니다.</value>
+    <value>빈 사용자 정의 컨트롤(WinUI).</value>
   </data>
   <data name="1025" xml:space="preserve">
-    <value>빈 앱, Windows 애플리케이션 패키징 프로젝트가 포함된 패키지(데스크톱의 WinUI 3)</value>
+    <value>WinUI 빈 앱(Windows 애플리케이션 패키징 프로젝트 패키지)</value>
   </data>
   <data name="1026" xml:space="preserve">
-    <value>[실험적] 빈 앱, Windows 애플리케이션 패키징 프로젝트 패키지됨(데스크톱의 WinUI 3)</value>
+    <value>[실험적] WinUI 빈 앱(Windows 애플리케이션 패키징 프로젝트 패키지)</value>
   </data>
   <data name="1027" xml:space="preserve">
-    <value>Windows UI 라이브러리(WinUI 3)를 기반으로 하는 데스크톱 앱을 만들기 위한 프로젝트 템플릿입니다. Microsoft Store를 통해 테스트용으로 로드하거나 배포하기 위한 MSIX 패키지를 만들기 위해 WAP(Windows 애플리케이션 패키징) 프로젝트가 포함되어 있습니다.</value>
+    <value>WinUI 앱을 만들기 위한 프로젝트 템플릿. Microsoft Store를 통해 테스트용으로 로드하거나 배포하기 위한 MSIX 패키지를 만들기 위해 WAP(Windows 애플리케이션 패키징) 프로젝트가 포함되어 있습니다.</value>
   </data>
   <data name="1029" xml:space="preserve">
-    <value>빈 앱, 패키지됨(데스크톱의 WinUI 3)</value>
+    <value>WinUI 빈 앱(패키지됨)</value>
   </data>
   <data name="1030" xml:space="preserve">
-    <value>[실험적] 빈 앱, 패키지됨(데스크톱의 WinUI 3)</value>
+    <value>[실험적] WinUI 빈 앱(패키지됨)</value>
   </data>
   <data name="1031" xml:space="preserve">
-    <value>Microsoft Store를 통해 테스트용으로 로드하거나 배포하기 위한 MSIX 패키지와 함께 Windows UI 라이브러리(WinUI 3)를 기반으로 하는 데스크톱 앱을 만들기 위한 프로젝트 템플릿입니다.</value>
+    <value>Microsoft Store 통해 테스트용 로드 또는 배포를 위한 MSIX 패키지와 함께 WinUI 앱을 만들기 위한 프로젝트 템플릿.</value>
   </data>
   <data name="1033" xml:space="preserve">
-    <value>Windows 런타임 구성 요소(WinUI 3)</value>
+    <value>WinUI Windows 런타임 구성 요소</value>
   </data>
   <data name="1034" xml:space="preserve">
-    <value>[실험적] Windows 런타임 구성 요소(WinUI 3)</value>
+    <value>[실험적] WinUI Windows 런타임 구성 요소(C++/WinRT)</value>
   </data>
   <data name="1035" xml:space="preserve">
-    <value>Windows UI 라이브러리(WinUI 3)를 기반으로 하는 데스크톱 및 유니버설 Windows 플랫폼(UWP) 앱 두 가지 모두를 위한 C++/WinRT Windows 런타임 구성 요소(.winmd)를 만들기 위한 프로젝트입니다.</value>
+    <value>WinUI를 기반으로 데스크톱 및 UWP(유니버설 Windows 플랫폼) 앱 모두에 대한 C++/WinRT Windows 런타임 구성 요소(.winmd)를 만드는 프로젝트입니다.</value>
   </data>
   <data name="1037" xml:space="preserve">
-    <value>단위 테스트 앱(WinUI 3)</value>
+    <value>WinUI 단위 테스트 앱</value>
   </data>
   <data name="1038" xml:space="preserve">
-    <value>[실험적] 단위 테스트 앱(WinUI 3)</value>
+    <value>[실험적] WinUI 단위 테스트 앱</value>
   </data>
   <data name="1039" xml:space="preserve">
-    <value>MSTest를 사용하여 WinUI 3용 C++/WinRT 단위 테스트 앱을 만드는 프로젝트입니다.</value>
+    <value>MSTest를 사용하여 WinUI용 C++/WinRT 단위 테스트 앱을 만드는 프로젝트입니다.</value>
+  </data>
+  <data name="1040" xml:space="preserve">
+    <value>WinUI 빈 앱</value>
+  </data>
+  <data name="1041" xml:space="preserve">
+    <value>빈 WinUI 앱을 만들기 위한 프로젝트.</value>
+  </data>
+  <data name="1042" xml:space="preserve">
+    <value>WinUI용 Windows 애플리케이션 패키징 프로젝트</value>
+  </data>
+  <data name="1043" xml:space="preserve">
+    <value>Microsoft Store 통해 테스트용 로드 또는 배포를 위한 WinUI 애플리케이션이 포함된 MSIX 패키지를 만드는 프로젝트 템플릿입니다.</value>
+  </data>
+  <data name="1044" xml:space="preserve">
+    <value>프로젝트에 NuGet 패키지를 설치하는 중입니다...</value>
+  </data>
+  <data name="1045" xml:space="preserve">
+    <value>작업이 진행 중입니다.</value>
+  </data>
+  <data name="1046" xml:space="preserve">
+    <value>누락된 패키지 참조</value>
+  </data>
+  <data name="1047" xml:space="preserve">
+    <value>{0} 대한 다음 패키지에 참조를 추가할 수 없습니다. {1}. 빌드하기 전에 패키지 참조를 추가하세요.</value>
+  </data>
+  <data name="1048" xml:space="preserve">
+    <value>[{0}] 다음 패키지에 대한 참조를 추가할 수 없습니다. {1}
+
+환경 오류입니다. 프로젝트를 빌드하기 전에 패키지 참조를 추가하세요.
+
+오류에 대한 자세한 내용은 출력 창에서 일반 탭을 확인하세요.</value>
+  </data>
+  <data name="1049" xml:space="preserve">
+    <value>NuGet 패키지 관리</value>
+  </data>
+  <data name="1050" xml:space="preserve">
+    <value>오류 세부 정보 보기</value>
+  </data>
+  <data name="1051" xml:space="preserve">
+    <value>{0}에 대해 누락된 패키지 참조:</value>
+  </data>
+  <data name="1052" xml:space="preserve">
+    <value>빌드하기 전에 패키지 참조를 수동으로 추가하세요.</value>
+  </data>
+  <data name="1053" xml:space="preserve">
+    <value>일반</value>
+  </data>
+  <data name="1054" xml:space="preserve">
+    <value>출력 정보를 사용할 수 없습니다.</value>
   </data>
 </root>

--- a/dev/VSIX/Extension/Cpp/Common/pl-PL/VSPackage.pl-PL.resx
+++ b/dev/VSIX/Extension/Cpp/Common/pl-PL/VSPackage.pl-PL.resx
@@ -118,31 +118,31 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="1001" xml:space="preserve">
-    <value>Puste okno (WinUI 3 na pulpicie)</value>
+    <value>Puste okno</value>
   </data>
   <data name="1002" xml:space="preserve">
-    <value>[Eksperymentalne] Puste okno (WinUI 3 na pulpicie)</value>
+    <value>[Eksperymentalne] Puste okno</value>
   </data>
   <data name="1003" xml:space="preserve">
-    <value>Puste okno dla aplikacji klasycznych opartych na bibliotece interfejsu użytkownika systemu Windows (WinUI 3).</value>
+    <value>Puste okno (WinUI).</value>
   </data>
   <data name="1005" xml:space="preserve">
-    <value>Pusta strona (WinUI 3)</value>
+    <value>Pusta strona</value>
   </data>
   <data name="1006" xml:space="preserve">
-    <value>[Eksperymentalne] Pusta strona (WinUI 3)</value>
+    <value>[Eksperymentalne] Pusta strona</value>
   </data>
   <data name="1007" xml:space="preserve">
-    <value>Pusta strona dla aplikacji opartych na bibliotece interfejsu użytkownika systemu Windows (WinUI 3).</value>
+    <value>Pusta strona (WinUI).</value>
   </data>
   <data name="1009" xml:space="preserve">
-    <value>Słownik zasobów (WinUI 3)</value>
+    <value>Słownik zasobów</value>
   </data>
   <data name="1010" xml:space="preserve">
-    <value>[Eksperymentalne] Słownik zasobów (WinUI 3)</value>
+    <value>[Eksperymentalne] Słownik zasobów</value>
   </data>
   <data name="1011" xml:space="preserve">
-    <value>Pusta kolekcja kluczy zasobów XAML dla aplikacji opartych na bibliotece interfejsu użytkownika systemu Windows (WinUI 3).</value>
+    <value>Pusta kolekcja kluczy zasobów XAML (WinUI).</value>
   </data>
   <data name="1013" xml:space="preserve">
     <value>Plik zasobów (resw)</value>
@@ -151,60 +151,109 @@
     <value>[Eksperymentalne] Plik zasobów (resw)</value>
   </data>
   <data name="1015" xml:space="preserve">
-    <value>Plik do przechowywania ciągów i zasobów warunkowych dla aplikacji opartych na bibliotece interfejsu użytkownika systemu Windows (WinUI 3).</value>
+    <value>Plik do przechowywania ciągów i zasobów warunkowych (WinUI).</value>
   </data>
   <data name="1017" xml:space="preserve">
-    <value>Kontrolka niestandardowa (WinUI 3)</value>
+    <value>Kontrolka z szablonem</value>
   </data>
   <data name="1018" xml:space="preserve">
-    <value>[Eksperymentalne] Kontrolka niestandardowa (WinUI 3)</value>
+    <value>[Eksperymentalne] Kontrolka z szablonem</value>
   </data>
   <data name="1019" xml:space="preserve">
-    <value>Kontrolka niestandardowa dla aplikacji opartych na bibliotece interfejsu użytkownika systemu Windows (WinUI 3).</value>
+    <value>Pusta kontrolka niestandardowa z odpowiednim domyślnym stylem (WinUI).</value>
   </data>
   <data name="1021" xml:space="preserve">
-    <value>Kontrolka użytkownika (WinUI 3)</value>
+    <value>Kontrola użytkownika</value>
   </data>
   <data name="1022" xml:space="preserve">
-    <value>[Eksperymentalne] Kontrolka użytkownika (WinUI 3)</value>
+    <value>[Eksperymentalne] Kontrola użytkownika</value>
   </data>
   <data name="1023" xml:space="preserve">
-    <value>Kontrolka użytkownika dla aplikacji opartych na bibliotece interfejsu użytkownika systemu Windows (WinUI 3).</value>
+    <value>Pusta kontrolka użytkownika (WinUI).</value>
   </data>
   <data name="1025" xml:space="preserve">
-    <value>Pusta aplikacja, spakietyzowana za pomocą projektu pakietu aplikacji systemu Windows (WinUI 3 na pulpicie)</value>
+    <value>Pusta aplikacja WinUI (spakowana z projektem pakietu aplikacji systemu Windows)</value>
   </data>
   <data name="1026" xml:space="preserve">
-    <value>[Eksperymentalne] Pusta aplikacja spakowana z projekt pakietu aplikacji systemu Windows (WinUI 3 na pulpicie)</value>
+    <value>[Eksperymentalne] Pusta aplikacja WinUI (spakowana z projektem pakietu aplikacji systemu Windows)</value>
   </data>
   <data name="1027" xml:space="preserve">
-    <value>Szablon projektu służący do tworzenia aplikacji klasycznej na podstawie biblioteki interfejsu użytkownika systemu Windows (WinUI 3). Projekt pakietu aplikacji systemu Windows (WAP) jest dołączany w celu utworzenia pakietu MSIX na potrzeby ładowania bezpośredniego lub dystrybucji za pośrednictwem sklepu Microsoft Store.</value>
+    <value>Szablon projektu do tworzenia aplikacji WinUI. Projekt pakietu aplikacji systemu Windows (WAP) jest dołączany w celu utworzenia pakietu MSIX na potrzeby ładowania bezpośredniego lub dystrybucji za pośrednictwem sklepu Microsoft Store.</value>
   </data>
   <data name="1029" xml:space="preserve">
-    <value>Pusta aplikacja, spakowana (WinUI 3 na pulpicie)</value>
+    <value>Pusta aplikacja WinUI (spakowana)</value>
   </data>
   <data name="1030" xml:space="preserve">
-    <value>[Eksperymentalne] Pusta aplikacja, spakowana (WinUI 3 na pulpicie)</value>
+    <value>[Eksperymentalne] Pusta aplikacja WinUI (spakowana)</value>
   </data>
   <data name="1031" xml:space="preserve">
-    <value>Szablon projektu służący do tworzenia aplikacji klasycznej opartej na bibliotece interfejsu użytkownika systemu Windows (WinUI 3) wraz z pakietem MSIX na potrzeby ładowania bezpośredniego lub dystrybucji za pośrednictwem sklepu Microsoft Store.</value>
+    <value>Szablon projektu do tworzenia aplikacji WinUI wraz z pakietem MSIX na potrzeby ładowania bezpośredniego lub dystrybucji za pośrednictwem sklepu Microsoft Store.</value>
   </data>
   <data name="1033" xml:space="preserve">
-    <value>Składnik środowiska wykonawczego systemu Windows (WinUI 3)</value>
+    <value>Składnik środowiska wykonawczego systemu Windows WinUI</value>
   </data>
   <data name="1034" xml:space="preserve">
-    <value>[Eksperymentalne] Składnik środowiska wykonawczego systemu Windows (WinUI 3)</value>
+    <value>[Eksperymentalne] Składnik środowiska wykonawczego systemu Windows WinUI (C++/WinRT)</value>
   </data>
   <data name="1035" xml:space="preserve">
-    <value>Projekt służący do tworzenia składnika środowiska wykonawczego systemu Windows C++/WinRT (winmd) dla aplikacji klasycznych i platformy uniwersalnej systemu Windows (UWP) na podstawie biblioteki interfejsu użytkownika systemu Windows (WinUI 3).</value>
+    <value>Projekt służący do tworzenia składnika środowiska wykonawczego systemu Windows C++/WinRT (.winmd) dla aplikacji klasycznych i platformy uniwersalnej systemu Windows (UWP) na podstawie biblioteki WinUI.</value>
   </data>
   <data name="1037" xml:space="preserve">
-    <value>Aplikacja testów jednostkowych (WinUI 3)</value>
+    <value>Aplikacja testów jednostkowych WinUI</value>
   </data>
   <data name="1038" xml:space="preserve">
-    <value>[Eksperymentalne] Aplikacja testów jednostkowych (WinUI 3)</value>
+    <value>[Eksperymentalne] Aplikacja testów jednostkowych WinUI</value>
   </data>
   <data name="1039" xml:space="preserve">
-    <value>Projekt do tworzenia aplikacji testów jednostkowych C++/WinRT dla WinUI 3 przy użyciu platformy MSTest.</value>
+    <value>Projekt do tworzenia aplikacji testów jednostkowych C++/WinRT dla WinUI przy użyciu platformy MSTest.</value>
+  </data>
+  <data name="1040" xml:space="preserve">
+    <value>Pusta aplikacja WinUI</value>
+  </data>
+  <data name="1041" xml:space="preserve">
+    <value>Projekt służący do tworzenia pustej aplikacji WinUI.</value>
+  </data>
+  <data name="1042" xml:space="preserve">
+    <value>Projekt pakietu aplikacji systemu Windows dla WinUI</value>
+  </data>
+  <data name="1043" xml:space="preserve">
+    <value>Szablon projektu, który tworzy pakiety MSIX zawierające aplikacje WinUI na potrzeby ładowania bezpośredniego lub dystrybucji za pośrednictwem Microsoft Store.</value>
+  </data>
+  <data name="1044" xml:space="preserve">
+    <value>Trwa instalowanie pakietów NuGet w projekcie...</value>
+  </data>
+  <data name="1045" xml:space="preserve">
+    <value>Operacja w toku...</value>
+  </data>
+  <data name="1046" xml:space="preserve">
+    <value>Brak odwołań do pakietu</value>
+  </data>
+  <data name="1047" xml:space="preserve">
+    <value>Nie można dodać odwołań do następujących pakietów dla {0}: {1}. Przed skompilowaniem dodaj odwołania do pakietu.</value>
+  </data>
+  <data name="1048" xml:space="preserve">
+    <value>[{0}] Nie można dodać odwołań do następujących pakietów: {1}.
+
+To jest błąd środowiska. Przed skompilowaniem projektu dodaj odwołania do pakietu.
+
+Aby uzyskać więcej informacji o błędzie, sprawdź kartę Ogólne w oknie Dane wyjściowe.</value>
+  </data>
+  <data name="1049" xml:space="preserve">
+    <value>Zarządzanie pakietami NuGet</value>
+  </data>
+  <data name="1050" xml:space="preserve">
+    <value>Zobacz szczegóły błędu</value>
+  </data>
+  <data name="1051" xml:space="preserve">
+    <value>Brak odwołań do pakietu dla {0}:</value>
+  </data>
+  <data name="1052" xml:space="preserve">
+    <value>Przed kompilacją ręcznie dodaj odwołania do pakietów.</value>
+  </data>
+  <data name="1053" xml:space="preserve">
+    <value>Ogólne</value>
+  </data>
+  <data name="1054" xml:space="preserve">
+    <value>Brak dostępnych informacji wyjściowych.</value>
   </data>
 </root>

--- a/dev/VSIX/Extension/Cpp/Common/pt-BR/VSPackage.pt-BR.resx
+++ b/dev/VSIX/Extension/Cpp/Common/pt-BR/VSPackage.pt-BR.resx
@@ -118,31 +118,31 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="1001" xml:space="preserve">
-    <value>Janela em Branco (WinUI 3 no Desktop)</value>
+    <value>Janela em Branco</value>
   </data>
   <data name="1002" xml:space="preserve">
-    <value>[Experimental] Janela em Branco (WinUI 3 no Desktop)</value>
+    <value>[Experimental] Janela em Branco</value>
   </data>
   <data name="1003" xml:space="preserve">
-    <value>Uma janela em branco para Aplicativos para desktop baseado na Biblioteca de Interface do Usuário do Windows (WinUI 3).</value>
+    <value>Uma janela em branco (WinUI).</value>
   </data>
   <data name="1005" xml:space="preserve">
-    <value>Página em Branco (WinUI 3)</value>
+    <value>Página em Branco</value>
   </data>
   <data name="1006" xml:space="preserve">
-    <value>[Experimental] Página em Branco (WinUI 3)</value>
+    <value>[Experimental] Página em Branco</value>
   </data>
   <data name="1007" xml:space="preserve">
-    <value>Uma página em branco para aplicativos baseado na Biblioteca de Interface do Usuário do Windows (WinUI 3).</value>
+    <value>Uma página em branco (WinUI).</value>
   </data>
   <data name="1009" xml:space="preserve">
-    <value>Dicionário de Recursos (WinUI 3)</value>
+    <value>Dicionário de Recursos</value>
   </data>
   <data name="1010" xml:space="preserve">
-    <value>[Experimental] Dicionário de Recursos (WinUI 3)</value>
+    <value>[Experimental] Dicionário de Recursos</value>
   </data>
   <data name="1011" xml:space="preserve">
-    <value>Uma coleção vazia e com chave de recursos XAML para aplicativos baseados na Biblioteca de Interface do Usuário do Windows (WinUI 3).</value>
+    <value>Uma coleção vazia de recursos XAML (WinUI) com chave.</value>
   </data>
   <data name="1013" xml:space="preserve">
     <value>Arquivo de Recursos (.resw)</value>
@@ -151,60 +151,109 @@
     <value>[Experimental] Arquivo de Recursos (.resw)</value>
   </data>
   <data name="1015" xml:space="preserve">
-    <value>Um arquivo para armazenar a cadeia de caracteres e os recursos condicionais para aplicativos com base na Biblioteca de Interface do Usuário do Windows (WinUI 3).</value>
+    <value>Um arquivo para armazenar a cadeia de caracteres e os recursos condicionais (WinUI).</value>
   </data>
   <data name="1017" xml:space="preserve">
-    <value>Controle Personalizado (WinUI 3)</value>
+    <value>Controle Modelo</value>
   </data>
   <data name="1018" xml:space="preserve">
-    <value>[Experimental] Controle Personalizado (WinUI 3)</value>
+    <value>[Experimental] Controle Modelo</value>
   </data>
   <data name="1019" xml:space="preserve">
-    <value>Um controle personalizado para aplicativos baseado na Biblioteca de Interface do Usuário do Windows (WinUI 3).</value>
+    <value>Um controle personalizado em branco com o estilo padrão apropriado (WinUI).</value>
   </data>
   <data name="1021" xml:space="preserve">
-    <value>Controle de Usuário (WinUI 3)</value>
+    <value>Controle de Usuário</value>
   </data>
   <data name="1022" xml:space="preserve">
-    <value>[Experimental] Controle de Usuário (WinUI 3)</value>
+    <value>[Experimental] Controle de Usuário</value>
   </data>
   <data name="1023" xml:space="preserve">
-    <value>Um controle de usuário para aplicativos baseado na Biblioteca de Interface do Usuário do Windows (WinUI 3).</value>
+    <value>Um controle de usuário em branco (WinUI).</value>
   </data>
   <data name="1025" xml:space="preserve">
-    <value>Aplicativo em Branco, Empacotado com Projeto de Empacotamento de Aplicativo do Windows (WinUI 3 na Área de Trabalho)</value>
+    <value>Aplicativo em Branco do WinUI (Empacotado com Projeto de Empacotamento de Aplicativo do Windows)</value>
   </data>
   <data name="1026" xml:space="preserve">
-    <value>[Experimental] Aplicativo em Branco, Empacotado com Projeto de Empacotamento de Aplicativo do Windows (WinUI 3 na Área de Trabalho)</value>
+    <value>[Experimental] Aplicativo em Branco do WinUI (Empacotado com Projeto de Empacotamento de Aplicativo do Windows)</value>
   </data>
   <data name="1027" xml:space="preserve">
-    <value>Um modelo de projeto para criar um Aplicativo para desktop com base na Biblioteca de Interface do Usuário do Windows (WinUI 3). Um projeto wap (empacotamento de aplicativo) do Windows é incluído para criar um pacote MSIX para sideload ou distribuição por meio do Microsoft Store.</value>
+    <value>Um modelo de projeto para criar um aplicativo WinUI. Um projeto de Empacotamento de Aplicativo do Windows (WAP) está incluído para criar um pacote MSIX para carregamento ou distribuição por meio da Microsoft Store.</value>
   </data>
   <data name="1029" xml:space="preserve">
-    <value>Aplicativo em Branco, Empacotado (WinUI 3 no Desktop)</value>
+    <value>Aplicativo em Branco do WinUI (Empacotado)</value>
   </data>
   <data name="1030" xml:space="preserve">
-    <value>[Experimental] Aplicativo em Branco, Empacotado (WinUI 3 na Área de Trabalho)</value>
+    <value>[Experimental] Aplicativo em Branco do WinUI (Empacotado)</value>
   </data>
   <data name="1031" xml:space="preserve">
-    <value>Um modelo de projeto para criar um Aplicativo para desktop baseado na Biblioteca de Interface do Usuário do Windows (WinUI 3) juntamente com um pacote MSIX para sideload ou distribuição por meio da Microsoft Store.</value>
+    <value>Um modelo de projeto para criar um aplicativo WinUI junto com um pacote MSIX para carregamento ou distribuição por meio da Microsoft Store.</value>
   </data>
   <data name="1033" xml:space="preserve">
-    <value>Componente do Windows Runtime (WinUI 3)</value>
+    <value>Componente do Windows Runtime do WinUI</value>
   </data>
   <data name="1034" xml:space="preserve">
-    <value>[Experimental] Componente do Windows Runtime (WinUI 3)</value>
+    <value>[Experimental] Componente do Windows Runtime do WinUI (C++/WinRT)</value>
   </data>
   <data name="1035" xml:space="preserve">
-    <value>Um projeto para criar um Componente de Windows Runtime C++/WinRT (.winmd) para Aplicativos desktop e Plataforma Universal do Windows (UWP), com base na Biblioteca de Interface do Usuário do Windows (WinUI 3).</value>
+    <value>Um projeto para criar um Componentes do Windows Runtime C++/WinRT (.winmd) para aplicativos de área de trabalho e Plataforma Universal do Windows (UWP), com base no WinUI.</value>
   </data>
   <data name="1037" xml:space="preserve">
-    <value>Aplicativo de Teste de Unidade (WinUI 3)</value>
+    <value>Aplicativo de Teste de Unidade do WinUI</value>
   </data>
   <data name="1038" xml:space="preserve">
-    <value>[Experimental] Aplicativo de Teste de Unidade (WinUI 3)</value>
+    <value>[Experimental] Aplicativo de Teste de Unidade do WinUI</value>
   </data>
   <data name="1039" xml:space="preserve">
-    <value>Um projeto para criar um aplicativo de teste de unidade C++/WinRT para WinUI 3 usando o MSTest.</value>
+    <value>Um projeto para criar um aplicativo de teste de unidade C++/WinRT para WinUI usando mSTest.</value>
+  </data>
+  <data name="1040" xml:space="preserve">
+    <value>Aplicativo em Branco do WinUI</value>
+  </data>
+  <data name="1041" xml:space="preserve">
+    <value>Um projeto para criar um aplicativo WinUI vazio.</value>
+  </data>
+  <data name="1042" xml:space="preserve">
+    <value>Projeto de Empacotamento de Aplicativo do Windows para WinUI</value>
+  </data>
+  <data name="1043" xml:space="preserve">
+    <value>Um modelo de projeto que cria pacotes MSIX contendo aplicativos WinUI para side loading ou distribuição por meio do Microsoft Store.</value>
+  </data>
+  <data name="1044" xml:space="preserve">
+    <value>Instalando pacotes NuGet no projeto...</value>
+  </data>
+  <data name="1045" xml:space="preserve">
+    <value>Operação em andamento...</value>
+  </data>
+  <data name="1046" xml:space="preserve">
+    <value>Referências de Pacote Ausentes</value>
+  </data>
+  <data name="1047" xml:space="preserve">
+    <value>Não é possível adicionar referências aos seguintes pacotes para {0}: {1}. Adicione referências de pacote antes de compilar.</value>
+  </data>
+  <data name="1048" xml:space="preserve">
+    <value>[{0}] Não é possível adicionar referências aos seguintes pacotes: {1}.
+
+Este é um erro de ambiente. Adicione referências de pacote antes de compilar o projeto.
+
+Para obter mais detalhes sobre o erro, marcar guia Geral na janela Saída.</value>
+  </data>
+  <data name="1049" xml:space="preserve">
+    <value>Gerenciar Pacotes NuGet</value>
+  </data>
+  <data name="1050" xml:space="preserve">
+    <value>Confira os detalhes do erro</value>
+  </data>
+  <data name="1051" xml:space="preserve">
+    <value>Referências de Pacote Ausentes para {0}:</value>
+  </data>
+  <data name="1052" xml:space="preserve">
+    <value>Adicione manualmente as referências de pacote antes de compilar.</value>
+  </data>
+  <data name="1053" xml:space="preserve">
+    <value>Geral</value>
+  </data>
+  <data name="1054" xml:space="preserve">
+    <value>Nenhuma informação de saída disponível.</value>
   </data>
 </root>

--- a/dev/VSIX/Extension/Cpp/Common/ru-RU/VSPackage.ru-RU.resx
+++ b/dev/VSIX/Extension/Cpp/Common/ru-RU/VSPackage.ru-RU.resx
@@ -118,31 +118,31 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="1001" xml:space="preserve">
-    <value>Пустое окно (WinUI 3 в "Классическом приложении")</value>
+    <value>Пустое окно</value>
   </data>
   <data name="1002" xml:space="preserve">
-    <value>[Экспериментальная версия] Пустое окно (WinUI 3 в "Классическом приложении")</value>
+    <value>[Экспериментальная функция] Пустое окно</value>
   </data>
   <data name="1003" xml:space="preserve">
-    <value>Пустое окно для классических приложений на основе библиотеки пользовательского интерфейса Windows (WinUI 3).</value>
+    <value>Пустое окно (WinUI).</value>
   </data>
   <data name="1005" xml:space="preserve">
-    <value>Пустая страница (WinUI 3)</value>
+    <value>Пустая страница</value>
   </data>
   <data name="1006" xml:space="preserve">
-    <value>[Экспериментальная версия] Пустая страница (WinUI 3)</value>
+    <value>[Экспериментальная функция] Пустая страница</value>
   </data>
   <data name="1007" xml:space="preserve">
-    <value>Пустая страница для приложений на основе библиотеки пользовательского интерфейса Windows (WinUI 3).</value>
+    <value>Пустая страница (WinUI).</value>
   </data>
   <data name="1009" xml:space="preserve">
-    <value>Словарь ресурсов (WinUI 3)</value>
+    <value>Словарь ресурсов</value>
   </data>
   <data name="1010" xml:space="preserve">
-    <value>[Экспериментальная версия] Словарь ресурсов (WinUI 3)</value>
+    <value>[Экспериментальная функция] Словарь ресурсов</value>
   </data>
   <data name="1011" xml:space="preserve">
-    <value>Пустая коллекция ресурсов XAML с ключами для приложений на основе библиотеки пользовательского интерфейса Windows (WinUI 3).</value>
+    <value>Пустая коллекция ресурсов XAML с ключами (WinUI).</value>
   </data>
   <data name="1013" xml:space="preserve">
     <value>Файл ресурсов (.resw)</value>
@@ -151,60 +151,109 @@
     <value>[Экспериментальная версия] Файл ресурсов (.resw)</value>
   </data>
   <data name="1015" xml:space="preserve">
-    <value>Файл для хранения строковых и условных ресурсов для приложений на основе библиотеки пользовательского интерфейса Windows (WinUI 3).</value>
+    <value>Файл для хранения строковых и условных ресурсов (WinUI).</value>
   </data>
   <data name="1017" xml:space="preserve">
-    <value>Пользовательский элемент управления (WinUI 3)</value>
+    <value>Шаблонный элемент управления</value>
   </data>
   <data name="1018" xml:space="preserve">
-    <value>[Экспериментальная версия] Пользовательский элемент управления (WinUI 3)</value>
+    <value>[Экспериментальная функция] Шаблонный элемент управления</value>
   </data>
   <data name="1019" xml:space="preserve">
-    <value>Пользовательский элемент управления для приложений на основе библиотеки пользовательского интерфейса Windows (WinUI 3).</value>
+    <value>Пустой пользовательский элемент управления с соответствующим стилем по умолчанию (WinUI).</value>
   </data>
   <data name="1021" xml:space="preserve">
-    <value>Пользовательский элемент управления (WinUI 3)</value>
+    <value>Пользовательский элемент управления</value>
   </data>
   <data name="1022" xml:space="preserve">
-    <value>[Экспериментальная версия] Пользовательский элемент управления (WinUI 3)</value>
+    <value>[Экспериментальная функция] Пользовательский элемент управления</value>
   </data>
   <data name="1023" xml:space="preserve">
-    <value>Пользовательский элемент управления для приложений на основе библиотеки пользовательского интерфейса Windows (WinUI 3).</value>
+    <value>Пустой пользовательский элемент управления (WinUI).</value>
   </data>
   <data name="1025" xml:space="preserve">
-    <value>Пустое приложение, упакованное с помощью проекта упаковки приложений Windows (WinUI 3 на компьютере)</value>
+    <value>Пустое приложение WinUI (упакованное с помощью Проекта упаковки приложений Windows)</value>
   </data>
   <data name="1026" xml:space="preserve">
-    <value>[Экспериментальная функция] Пустое приложение, упакованное с помощью проекта упаковки приложений Windows (WinUI 3 на компьютере)</value>
+    <value>[Экспериментальная функция] Пустое приложение WinUI (упакованное с помощью Проекта упаковки приложений Windows)</value>
   </data>
   <data name="1027" xml:space="preserve">
-    <value>Шаблон проекта для создания классического приложения на основе библиотеки пользовательского интерфейса Windows (WinUI 3). Для создания пакета MSIX для загрузки неопубликованного приложения или распространения через Microsoft Store включен проект упаковки приложений Windows (WAP).</value>
+    <value>Шаблон проекта для создания приложения WinUI. Для создания пакета MSIX с целью загрузки неопубликованного приложения или распространения через Microsoft Store включен проект упаковки приложений Windows (WAP).</value>
   </data>
   <data name="1029" xml:space="preserve">
-    <value>Пустое приложение, упакованное (WinUI 3 в "Классическом приложении")</value>
+    <value>Пустое приложение WinUI (упакованное)</value>
   </data>
   <data name="1030" xml:space="preserve">
-    <value>[Экспериментальная версия] Пустое приложение, упакованное (WinUI 3 в "Классическом приложении")</value>
+    <value>[Экспериментальная функция] Пустое приложение WinUI (упакованное)</value>
   </data>
   <data name="1031" xml:space="preserve">
-    <value>Шаблон проекта для создания классического приложения на основе библиотеки пользовательского интерфейса Windows (WinUI 3) и пакета MSIX для загрузки неопубликованного приложения или распространения через Microsoft Store.</value>
+    <value>Шаблон проекта для создания приложения WinUI вместе с пакетом MSIX с целью загрузки неопубликованного приложения или распространения через Microsoft Store.</value>
   </data>
   <data name="1033" xml:space="preserve">
-    <value>Компонент среды выполнения Windows (WinUI 3)</value>
+    <value>Компонент среды выполнения Windows WinUI</value>
   </data>
   <data name="1034" xml:space="preserve">
-    <value>[Экспериментальная версия] Компонент среды выполнения Windows (WinUI 3)</value>
+    <value>[Экспериментальная функция] Компонент среды выполнения Windows WinUI (C++/WinRT)</value>
   </data>
   <data name="1035" xml:space="preserve">
-    <value>Проект по созданию компонента среды выполнения Windows (.winmd) C++/WinRT для классических приложений и приложений на универсальной платформе Windows (UWP) на основе библиотеки пользовательского интерфейса Windows (WinUI 3).</value>
+    <value>Проект создания компонента среды выполнения Windows (.winmd) C++/WinRT для классических приложений и приложений на универсальной платформе Windows (UWP) на основе WinUI.</value>
   </data>
   <data name="1037" xml:space="preserve">
-    <value>Приложение модульного тестирования (WinUI 3)</value>
+    <value>Приложение модульного тестирования WinUI</value>
   </data>
   <data name="1038" xml:space="preserve">
-    <value>[Эксперимент] Приложение модульного тестирования (WinUI 3)</value>
+    <value>[Экспериментальная функция] Приложение модульного тестирования WinUI</value>
   </data>
   <data name="1039" xml:space="preserve">
-    <value>Проект по созданию приложения модульного теста C++/WinRT для WinUI 3 с помощью MSTest.</value>
+    <value>Проект создания приложения модульного тестирования C++/WinRT для WinUI 3 с использованием MSTest.</value>
+  </data>
+  <data name="1040" xml:space="preserve">
+    <value>Пустое приложение WinUI</value>
+  </data>
+  <data name="1041" xml:space="preserve">
+    <value>Проект создания пустого приложения WinUI.</value>
+  </data>
+  <data name="1042" xml:space="preserve">
+    <value>Проект упаковки приложений Windows для WinUI</value>
+  </data>
+  <data name="1043" xml:space="preserve">
+    <value>Шаблон проекта, который создает пакеты MSIX, содержащие приложения WinUI для загрузки неопубликованного приложения или распространения через Microsoft Store.</value>
+  </data>
+  <data name="1044" xml:space="preserve">
+    <value>Установка пакетов NuGet в проект...</value>
+  </data>
+  <data name="1045" xml:space="preserve">
+    <value>Операция выполняется...</value>
+  </data>
+  <data name="1046" xml:space="preserve">
+    <value>Отсутствуют ссылки на пакеты</value>
+  </data>
+  <data name="1047" xml:space="preserve">
+    <value>Не удалось добавить ссылки на следующие пакеты для {0}: {1}. Перед сборкой добавьте ссылки на пакеты.</value>
+  </data>
+  <data name="1048" xml:space="preserve">
+    <value>[{0}] Не удалось добавить ссылки на следующие пакеты: {1}.
+
+Это ошибка среды. Добавьте ссылки на пакеты перед сборкой проекта.
+
+Дополнительные сведения об ошибке см. проверка вкладке "Общие" в окне вывода.</value>
+  </data>
+  <data name="1049" xml:space="preserve">
+    <value>Управление пакетами NuGet</value>
+  </data>
+  <data name="1050" xml:space="preserve">
+    <value>Просмотреть сведения об ошибке</value>
+  </data>
+  <data name="1051" xml:space="preserve">
+    <value>Отсутствуют ссылки на пакеты для {0}:</value>
+  </data>
+  <data name="1052" xml:space="preserve">
+    <value>Вручную добавьте ссылки на пакеты перед сборкой.</value>
+  </data>
+  <data name="1053" xml:space="preserve">
+    <value>Общее</value>
+  </data>
+  <data name="1054" xml:space="preserve">
+    <value>Информация о выходных данных недоступна.</value>
   </data>
 </root>

--- a/dev/VSIX/Extension/Cpp/Common/tr-TR/VSPackage.tr-TR.resx
+++ b/dev/VSIX/Extension/Cpp/Common/tr-TR/VSPackage.tr-TR.resx
@@ -118,31 +118,31 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="1001" xml:space="preserve">
-    <value>Boş Pencere (Masaüstünde WinUI 3)</value>
+    <value>Boş Pencere</value>
   </data>
   <data name="1002" xml:space="preserve">
-    <value>[Deneysel] Boş Pencere (Masaüstünde WinUI 3)</value>
+    <value>[Deneysel] Boş Pencere</value>
   </data>
   <data name="1003" xml:space="preserve">
-    <value>Windows UI Kitaplığı’nı (WinUI 3) temel alan Masaüstü uygulamaları için boş bir pencere.</value>
+    <value>Boş bir pencere (WinUI).</value>
   </data>
   <data name="1005" xml:space="preserve">
-    <value>Boş Sayfa (WinUI 3)</value>
+    <value>Boş Sayfa</value>
   </data>
   <data name="1006" xml:space="preserve">
-    <value>[Deneysel] Boş Sayfa (WinUI 3)</value>
+    <value>[Deneysel] Boş Sayfa</value>
   </data>
   <data name="1007" xml:space="preserve">
-    <value>Windows UI Kitaplığı'nı (WinUI 3) temel alan uygulamalar için boş bir sayfa.</value>
+    <value>Boş bir sayfa (WinUI).</value>
   </data>
   <data name="1009" xml:space="preserve">
-    <value>Kaynak Sözlüğü (WinUI 3)</value>
+    <value>Kaynak Sözlüğü</value>
   </data>
   <data name="1010" xml:space="preserve">
-    <value>[Deneysel] Kaynak Sözlüğü (WinUI 3)</value>
+    <value>[Deneysel] Kaynak Sözlüğü</value>
   </data>
   <data name="1011" xml:space="preserve">
-    <value>Windows UI Kitaplığı'nı (WinUI 3) temel alan uygulamalar için boş bir anahtarlı XAML kaynakları koleksiyonu.</value>
+    <value>Boş, anahtarlı XAML kaynakları koleksiyonu (WinUI).</value>
   </data>
   <data name="1013" xml:space="preserve">
     <value>Kaynak Dosyası (.resw)</value>
@@ -151,60 +151,109 @@
     <value>[Deneysel] Kaynak Dosyası (.resw)</value>
   </data>
   <data name="1015" xml:space="preserve">
-    <value>Windows UI Kitaplığı’nı (WinUI 3) temel alan uygulamalar için dize ve koşullu kaynakları depolamaya yönelik bir dosya.</value>
+    <value>Dize ve koşullu kaynakları (WinUI) depolamak için bir dosya.</value>
   </data>
   <data name="1017" xml:space="preserve">
-    <value>Özel Denetim (WinUI 3)</value>
+    <value>Şablonlanmış Denetim</value>
   </data>
   <data name="1018" xml:space="preserve">
-    <value>[Deneysel] Özel Denetim (WinUI 3)</value>
+    <value>[Deneysel] Şablonlanmış Denetim</value>
   </data>
   <data name="1019" xml:space="preserve">
-    <value>Windows UI Kitaplığı'nı (WinUI 3) temel alan uygulamalar için bir özel denetim.</value>
+    <value>Uygun varsayılan stile sahip boş bir özel denetim (WinUI).</value>
   </data>
   <data name="1021" xml:space="preserve">
-    <value>Kullanıcı Kontrolü (WinUI 3)</value>
+    <value>Kullanıcı Denetimi</value>
   </data>
   <data name="1022" xml:space="preserve">
-    <value>[Deneysel] Kullanıcı Kontrolü (WinUI 3)</value>
+    <value>[Deneysel] Kullanıcı Kontrolü</value>
   </data>
   <data name="1023" xml:space="preserve">
-    <value>Windows UI Kitaplığı'nı (WinUI 3) temel alan uygulamalar için bir kullanıcı kontrolü.</value>
+    <value>Boş bir kullanıcı kontrolü (WinUI).</value>
   </data>
   <data name="1025" xml:space="preserve">
-    <value>Boş Uygulama, Paketli Windows Uygulama Paketleme Projesi (Masaüstünde WinUI 3)</value>
+    <value>WinUI Boş Uygulama (Windows Uygulama Paketleme Projesiyle Paketlenmiş)</value>
   </data>
   <data name="1026" xml:space="preserve">
-    <value>[Deneysel] Boş Uygulama, Paketli Windows Uygulama Paketleme Projesi (Masaüstünde WinUI 3)</value>
+    <value>[Deneysel] WinUI Boş Uygulama (Windows Uygulama Paketleme Projesiyle Paketlenmiş)</value>
   </data>
   <data name="1027" xml:space="preserve">
-    <value>Windows UI Kitaplığı’nı (WinUI 3) temel alan bir Masaüstü uygulaması oluşturmaya yönelik bir proje şablonu. Microsoft Store aracılığıyla dışarıdan yükleme veya dağıtım için bir MSIX paketi oluşturmak için Windows Uygulama Paketleme (WAP) projesi dahildir.</value>
+    <value>Bir WinUI uygulaması oluşturmaya yönelik bir proje şablonu. Microsoft Store aracılığıyla dışarıdan yükleme veya dağıtım için bir MSIX paketi oluşturmak için Windows Uygulama Paketleme (WAP) projesi dahildir.</value>
   </data>
   <data name="1029" xml:space="preserve">
-    <value>Boş Uygulama, Paketlenmiş (Masaüstünde WinUI 3)</value>
+    <value>WinUI Boş Uygulaması (Paketlenmiş)</value>
   </data>
   <data name="1030" xml:space="preserve">
-    <value>[Deneysel] Boş Uygulama, Paketlenmiş (Masaüstünde WinUI 3)</value>
+    <value>[Deneysel] WinUI Boş Uygulaması (Paketlenmiş)</value>
   </data>
   <data name="1031" xml:space="preserve">
-    <value>Microsoft Store aracılığıyla dışarıdan yükleme veya dağıtım için bir MSIX paketi ile birlikte Windows UI Kitaplığı’nı (WinUI 3) temel alan bir Masaüstü uygulaması oluşturmaya yönelik bir proje şablonu.</value>
+    <value>Microsoft Store aracılığıyla dışarıdan yükleme veya dağıtım için bir MSIX paketiyle birlikte WinUI uygulaması oluşturmaya yönelik bir proje şablonu.</value>
   </data>
   <data name="1033" xml:space="preserve">
-    <value>Windows Çalışma Zamanı Bileşeni (WinUI 3)</value>
+    <value>WinUI Windows Çalışma Zamanı Bileşeni</value>
   </data>
   <data name="1034" xml:space="preserve">
-    <value>[Deneysel] Windows Çalışma Zamanı Bileşeni (WinUI 3)</value>
+    <value>[Deneysel] WinUI Windows Çalışma Zamanı Bileşeni (C++/WinRT)</value>
   </data>
   <data name="1035" xml:space="preserve">
-    <value>Windows UI Kitaplığı'nı (WinUI 3) temel alan, hem Masaüstü hem de Evrensel Windows Platformu (UWP) uygulamaları için bir C++/WinRT Windows Çalışma Zamanı Bileşeni (.winmd) oluşturmaya yönelik proje.</value>
+    <value>WinUI’yi temel alan, hem masaüstü hem de Evrensel Windows Platformu (UWP) uygulamaları için bir C++/WinRT Windows Çalışma Zamanı Bileşeni (.winmd) oluşturmaya yönelik proje.</value>
   </data>
   <data name="1037" xml:space="preserve">
-    <value>Birim Testi Uygulaması (WinUI 3)</value>
+    <value>WinUI Birim Testi Uygulaması</value>
   </data>
   <data name="1038" xml:space="preserve">
-    <value>[Deneysel] Birim Testi Uygulaması (WinUI 3)</value>
+    <value>[Deneysel] WinUI Birim Testi Uygulaması</value>
   </data>
   <data name="1039" xml:space="preserve">
-    <value>MSTest kullanarak WinUI 3 için bir C++/WinRT birim testi uygulamasını oluşturmaya yönelik bir proje.</value>
+    <value>MSTest kullanarak WinUI için bir C++/WinRT birim testi uygulamasını oluşturmaya yönelik bir proje.</value>
+  </data>
+  <data name="1040" xml:space="preserve">
+    <value>WinUI Boş Uygulaması</value>
+  </data>
+  <data name="1041" xml:space="preserve">
+    <value>Boş bir WinUI uygulaması oluşturmak için bir proje.</value>
+  </data>
+  <data name="1042" xml:space="preserve">
+    <value>WinUI için Windows Uygulama Paketleme Projesi</value>
+  </data>
+  <data name="1043" xml:space="preserve">
+    <value>Takım projesi aracılığıyla dışarıdan yükleme veya dağıtım için WinUI uygulamaları içeren MSIX paketleri Microsoft Store.</value>
+  </data>
+  <data name="1044" xml:space="preserve">
+    <value>Projeye NuGet paketleri yükleniyor...</value>
+  </data>
+  <data name="1045" xml:space="preserve">
+    <value>İşlem sürüyor...</value>
+  </data>
+  <data name="1046" xml:space="preserve">
+    <value>Eksik Paket Başvuruları</value>
+  </data>
+  <data name="1047" xml:space="preserve">
+    <value>Şu paketlere başvurular eklenemiyor: {0}: {1}. Lütfen derlemeden önce paket başvuruları ekleyin.</value>
+  </data>
+  <data name="1048" xml:space="preserve">
+    <value>[{0}] Şu paketlere başvurular eklenemiyor: {1}.
+
+Bu bir ortam hatasıdır. Projeyi derlemeden önce lütfen paket başvuruları ekleyin.
+
+Hatayla ilgili daha fazla ayrıntı için Çıkış penceresindeki Genel sekmesine bakın.</value>
+  </data>
+  <data name="1049" xml:space="preserve">
+    <value>NuGet Paketlerini yönet</value>
+  </data>
+  <data name="1050" xml:space="preserve">
+    <value>Hata ayrıntılarına bakın</value>
+  </data>
+  <data name="1051" xml:space="preserve">
+    <value>{0} için Eksik Paket Başvuruları:</value>
+  </data>
+  <data name="1052" xml:space="preserve">
+    <value>Derlemeden önce paket referanslarını el ile ekleyin.</value>
+  </data>
+  <data name="1053" xml:space="preserve">
+    <value>Genel</value>
+  </data>
+  <data name="1054" xml:space="preserve">
+    <value>Kullanılabilir çıkış bilgisi yok.</value>
   </data>
 </root>

--- a/dev/VSIX/Extension/Cpp/Common/zh-CN/VSPackage.zh-CN.resx
+++ b/dev/VSIX/Extension/Cpp/Common/zh-CN/VSPackage.zh-CN.resx
@@ -118,31 +118,31 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="1001" xml:space="preserve">
-    <value>空白窗口 (桌面版中的 WinUI 3)</value>
+    <value>空白窗口</value>
   </data>
   <data name="1002" xml:space="preserve">
-    <value>[实验性] 空白窗口 (桌面版中的 WinUI 3)</value>
+    <value>[实验性] 空白窗口</value>
   </data>
   <data name="1003" xml:space="preserve">
-    <value>基于 Windows UI 库 (WinUI 3) 的桌面应用的空白窗口。</value>
+    <value>空白窗口(WinUI)。</value>
   </data>
   <data name="1005" xml:space="preserve">
-    <value>空白页 (WinUI 3)</value>
+    <value>空白页</value>
   </data>
   <data name="1006" xml:space="preserve">
-    <value>[实验性] 空白页 (WinUI 3)</value>
+    <value>[实验性] 空白页</value>
   </data>
   <data name="1007" xml:space="preserve">
-    <value>基于 Windows UI 库 (WinUI 3) 的应用的空白页。</value>
+    <value>空白页(WinUI)。</value>
   </data>
   <data name="1009" xml:space="preserve">
-    <value>资源字典 (WinUI 3)</value>
+    <value>资源字典</value>
   </data>
   <data name="1010" xml:space="preserve">
-    <value>[实验性] 资源字典 (WinUI 3)</value>
+    <value>[实验性] 资源字典</value>
   </data>
   <data name="1011" xml:space="preserve">
-    <value>基于 Windows UI 库 (WinUI 3) 应用的 XAML 资源的空密钥集合。</value>
+    <value>WinUI) (XAML 资源的空密钥集合。</value>
   </data>
   <data name="1013" xml:space="preserve">
     <value>资源文件 (.resw)</value>
@@ -151,60 +151,109 @@
     <value>[实验性] 资源文件 (.resw)</value>
   </data>
   <data name="1015" xml:space="preserve">
-    <value>用于存储基于 Windows UI 库 (WinUI 3) 的应用字符串和条件资源文件。</value>
+    <value>用于存储字符串和条件资源的文件(WinUI)。</value>
   </data>
   <data name="1017" xml:space="preserve">
-    <value>自定义控件 (WinUI 3)</value>
+    <value>模板化控件</value>
   </data>
   <data name="1018" xml:space="preserve">
-    <value>[实验性] 自定义控件 (WinUI 3)</value>
+    <value>[实验性] 模板化控件</value>
   </data>
   <data name="1019" xml:space="preserve">
-    <value>基于 Windows UI 库 (WinUI 3) 的应用的自定义控件。</value>
+    <value>具有适当默认样式的空白自定义控件 (WinUI)。</value>
   </data>
   <data name="1021" xml:space="preserve">
-    <value>用户控件 (WinUI 3)</value>
+    <value>用户控件</value>
   </data>
   <data name="1022" xml:space="preserve">
-    <value>[实验性] 用户控件 (WinUI 3)</value>
+    <value>[实验性] 用户控件</value>
   </data>
   <data name="1023" xml:space="preserve">
-    <value>基于 Windows UI 库 (WinUI 3) 的应用的用户控件。</value>
+    <value>空白用户控件(WinUI)。</value>
   </data>
   <data name="1025" xml:space="preserve">
-    <value>空白应用，使用 Windows 应用程序打包项目打包(桌面版中的 WinUI 3)</value>
+    <value>WinUI 空白应用(使用 Windows 应用程序打包项目打包)</value>
   </data>
   <data name="1026" xml:space="preserve">
-    <value>[实验性] 空白应用，使用 Windows 应用程序打包项目打包(桌面版中的 WinUI 3)</value>
+    <value>[实验性] WinUI 空白应用(使用 Windows 应用程序打包项目打包)</value>
   </data>
   <data name="1027" xml:space="preserve">
-    <value>用于基于 Windows UI 库 (WinUI 3) 创建桌面应用的项目模板。包含 Windows 应用程序打包 (WAP) 项目，用于创建 MSIX 包，以便通过 Microsoft Store 进行旁加载或分发。</value>
+    <value>用于创建 WinUI 应用的项目模板。包含 Windows 应用程序打包(WAP)项目，用于创建 MSIX 包，以便通过 Microsoft Store 进行旁加载或分发。</value>
   </data>
   <data name="1029" xml:space="preserve">
-    <value>空白应用，已打包(桌面版中的 WinUI 3)</value>
+    <value>WinUI 空白应用(已打包)</value>
   </data>
   <data name="1030" xml:space="preserve">
-    <value>[实验性] 空白应用，已打包(桌面版中的 WinUI 3)</value>
+    <value>[实验性] WinUI 空白应用(已打包)</value>
   </data>
   <data name="1031" xml:space="preserve">
-    <value>用于基于 Windows UI 库 (WinUI 3) 创建桌面应用的项目模板，以及用于通过 Microsoft Store 旁加载或分发的 MSIX 包。</value>
+    <value>一个项目模板，用于创建 WinUI 应用以及 MSIX 包，以便通过 Microsoft Store 进行旁加载或分发。</value>
   </data>
   <data name="1033" xml:space="preserve">
-    <value>Windows 运行时组件 (WinUI 3)</value>
+    <value>WinUI Windows 运行时组件</value>
   </data>
   <data name="1034" xml:space="preserve">
-    <value>[实验性] Windows 运行时组件 (WinUI 3)</value>
+    <value>[实验性] WinUI Windows 运行时组件(C++/WinRT)</value>
   </data>
   <data name="1035" xml:space="preserve">
-    <value>用于基于 Windows UI 库 (WinUI 3) 为桌面和通用 Windows 平台 (UWP) 应用创建 C++/WinRT Windows 运行时组件 (.winmd) 的项目。</value>
+    <value>用于基于 WinUI 为桌面和通用 Windows 平台(UWP)应用创建 C++/WinRT Windows 运行时组件(.winmd)的项目。</value>
   </data>
   <data name="1037" xml:space="preserve">
-    <value>单元测试应用(WinUI 3)</value>
+    <value>WinUI 单元测试应用</value>
   </data>
   <data name="1038" xml:space="preserve">
-    <value>[Experimental] 单元测试应用(WinUI 3)</value>
+    <value>[实验性] WinUI 单元测试应用</value>
   </data>
   <data name="1039" xml:space="preserve">
-    <value>用于使用 MSTest 为 WinUI 3 创建 C++/WinRT 单元测试应用的项目。</value>
+    <value>用于使用 MSTest 为 WinUI 创建 C++/WinRT 单元测试应用的项目。</value>
+  </data>
+  <data name="1040" xml:space="preserve">
+    <value>WinUI 空白应用</value>
+  </data>
+  <data name="1041" xml:space="preserve">
+    <value>用于创建空 WinUI 应用的项目。</value>
+  </data>
+  <data name="1042" xml:space="preserve">
+    <value>适用于 WinUI 的 Windows 应用程序打包项目</value>
+  </data>
+  <data name="1043" xml:space="preserve">
+    <value>一个项目模板，用于创建 MSIX 包，其中包含用于通过Microsoft Store旁加载或分发的 WinUI 应用程序。</value>
+  </data>
+  <data name="1044" xml:space="preserve">
+    <value>正在将 NuGet 包安装到项目中...</value>
+  </data>
+  <data name="1045" xml:space="preserve">
+    <value>操作在进行中...</value>
+  </data>
+  <data name="1046" xml:space="preserve">
+    <value>缺少包引用</value>
+  </data>
+  <data name="1047" xml:space="preserve">
+    <value>无法为 {0} 添加对以下包的引用： {1}。请在生成前添加包引用。</value>
+  </data>
+  <data name="1048" xml:space="preserve">
+    <value>[{0}]无法添加对以下包的引用： {1}。
+
+这是环境错误。请在生成项目之前添加包引用。
+
+有关错误的详细信息，请检查“输出”窗口中的“常规”选项卡。</value>
+  </data>
+  <data name="1049" xml:space="preserve">
+    <value>管理 NuGet 包</value>
+  </data>
+  <data name="1050" xml:space="preserve">
+    <value>查看错误详细信息</value>
+  </data>
+  <data name="1051" xml:space="preserve">
+    <value>{0} 缺少以下包引用:</value>
+  </data>
+  <data name="1052" xml:space="preserve">
+    <value>请在生成项目前手动添加包引用。</value>
+  </data>
+  <data name="1053" xml:space="preserve">
+    <value>常规</value>
+  </data>
+  <data name="1054" xml:space="preserve">
+    <value>没有可用的输出信息。</value>
   </data>
 </root>

--- a/dev/VSIX/Extension/Cpp/Common/zh-TW/VSPackage.zh-TW.resx
+++ b/dev/VSIX/Extension/Cpp/Common/zh-TW/VSPackage.zh-TW.resx
@@ -118,31 +118,31 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="1001" xml:space="preserve">
-    <value>空白視窗 (桌面中的 WinUI 3)</value>
+    <value>空白視窗</value>
   </data>
   <data name="1002" xml:space="preserve">
-    <value>[實驗性] 空白視窗 (桌面中的 WinUI 3)</value>
+    <value>[實驗性] 空白視窗</value>
   </data>
   <data name="1003" xml:space="preserve">
-    <value>使用 Windows UI 程式庫 (WinUI 3) 的傳統型應用程式空白視窗。</value>
+    <value>空白視窗 (WinUI)。</value>
   </data>
   <data name="1005" xml:space="preserve">
-    <value>空白頁 (WinUI 3)</value>
+    <value>空白頁</value>
   </data>
   <data name="1006" xml:space="preserve">
-    <value>[實驗性] 空白頁 (WinUI 3)</value>
+    <value>[實驗性] 空白頁</value>
   </data>
   <data name="1007" xml:space="preserve">
-    <value>使用 Windows UI 程式庫 (WinUI 3) 的應用程式空白頁面。</value>
+    <value>空白頁 (WinUI)。</value>
   </data>
   <data name="1009" xml:space="preserve">
-    <value>資源字典 (WinUI 3)</value>
+    <value>資源字典</value>
   </data>
   <data name="1010" xml:space="preserve">
-    <value>[實驗性] 資源字典 (WinUI 3)</value>
+    <value>[實驗性] 資源字典</value>
   </data>
   <data name="1011" xml:space="preserve">
-    <value>使用 Windows UI 程式庫 (WinUI 3) 之應用程式的 XAML 資源空白金鑰集合。</value>
+    <value>WinUI) (XAML 資源的空白金鑰集合。</value>
   </data>
   <data name="1013" xml:space="preserve">
     <value>資源檔 (.resw)</value>
@@ -151,60 +151,109 @@
     <value>[實驗性] 資源檔 (.resw)</value>
   </data>
   <data name="1015" xml:space="preserve">
-    <value>檔案，可儲存使用 Windows UI 程式庫 (WinUI 3) 之應用程式的字串和條件式資源。</value>
+    <value>用於在 WinUI) (儲存字串和條件式資源的檔案。</value>
   </data>
   <data name="1017" xml:space="preserve">
-    <value>自訂控制項 (WinUI 3)</value>
+    <value>範本控制項</value>
   </data>
   <data name="1018" xml:space="preserve">
-    <value>[實驗性] 自訂控制項 (WinUI 3)</value>
+    <value>[實驗性] 範本控制項</value>
   </data>
   <data name="1019" xml:space="preserve">
-    <value>使用 Windows UI 程式庫 (WinUI 3) 的應用程式自訂控制項。</value>
+    <value>具有適當預設樣式的空白自定義控件 (WinUI)。</value>
   </data>
   <data name="1021" xml:space="preserve">
-    <value>使用者控制項 (WinUI 3)</value>
+    <value>使用者控制項</value>
   </data>
   <data name="1022" xml:space="preserve">
-    <value>[實驗性] 使用者控制項 (WinUI 3)</value>
+    <value>[實驗性] 使用者控制項</value>
   </data>
   <data name="1023" xml:space="preserve">
-    <value>使用 Windows UI 程式庫 (WinUI 3) 的應用程式使用者控制項。</value>
+    <value>空白使用者控制項 (WinUI)。</value>
   </data>
   <data name="1025" xml:space="preserve">
-    <value>空白應用程式，與 Windows 應用程式封裝專案 (電腦版 WinUI 3)</value>
+    <value>WinUI 空白應用程式 (與 Windows 應用程式封裝專案封裝)</value>
   </data>
   <data name="1026" xml:space="preserve">
-    <value>[實驗性]空白應用程式，與 Windows 應用程式封裝專案 (電腦版 WinUI 3)</value>
+    <value>[實驗性] WinUI 空白應用程式 (與 Windows 應用程式封裝專案封裝)</value>
   </data>
   <data name="1027" xml:space="preserve">
-    <value>專案範本，用於建立使用 Windows UI 程式庫 (WinUI 3) 的傳統型應用程式。會包含 Windows 應用程式封裝 (WAP) 專案，以建立 MSIX 套件，以便透過 Microsoft Store 側載或散佈。</value>
+    <value>用於建立 WinUI 應用程式的專案範本。會包含 Windows 應用程式封裝 (WAP) 專案，以建立 MSIX 套件，以便透過 Microsoft Store 側載或散佈。</value>
   </data>
   <data name="1029" xml:space="preserve">
-    <value>空白應用程式，已封裝 (桌面中的 WinUI 3)</value>
+    <value>WinUI 空白應用程式 (已封裝)</value>
   </data>
   <data name="1030" xml:space="preserve">
-    <value>[實驗性] 空白應用程式，已封裝 (桌面中的 WinUI 3)</value>
+    <value>[實驗性] WinUI 空白應用程式 (已封裝)</value>
   </data>
   <data name="1031" xml:space="preserve">
-    <value>專案範本，用於建立使用 Windows UI 程式庫 (WinUI 3) 的傳統型應用程式以及 MSIX 套件，以便透過 Microsoft Store 側載或散佈。</value>
+    <value>用於建立 WinUI 應用程式以及 MSIX 套件，以便透過 Microsoft Store 側載或發行的專案範本。</value>
   </data>
   <data name="1033" xml:space="preserve">
-    <value>Windows 執行階段元件 (WinUI 3)</value>
+    <value>WinUI Windows 執行階段元件</value>
   </data>
   <data name="1034" xml:space="preserve">
-    <value>[實驗性] Windows 執行階段元件 (WinUI 3)</value>
+    <value>[實驗性] WinUI Windows 執行階段元件 (C++/WinRT)</value>
   </data>
   <data name="1035" xml:space="preserve">
-    <value>專案，可用於建立使用 Windows UI 程式庫 (WinUI 3) 之桌面及通用 Windows 平台 (UWP) 應用程式的 C++/WinRT Windows 執行階段元件(.winmd)。</value>
+    <value>可用於建立基於 WinUI 之桌面及通用 Windows 平台 (UWP) 應用程式的 C++/WinRT Windows 執行階段元件 (.winmd) 之專案。</value>
   </data>
   <data name="1037" xml:space="preserve">
-    <value>單元測試應用程式 (WinUI 3)</value>
+    <value>WinUI 單元測試應用程式</value>
   </data>
   <data name="1038" xml:space="preserve">
-    <value>[實驗性] 單元測試應用程式 (WinUI 3)</value>
+    <value>[實驗性] WinUI 單元測試應用程式</value>
   </data>
   <data name="1039" xml:space="preserve">
-    <value>此專案可用於使用 MSTest 建立 WinUI 3 的 C++/WinRT 單元測試應用程式。</value>
+    <value>用於使用 MSTest 建立 WinUI C++/WinRT 單元測試應用程式的專案。</value>
+  </data>
+  <data name="1040" xml:space="preserve">
+    <value>WinUI 空白應用程式</value>
+  </data>
+  <data name="1041" xml:space="preserve">
+    <value>用於建立空白 WinUI 應用程式的專案。</value>
+  </data>
+  <data name="1042" xml:space="preserve">
+    <value>WinUI 的 Windows 應用程式封裝專案</value>
+  </data>
+  <data name="1043" xml:space="preserve">
+    <value>此項目範本會建立 MSIX 套件，其中包含 WinUI 應用程式以透過Microsoft Store側載或散發。</value>
+  </data>
+  <data name="1044" xml:space="preserve">
+    <value>正在將 NuGet 套件安裝到專案中...</value>
+  </data>
+  <data name="1045" xml:space="preserve">
+    <value>操作進行中...</value>
+  </data>
+  <data name="1046" xml:space="preserve">
+    <value>缺少套件參考</value>
+  </data>
+  <data name="1047" xml:space="preserve">
+    <value>無法為以下套件添加參考，{0}：{1}。請在製作前加入套件參考資料。</value>
+  </data>
+  <data name="1048" xml:space="preserve">
+    <value>[{0}]無法新增以下套件的參考：{1}。
+
+這是環境錯誤。請在建置專案前先加入套件參考。
+
+想了解更多錯誤細節，請查看輸出視窗中的「一般」標籤。</value>
+  </data>
+  <data name="1049" xml:space="preserve">
+    <value>管理 NuGet 套件</value>
+  </data>
+  <data name="1050" xml:space="preserve">
+    <value>請參閱錯誤詳細資料</value>
+  </data>
+  <data name="1051" xml:space="preserve">
+    <value>缺少 {0} 的套件參考:</value>
+  </data>
+  <data name="1052" xml:space="preserve">
+    <value>請在建置之前手動新增套件參考。</value>
+  </data>
+  <data name="1053" xml:space="preserve">
+    <value>一般</value>
+  </data>
+  <data name="1054" xml:space="preserve">
+    <value>沒有可用的輸出資訊。</value>
   </data>
 </root>

--- a/dev/VSIX/Extension/Cs/Common/cs-CZ/VSPackage.cs-CZ.resx
+++ b/dev/VSIX/Extension/Cs/Common/cs-CZ/VSPackage.cs-CZ.resx
@@ -118,31 +118,31 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="1001" xml:space="preserve">
-    <value>Prázdné okno (WinUI 3 na ploše)</value>
+    <value>Prázdné okno</value>
   </data>
   <data name="1002" xml:space="preserve">
-    <value>[Experimentální] Prázdné okno (WinUI 3 na ploše)</value>
+    <value>[Experimentální] Prázdné okno</value>
   </data>
   <data name="1003" xml:space="preserve">
-    <value>Prázdné okno pro desktopové aplikace založené na Knihovně uživatelského rozhraní Windows (WinUI 3)</value>
+    <value>Prázdné okno (WinUI).</value>
   </data>
   <data name="1005" xml:space="preserve">
-    <value>Prázdná stránka (WinUI 3)</value>
+    <value>Prázdná stránka</value>
   </data>
   <data name="1006" xml:space="preserve">
-    <value>[Experimentální] Prázdná stránka (WinUI 3)</value>
+    <value>[Experimentální] Prázdná stránka</value>
   </data>
   <data name="1007" xml:space="preserve">
-    <value>Prázdná stránka pro aplikace založené na Knihovně uživatelského rozhraní Windows (WinUI 3)</value>
+    <value>Prázdná stránka (WinUI).</value>
   </data>
   <data name="1009" xml:space="preserve">
-    <value>Slovník prostředků (WinUI 3)</value>
+    <value>Slovník prostředků</value>
   </data>
   <data name="1010" xml:space="preserve">
-    <value>[Experimentální] Slovník prostředků (WinUI 3)</value>
+    <value>[Experimentální] Slovník prostředků</value>
   </data>
   <data name="1011" xml:space="preserve">
-    <value>Prázdná kolekce prostředků XAML s klíči pro aplikace založené na Knihovně uživatelského rozhraní Windows (WinUI 3).</value>
+    <value>Prázdná kolekce prostředků XAML (WinUI) s klíči</value>
   </data>
   <data name="1013" xml:space="preserve">
     <value>Soubor prostředků (.resw)</value>
@@ -151,60 +151,105 @@
     <value>[Experimental] Soubor prostředků (.resw)</value>
   </data>
   <data name="1015" xml:space="preserve">
-    <value>Soubor pro ukládání řetězců a podmíněných prostředků pro aplikace založené na Knihovně uživatelského rozhraní Windows (WinUI 3)</value>
+    <value>Soubor pro ukládání řetězce a podmíněných prostředků (WinUI)</value>
   </data>
   <data name="1017" xml:space="preserve">
-    <value>Vlastní ovládací prvek (WinUI 3)</value>
+    <value>Ovládací prvek v šabloně</value>
   </data>
   <data name="1018" xml:space="preserve">
-    <value>[Experimentální] Vlastní ovládací prvek (WinUI 3)</value>
+    <value>[Experimentální] Ovládací prvek v šabloně</value>
   </data>
   <data name="1019" xml:space="preserve">
-    <value>Vlastní ovládací prvek pro aplikace založené na Knihovně uživatelského rozhraní Windows (WinUI 3).</value>
+    <value>Prázdný vlastní ovládací prvek s odpovídajícím výchozím stylem (WinUI)</value>
   </data>
   <data name="1021" xml:space="preserve">
-    <value>Uživatelský ovládací prvek (WinUI 3)</value>
+    <value>Uživatelský ovládací prvek</value>
   </data>
   <data name="1022" xml:space="preserve">
-    <value>[Experimentální] Uživatelský ovládací prvek (WinUI 3)</value>
+    <value>[Experimentální] Uživatelský ovládací prvek</value>
   </data>
   <data name="1023" xml:space="preserve">
-    <value>Uživatelský ovládací prvek pro aplikace založené na Knihovně uživatelského rozhraní Windows (WinUI 3)</value>
+    <value>Prázdný uživatelský ovládací prvek (WinUI).</value>
   </data>
   <data name="1025" xml:space="preserve">
-    <value>Knihovna tříd (WinUI 3 na ploše)</value>
+    <value>Knihovna tříd WinUI</value>
   </data>
   <data name="1026" xml:space="preserve">
-    <value>[Experimentální] Knihovna tříd (WinUI 3 na ploše)</value>
+    <value>[Experimentální] Knihovna tříd WinUI</value>
   </data>
   <data name="1027" xml:space="preserve">
-    <value>Projekt pro vytvoření spravované knihovny tříd (.dll) pro desktopové aplikace založené na Knihovně uživatelského rozhraní Windows (WinUI 3).</value>
+    <value>Projekt pro vytvoření spravované knihovny tříd (.dll) (WinUI)</value>
   </data>
   <data name="1029" xml:space="preserve">
-    <value>Prázdná aplikace zabalená s Projekt vytváření balíčku aplikace Windows (WinUI 3 v desktopové verzi)</value>
+    <value>Prázdná aplikace WinUI (zabalená s projektem vytváření balíčku aplikace Windows)</value>
   </data>
   <data name="1030" xml:space="preserve">
-    <value>[Experimentální] Prázdná aplikace zabalená s Projekt vytváření balíčku aplikace Windows (WinUI 3 v desktopu)</value>
+    <value>[Experimentální] Prázdná aplikace WinUI (zabalená s projektem vytváření balíčku aplikace Windows)</value>
   </data>
   <data name="1031" xml:space="preserve">
-    <value>Šablona projektu pro vytvoření desktopové aplikace založené na Knihovně uživatelského rozhraní Windows (WinUI 3). K vytvoření balíčku MSIX pro instalaci bokem nebo distribuci prostřednictvím Microsoft Store je zahrnutý projekt WAP (vytváření balíčku aplikace Windows).</value>
+    <value>Šablona projektu pro vytvoření aplikace WinUI. Součástí je projekt vytváření balíčku aplikace Windows (WAP), který vytvoří balíček MSIX pro zkušební načtení před prodejem nebo distribuci prostřednictvím obchodu Microsoft Store.</value>
   </data>
   <data name="1033" xml:space="preserve">
-    <value>Prázdná aplikace, zabalená (WinUI 3 v desktopové verzi)</value>
+    <value>Prázdná aplikace WinUI (zabalená)</value>
   </data>
   <data name="1034" xml:space="preserve">
-    <value>[Experimentální] Prázdná aplikace, zabalená (WinUI 3 v desktopové verzi)</value>
+    <value>[Experimentální] Prázdná aplikace WinUI (zabalená)</value>
   </data>
   <data name="1035" xml:space="preserve">
-    <value>Šablona projektu pro vytvoření desktopové aplikace založené na Knihovně uživatelského rozhraní Windows (WinUI 3) spolu s balíčkem MSIX pro zkušební načtení nebo distribuci prostřednictvím Microsoft Store.</value>
+    <value>Šablona projektu pro vytvoření aplikace WinUI spolu s balíčkem MSIX pro zkušební načtení před prodejem nebo distribuci prostřednictvím obchodu Microsoft Store.</value>
   </data>
   <data name="1037" xml:space="preserve">
-    <value>Aplikace pro testování jednotek (WinUI 3 na desktopu)</value>
+    <value>Testovací aplikace jednotek WinUI</value>
   </data>
   <data name="1038" xml:space="preserve">
-    <value>[Experimentální] Testovací Aplikace Jednotky (WinUI 3 pro Desktopové zařízení)</value>
+    <value>[Experimentální] Testovací aplikace jednotek WinUI</value>
   </data>
   <data name="1039" xml:space="preserve">
-    <value>Projekt pro vytvoření aplikace testu jednotek pro aplikace WinUI 3 pomocí NÁSTROJE MSTest</value>
+    <value>Projekt pro vytvoření aplikace testu jednotek C# pro WinUI pomocí MSTestu</value>
+  </data>
+  <data name="1040" xml:space="preserve">
+    <value>Prázdná aplikace WinUI</value>
+  </data>
+  <data name="1041" xml:space="preserve">
+    <value>Projekt pro vytvoření prázdné aplikace WinUI.</value>
+  </data>
+  <data name="1042" xml:space="preserve">
+    <value>Projekt vytváření balíčku aplikace Windows pro WinUI</value>
+  </data>
+  <data name="1043" xml:space="preserve">
+    <value>Šablona projektu, která vytváří balíčky MSIX obsahující aplikace WinUI pro instalaci bokem nebo distribuci prostřednictvím Microsoft Store</value>
+  </data>
+  <data name="1044" xml:space="preserve">
+    <value>Instalují se balíčky NuGet do projektu...</value>
+  </data>
+  <data name="1045" xml:space="preserve">
+    <value>Probíhá operace...</value>
+  </data>
+  <data name="1046" xml:space="preserve">
+    <value>Chybějící odkaz(y) na balíček</value>
+  </data>
+  <data name="1047" xml:space="preserve">
+    <value>Nelze přidat odkazy na následující balíčky pro {0}: {1}. Před sestavením prosím přidejte odkazy na balíček.</value>
+  </data>
+  <data name="1048" xml:space="preserve">
+    <value>[{0}] Nelze přidat odkazy na následující balíčky: {1}. Toto je chyba prostředí. Před sestavením projektu prosím přidejte odkazy na balíček.</value>
+  </data>
+  <data name="1049" xml:space="preserve">
+    <value>Správa balíčků NuGet</value>
+  </data>
+  <data name="1050" xml:space="preserve">
+    <value>Zobrazit podrobnosti chyby</value>
+  </data>
+  <data name="1051" xml:space="preserve">
+    <value>Chybějící odkazy na balíčky pro {0}:</value>
+  </data>
+  <data name="1052" xml:space="preserve">
+    <value>Před sestavením ručně přidejte odkazy na balíček.</value>
+  </data>
+  <data name="1053" xml:space="preserve">
+    <value>Obecné</value>
+  </data>
+  <data name="1054" xml:space="preserve">
+    <value>Nejsou k dispozici žádné výstupní informace.</value>
   </data>
 </root>

--- a/dev/VSIX/Extension/Cs/Common/de-DE/VSPackage.de-DE.resx
+++ b/dev/VSIX/Extension/Cs/Common/de-DE/VSPackage.de-DE.resx
@@ -118,31 +118,31 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="1001" xml:space="preserve">
-    <value>Leeres Fenster (WinUI 3 in Desktop)</value>
+    <value>Leeres Fenster</value>
   </data>
   <data name="1002" xml:space="preserve">
-    <value>[Experimentell] Leeres Fenster (WinUI 3 in Desktop)</value>
+    <value>[Experimentell] Leeres Fenster</value>
   </data>
   <data name="1003" xml:space="preserve">
-    <value>Ein leeres Fenster für Desktop-Apps, die auf der Windows-UI-Bibliothek (WinUI 3) basieren.</value>
+    <value>Ein leeres Fenster (WinUI).</value>
   </data>
   <data name="1005" xml:space="preserve">
-    <value>Leere Seite (WinUI 3)</value>
+    <value>Leere Seite</value>
   </data>
   <data name="1006" xml:space="preserve">
-    <value>[Experimentell] Leere Seite (WinUI 3)</value>
+    <value>[Experimentell] Leere Seite</value>
   </data>
   <data name="1007" xml:space="preserve">
-    <value>Eine leere Seite für Apps, die auf der Windows-UI-Bibliothek (WinUI 3) basieren.</value>
+    <value>Eine leere Seite (WinUI).</value>
   </data>
   <data name="1009" xml:space="preserve">
-    <value>Ressourcenverzeichnis (WinUI 3)</value>
+    <value>Ressourcenverzeichnis</value>
   </data>
   <data name="1010" xml:space="preserve">
-    <value>[Experimentell] Ressourcenverzeichnis (WinUI 3)</value>
+    <value>[Experimentell] Ressourcenverzeichnis</value>
   </data>
   <data name="1011" xml:space="preserve">
-    <value>Eine leere, schlüsselgesteuerte Sammlung von XAML-Ressourcen für Apps, die auf der Windows-UI-Bibliothek (WinUI 3) basieren.</value>
+    <value>Eine leere, schlüsselierte Sammlung von XAML-Ressourcen (WinUI).</value>
   </data>
   <data name="1013" xml:space="preserve">
     <value>Ressourcendatei (.resw)</value>
@@ -151,60 +151,105 @@
     <value>[Experimentell] Ressourcendatei (.resw)</value>
   </data>
   <data name="1015" xml:space="preserve">
-    <value>Eine Datei zum Speichern von Zeichenfolgen und bedingten Ressourcen für Apps, die auf der Windows-UI-Bibliothek (WinUI 3) basieren.</value>
+    <value>Eine Datei zum Speichern von Zeichenfolgen- und bedingten Ressourcen (WinUI).</value>
   </data>
   <data name="1017" xml:space="preserve">
-    <value>Benutzerdefiniertes Steuerelement (WinUI 3)</value>
+    <value>Steuerelement mit Vorlagen</value>
   </data>
   <data name="1018" xml:space="preserve">
-    <value>[Experimentell] Benutzerdefiniertes Steuerelement (WinUI 3)</value>
+    <value>[Experimentell] Steuerelement mit Vorlagen</value>
   </data>
   <data name="1019" xml:space="preserve">
-    <value>Ein benutzerdefiniertes Steuerelement für Apps, die auf der Windows-UI-Bibliothek (WinUI 3) basieren.</value>
+    <value>Ein leeres benutzerdefiniertes Steuerelement mit der entsprechenden Standardformatierung (WinUI).</value>
   </data>
   <data name="1021" xml:space="preserve">
-    <value>Benutzersteuerelement (WinUI 3)</value>
+    <value>Benutzersteuerelement</value>
   </data>
   <data name="1022" xml:space="preserve">
-    <value>[Experimentell] Benutzersteuerelement (WinUI 3)</value>
+    <value>[Experimentell] Benutzerkontrolle</value>
   </data>
   <data name="1023" xml:space="preserve">
-    <value>Ein Benutzersteuerelement für Apps, die auf der Windows-UI-Bibliothek (WinUI 3) basieren.</value>
+    <value>Ein leeres Benutzersteuerelement (WinUI).</value>
   </data>
   <data name="1025" xml:space="preserve">
-    <value>Klassenbibliothek (WinUI 3 in Desktop)</value>
+    <value>WinUI-Klassenbibliothek</value>
   </data>
   <data name="1026" xml:space="preserve">
-    <value>[Experimentell] Klassenbibliothek (WinUI 3 in Desktop)</value>
+    <value>[Experimentell] WinUI-Klassenbibliothek</value>
   </data>
   <data name="1027" xml:space="preserve">
-    <value>Ein Projekt zum Erstellen einer verwalteten Klassenbibliothek (DLL) für Desktop-Apps, die auf der Windows-UI-Bibliothek (WinUI 3) basieren.</value>
+    <value>Ein Projekt zum Erstellen einer verwalteten Klassenbibliothek (.dll) (WinUI).</value>
   </data>
   <data name="1029" xml:space="preserve">
-    <value>Leere App, verpackt mit Paketerstellungsprojekt für Windows-Anwendungen (WinUI 3 in Desktop)</value>
+    <value>Leere WinUI-App (mit Paketerstellungsprojekt für Windows-Anwendungen verpackt)</value>
   </data>
   <data name="1030" xml:space="preserve">
-    <value>[Experimentell] Leere App, verpackt mit Paketerstellungsprojekt für Windows-Anwendungen (WinUI 3 in Desktop)</value>
+    <value>[Experimentell] Leere WinUI-App (mit Paketerstellungsprojekt für Windows-Anwendungen verpackt)</value>
   </data>
   <data name="1031" xml:space="preserve">
-    <value>Eine Projektvorlage zum Erstellen einer Desktop-App, die auf der Windows-UI-Bibliothek (WinUI 3) basiert. Ein WAP-Projekt (Paketerstellungsprojekt für Windows-Anwendungen) ist enthalten, um ein MSIX-Paket zum Querladen oder Verteilen über den Microsoft Store zu erstellen.</value>
+    <value>Eine Projektvorlage zum Erstellen einer WinUI-App. Ein WAP-Projekt (Paketerstellungsprojekt für Windows-Anwendungen) ist enthalten, um ein MSIX-Paket zum Querladen oder Verteilen über den Microsoft Store zu erstellen.</value>
   </data>
   <data name="1033" xml:space="preserve">
-    <value>Leere App, verpackt (WinUI 3 in Desktop)</value>
+    <value>Leere WinUI-App (verpackt)</value>
   </data>
   <data name="1034" xml:space="preserve">
-    <value>[Experimentell] Leere App, verpackt (WinUI 3 in Desktop)</value>
+    <value>[Experimentell] Leere WinUI-App (verpackt)</value>
   </data>
   <data name="1035" xml:space="preserve">
-    <value>Eine Projektvorlage zum Erstellen einer Desktop-App, die auf der Windows-UI-Bibliothek (WinUI 3) basiert, zusammen mit einem MSIX-Paket zum Querladen oder Verteilen über den Microsoft Store.</value>
+    <value>Eine Projektvorlage zum Erstellen einer WinUI-App zusammen mit einem MSIX-Paket zum Querladen oder Verteilen über den Microsoft Store.</value>
   </data>
   <data name="1037" xml:space="preserve">
-    <value>Komponententest-App (WinUI 3 in Desktop)</value>
+    <value>WinUI-Komponententest-App</value>
   </data>
   <data name="1038" xml:space="preserve">
-    <value>[Experimentell] Komponententest-App (WinUI 3 in Desktop)</value>
+    <value>[Experimentell] WinUI-Komponententest-App</value>
   </data>
   <data name="1039" xml:space="preserve">
-    <value>Ein Projekt zum Erstellen einer Komponententest-App für WinUI 3-Apps mit MSTest.</value>
+    <value>Ein Projekt zum Erstellen einer C#-Komponententest-App für WinUI mithilfe von MSTest.</value>
+  </data>
+  <data name="1040" xml:space="preserve">
+    <value>Leere WinUI-App</value>
+  </data>
+  <data name="1041" xml:space="preserve">
+    <value>Ein Projekt zum Erstellen einer leeren WinUI-App.</value>
+  </data>
+  <data name="1042" xml:space="preserve">
+    <value>Paketerstellungsprojekt für Windows-Anwendungen für WinUI</value>
+  </data>
+  <data name="1043" xml:space="preserve">
+    <value>Eine Projektvorlage, die MSIX-Pakete mit WinUI-Anwendungen zum Querladen oder Verteilen über den Microsoft Store erstellt.</value>
+  </data>
+  <data name="1044" xml:space="preserve">
+    <value>NuGet-Pakete werden in das Projekt installiert...</value>
+  </data>
+  <data name="1045" xml:space="preserve">
+    <value>Wird ausgeführt...</value>
+  </data>
+  <data name="1046" xml:space="preserve">
+    <value>Fehlende Paketverweise</value>
+  </data>
+  <data name="1047" xml:space="preserve">
+    <value>Für {0} können den folgenden Paketen keine Verweise hinzugefügt werden: {1}. Fügen Sie vor dem Erstellen Paketverweise hinzu.</value>
+  </data>
+  <data name="1048" xml:space="preserve">
+    <value>[{0}] Den folgenden Paketen können keine Verweise hinzugefügt werden: {1}. Dies ist ein Umgebungsfehler. Fügen Sie Vor dem Erstellen des Projekts Paketverweise hinzu.</value>
+  </data>
+  <data name="1049" xml:space="preserve">
+    <value>NuGet-Pakete verwalten</value>
+  </data>
+  <data name="1050" xml:space="preserve">
+    <value>Fehlerdetails anzeigen</value>
+  </data>
+  <data name="1051" xml:space="preserve">
+    <value>Fehlende Paketverweise für {0}:</value>
+  </data>
+  <data name="1052" xml:space="preserve">
+    <value>Fügen Sie die Paketverweise manuell hinzu, bevor Sie mit dem Erstellen beginnen.</value>
+  </data>
+  <data name="1053" xml:space="preserve">
+    <value>Allgemein</value>
+  </data>
+  <data name="1054" xml:space="preserve">
+    <value>Keine Ausgabedaten verfügbar.</value>
   </data>
 </root>

--- a/dev/VSIX/Extension/Cs/Common/es-ES/VSPackage.es-ES.resx
+++ b/dev/VSIX/Extension/Cs/Common/es-ES/VSPackage.es-ES.resx
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <root>
   <!-- 
     Microsoft ResX Schema 
@@ -118,31 +118,31 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="1001" xml:space="preserve">
-    <value>Ventana en blanco (WinUI 3 en escritorio)</value>
+    <value>Ventana en blanco</value>
   </data>
   <data name="1002" xml:space="preserve">
-    <value>[Experimental] Ventana en blanco (WinUI 3 en escritorio)</value>
+    <value>[Experimental] Ventana en blanco</value>
   </data>
   <data name="1003" xml:space="preserve">
-    <value>Ventana en blanco para aplicaciones de escritorio basadas en la Biblioteca de interfaz de usuario de Windows (WinUI 3).</value>
+    <value>Una ventana en blanco (WinUI).</value>
   </data>
   <data name="1005" xml:space="preserve">
-    <value>Página en blanco (WinUI 3)</value>
+    <value>Página en blanco</value>
   </data>
   <data name="1006" xml:space="preserve">
-    <value>[Experimental] Página en blanco (WinUI 3)</value>
+    <value>[Experimental] Página en blanco</value>
   </data>
   <data name="1007" xml:space="preserve">
-    <value>Página en blanco para aplicaciones basadas en la Biblioteca de interfaz de usuario de Windows (WinUI 3).</value>
+    <value>Una página en blanco (WinUI).</value>
   </data>
   <data name="1009" xml:space="preserve">
-    <value>Diccionario de recursos (WinUI 3)</value>
+    <value>Diccionario de recursos</value>
   </data>
   <data name="1010" xml:space="preserve">
-    <value>[Experimental] Diccionario de recursos (WinUI 3)</value>
+    <value>[Experimental] Diccionario de recursos</value>
   </data>
   <data name="1011" xml:space="preserve">
-    <value>Colección vacía con clave de recursos XAML para aplicaciones basadas en la Biblioteca de interfaz de usuario de Windows (WinUI 3).</value>
+    <value>Colección vacía con clave de recursos XAML (WinUI).</value>
   </data>
   <data name="1013" xml:space="preserve">
     <value>Archivo de recursos (.resw)</value>
@@ -151,60 +151,105 @@
     <value>[Experimental] Archivo de recursos (.resw)</value>
   </data>
   <data name="1015" xml:space="preserve">
-    <value>Archivo para almacenar recursos condicionales y de cadena para aplicaciones basadas en la Biblioteca de interfaz de usuario de Windows (WinUI 3).</value>
+    <value>Un archivo para almacenar recursos condicionales y de cadena (WinUI).</value>
   </data>
   <data name="1017" xml:space="preserve">
-    <value>Control personalizado (WinUI 3)</value>
+    <value>Control con plantilla</value>
   </data>
   <data name="1018" xml:space="preserve">
-    <value>[Experimental] Control personalizado (WinUI 3)</value>
+    <value>[Experimental] Control con plantilla</value>
   </data>
   <data name="1019" xml:space="preserve">
-    <value>Control personalizado para aplicaciones basadas en la Biblioteca de interfaz de usuario de Windows (WinUI 3).</value>
+    <value>Control personalizado en blanco con el estilo predeterminado adecuado (WinUI).</value>
   </data>
   <data name="1021" xml:space="preserve">
-    <value>Control de usuario (WinUI 3)</value>
+    <value>Control de usuario</value>
   </data>
   <data name="1022" xml:space="preserve">
-    <value>[Experimental] Control de usuario (WinUI 3)</value>
+    <value>[Experimental] Control de usuario</value>
   </data>
   <data name="1023" xml:space="preserve">
-    <value>Control de usuario para aplicaciones basadas en la Biblioteca de interfaz de usuario de Windows (WinUI 3).</value>
+    <value>Un control de usuario en blanco (WinUI).</value>
   </data>
   <data name="1025" xml:space="preserve">
-    <value>Biblioteca de clases (WinUI 3 en escritorio)</value>
+    <value>Biblioteca de clases WinUI</value>
   </data>
   <data name="1026" xml:space="preserve">
-    <value>[Experimental] Biblioteca de clases (WinUI 3 en escritorio)</value>
+    <value>[Experimental] Biblioteca de clases WinUI</value>
   </data>
   <data name="1027" xml:space="preserve">
-    <value>Proyecto para crear una biblioteca de clases administrada (.dll) para aplicaciones de escritorio basadas en la Biblioteca de interfaz de usuario de Windows (WinUI 3).</value>
+    <value>Proyecto para crear una biblioteca de clases administradas (.dll) (WinUI).</value>
   </data>
   <data name="1029" xml:space="preserve">
-    <value>Aplicación en blanco, empaquetada con Proyecto de paquete de aplicación de Windows (WinUI 3 en el escritorio)</value>
+    <value>Aplicación en blanco de WinUI (empaquetada con Proyecto de paquete de aplicación de Windows)</value>
   </data>
   <data name="1030" xml:space="preserve">
-    <value>[Experimental] Aplicación en blanco, empaquetada con Proyecto de paquete de aplicación de Windows (WinUI 3 en el escritorio)</value>
+    <value>[Experimental] Aplicación en blanco de WinUI (empaquetada con Proyecto de paquete de aplicación de Windows)</value>
   </data>
   <data name="1031" xml:space="preserve">
-    <value>Plantilla de proyecto para crear una aplicación de escritorio basada en la Biblioteca de interfaz de usuario de Windows (WinUI 3). Se incluye un proyecto de paquete de aplicación de Windows (WAP) para crear un paquete MSIX para la carga lateral o distribución mediante Microsoft Store.</value>
+    <value>Plantilla de proyecto para crear una aplicación WinUI. Se incluye un proyecto de empaquetado de aplicaciones de Windows (WAP) para crear un paquete MSIX para transferencia local o distribución a través de Microsoft Store.</value>
   </data>
   <data name="1033" xml:space="preserve">
-    <value>Aplicación en blanco, empaquetada (WinUI 3 en escritorio)</value>
+    <value>Aplicación en blanco de WinUI (empaquetada)</value>
   </data>
   <data name="1034" xml:space="preserve">
-    <value>[Experimental] Aplicación en blanco, empaquetada (WinUI 3 en escritorio)</value>
+    <value>[Experimental] Aplicación en blanco de WinUI (empaquetada)</value>
   </data>
   <data name="1035" xml:space="preserve">
-    <value>Plantilla de proyecto para crear una aplicación de escritorio basada en la Biblioteca de interfaz de usuario de Windows (WinUI 3) junto con un paquete MSIX para la carga lateral o distribución mediante Microsoft Store.</value>
+    <value>Una plantilla de proyecto para crear una aplicación de WinUI junto con un paquete MSIX para la transferencia local o la distribución a través de Microsoft Store.</value>
   </data>
   <data name="1037" xml:space="preserve">
-    <value>Aplicación de prueba unitaria (WinUI 3 en escritorio)</value>
+    <value>Aplicación de prueba unitaria de WinUI</value>
   </data>
   <data name="1038" xml:space="preserve">
-    <value>[Experimental] Aplicación de prueba unitaria (WinUI 3 en escritorio)</value>
+    <value>[Experimental] Aplicación de prueba unitaria de WinUI</value>
   </data>
   <data name="1039" xml:space="preserve">
-    <value>Proyecto para crear una aplicación de prueba unitaria para aplicaciones WinUI 3 con MSTest.</value>
+    <value>Proyecto para crear una aplicación de prueba unitaria de C# para WinUI mediante MSTest.</value>
+  </data>
+  <data name="1040" xml:space="preserve">
+    <value>Aplicación en blanco de WinUI</value>
+  </data>
+  <data name="1041" xml:space="preserve">
+    <value>Proyecto para crear una aplicación WinUI vacía.</value>
+  </data>
+  <data name="1042" xml:space="preserve">
+    <value>Proyecto de paquete de aplicación de Windows para WinUI</value>
+  </data>
+  <data name="1043" xml:space="preserve">
+    <value>Plantilla de proyecto que crea paquetes MSIX que contienen aplicaciones WinUI para la carga o distribución de prueba mediante el Microsoft Store.</value>
+  </data>
+  <data name="1044" xml:space="preserve">
+    <value>Instalando paquetes NuGet en el proyecto...</value>
+  </data>
+  <data name="1045" xml:space="preserve">
+    <value>Operación en progreso...</value>
+  </data>
+  <data name="1046" xml:space="preserve">
+    <value>Faltan referencias de paquete</value>
+  </data>
+  <data name="1047" xml:space="preserve">
+    <value>No se pueden agregar referencias a los siguientes paquetes para {0}: {1}. Agregue referencias de paquete antes de compilar.</value>
+  </data>
+  <data name="1048" xml:space="preserve">
+    <value>[{0}] No se pueden agregar referencias a los siguientes paquetes: {1}. Se trata de un error de entorno. Agregue referencias de paquete antes de compilar el proyecto.</value>
+  </data>
+  <data name="1049" xml:space="preserve">
+    <value>Administrar paquetes NuGet</value>
+  </data>
+  <data name="1050" xml:space="preserve">
+    <value>Ver detalles del error</value>
+  </data>
+  <data name="1051" xml:space="preserve">
+    <value>Faltan referencias de paquete para {0}:</value>
+  </data>
+  <data name="1052" xml:space="preserve">
+    <value>Agregue manualmente las referencias de paquete antes de compilar.</value>
+  </data>
+  <data name="1053" xml:space="preserve">
+    <value>General</value>
+  </data>
+  <data name="1054" xml:space="preserve">
+    <value>No hay información de salida disponible.</value>
   </data>
 </root>

--- a/dev/VSIX/Extension/Cs/Common/fr-FR/VSPackage.fr-FR.resx
+++ b/dev/VSIX/Extension/Cs/Common/fr-FR/VSPackage.fr-FR.resx
@@ -118,31 +118,31 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="1001" xml:space="preserve">
-    <value>Fenêtre vide (WinUI 3 dans le Bureau)</value>
+    <value>Fenêtre vierge</value>
   </data>
   <data name="1002" xml:space="preserve">
-    <value>Fenêtre vierge (WinUI 3 dans le Bureau)</value>
+    <value>[Expérimental] Fenêtre vierge</value>
   </data>
   <data name="1003" xml:space="preserve">
-    <value>Fenêtre vide pour les applications de bureau basées sur la Bibliothèque d’interface utilisateur Windows (WinUI 3).</value>
+    <value>Une fenêtre vierge (WinUI).</value>
   </data>
   <data name="1005" xml:space="preserve">
-    <value>Page vierge (WinUI 3)</value>
+    <value>Page vierge</value>
   </data>
   <data name="1006" xml:space="preserve">
-    <value>[Experimental] Page vierge (WinUI 3)</value>
+    <value>[Expérimental] Page vierge</value>
   </data>
   <data name="1007" xml:space="preserve">
-    <value>Page vide pour les applications basées sur la Bibliothèque d’interface utilisateur Windows (WinUI 3).</value>
+    <value>Une page vierge (WinUI).</value>
   </data>
   <data name="1009" xml:space="preserve">
-    <value>Dictionnaire de ressources (WinUI 3)</value>
+    <value>Dictionnaire de ressources</value>
   </data>
   <data name="1010" xml:space="preserve">
-    <value>[Expérimental] Dictionnaire de ressources (WinUI 3)</value>
+    <value>[Expérimental] Dictionnaire de ressources</value>
   </data>
   <data name="1011" xml:space="preserve">
-    <value>Collection vide et à clé de ressources XAML pour les applications basées sur la Bibliothèque d’interface utilisateur Windows (WinUI 3).</value>
+    <value>Une collection de ressources XAML (WinUI) vide à clé.</value>
   </data>
   <data name="1013" xml:space="preserve">
     <value>Fichier de ressources (.resw)</value>
@@ -151,60 +151,105 @@
     <value>[Experimental] Fichier de ressources (.resw)</value>
   </data>
   <data name="1015" xml:space="preserve">
-    <value>Fichier de stockage de ressources conditionnelles et de chaîne pour les applications basées sur la Bibliothèque d’interface utilisateur Windows (WinUI 3).</value>
+    <value>Fichier de stockage de la chaîne et des ressources conditionnelles (WinUI).</value>
   </data>
   <data name="1017" xml:space="preserve">
-    <value>Contrôle personnalisé (WinUI 3)</value>
+    <value>Contrôle avec modèle</value>
   </data>
   <data name="1018" xml:space="preserve">
-    <value>[Expérimental] Contrôle personnalisé (WinUI 3)</value>
+    <value>[Expérimental] Contrôle avec modèle</value>
   </data>
   <data name="1019" xml:space="preserve">
-    <value>Contrôle personnalisé pour les applications basé sur la Bibliothèque d’interface utilisateur Windows (WinUI 3).</value>
+    <value>Contrôle personnalisé vide avec le style par défaut approprié (WinUI).</value>
   </data>
   <data name="1021" xml:space="preserve">
-    <value>Contrôle utilisateur (WinUI 3)</value>
+    <value>Contrôle utilisateur</value>
   </data>
   <data name="1022" xml:space="preserve">
-    <value>[Expérimental] Contrôle utilisateur (WinUI 3)</value>
+    <value>[Expérimental] Contrôle utilisateur</value>
   </data>
   <data name="1023" xml:space="preserve">
-    <value>Contrôle utilisateur pour les applications basé sur la Bibliothèque d’interface utilisateur Windows (WinUI 3).</value>
+    <value>Contrôle utilisateur vierge (WinUI).</value>
   </data>
   <data name="1025" xml:space="preserve">
-    <value>Bibliothèque de classes (WinUI 3 dans desktop)</value>
+    <value>Bibliothèque de classes WinUI</value>
   </data>
   <data name="1026" xml:space="preserve">
-    <value>[Expérimental] Bibliothèque de classes (WinUI 3 dans UWP)</value>
+    <value>[Expérimental] Bibliothèque de classes WinUI</value>
   </data>
   <data name="1027" xml:space="preserve">
-    <value>Projet de création d’une bibliothèque de classes managées (.dll) pour les applications de bureau basées sur la bibliothèque d’interface utilisateur Windows (WinUI 3).</value>
+    <value>Projet de création d’une bibliothèque de classes managée (.dll) (WinUI).</value>
   </data>
   <data name="1029" xml:space="preserve">
-    <value>Application vide, empaquetée avec Projet de création de packages d'applications Windows (WinUI 3 sur le Bureau)</value>
+    <value>Application vide WinUI, (Empaquetée avec Projet de création de packages d'applications Windows)</value>
   </data>
   <data name="1030" xml:space="preserve">
-    <value>[Expérimental] Application vide, empaquetée avec Projet de création de packages d'applications Windows (WinUI 3 sur le Bureau)</value>
+    <value>[Expérimental] Application vierge WinUI, (empaquetée avec Projet de création de packages d'applications Windows)</value>
   </data>
   <data name="1031" xml:space="preserve">
-    <value>Modèle de projet pour la création d’une application de bureau basée sur la bibliothèque d’interface utilisateur Windows (WinUI 3). Un projet d’empaquetage d’application Windows (WAP) est inclus pour créer un package MSIX pour le chargement indépendant ou la distribution via le Microsoft Store.</value>
+    <value>Modèle de projet pour la création d’une application WinUI. Un projet d’empaquetage d’application Windows (WAP) est inclus pour créer un package MSIX pour le chargement indépendant ou la distribution via le Microsoft Store.</value>
   </data>
   <data name="1033" xml:space="preserve">
-    <value>Application vide, empaquetée (WinUI 3 sur le Bureau)</value>
+    <value>Application WinUI vierge (Empaquetée)</value>
   </data>
   <data name="1034" xml:space="preserve">
-    <value>[Expérimental] Application vide, empaquetée (WinUI 3 sur le Bureau)</value>
+    <value>[Expérimental] Application WinUI vierge (Empaquetée)</value>
   </data>
   <data name="1035" xml:space="preserve">
-    <value>Modèle de projet pour la création d’une application de bureau basée sur la Bibliothèque d’interface utilisateur Windows (WinUI 3) ainsi qu’un package MSIX pour le chargement indépendant ou la distribution via le Microsoft Store.</value>
+    <value>Modèle de projet pour la création d’une application WinUI ainsi qu’un package MSIX pour le chargement indépendant ou la distribution via le Microsoft Store.</value>
   </data>
   <data name="1037" xml:space="preserve">
-    <value>Application de test unitaire (WinUI 3 in Desktop)</value>
+    <value>Application de test unitaire WinUI</value>
   </data>
   <data name="1038" xml:space="preserve">
-    <value>[Expérimental] Application de test unitaire (WinUI 3 dans Bureau)</value>
+    <value>[Expérimental] Application de test unitaire WinUI</value>
   </data>
   <data name="1039" xml:space="preserve">
-    <value>Projet de création d’une application de test unitaire pour les applications WinUI 3 à l’aide de MSTest.</value>
+    <value>Projet de création d’une application de test unitaire C# pour WinUI à l’aide de MSTest.</value>
+  </data>
+  <data name="1040" xml:space="preserve">
+    <value>Application WinUI vierge</value>
+  </data>
+  <data name="1041" xml:space="preserve">
+    <value>Projet de création d’une application WinUI vide.</value>
+  </data>
+  <data name="1042" xml:space="preserve">
+    <value>Projet de création de packages d'applications Windows pour WinUI</value>
+  </data>
+  <data name="1043" xml:space="preserve">
+    <value>Modèle de projet qui crée des packages MSIX contenant des applications WinUI pour le chargement indépendant ou la distribution via le Microsoft Store.</value>
+  </data>
+  <data name="1044" xml:space="preserve">
+    <value>Installation des packages NuGet dans le projet...</value>
+  </data>
+  <data name="1045" xml:space="preserve">
+    <value>Opération en cours...</value>
+  </data>
+  <data name="1046" xml:space="preserve">
+    <value>Référence(s) de package manquante(s)</value>
+  </data>
+  <data name="1047" xml:space="preserve">
+    <value>Impossible d’ajouter des références aux packages suivants pour {0} : {1}. Ajoutez des références de package avant de générer.</value>
+  </data>
+  <data name="1048" xml:space="preserve">
+    <value>[{0}] Impossible d’ajouter des références aux packages suivants : {1}. Il s’agit d’une erreur d’environnement. Ajoutez des références de package avant de générer le projet.</value>
+  </data>
+  <data name="1049" xml:space="preserve">
+    <value>Gérer les packages NuGet</value>
+  </data>
+  <data name="1050" xml:space="preserve">
+    <value>Voir les détails des erreurs</value>
+  </data>
+  <data name="1051" xml:space="preserve">
+    <value>Références de package manquantes pour {0}:</value>
+  </data>
+  <data name="1052" xml:space="preserve">
+    <value>Ajoutez manuellement les références de package avant de compiler.</value>
+  </data>
+  <data name="1053" xml:space="preserve">
+    <value>Général</value>
+  </data>
+  <data name="1054" xml:space="preserve">
+    <value>Aucune information de résultat disponible.</value>
   </data>
 </root>

--- a/dev/VSIX/Extension/Cs/Common/it-IT/VSPackage.it-IT.resx
+++ b/dev/VSIX/Extension/Cs/Common/it-IT/VSPackage.it-IT.resx
@@ -118,31 +118,31 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="1001" xml:space="preserve">
-    <value>Finestra vuota (WinUI 3 su desktop)</value>
+    <value>Finestra vuota</value>
   </data>
   <data name="1002" xml:space="preserve">
-    <value>[Esperimento] Finestra vuota (WinUI 3 su desktop)</value>
+    <value>[Sperimentale] Finestra vuota</value>
   </data>
   <data name="1003" xml:space="preserve">
-    <value>Una finestra vuota per le app desktop basata sulla libreria dell'interfaccia utente di Windows (WinUI 3).</value>
+    <value>Una finestra vuota (WinUI).</value>
   </data>
   <data name="1005" xml:space="preserve">
-    <value>Pagina vuota (WinUI 3)</value>
+    <value>Pagina vuota</value>
   </data>
   <data name="1006" xml:space="preserve">
-    <value>[Esperimento] Pagina vuota (WinUI 3)</value>
+    <value>[Sperimentale] Pagina vuota</value>
   </data>
   <data name="1007" xml:space="preserve">
-    <value>Una pagina vuota per le app basata sulla libreria dell'interfaccia utente di Windows (WinUI 3).</value>
+    <value>Una pagina vuota (WinUI).</value>
   </data>
   <data name="1009" xml:space="preserve">
-    <value>Dizionario risorse (WinUI 3)</value>
+    <value>Dizionario risorse</value>
   </data>
   <data name="1010" xml:space="preserve">
-    <value>[Esperimento] Dizionario risorse (WinUI 3)</value>
+    <value>[Sperimentale] Dizionario risorse</value>
   </data>
   <data name="1011" xml:space="preserve">
-    <value>Una raccolta vuota con chiave di risorse XAML per le app basate sulla libreria dell'interfaccia utente di Windows (WinUI 3).</value>
+    <value>Raccolta con chiave vuota di risorse XAML (WinUI).</value>
   </data>
   <data name="1013" xml:space="preserve">
     <value>File di risorse (.resw)</value>
@@ -151,60 +151,105 @@
     <value>[Esperimento] File di risorse (.resw)</value>
   </data>
   <data name="1015" xml:space="preserve">
-    <value>Un file per l'archiviazione di risorse di tipo stringa e condizionale per le app basate sulla libreria dell'interfaccia utente di Windows (WinUI 3).</value>
+    <value>File per l'archiviazione di risorse stringa e condizionali (WinUI).</value>
   </data>
   <data name="1017" xml:space="preserve">
-    <value>Controllo personalizzato (WinUI 3)</value>
+    <value>Controllo con modello</value>
   </data>
   <data name="1018" xml:space="preserve">
-    <value>[Esperimento] Controllo personalizzato (WinUI 3)</value>
+    <value>[Sperimentale] Controllo con modello</value>
   </data>
   <data name="1019" xml:space="preserve">
-    <value>Un controllo personalizzato per le app basato sulla libreria dell'interfaccia utente di Windows (WinUI 3).</value>
+    <value>Controllo personalizzato vuoto con lo stile predefinito appropriato (WinUI).</value>
   </data>
   <data name="1021" xml:space="preserve">
-    <value>Controllo utente (WinUI 3)</value>
+    <value>Controllo utente</value>
   </data>
   <data name="1022" xml:space="preserve">
-    <value>[Esperimento] Controllo utente (WinUI 3)</value>
+    <value>[Sperimentale] Controllo utente</value>
   </data>
   <data name="1023" xml:space="preserve">
-    <value>Un controllo utente per le app basato sulla Libreria dell'interfaccia utente di Windows (WinUI 3).</value>
+    <value>Un controllo utente vuoto (WinUI).</value>
   </data>
   <data name="1025" xml:space="preserve">
-    <value>Libreria di classi (WinUI 3 su desktop)</value>
+    <value>Libreria di classi WinUI</value>
   </data>
   <data name="1026" xml:space="preserve">
-    <value>[Esperimento] Libreria di classi (WinUI 3 su desktop)</value>
+    <value>[Sperimentale] Libreria di classi WinUI</value>
   </data>
   <data name="1027" xml:space="preserve">
-    <value>Un progetto per la creazione di una libreria di classi gestita (.dll) per le app desktop basato sulla libreria dell'interfaccia utente di Windows (WinUI 3).</value>
+    <value>Progetto per la creazione di una libreria di classi gestita (.dll) (WinUI).</value>
   </data>
   <data name="1029" xml:space="preserve">
-    <value>App vuota, in pacchetto con Progetto di creazione pacchetti per applicazioni Windows (WinUI 3 in desktop)</value>
+    <value>App vuota WinUI (in pacchetto con il Progetto di creazione pacchetti per applicazioni Windows)</value>
   </data>
   <data name="1030" xml:space="preserve">
-    <value>[Sperimentale] App vuota, in pacchetto con Progetto di creazione pacchetti per applicazioni Windows (WinUI 3 in desktop)</value>
+    <value>[Sperimentale] App vuota WinUI (in pacchetto con il Progetto di creazione pacchetti per applicazioni Windows)</value>
   </data>
   <data name="1031" xml:space="preserve">
-    <value>Modello di progetto per la creazione di un'app desktop basata sulla libreria dell'interfaccia utente di Windows (WinUI 3). È incluso un progetto WAP (Progetto di creazione pacchetti per applicazioni Windows) per la creazione di un pacchetto MSIX per il trasferimento locale o la distribuzione tramite il Microsoft Store.</value>
+    <value>Un modello di progetto per la creazione di un'app WinUI. È incluso un progetto WAP (Progetto di creazione pacchetti per applicazioni Windows) per la creazione di un pacchetto MSIX per il trasferimento locale o la distribuzione tramite Microsoft Store.</value>
   </data>
   <data name="1033" xml:space="preserve">
-    <value>App vuota, pacchetto (WinUI 3 su desktop)</value>
+    <value>App vuota WinUI (in pacchetto)</value>
   </data>
   <data name="1034" xml:space="preserve">
-    <value>[Sperimentale] App vuota, in pacchetto (WinUI 3 in desktop)</value>
+    <value>[Sperimentale] App vuota WinUI (in pacchetto)</value>
   </data>
   <data name="1035" xml:space="preserve">
-    <value>Modello di progetto per la creazione di un'app desktop basata sulla libreria dell'interfaccia utente di Windows (WinUI 3) insieme a un pacchetto MSIX per il trasferimento locale o la distribuzione tramite il Microsoft Store.</value>
+    <value>Un modello di progetto per la creazione di un'app WinUI insieme a un pacchetto MSIX per il trasferimento locale o la distribuzione tramite Microsoft Store.</value>
   </data>
   <data name="1037" xml:space="preserve">
-    <value>Test unitario app (WinUI 3 in desktop)</value>
+    <value>App di test unità WinUI</value>
   </data>
   <data name="1038" xml:space="preserve">
-    <value>[Sperimentale] Test unitario app (WinUI 3 in desktop)</value>
+    <value>[Sperimentale] App di test unità WinUI</value>
   </data>
   <data name="1039" xml:space="preserve">
-    <value>Progetto per creare un'app unit test per le app WinUI 3 con MSTest.</value>
+    <value>Un progetto per creare un'app di test unità C# per WinUI usando MSTest.</value>
+  </data>
+  <data name="1040" xml:space="preserve">
+    <value>App vuota WinUI</value>
+  </data>
+  <data name="1041" xml:space="preserve">
+    <value>Progetto per la creazione di un'app WinUI vuota.</value>
+  </data>
+  <data name="1042" xml:space="preserve">
+    <value>Progetto di creazione pacchetti per applicazioni Windows per WinUI</value>
+  </data>
+  <data name="1043" xml:space="preserve">
+    <value>Modello di progetto che crea pacchetti MSIX contenenti applicazioni WinUI per il sideload o la distribuzione tramite il Microsoft Store.</value>
+  </data>
+  <data name="1044" xml:space="preserve">
+    <value>Installazione dei pacchetti NuGet nel progetto...</value>
+  </data>
+  <data name="1045" xml:space="preserve">
+    <value>Operazione in corso...</value>
+  </data>
+  <data name="1046" xml:space="preserve">
+    <value>Riferimenti ai pacchetti mancanti</value>
+  </data>
+  <data name="1047" xml:space="preserve">
+    <value>Non è possibile aggiungere riferimenti ai pacchetti seguenti per {0}: {1}. Aggiungere i riferimenti al pacchetto prima della compilazione.</value>
+  </data>
+  <data name="1048" xml:space="preserve">
+    <value>[{0}] Non è possibile aggiungere riferimenti ai pacchetti seguenti: {1}. Errore di ambiente. Aggiungere i riferimenti al pacchetto prima di compilare il progetto.</value>
+  </data>
+  <data name="1049" xml:space="preserve">
+    <value>Gestisci pacchetti NuGet</value>
+  </data>
+  <data name="1050" xml:space="preserve">
+    <value>Visualizza dettagli errore</value>
+  </data>
+  <data name="1051" xml:space="preserve">
+    <value>Riferimenti ai pacchetti mancanti per {0}:</value>
+  </data>
+  <data name="1052" xml:space="preserve">
+    <value>Aggiungi manualmente i riferimenti ai pacchetti prima della compilazione.</value>
+  </data>
+  <data name="1053" xml:space="preserve">
+    <value>Generale</value>
+  </data>
+  <data name="1054" xml:space="preserve">
+    <value>Nessuna informazione sull'output disponibile.</value>
   </data>
 </root>

--- a/dev/VSIX/Extension/Cs/Common/ja-JP/VSPackage.ja-JP.resx
+++ b/dev/VSIX/Extension/Cs/Common/ja-JP/VSPackage.ja-JP.resx
@@ -118,31 +118,31 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="1001" xml:space="preserve">
-    <value>空白のウィンドウ (デスクトップの WinUI 3)</value>
+    <value>空のウィンドウ</value>
   </data>
   <data name="1002" xml:space="preserve">
-    <value>[試験段階] 空白のウィンドウ (デスクトップの WinUI 3)</value>
+    <value>[試験段階] 空のウィンドウ</value>
   </data>
   <data name="1003" xml:space="preserve">
-    <value>Windows UI ライブラリ (WinUI 3) に基づくデスクトップ アプリの空白のウィンドウです。</value>
+    <value>空白のウィンドウ (WinUI)。</value>
   </data>
   <data name="1005" xml:space="preserve">
-    <value>空白のページ (WinUI 3)</value>
+    <value>空白のページ</value>
   </data>
   <data name="1006" xml:space="preserve">
-    <value>[試験段階] 空白のページ (WinUI 3)</value>
+    <value>[試験段階] 空のページ</value>
   </data>
   <data name="1007" xml:space="preserve">
-    <value>Windows UI ライブラリ (WinUI 3) に基づくアプリの空白のページ。</value>
+    <value>空のページ (WinUI)。</value>
   </data>
   <data name="1009" xml:space="preserve">
-    <value>リソース ディクショナリ (WinUI 3)</value>
+    <value>リソース ディクショナリ</value>
   </data>
   <data name="1010" xml:space="preserve">
-    <value>[試験段階] リソース ディクショナリ (WinUI 3)</value>
+    <value>[試験段階] リソース ディクショナリ</value>
   </data>
   <data name="1011" xml:space="preserve">
-    <value>Windows UI ライブラリ (WinUI 3) に基づくアプリの XAML リソースの、空のキー付きコレクションです。</value>
+    <value>XAML リソースの空のキー化されたコレクション (WinUI)。</value>
   </data>
   <data name="1013" xml:space="preserve">
     <value>リソース ファイル (.resw)</value>
@@ -151,60 +151,105 @@
     <value>[試験段階] リソース ファイル (.resw)</value>
   </data>
   <data name="1015" xml:space="preserve">
-    <value>Windows UI ライブラリ (WinUI 3) に基づいてアプリの文字列と条件付きリソースを格納するためのファイルです。</value>
+    <value>文字列と条件付きリソース (WinUI) を格納するためのファイルです。</value>
   </data>
   <data name="1017" xml:space="preserve">
-    <value>カスタム コントロール (WinUI 3)</value>
+    <value>テンプレート化されたコントロール</value>
   </data>
   <data name="1018" xml:space="preserve">
-    <value>[試験段階] カスタム コントロール (WinUI 3)</value>
+    <value>[試験段階] テンプレート化されたコントロール</value>
   </data>
   <data name="1019" xml:space="preserve">
-    <value>Windows UI ライブラリ (WinUI 3) に基づくアプリのカスタム コントロール。</value>
+    <value>適切な既定のスタイルを持つ空のカスタム コントロール (WinUI)。</value>
   </data>
   <data name="1021" xml:space="preserve">
-    <value>ユーザー コントロール (WinUI 3)</value>
+    <value>ユーザー コントロール</value>
   </data>
   <data name="1022" xml:space="preserve">
-    <value>[試験段階] ユーザー コントロール (WinUI 3)</value>
+    <value>[試験段階] ユーザー コントロール</value>
   </data>
   <data name="1023" xml:space="preserve">
-    <value>Windows UI ライブラリ (WinUI 3) に基づくアプリのユーザー コントロール。</value>
+    <value>空のユーザー コントロール (WinUI)。</value>
   </data>
   <data name="1025" xml:space="preserve">
-    <value>クラス ライブラリ (デスクトップの WinUI 3)</value>
+    <value>WinUI クラス ライブラリ</value>
   </data>
   <data name="1026" xml:space="preserve">
-    <value>[試験段階] クラス ライブラリ (デスクトップの WinUI 3)</value>
+    <value>[試験段階] WinUI クラス ライブラリ</value>
   </data>
   <data name="1027" xml:space="preserve">
-    <value>Windows UI ライブラリ (WinUI 3) に基づいてデスクトップ アプリ用のマネージド クラス ライブラリ (.dll) を作成するためのプロジェクトです。</value>
+    <value>マネージ クラス ライブラリ (.dll) (WinUI) を作成するためのプロジェクトです。</value>
   </data>
   <data name="1029" xml:space="preserve">
-    <value>空白のアプリ、Windows アプリケーション パッケージ プロジェクトでパッケージ化 (デスクトップの WinUI 3)</value>
+    <value>WinUI の空のアプリ (Windows アプリケーション パッケージ プロジェクトでパッケージ化)</value>
   </data>
   <data name="1030" xml:space="preserve">
-    <value>[試験段階]空のアプリ、Windows アプリケーション パッケージ プロジェクトでパッケージ化 (デスクトップの WinUI 3)</value>
+    <value>[試験段階] WinUI の空のアプリ (Windows アプリケーション パッケージ プロジェクトでパッケージ化)</value>
   </data>
   <data name="1031" xml:space="preserve">
-    <value>Windows UI ライブラリ (WinUI 3) に基づいてデスクトップ アプリを作成するためのプロジェクト テンプレートです。Microsoft Store を介してサイドローディングまたは配布するための MSIX パッケージを作成するために Windows アプリケーション パッケージ (WAP) プロジェクトが含まれています。</value>
+    <value>WinUI アプリを作成するためのプロジェクト テンプレート。サイドローディングまたは Microsoft Store を介した配布のための MSIX パッケージを作成するために Windows アプリケーション パッケージ (WAP) プロジェクトが含まれています。</value>
   </data>
   <data name="1033" xml:space="preserve">
-    <value>空のアプリ、パッケージ化 (デスクトップの WinUI 3)</value>
+    <value>WinUI の空のアプリ (パッケージ化)</value>
   </data>
   <data name="1034" xml:space="preserve">
-    <value>[試験段階]空のアプリ、パッケージ化 (デスクトップの WinUI 3)</value>
+    <value>[試験段階] WinUI の空のアプリ (パッケージ化)</value>
   </data>
   <data name="1035" xml:space="preserve">
-    <value>Windows UI ライブラリ (WinUI 3) に基づいてデスクトップ アプリを作成するためのプロジェクト テンプレートと、Microsoft Store を介したサイドローディングまたは配布用の MSIX パッケージです。</value>
+    <value>サイドローディングまたは Microsoft Store を介した配布のための MSIX パッケージを利用した WinUI アプリを作成するためのプロジェクト テンプレート。</value>
   </data>
   <data name="1037" xml:space="preserve">
-    <value>単体テスト アプリ (デスクトップの WinUI 3)</value>
+    <value>WinUI 単体テスト アプリ</value>
   </data>
   <data name="1038" xml:space="preserve">
-    <value>(試験段階) 単体テスト アプリ (デスクトップの WinUI 3)</value>
+    <value>[試験段階] WinUI 単体テスト アプリ</value>
   </data>
   <data name="1039" xml:space="preserve">
-    <value>MSTest を使用して WinUI 3 アプリの単体テスト アプリを作成するプロジェクトです。</value>
+    <value>MSTest を使用して WinUI の C# 単体テスト アプリを作成するプロジェクトです。</value>
+  </data>
+  <data name="1040" xml:space="preserve">
+    <value>WinUI の空のアプリ</value>
+  </data>
+  <data name="1041" xml:space="preserve">
+    <value>空の WinUI アプリを作成するためのプロジェクトです。</value>
+  </data>
+  <data name="1042" xml:space="preserve">
+    <value>WinUI 用の Windows アプリケーション パッケージ プロジェクト</value>
+  </data>
+  <data name="1043" xml:space="preserve">
+    <value>Microsoft Storeを使用してサイドローディングまたはディストリビューションを行う WinUI アプリケーションを含む MSIX パッケージを作成するプロジェクト テンプレートです。</value>
+  </data>
+  <data name="1044" xml:space="preserve">
+    <value>NuGet パッケージをプロジェクトにインストールしています...</value>
+  </data>
+  <data name="1045" xml:space="preserve">
+    <value>操作は実行中です...</value>
+  </data>
+  <data name="1046" xml:space="preserve">
+    <value>パッケージ参照がありません</value>
+  </data>
+  <data name="1047" xml:space="preserve">
+    <value>{0} の次のパッケージへの参照を追加できません: {1}。ビルドする前にパッケージ参照を追加してください。</value>
+  </data>
+  <data name="1048" xml:space="preserve">
+    <value>[{0}]次のパッケージへの参照を追加できません: {1}。これは環境エラーです。プロジェクトをビルドする前に、パッケージ参照を追加してください。</value>
+  </data>
+  <data name="1049" xml:space="preserve">
+    <value>NuGet パッケージの管理</value>
+  </data>
+  <data name="1050" xml:space="preserve">
+    <value>エラーの詳細を表示</value>
+  </data>
+  <data name="1051" xml:space="preserve">
+    <value>{0} のパッケージ参照がありません:</value>
+  </data>
+  <data name="1052" xml:space="preserve">
+    <value>ビルドする前に、パッケージ参照を手動で追加してください。</value>
+  </data>
+  <data name="1053" xml:space="preserve">
+    <value>全般</value>
+  </data>
+  <data name="1054" xml:space="preserve">
+    <value>使用できる出力情報がありません。</value>
   </data>
 </root>

--- a/dev/VSIX/Extension/Cs/Common/ko-KR/VSPackage.ko-KR.resx
+++ b/dev/VSIX/Extension/Cs/Common/ko-KR/VSPackage.ko-KR.resx
@@ -118,31 +118,31 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="1001" xml:space="preserve">
-    <value>빈 창(데스크탑의 WinUI 3)</value>
+    <value>빈 창</value>
   </data>
   <data name="1002" xml:space="preserve">
-    <value>[실험적] 빈 창(데스크톱의 WinUI 3)</value>
+    <value>[실험적] 빈 창</value>
   </data>
   <data name="1003" xml:space="preserve">
-    <value>Windows UI 라이브러리(WinUI 3)를 기반으로 하는 데스크톱 앱의 빈 창입니다.</value>
+    <value>빈 창(WinUI).</value>
   </data>
   <data name="1005" xml:space="preserve">
-    <value>빈 페이지(WinUI 3)</value>
+    <value>빈 페이지</value>
   </data>
   <data name="1006" xml:space="preserve">
-    <value>[실험적] 빈 페이지(WinUI 3)</value>
+    <value>[실험적] 빈 페이지</value>
   </data>
   <data name="1007" xml:space="preserve">
-    <value>Windows UI 라이브러리(WinUI 3)를 기반으로 하는 앱의 빈 페이지입니다.</value>
+    <value>빈 페이지(WinUI).</value>
   </data>
   <data name="1009" xml:space="preserve">
-    <value>리소스 사전(WinUI 3)</value>
+    <value>리소스 사전</value>
   </data>
   <data name="1010" xml:space="preserve">
-    <value>[실험적] 리소스 사전(WinUI 3)</value>
+    <value>[실험적] 리소스 사전</value>
   </data>
   <data name="1011" xml:space="preserve">
-    <value>Windows UI 라이브러리(WinUI 3)를 기반으로 하는 앱용 빈 키가 있는 XAML 리소스 컬렉션입니다.</value>
+    <value>비어 있는 키로 구성된 XAML 리소스 컬렉션입니다(WinUI).</value>
   </data>
   <data name="1013" xml:space="preserve">
     <value>리소스 파일(.resw)</value>
@@ -151,60 +151,105 @@
     <value>[실험] 리소스 파일(.resw)</value>
   </data>
   <data name="1015" xml:space="preserve">
-    <value>Windows UI 라이브러리(WinUI 3)를 기반으로 하는 앱용 문자열 및 조건부 리소스를 저장하기 위한 파일입니다.</value>
+    <value>WinUI(문자열 및 조건부 리소스)를 저장하는 파일입니다.</value>
   </data>
   <data name="1017" xml:space="preserve">
-    <value>사용자 지정 컨트롤(WinUI 3)</value>
+    <value>템플릿 제공 컨트롤</value>
   </data>
   <data name="1018" xml:space="preserve">
-    <value>[실험적] 사용자 지정 컨트롤(WinUI 3)</value>
+    <value>[실험적] 템플릿 제공 컨트롤</value>
   </data>
   <data name="1019" xml:space="preserve">
-    <value>Windows UI 라이브러리(WinUI 3)를 기반으로 하는 앱용 사용자 지정 컨트롤입니다.</value>
+    <value>적절한 기본 스타일(WinUI)을 사용하는 빈 사용자 지정 컨트롤입니다.</value>
   </data>
   <data name="1021" xml:space="preserve">
-    <value>사용자 정의 컨트롤(WinUI 3)</value>
+    <value>사용자 정의 컨트롤</value>
   </data>
   <data name="1022" xml:space="preserve">
-    <value>[실험적] 사용자 정의 컨트롤(WinUI 3)</value>
+    <value>[실험적] 사용자 정의 컨트롤</value>
   </data>
   <data name="1023" xml:space="preserve">
-    <value>Windows UI 라이브러리(WinUI 3)를 기반으로 하는 앱용 사용자 정의 컨트롤입니다.</value>
+    <value>빈 사용자 정의 컨트롤(WinUI).</value>
   </data>
   <data name="1025" xml:space="preserve">
-    <value>클래스 라이브러리(데스크톱의 WinUI 3)</value>
+    <value>WinUI 클래스 라이브러리</value>
   </data>
   <data name="1026" xml:space="preserve">
-    <value>[실험적] 클래스 라이브러리(데스크톱의 WinUI 3)</value>
+    <value>[실험적] WinUI 클래스 라이브러리</value>
   </data>
   <data name="1027" xml:space="preserve">
-    <value>Windows UI 라이브러리(WinUI 3)를 기반으로 하는 데스크톱 앱용 관리되는 클래스 라이브러리(.dll)를 만들기 위한 프로젝트입니다.</value>
+    <value>WinUI(관리되는 클래스 라이브러리)(.dll)를 만드는 프로젝트입니다.</value>
   </data>
   <data name="1029" xml:space="preserve">
-    <value>빈 앱, Windows 애플리케이션 패키징 프로젝트가 포함된 패키지(데스크톱의 WinUI 3)</value>
+    <value>WinUI 빈 앱(Windows 애플리케이션 패키징 프로젝트 패키지)</value>
   </data>
   <data name="1030" xml:space="preserve">
-    <value>[실험적] 빈 앱, Windows 애플리케이션 패키징 프로젝트 패키지됨(데스크톱의 WinUI 3)</value>
+    <value>[실험적] WinUI 빈 앱(Windows 애플리케이션 패키징 프로젝트 패키지)</value>
   </data>
   <data name="1031" xml:space="preserve">
-    <value>Windows UI 라이브러리(WinUI 3)를 기반으로 하는 데스크톱 앱을 만들기 위한 프로젝트 템플릿입니다. Microsoft Store를 통해 테스트용으로 로드하거나 배포하기 위한 MSIX 패키지를 만들기 위해 WAP(Windows 애플리케이션 패키징) 프로젝트가 포함되어 있습니다.</value>
+    <value>WinUI 앱을 만들기 위한 프로젝트 템플릿. Microsoft Store를 통해 테스트용으로 로드하거나 배포하기 위한 MSIX 패키지를 만들기 위해 WAP(Windows 애플리케이션 패키징) 프로젝트가 포함되어 있습니다.</value>
   </data>
   <data name="1033" xml:space="preserve">
-    <value>빈 앱, 패키지됨(데스크톱의 WinUI 3)</value>
+    <value>WinUI 빈 앱(패키지됨)</value>
   </data>
   <data name="1034" xml:space="preserve">
-    <value>[실험적] 빈 앱, 패키지됨(데스크톱의 WinUI 3)</value>
+    <value>[실험적] WinUI 빈 앱(패키지됨)</value>
   </data>
   <data name="1035" xml:space="preserve">
-    <value>Microsoft Store를 통해 테스트용으로 로드하거나 배포하기 위한 MSIX 패키지와 함께 Windows UI 라이브러리(WinUI 3)를 기반으로 하는 데스크톱 앱을 만들기 위한 프로젝트 템플릿입니다.</value>
+    <value>Microsoft Store 통해 테스트용 로드 또는 배포를 위한 MSIX 패키지와 함께 WinUI 앱을 만들기 위한 프로젝트 템플릿.</value>
   </data>
   <data name="1037" xml:space="preserve">
-    <value>단위 테스트 앱(데스크톱의 WinUI 3)</value>
+    <value>WinUI 단위 테스트 앱</value>
   </data>
   <data name="1038" xml:space="preserve">
-    <value>[실험적] 단위 테스트 앱(데스크톱의 WinUI 3)</value>
+    <value>[실험적] WinUI 단위 테스트 앱</value>
   </data>
   <data name="1039" xml:space="preserve">
-    <value>MSTest를 사용하여 WinUI 3 앱용 단위 테스트 앱을 만드는 프로젝트입니다.</value>
+    <value>MSTest를 사용하여 WinUI용 C# 단위 테스트 앱을 만드는 프로젝트입니다.</value>
+  </data>
+  <data name="1040" xml:space="preserve">
+    <value>WinUI 빈 앱</value>
+  </data>
+  <data name="1041" xml:space="preserve">
+    <value>빈 WinUI 앱을 만들기 위한 프로젝트.</value>
+  </data>
+  <data name="1042" xml:space="preserve">
+    <value>WinUI용 Windows 애플리케이션 패키징 프로젝트</value>
+  </data>
+  <data name="1043" xml:space="preserve">
+    <value>Microsoft Store 통해 테스트용 로드 또는 배포를 위한 WinUI 애플리케이션이 포함된 MSIX 패키지를 만드는 프로젝트 템플릿입니다.</value>
+  </data>
+  <data name="1044" xml:space="preserve">
+    <value>프로젝트에 NuGet 패키지를 설치하는 중입니다...</value>
+  </data>
+  <data name="1045" xml:space="preserve">
+    <value>작업이 진행 중입니다.</value>
+  </data>
+  <data name="1046" xml:space="preserve">
+    <value>누락된 패키지 참조</value>
+  </data>
+  <data name="1047" xml:space="preserve">
+    <value>{0} 대한 다음 패키지에 참조를 추가할 수 없습니다. {1}. 빌드하기 전에 패키지 참조를 추가하세요.</value>
+  </data>
+  <data name="1048" xml:space="preserve">
+    <value>[{0}] 다음 패키지에 참조를 추가할 수 없습니다. {1}. 환경 오류입니다. 프로젝트를 빌드하기 전에 패키지 참조를 추가하세요.</value>
+  </data>
+  <data name="1049" xml:space="preserve">
+    <value>NuGet 패키지 관리</value>
+  </data>
+  <data name="1050" xml:space="preserve">
+    <value>오류 세부 정보 보기</value>
+  </data>
+  <data name="1051" xml:space="preserve">
+    <value>{0}에 대해 누락된 패키지 참조:</value>
+  </data>
+  <data name="1052" xml:space="preserve">
+    <value>빌드하기 전에 패키지 참조를 수동으로 추가하세요.</value>
+  </data>
+  <data name="1053" xml:space="preserve">
+    <value>일반</value>
+  </data>
+  <data name="1054" xml:space="preserve">
+    <value>출력 정보를 사용할 수 없습니다.</value>
   </data>
 </root>

--- a/dev/VSIX/Extension/Cs/Common/pl-PL/VSPackage.pl-PL.resx
+++ b/dev/VSIX/Extension/Cs/Common/pl-PL/VSPackage.pl-PL.resx
@@ -118,31 +118,31 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="1001" xml:space="preserve">
-    <value>Puste okno (WinUI 3 na pulpicie)</value>
+    <value>Puste okno</value>
   </data>
   <data name="1002" xml:space="preserve">
-    <value>[Eksperymentalne] Puste okno (WinUI 3 na pulpicie)</value>
+    <value>[Eksperymentalne] Puste okno</value>
   </data>
   <data name="1003" xml:space="preserve">
-    <value>Puste okno dla aplikacji klasycznych opartych na bibliotece interfejsu użytkownika systemu Windows (WinUI 3).</value>
+    <value>Puste okno (WinUI).</value>
   </data>
   <data name="1005" xml:space="preserve">
-    <value>Pusta strona (WinUI 3)</value>
+    <value>Pusta strona</value>
   </data>
   <data name="1006" xml:space="preserve">
-    <value>[Eksperymentalne] Pusta strona (WinUI 3)</value>
+    <value>[Eksperymentalne] Pusta strona</value>
   </data>
   <data name="1007" xml:space="preserve">
-    <value>Pusta strona dla aplikacji opartych na bibliotece interfejsu użytkownika systemu Windows (WinUI 3).</value>
+    <value>Pusta strona (WinUI).</value>
   </data>
   <data name="1009" xml:space="preserve">
-    <value>Słownik zasobów (WinUI 3)</value>
+    <value>Słownik zasobów</value>
   </data>
   <data name="1010" xml:space="preserve">
-    <value>[Eksperymentalne] Słownik zasobów (WinUI 3)</value>
+    <value>[Eksperymentalne] Słownik zasobów</value>
   </data>
   <data name="1011" xml:space="preserve">
-    <value>Pusta kolekcja kluczy zasobów XAML dla aplikacji opartych na bibliotece interfejsu użytkownika systemu Windows (WinUI 3).</value>
+    <value>Pusta kolekcja kluczy zasobów XAML (WinUI).</value>
   </data>
   <data name="1013" xml:space="preserve">
     <value>Plik zasobów (resw)</value>
@@ -151,60 +151,105 @@
     <value>[Eksperymentalne] Plik zasobów (resw)</value>
   </data>
   <data name="1015" xml:space="preserve">
-    <value>Plik do przechowywania ciągów i zasobów warunkowych dla aplikacji opartych na bibliotece interfejsu użytkownika systemu Windows (WinUI 3).</value>
+    <value>Plik do przechowywania ciągów i zasobów warunkowych (WinUI).</value>
   </data>
   <data name="1017" xml:space="preserve">
-    <value>Kontrolka niestandardowa (WinUI 3)</value>
+    <value>Kontrolka z szablonem</value>
   </data>
   <data name="1018" xml:space="preserve">
-    <value>[Eksperymentalne] Kontrolka niestandardowa (WinUI 3)</value>
+    <value>[Eksperymentalne] Kontrolka z szablonem</value>
   </data>
   <data name="1019" xml:space="preserve">
-    <value>Kontrolka niestandardowa dla aplikacji opartych na bibliotece interfejsu użytkownika systemu Windows (WinUI 3).</value>
+    <value>Pusta kontrolka niestandardowa z odpowiednim domyślnym stylem (WinUI).</value>
   </data>
   <data name="1021" xml:space="preserve">
-    <value>Kontrolka użytkownika (WinUI 3)</value>
+    <value>Kontrola użytkownika</value>
   </data>
   <data name="1022" xml:space="preserve">
-    <value>[Eksperymentalne] Kontrolka użytkownika (WinUI 3)</value>
+    <value>[Eksperymentalne] Kontrola użytkownika</value>
   </data>
   <data name="1023" xml:space="preserve">
-    <value>Kontrolka użytkownika dla aplikacji opartych na bibliotece interfejsu użytkownika systemu Windows (WinUI 3).</value>
+    <value>Pusta kontrolka użytkownika (WinUI).</value>
   </data>
   <data name="1025" xml:space="preserve">
-    <value>Biblioteka klas (WinUI 3 na pulpicie)</value>
+    <value>Biblioteka klas WinUI</value>
   </data>
   <data name="1026" xml:space="preserve">
-    <value>[Eksperymentalne] Biblioteka klas (WinUI 3 na pulpicie)</value>
+    <value>[Eksperymentalne] Biblioteka klas WinUI</value>
   </data>
   <data name="1027" xml:space="preserve">
-    <value>Projekt służący do tworzenia zarządzanej biblioteki klas (dll) dla aplikacji klasycznych opartych na bibliotece interfejsu użytkownika systemu Windows (WinUI 3).</value>
+    <value>Projekt służący do tworzenia zarządzanej biblioteki klas (.dll) (WinUI).</value>
   </data>
   <data name="1029" xml:space="preserve">
-    <value>Pusta aplikacja, spakietyzowana za pomocą projektu pakietu aplikacji systemu Windows (WinUI 3 na pulpicie)</value>
+    <value>Pusta aplikacja WinUI (spakowana z projektem pakietu aplikacji systemu Windows)</value>
   </data>
   <data name="1030" xml:space="preserve">
-    <value>[Eksperymentalne] Pusta aplikacja spakowana z projekt pakietu aplikacji systemu Windows (WinUI 3 na pulpicie)</value>
+    <value>[Eksperymentalne] Pusta aplikacja WinUI (spakowana z projektem pakietu aplikacji systemu Windows)</value>
   </data>
   <data name="1031" xml:space="preserve">
-    <value>Szablon projektu służący do tworzenia aplikacji klasycznej na podstawie biblioteki interfejsu użytkownika systemu Windows (WinUI 3). Projekt pakietu aplikacji systemu Windows (WAP) jest dołączany w celu utworzenia pakietu MSIX na potrzeby ładowania bezpośredniego lub dystrybucji za pośrednictwem sklepu Microsoft Store.</value>
+    <value>Szablon projektu do tworzenia aplikacji WinUI. Projekt pakietu aplikacji systemu Windows (WAP) jest dołączany w celu utworzenia pakietu MSIX na potrzeby ładowania bezpośredniego lub dystrybucji za pośrednictwem sklepu Microsoft Store.</value>
   </data>
   <data name="1033" xml:space="preserve">
-    <value>Pusta aplikacja, spakowana (WinUI 3 na pulpicie)</value>
+    <value>Pusta aplikacja WinUI (spakowana)</value>
   </data>
   <data name="1034" xml:space="preserve">
-    <value>[Eksperymentalne] Pusta aplikacja, spakowana (WinUI 3 na pulpicie)</value>
+    <value>[Eksperymentalne] Pusta aplikacja WinUI (spakowana)</value>
   </data>
   <data name="1035" xml:space="preserve">
-    <value>Szablon projektu służący do tworzenia aplikacji klasycznej opartej na bibliotece interfejsu użytkownika systemu Windows (WinUI 3) wraz z pakietem MSIX na potrzeby ładowania bezpośredniego lub dystrybucji za pośrednictwem sklepu Microsoft Store.</value>
+    <value>Szablon projektu do tworzenia aplikacji WinUI wraz z pakietem MSIX na potrzeby ładowania bezpośredniego lub dystrybucji za pośrednictwem sklepu Microsoft Store.</value>
   </data>
   <data name="1037" xml:space="preserve">
-    <value>Aplikacja testów jednostkowych (WinUI 3 na pulpicie)</value>
+    <value>Aplikacja testów jednostkowych WinUI</value>
   </data>
   <data name="1038" xml:space="preserve">
-    <value>[Eksperymentalne] Aplikacja testów jednostkowych (WinUI 3 w wersji klasycznej)</value>
+    <value>[Eksperymentalne] Aplikacja testów jednostkowych WinUI</value>
   </data>
   <data name="1039" xml:space="preserve">
-    <value>Projekt do tworzenia aplikacji testów jednostkowych dla WinUI 3 przy użyciu platformy MSTest.</value>
+    <value>Projekt do tworzenia aplikacji testów jednostkowych w języku C# dla biblioteki WinUI przy użyciu platformy MSTest.</value>
+  </data>
+  <data name="1040" xml:space="preserve">
+    <value>Pusta aplikacja WinUI</value>
+  </data>
+  <data name="1041" xml:space="preserve">
+    <value>Projekt służący do tworzenia pustej aplikacji WinUI.</value>
+  </data>
+  <data name="1042" xml:space="preserve">
+    <value>Projekt pakietu aplikacji systemu Windows dla WinUI</value>
+  </data>
+  <data name="1043" xml:space="preserve">
+    <value>Szablon projektu, który tworzy pakiety MSIX zawierające aplikacje WinUI na potrzeby ładowania bezpośredniego lub dystrybucji za pośrednictwem Microsoft Store.</value>
+  </data>
+  <data name="1044" xml:space="preserve">
+    <value>Trwa instalowanie pakietów NuGet w projekcie...</value>
+  </data>
+  <data name="1045" xml:space="preserve">
+    <value>Operacja w toku...</value>
+  </data>
+  <data name="1046" xml:space="preserve">
+    <value>Brak odwołań do pakietu</value>
+  </data>
+  <data name="1047" xml:space="preserve">
+    <value>Nie można dodać odwołań do następujących pakietów dla {0}: {1}. Przed skompilowaniem dodaj odwołania do pakietu.</value>
+  </data>
+  <data name="1048" xml:space="preserve">
+    <value>[{0}] Nie można dodać odwołań do następujących pakietów: {1}. To jest błąd środowiska. Przed skompilowaniem projektu dodaj odwołania do pakietu.</value>
+  </data>
+  <data name="1049" xml:space="preserve">
+    <value>Zarządzanie pakietami NuGet</value>
+  </data>
+  <data name="1050" xml:space="preserve">
+    <value>Zobacz szczegóły błędu</value>
+  </data>
+  <data name="1051" xml:space="preserve">
+    <value>Brak odwołań do pakietu dla {0}:</value>
+  </data>
+  <data name="1052" xml:space="preserve">
+    <value>Przed utworzeniem ręcznie dodaj odwołania do pakietów.</value>
+  </data>
+  <data name="1053" xml:space="preserve">
+    <value>Ogólne</value>
+  </data>
+  <data name="1054" xml:space="preserve">
+    <value>Brak dostępnych informacji wyjściowych.</value>
   </data>
 </root>

--- a/dev/VSIX/Extension/Cs/Common/pt-BR/VSPackage.pt-BR.resx
+++ b/dev/VSIX/Extension/Cs/Common/pt-BR/VSPackage.pt-BR.resx
@@ -118,31 +118,31 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="1001" xml:space="preserve">
-    <value>Janela em Branco (WinUI 3 no Desktop)</value>
+    <value>Janela em Branco</value>
   </data>
   <data name="1002" xml:space="preserve">
-    <value>[Experimental] Janela em Branco (WinUI 3 no Desktop)</value>
+    <value>[Experimental] Janela em Branco</value>
   </data>
   <data name="1003" xml:space="preserve">
-    <value>Uma janela em branco para Aplicativos para desktop baseado na Biblioteca de Interface do Usuário do Windows (WinUI 3).</value>
+    <value>Uma janela em branco (WinUI).</value>
   </data>
   <data name="1005" xml:space="preserve">
-    <value>Página em Branco (WinUI 3)</value>
+    <value>Página em Branco</value>
   </data>
   <data name="1006" xml:space="preserve">
-    <value>[Experimental] Página em Branco (WinUI 3)</value>
+    <value>[Experimental] Página em Branco</value>
   </data>
   <data name="1007" xml:space="preserve">
-    <value>Uma página em branco para aplicativos baseado na Biblioteca de Interface do Usuário do Windows (WinUI 3).</value>
+    <value>Uma página em branco (WinUI).</value>
   </data>
   <data name="1009" xml:space="preserve">
-    <value>Dicionário de Recursos (WinUI 3)</value>
+    <value>Dicionário de Recursos</value>
   </data>
   <data name="1010" xml:space="preserve">
-    <value>[Experimental] Dicionário de Recursos (WinUI 3)</value>
+    <value>[Experimental] Dicionário de Recursos</value>
   </data>
   <data name="1011" xml:space="preserve">
-    <value>Uma coleção vazia e com chave de recursos XAML para aplicativos baseados na Biblioteca de Interface do Usuário do Windows (WinUI 3).</value>
+    <value>Uma coleção vazia de recursos XAML (WinUI) com chave.</value>
   </data>
   <data name="1013" xml:space="preserve">
     <value>Arquivo de Recursos (.resw)</value>
@@ -151,60 +151,105 @@
     <value>[Experimental] Arquivo de Recursos (.resw)</value>
   </data>
   <data name="1015" xml:space="preserve">
-    <value>Um arquivo para armazenar a cadeia de caracteres e os recursos condicionais para aplicativos com base na Biblioteca de Interface do Usuário do Windows (WinUI 3).</value>
+    <value>Um arquivo para armazenar a cadeia de caracteres e os recursos condicionais (WinUI).</value>
   </data>
   <data name="1017" xml:space="preserve">
-    <value>Controle Personalizado (WinUI 3)</value>
+    <value>Controle de Modelo</value>
   </data>
   <data name="1018" xml:space="preserve">
-    <value>[Experimental] Controle Personalizado (WinUI 3)</value>
+    <value>[Experimental] Controle de Modelo</value>
   </data>
   <data name="1019" xml:space="preserve">
-    <value>Um controle personalizado para aplicativos baseado na Biblioteca de Interface do Usuário do Windows (WinUI 3).</value>
+    <value>Um controle personalizado em branco com o estilo padrão apropriado (WinUI).</value>
   </data>
   <data name="1021" xml:space="preserve">
-    <value>Controle de Usuário (WinUI 3)</value>
+    <value>Controle de Usuário</value>
   </data>
   <data name="1022" xml:space="preserve">
-    <value>[Experimental] Controle de Usuário (WinUI 3)</value>
+    <value>[Experimental] Controle de Usuário</value>
   </data>
   <data name="1023" xml:space="preserve">
-    <value>Um controle de usuário para aplicativos baseado na Biblioteca de Interface do Usuário do Windows (WinUI 3).</value>
+    <value>Um controle de usuário em branco (WinUI).</value>
   </data>
   <data name="1025" xml:space="preserve">
-    <value>Biblioteca de Classes (WinUI 3 no Desktop)</value>
+    <value>Biblioteca de Classes WinUI</value>
   </data>
   <data name="1026" xml:space="preserve">
-    <value>[Experimental] Biblioteca de Classes (WinUI 3 no Desktop)</value>
+    <value>[Experimental] Biblioteca de Classes WinUI</value>
   </data>
   <data name="1027" xml:space="preserve">
-    <value>Um projeto para criar uma biblioteca de classes gerenciadas (.dll) para Aplicativos para desktop com base na Biblioteca de Interface do Usuário do Windows (WinUI 3).</value>
+    <value>Um projeto para criar uma biblioteca de classes gerenciada (.dll) (WinUI).</value>
   </data>
   <data name="1029" xml:space="preserve">
-    <value>Aplicativo em Branco, Empacotado com Projeto de Empacotamento de Aplicativo do Windows (WinUI 3 na Área de Trabalho)</value>
+    <value>Aplicativo WinUI em Branco (Empacotado com Projeto de Empacotamento de Aplicativo do Windows)</value>
   </data>
   <data name="1030" xml:space="preserve">
-    <value>[Experimental] Aplicativo em Branco, Empacotado com Projeto de Empacotamento de Aplicativo do Windows (WinUI 3 na Área de Trabalho)</value>
+    <value>[Experimental] Aplicativo WinUI em Branco (Empacotado com Projeto de Empacotamento de Aplicativo do Windows)</value>
   </data>
   <data name="1031" xml:space="preserve">
-    <value>Um modelo de projeto para criar um Aplicativo para desktop com base na Biblioteca de Interface do Usuário do Windows (WinUI 3). Um projeto wap (empacotamento de aplicativo) do Windows é incluído para criar um pacote MSIX para sideload ou distribuição por meio do Microsoft Store.</value>
+    <value>Um modelo de projeto para criar um aplicativo WinUI. Um projeto de Empacotamento de Aplicativo do Windows (WAP) está incluído para criar um pacote MSIX para carregamento lateral ou distribuição por meio da Microsoft Store.</value>
   </data>
   <data name="1033" xml:space="preserve">
-    <value>Aplicativo em Branco, Empacotado (WinUI 3 no Desktop)</value>
+    <value>Aplicativo WinUI em Branco (Empacotado)</value>
   </data>
   <data name="1034" xml:space="preserve">
-    <value>[Experimental] Aplicativo em Branco, Empacotado (WinUI 3 na Área de Trabalho)</value>
+    <value>[Experimental] Aplicativo WinUI em Branco (Empacotado)</value>
   </data>
   <data name="1035" xml:space="preserve">
-    <value>Um modelo de projeto para criar um Aplicativo para desktop baseado na Biblioteca de Interface do Usuário do Windows (WinUI 3) juntamente com um pacote MSIX para sideload ou distribuição por meio da Microsoft Store.</value>
+    <value>Um modelo de projeto para criar um aplicativo WinUI juntamente com um pacote MSIX para carregamento lateral ou distribuição por meio da Microsoft Store.</value>
   </data>
   <data name="1037" xml:space="preserve">
-    <value>Aplicativo de Teste de Unidade (WinUI 3 na Área de Trabalho)</value>
+    <value>Aplicativo de Teste de Unidade WinUI</value>
   </data>
   <data name="1038" xml:space="preserve">
-    <value>[Experimental] Aplicativo de Teste de Unidade (WinUI 3 na Área de Trabalho)</value>
+    <value>[Experimental] Aplicativo de Teste de Unidade WinUI</value>
   </data>
   <data name="1039" xml:space="preserve">
-    <value>Um projeto para criar um aplicativo de teste de unidade para aplicativos WinUI 3 usando o MSTest.</value>
+    <value>Um projeto para criar um aplicativo de teste de unidade C# para WinUI usando o MSTest.</value>
+  </data>
+  <data name="1040" xml:space="preserve">
+    <value>Aplicativo WinUI em Branco</value>
+  </data>
+  <data name="1041" xml:space="preserve">
+    <value>Um projeto para criar um aplicativo WinUI vazio.</value>
+  </data>
+  <data name="1042" xml:space="preserve">
+    <value>Projeto de Empacotamento de Aplicativo do Windows para WinUI</value>
+  </data>
+  <data name="1043" xml:space="preserve">
+    <value>Um modelo de projeto que cria pacotes MSIX contendo aplicativos WinUI para side loading ou distribuição por meio do Microsoft Store.</value>
+  </data>
+  <data name="1044" xml:space="preserve">
+    <value>Instalando pacotes NuGet no projeto...</value>
+  </data>
+  <data name="1045" xml:space="preserve">
+    <value>Operação em andamento...</value>
+  </data>
+  <data name="1046" xml:space="preserve">
+    <value>Referências de Pacote Ausentes</value>
+  </data>
+  <data name="1047" xml:space="preserve">
+    <value>Não é possível adicionar referências aos seguintes pacotes para {0}: {1}. Adicione referências de pacote antes de compilar.</value>
+  </data>
+  <data name="1048" xml:space="preserve">
+    <value>[{0}] Não é possível adicionar referências aos seguintes pacotes: {1}. Este é um erro de ambiente. Adicione referências de pacote antes de compilar o projeto.</value>
+  </data>
+  <data name="1049" xml:space="preserve">
+    <value>Gerenciar Pacotes NuGet</value>
+  </data>
+  <data name="1050" xml:space="preserve">
+    <value>Confira os detalhes do erro</value>
+  </data>
+  <data name="1051" xml:space="preserve">
+    <value>Referências de Pacote Ausentes para {0}:</value>
+  </data>
+  <data name="1052" xml:space="preserve">
+    <value>Adicione manualmente as referências de pacote antes de compilar.</value>
+  </data>
+  <data name="1053" xml:space="preserve">
+    <value>Geral</value>
+  </data>
+  <data name="1054" xml:space="preserve">
+    <value>Nenhuma informação de saída disponível.</value>
   </data>
 </root>

--- a/dev/VSIX/Extension/Cs/Common/ru-RU/VSPackage.ru-RU.resx
+++ b/dev/VSIX/Extension/Cs/Common/ru-RU/VSPackage.ru-RU.resx
@@ -118,31 +118,31 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="1001" xml:space="preserve">
-    <value>Пустое окно (WinUI 3 в "Классическом приложении")</value>
+    <value>Пустое окно</value>
   </data>
   <data name="1002" xml:space="preserve">
-    <value>[Экспериментальная версия] Пустое окно (WinUI 3 в "Классическом приложении")</value>
+    <value>[Экспериментальная функция] Пустое окно</value>
   </data>
   <data name="1003" xml:space="preserve">
-    <value>Пустое окно для классических приложений на основе библиотеки пользовательского интерфейса Windows (WinUI 3).</value>
+    <value>Пустое окно (WinUI).</value>
   </data>
   <data name="1005" xml:space="preserve">
-    <value>Пустая страница (WinUI 3)</value>
+    <value>Пустая страница</value>
   </data>
   <data name="1006" xml:space="preserve">
-    <value>[Экспериментальная версия] Пустая страница (WinUI 3)</value>
+    <value>[Экспериментальная функция] Пустая страница</value>
   </data>
   <data name="1007" xml:space="preserve">
-    <value>Пустая страница для приложений на основе библиотеки пользовательского интерфейса Windows (WinUI 3).</value>
+    <value>Пустая страница (WinUI).</value>
   </data>
   <data name="1009" xml:space="preserve">
-    <value>Словарь ресурсов (WinUI 3)</value>
+    <value>Словарь ресурсов</value>
   </data>
   <data name="1010" xml:space="preserve">
-    <value>[Экспериментальная версия] Словарь ресурсов (WinUI 3)</value>
+    <value>[Экспериментальная функция] Словарь ресурсов</value>
   </data>
   <data name="1011" xml:space="preserve">
-    <value>Пустая коллекция ресурсов XAML с ключами для приложений на основе библиотеки пользовательского интерфейса Windows (WinUI 3).</value>
+    <value>Пустая коллекция ресурсов XAML с ключами (WinUI).</value>
   </data>
   <data name="1013" xml:space="preserve">
     <value>Файл ресурсов (.resw)</value>
@@ -151,60 +151,105 @@
     <value>[Экспериментальная версия] Файл ресурсов (.resw)</value>
   </data>
   <data name="1015" xml:space="preserve">
-    <value>Файл для хранения строковых и условных ресурсов для приложений на основе библиотеки пользовательского интерфейса Windows (WinUI 3).</value>
+    <value>Файл для хранения строковых и условных ресурсов (WinUI).</value>
   </data>
   <data name="1017" xml:space="preserve">
-    <value>Пользовательский элемент управления (WinUI 3)</value>
+    <value>Шаблонный элемент управления</value>
   </data>
   <data name="1018" xml:space="preserve">
-    <value>[Экспериментальная версия] Пользовательский элемент управления (WinUI 3)</value>
+    <value>[Экспериментальная функция] Шаблонный элемент управления</value>
   </data>
   <data name="1019" xml:space="preserve">
-    <value>Пользовательский элемент управления для приложений на основе библиотеки пользовательского интерфейса Windows (WinUI 3).</value>
+    <value>Пустой пользовательский элемент управления с соответствующим стилем по умолчанию (WinUI).</value>
   </data>
   <data name="1021" xml:space="preserve">
-    <value>Пользовательский элемент управления (WinUI 3)</value>
+    <value>Пользовательский элемент управления</value>
   </data>
   <data name="1022" xml:space="preserve">
-    <value>[Экспериментальная версия] Пользовательский элемент управления (WinUI 3)</value>
+    <value>[Экспериментальная функция] Пользовательский элемент управления</value>
   </data>
   <data name="1023" xml:space="preserve">
-    <value>Пользовательский элемент управления для приложений на основе библиотеки пользовательского интерфейса Windows (WinUI 3).</value>
+    <value>Пустой пользовательский элемент управления (WinUI).</value>
   </data>
   <data name="1025" xml:space="preserve">
-    <value>Библиотека классов (WinUI 3 в "Классическом приложении")</value>
+    <value>Библиотека классов WinUI</value>
   </data>
   <data name="1026" xml:space="preserve">
-    <value>[Экспериментальная версия] Библиотека классов (WinUI 3 в "Классическом приложении")</value>
+    <value>[Экспериментальная функция] Библиотека классов WinUI</value>
   </data>
   <data name="1027" xml:space="preserve">
-    <value>Проект по созданию управляемой библиотеки классов (.dll) для классических приложений на основе библиотеки пользовательского интерфейса Windows (WinUI 3).</value>
+    <value>Проект для создания управляемой библиотеки классов (.dll) (WinUI).</value>
   </data>
   <data name="1029" xml:space="preserve">
-    <value>Пустое приложение, упакованное с помощью проекта упаковки приложений Windows (WinUI 3 на компьютере)</value>
+    <value>Пустое приложение WinUI (упакованное с помощью Проекта упаковки приложений Windows)</value>
   </data>
   <data name="1030" xml:space="preserve">
-    <value>[Экспериментальная функция] Пустое приложение, упакованное с помощью проекта упаковки приложений Windows (WinUI 3 на компьютере)</value>
+    <value>[Экспериментальная функция] Пустое приложение WinUI (упакованное с помощью Проекта упаковки приложений Windows)</value>
   </data>
   <data name="1031" xml:space="preserve">
-    <value>Шаблон проекта для создания классического приложения на основе библиотеки пользовательского интерфейса Windows (WinUI 3). Для создания пакета MSIX для загрузки неопубликованного приложения или распространения через Microsoft Store включен проект упаковки приложений Windows (WAP).</value>
+    <value>Шаблон проекта для создания приложения WinUI. Для создания пакета MSIX с целью загрузки неопубликованного приложения или распространения через Microsoft Store включен проект упаковки приложений Windows (WAP).</value>
   </data>
   <data name="1033" xml:space="preserve">
-    <value>Пустое приложение, упакованное (WinUI 3 в "Классическом приложении")</value>
+    <value>Пустое приложение WinUI (упакованное)</value>
   </data>
   <data name="1034" xml:space="preserve">
-    <value>[Экспериментальная версия] Пустое приложение, упакованное (WinUI 3 в "Классическом приложении")</value>
+    <value>[Экспериментальная функция] Пустое приложение WinUI (упакованное)</value>
   </data>
   <data name="1035" xml:space="preserve">
-    <value>Шаблон проекта для создания классического приложения на основе библиотеки пользовательского интерфейса Windows (WinUI 3) и пакета MSIX для загрузки неопубликованного приложения или распространения через Microsoft Store.</value>
+    <value>Шаблон проекта для создания приложения WinUI вместе с пакетом MSIX с целью загрузки неопубликованного приложения или распространения через Microsoft Store.</value>
   </data>
   <data name="1037" xml:space="preserve">
-    <value>Приложение модульного тестирования (WinUI 3 на рабочем столе)</value>
+    <value>Приложение модульного тестирования WinUI</value>
   </data>
   <data name="1038" xml:space="preserve">
-    <value>[Эксперимент] Приложение модульного тестирования (WinUI 3 на рабочем столе)</value>
+    <value>[Экспериментальная функция] Приложение модульного тестирования WinUI</value>
   </data>
   <data name="1039" xml:space="preserve">
-    <value>Проект по созданию приложения модульного тестирования для приложений WinUI 3 с использованием MSTest.</value>
+    <value>Проект по созданию приложения модульного тестирования C# для WinUI с использованием MSTest.</value>
+  </data>
+  <data name="1040" xml:space="preserve">
+    <value>Пустое приложение WinUI</value>
+  </data>
+  <data name="1041" xml:space="preserve">
+    <value>Проект создания пустого приложения WinUI.</value>
+  </data>
+  <data name="1042" xml:space="preserve">
+    <value>Проект упаковки приложений Windows для WinUI</value>
+  </data>
+  <data name="1043" xml:space="preserve">
+    <value>Шаблон проекта, который создает пакеты MSIX, содержащие приложения WinUI для загрузки неопубликованного приложения или распространения через Microsoft Store.</value>
+  </data>
+  <data name="1044" xml:space="preserve">
+    <value>Установка пакетов NuGet в проект...</value>
+  </data>
+  <data name="1045" xml:space="preserve">
+    <value>Операция выполняется...</value>
+  </data>
+  <data name="1046" xml:space="preserve">
+    <value>Отсутствуют ссылки на пакеты</value>
+  </data>
+  <data name="1047" xml:space="preserve">
+    <value>Не удалось добавить ссылки на следующие пакеты для {0}: {1}. Перед сборкой добавьте ссылки на пакеты.</value>
+  </data>
+  <data name="1048" xml:space="preserve">
+    <value>[{0}] Не удалось добавить ссылки на следующие пакеты: {1}. Это ошибка среды. Добавьте ссылки на пакеты перед сборкой проекта.</value>
+  </data>
+  <data name="1049" xml:space="preserve">
+    <value>Управление пакетами NuGet</value>
+  </data>
+  <data name="1050" xml:space="preserve">
+    <value>Просмотреть сведения об ошибке</value>
+  </data>
+  <data name="1051" xml:space="preserve">
+    <value>Отсутствуют ссылки на пакеты для {0}:</value>
+  </data>
+  <data name="1052" xml:space="preserve">
+    <value>Вручную добавьте ссылки на пакеты перед сборкой.</value>
+  </data>
+  <data name="1053" xml:space="preserve">
+    <value>Общее</value>
+  </data>
+  <data name="1054" xml:space="preserve">
+    <value>Информация о выходных данных недоступна.</value>
   </data>
 </root>

--- a/dev/VSIX/Extension/Cs/Common/tr-TR/VSPackage.tr-TR.resx
+++ b/dev/VSIX/Extension/Cs/Common/tr-TR/VSPackage.tr-TR.resx
@@ -118,31 +118,31 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="1001" xml:space="preserve">
-    <value>Boş Pencere (Masaüstünde WinUI 3)</value>
+    <value>Boş Pencere</value>
   </data>
   <data name="1002" xml:space="preserve">
-    <value>[Deneysel] Boş Pencere (Masaüstünde WinUI 3)</value>
+    <value>[Deneysel] Boş Pencere</value>
   </data>
   <data name="1003" xml:space="preserve">
-    <value>Windows UI Kitaplığı’nı (WinUI 3) temel alan Masaüstü uygulamaları için boş bir pencere.</value>
+    <value>Boş bir pencere (WinUI).</value>
   </data>
   <data name="1005" xml:space="preserve">
-    <value>Boş Sayfa (WinUI 3)</value>
+    <value>Boş Sayfa</value>
   </data>
   <data name="1006" xml:space="preserve">
-    <value>[Deneysel] Boş Sayfa (WinUI 3)</value>
+    <value>[Deneysel] Boş Sayfa</value>
   </data>
   <data name="1007" xml:space="preserve">
-    <value>Windows UI Kitaplığı'nı (WinUI 3) temel alan uygulamalar için boş bir sayfa.</value>
+    <value>Boş bir sayfa (WinUI).</value>
   </data>
   <data name="1009" xml:space="preserve">
-    <value>Kaynak Sözlüğü (WinUI 3)</value>
+    <value>Kaynak Sözlüğü</value>
   </data>
   <data name="1010" xml:space="preserve">
-    <value>[Deneysel] Kaynak Sözlüğü (WinUI 3)</value>
+    <value>[Deneysel] Kaynak Sözlüğü</value>
   </data>
   <data name="1011" xml:space="preserve">
-    <value>Windows UI Kitaplığı'nı (WinUI 3) temel alan uygulamalar için boş bir anahtarlı XAML kaynakları koleksiyonu.</value>
+    <value>Boş, anahtarlı XAML kaynakları koleksiyonu (WinUI).</value>
   </data>
   <data name="1013" xml:space="preserve">
     <value>Kaynak Dosyası (.resw)</value>
@@ -151,60 +151,105 @@
     <value>[Deneysel] Kaynak Dosyası (.resw)</value>
   </data>
   <data name="1015" xml:space="preserve">
-    <value>Windows UI Kitaplığı’nı (WinUI 3) temel alan uygulamalar için dize ve koşullu kaynakları depolamaya yönelik bir dosya.</value>
+    <value>Dize ve koşullu kaynakları (WinUI) depolamak için bir dosya.</value>
   </data>
   <data name="1017" xml:space="preserve">
-    <value>Özel Denetim (WinUI 3)</value>
+    <value>Şablonlanmış Denetim</value>
   </data>
   <data name="1018" xml:space="preserve">
-    <value>[Deneysel] Özel Denetim (WinUI 3)</value>
+    <value>[Deneysel] Şablonlanmış Denetim</value>
   </data>
   <data name="1019" xml:space="preserve">
-    <value>Windows UI Kitaplığı'nı (WinUI 3) temel alan uygulamalar için bir özel denetim.</value>
+    <value>Uygun varsayılan stile sahip boş bir özel denetim (WinUI).</value>
   </data>
   <data name="1021" xml:space="preserve">
-    <value>Kullanıcı Kontrolü (WinUI 3)</value>
+    <value>Kullanıcı Denetimi</value>
   </data>
   <data name="1022" xml:space="preserve">
-    <value>[Deneysel] Kullanıcı Kontrolü (WinUI 3)</value>
+    <value>[Deneysel] Kullanıcı Kontrolü</value>
   </data>
   <data name="1023" xml:space="preserve">
-    <value>Windows UI Kitaplığı'nı (WinUI 3) temel alan uygulamalar için bir kullanıcı kontrolü.</value>
+    <value>Boş bir kullanıcı kontrolü (WinUI).</value>
   </data>
   <data name="1025" xml:space="preserve">
-    <value>Sınıf Kitaplığı (Masaüstünde WinUI 3)</value>
+    <value>WinUI Sınıf Kitaplığı</value>
   </data>
   <data name="1026" xml:space="preserve">
-    <value>[Deneysel] Sınıf Kitaplığı (Masaüstünde WinUI 3)</value>
+    <value>[Deneysel] WinUI Sınıf Kitaplığı</value>
   </data>
   <data name="1027" xml:space="preserve">
-    <value>Windows UI Kitaplığı'nı (WinUI 3) temel alan Masaüstü uygulamaları için yönetilen bir sınıf kitaplığı (.dll) oluşturmaya yönelik bir proje.</value>
+    <value>Yönetilen sınıf kitaplığı (.dll) (WinUI) oluşturma projesi.</value>
   </data>
   <data name="1029" xml:space="preserve">
-    <value>Boş Uygulama, Paketli Windows Uygulama Paketleme Projesi (Masaüstünde WinUI 3)</value>
+    <value>WinUI Boş Uygulama (Windows Uygulama Paketleme Projesiyle Paketlenmiş)</value>
   </data>
   <data name="1030" xml:space="preserve">
-    <value>[Deneysel] Boş Uygulama, Paketli Windows Uygulama Paketleme Projesi (Masaüstünde WinUI 3)</value>
+    <value>[Deneysel] WinUI Boş Uygulama (Windows Uygulama Paketleme Projesiyle Paketlenmiş)</value>
   </data>
   <data name="1031" xml:space="preserve">
-    <value>Windows UI Kitaplığı’nı (WinUI 3) temel alan bir Masaüstü uygulaması oluşturmaya yönelik bir proje şablonu. Microsoft Store aracılığıyla dışarıdan yükleme veya dağıtım için bir MSIX paketi oluşturmak için Windows Uygulama Paketleme (WAP) projesi dahildir.</value>
+    <value>Bir WinUI uygulaması oluşturmaya yönelik bir proje şablonu. Microsoft Store aracılığıyla dışarıdan yükleme veya dağıtım için bir MSIX paketi oluşturmak için Windows Uygulama Paketleme (WAP) projesi dahildir.</value>
   </data>
   <data name="1033" xml:space="preserve">
-    <value>Boş Uygulama, Paketlenmiş (Masaüstünde WinUI 3)</value>
+    <value>WinUI Boş Uygulaması (Paketlenmiş)</value>
   </data>
   <data name="1034" xml:space="preserve">
-    <value>[Deneysel] Boş Uygulama, Paketlenmiş (Masaüstünde WinUI 3)</value>
+    <value>[Deneysel] WinUI Boş Uygulaması (Paketlenmiş)</value>
   </data>
   <data name="1035" xml:space="preserve">
-    <value>Microsoft Store aracılığıyla dışarıdan yükleme veya dağıtım için bir MSIX paketi ile birlikte Windows UI Kitaplığı’nı (WinUI 3) temel alan bir Masaüstü uygulaması oluşturmaya yönelik bir proje şablonu.</value>
+    <value>Microsoft Store aracılığıyla dışarıdan yükleme veya dağıtım için bir MSIX paketiyle birlikte WinUI uygulaması oluşturmaya yönelik bir proje şablonu.</value>
   </data>
   <data name="1037" xml:space="preserve">
-    <value>Birim Testi Uygulaması (Masaüstünde WinUI 3)</value>
+    <value>WinUI Birim Testi Uygulaması</value>
   </data>
   <data name="1038" xml:space="preserve">
-    <value>[Deneysel] Birim Testi Uygulaması (Masaüstünde WinUI 3)</value>
+    <value>[Deneysel] WinUI Birim Testi Uygulaması</value>
   </data>
   <data name="1039" xml:space="preserve">
-    <value>MSTest kullanarak WinUI 3 uygulamaları için bir birim testi uygulamasını oluşturmaya yönelik bir proje.</value>
+    <value>MSTest kullanarak WinUI için bir C# birim test uygulaması oluşturmaya yönelik bir proje.</value>
+  </data>
+  <data name="1040" xml:space="preserve">
+    <value>WinUI Boş Uygulaması</value>
+  </data>
+  <data name="1041" xml:space="preserve">
+    <value>Boş bir WinUI uygulaması oluşturmak için bir proje.</value>
+  </data>
+  <data name="1042" xml:space="preserve">
+    <value>WinUI için Windows Uygulama Paketleme Projesi</value>
+  </data>
+  <data name="1043" xml:space="preserve">
+    <value>Takım projesi aracılığıyla dışarıdan yükleme veya dağıtım için WinUI uygulamaları içeren MSIX paketleri Microsoft Store.</value>
+  </data>
+  <data name="1044" xml:space="preserve">
+    <value>Projeye NuGet paketleri yükleniyor...</value>
+  </data>
+  <data name="1045" xml:space="preserve">
+    <value>İşlem sürüyor...</value>
+  </data>
+  <data name="1046" xml:space="preserve">
+    <value>Eksik Paket Başvuruları</value>
+  </data>
+  <data name="1047" xml:space="preserve">
+    <value>Şu paketlere başvurular eklenemiyor: {0}: {1}. Lütfen derlemeden önce paket başvuruları ekleyin.</value>
+  </data>
+  <data name="1048" xml:space="preserve">
+    <value>[{0}] Şu paketlere başvurular eklenemiyor: {1}. Bu bir ortam hatasıdır. Projeyi derlemeden önce lütfen paket başvuruları ekleyin.</value>
+  </data>
+  <data name="1049" xml:space="preserve">
+    <value>NuGet Paketlerini yönet</value>
+  </data>
+  <data name="1050" xml:space="preserve">
+    <value>Hata ayrıntılarına bakın</value>
+  </data>
+  <data name="1051" xml:space="preserve">
+    <value>{0} için Eksik Paket Başvuruları:</value>
+  </data>
+  <data name="1052" xml:space="preserve">
+    <value>Derlemeden önce paket referanslarını el ile ekleyin.</value>
+  </data>
+  <data name="1053" xml:space="preserve">
+    <value>Genel</value>
+  </data>
+  <data name="1054" xml:space="preserve">
+    <value>Kullanılabilir çıkış bilgisi yok.</value>
   </data>
 </root>

--- a/dev/VSIX/Extension/Cs/Common/zh-CN/VSPackage.zh-CN.resx
+++ b/dev/VSIX/Extension/Cs/Common/zh-CN/VSPackage.zh-CN.resx
@@ -118,31 +118,31 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="1001" xml:space="preserve">
-    <value>空白窗口 (桌面版中的 WinUI 3)</value>
+    <value>空白窗口</value>
   </data>
   <data name="1002" xml:space="preserve">
-    <value>[实验性] 空白窗口(桌面版中的 WinUI 3)</value>
+    <value>[实验性] 空白窗口</value>
   </data>
   <data name="1003" xml:space="preserve">
-    <value>基于 Windows UI 库 (WinUI 3) 的桌面应用的空白窗口。</value>
+    <value>空白窗口(WinUI)。</value>
   </data>
   <data name="1005" xml:space="preserve">
-    <value>空白页 (WinUI 3)</value>
+    <value>空白页</value>
   </data>
   <data name="1006" xml:space="preserve">
-    <value>[实验性] 空白页 (WinUI 3)</value>
+    <value>[实验性] 空白页</value>
   </data>
   <data name="1007" xml:space="preserve">
-    <value>基于 Windows UI 库 (WinUI 3) 的应用的空白页。</value>
+    <value>空白页(WinUI)。</value>
   </data>
   <data name="1009" xml:space="preserve">
-    <value>资源字典 (WinUI 3)</value>
+    <value>资源字典</value>
   </data>
   <data name="1010" xml:space="preserve">
-    <value>[实验性] 资源字典 (WinUI 3)</value>
+    <value>[实验性] 资源字典</value>
   </data>
   <data name="1011" xml:space="preserve">
-    <value>基于 Windows UI 库 (WinUI 3) 应用的 XAML 资源的空密钥集合。</value>
+    <value>WinUI) (XAML 资源的空密钥集合。</value>
   </data>
   <data name="1013" xml:space="preserve">
     <value>资源文件 (.resw)</value>
@@ -151,60 +151,105 @@
     <value>[实验性] 资源文件 (.resw)</value>
   </data>
   <data name="1015" xml:space="preserve">
-    <value>用于存储基于 Windows UI 库 (WinUI 3) 的应用字符串和条件资源文件。</value>
+    <value>用于存储字符串和条件资源的文件(WinUI)。</value>
   </data>
   <data name="1017" xml:space="preserve">
-    <value>自定义控件 (WinUI 3)</value>
+    <value>模板化控件</value>
   </data>
   <data name="1018" xml:space="preserve">
-    <value>[实验性] 自定义控件 (WinUI 3)</value>
+    <value>[实验性] 模板化控件</value>
   </data>
   <data name="1019" xml:space="preserve">
-    <value>基于 Windows UI 库 (WinUI 3) 的应用的自定义控件。</value>
+    <value>具有适当默认样式的空白自定义控件 (WinUI)。</value>
   </data>
   <data name="1021" xml:space="preserve">
-    <value>用户控件 (WinUI 3)</value>
+    <value>用户控件</value>
   </data>
   <data name="1022" xml:space="preserve">
-    <value>[实验性] 用户控件 (WinUI 3)</value>
+    <value>[实验性] 用户控件</value>
   </data>
   <data name="1023" xml:space="preserve">
-    <value>基于 Windows UI 库 (WinUI 3) 的应用的用户控件。</value>
+    <value>空白用户控件(WinUI)。</value>
   </data>
   <data name="1025" xml:space="preserve">
-    <value>类库 (桌面版中的 WinUI 3)</value>
+    <value>WinUI 类库</value>
   </data>
   <data name="1026" xml:space="preserve">
-    <value>[实验性] 类库 (桌面版中的 WinUI 3)</value>
+    <value>[实验性] WinUI 类库</value>
   </data>
   <data name="1027" xml:space="preserve">
-    <value>用于创建基于 Windows UI 库 (WinUI 3) 桌面应用托管类库 (.dll) 的项目。</value>
+    <value>用于 (.dll) (WinUI) 创建托管类库的项目。</value>
   </data>
   <data name="1029" xml:space="preserve">
-    <value>空白应用，使用 Windows 应用程序打包项目打包(桌面版中的 WinUI 3)</value>
+    <value>WinUI 空白应用(使用 Windows 应用程序打包项目打包)</value>
   </data>
   <data name="1030" xml:space="preserve">
-    <value>[实验性] 空白应用，使用 Windows 应用程序打包项目打包(桌面版中的 WinUI 3)</value>
+    <value>[实验性] WinUI 空白应用(使用 Windows 应用程序打包项目打包)</value>
   </data>
   <data name="1031" xml:space="preserve">
-    <value>用于基于 Windows UI 库 (WinUI 3) 创建桌面应用的项目模板。包含 Windows 应用程序打包 (WAP) 项目，用于创建 MSIX 包，以便通过 Microsoft Store 进行旁加载或分发。</value>
+    <value>用于创建 WinUI 应用的项目模板。包含 Windows 应用程序打包(WAP)项目，用于创建 MSIX 包，以便通过 Microsoft Store 进行旁加载或分发。</value>
   </data>
   <data name="1033" xml:space="preserve">
-    <value>空白应用，已打包(桌面版中的 WinUI 3)</value>
+    <value>WinUI 空白应用(已打包)</value>
   </data>
   <data name="1034" xml:space="preserve">
-    <value>[实验性] 空白应用，已打包(桌面版中的 WinUI 3)</value>
+    <value>[实验性] WinUI 空白应用(已打包)</value>
   </data>
   <data name="1035" xml:space="preserve">
-    <value>用于基于 Windows UI 库 (WinUI 3) 创建桌面应用的项目模板，以及用于通过 Microsoft Store 旁加载或分发的 MSIX 包。</value>
+    <value>一个项目模板，用于创建 WinUI 应用以及 MSIX 包，以便通过 Microsoft Store 进行旁加载或分发。</value>
   </data>
   <data name="1037" xml:space="preserve">
-    <value>单元测试应用(桌面中的 WinUI 3)</value>
+    <value>WinUI 单元测试应用</value>
   </data>
   <data name="1038" xml:space="preserve">
-    <value>[Experimental] 单元测试应用(桌面中的 WinUI 3)</value>
+    <value>[实验性] WinUI 单元测试应用</value>
   </data>
   <data name="1039" xml:space="preserve">
-    <value>用于使用 MSTest 为 WinUI 3 应用创建单元测试应用的项目。</value>
+    <value>用于使用 MSTest 为 WinUI 创建 C# 单元测试应用的项目。</value>
+  </data>
+  <data name="1040" xml:space="preserve">
+    <value>WinUI 空白应用</value>
+  </data>
+  <data name="1041" xml:space="preserve">
+    <value>用于创建空 WinUI 应用的项目。</value>
+  </data>
+  <data name="1042" xml:space="preserve">
+    <value>适用于 WinUI 的 Windows 应用程序打包项目</value>
+  </data>
+  <data name="1043" xml:space="preserve">
+    <value>一个项目模板，用于创建 MSIX 包，其中包含用于通过Microsoft Store旁加载或分发的 WinUI 应用程序。</value>
+  </data>
+  <data name="1044" xml:space="preserve">
+    <value>正在将 NuGet 包安装到项目中...</value>
+  </data>
+  <data name="1045" xml:space="preserve">
+    <value>操作在进行中...</value>
+  </data>
+  <data name="1046" xml:space="preserve">
+    <value>缺少包引用</value>
+  </data>
+  <data name="1047" xml:space="preserve">
+    <value>无法为 {0} 添加对以下包的引用： {1}。请在生成前添加包引用。</value>
+  </data>
+  <data name="1048" xml:space="preserve">
+    <value>[{0}]无法添加对以下包的引用： {1}。这是环境错误。请在生成项目之前添加包引用。</value>
+  </data>
+  <data name="1049" xml:space="preserve">
+    <value>管理 NuGet 包</value>
+  </data>
+  <data name="1050" xml:space="preserve">
+    <value>查看错误详细信息</value>
+  </data>
+  <data name="1051" xml:space="preserve">
+    <value>{0} 缺少以下包引用:</value>
+  </data>
+  <data name="1052" xml:space="preserve">
+    <value>请在生成项目前手动添加包引用。</value>
+  </data>
+  <data name="1053" xml:space="preserve">
+    <value>常规</value>
+  </data>
+  <data name="1054" xml:space="preserve">
+    <value>没有可用的输出信息。</value>
   </data>
 </root>

--- a/dev/VSIX/Extension/Cs/Common/zh-TW/VSPackage.zh-TW.resx
+++ b/dev/VSIX/Extension/Cs/Common/zh-TW/VSPackage.zh-TW.resx
@@ -118,31 +118,31 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="1001" xml:space="preserve">
-    <value>空白視窗 (桌面中的 WinUI 3)</value>
+    <value>空白視窗</value>
   </data>
   <data name="1002" xml:space="preserve">
-    <value>[實驗性] 空白視窗 (桌面中的 WinUI 3)</value>
+    <value>[實驗性] 空白視窗</value>
   </data>
   <data name="1003" xml:space="preserve">
-    <value>使用 Windows UI 程式庫 (WinUI 3) 的傳統型應用程式空白視窗。</value>
+    <value>空白視窗 (WinUI)。</value>
   </data>
   <data name="1005" xml:space="preserve">
-    <value>空白頁 (WinUI 3)</value>
+    <value>空白頁</value>
   </data>
   <data name="1006" xml:space="preserve">
-    <value>[實驗性] 空白頁 (WinUI 3)</value>
+    <value>[實驗性] 空白頁</value>
   </data>
   <data name="1007" xml:space="preserve">
-    <value>使用 Windows UI 程式庫 (WinUI 3) 的應用程式空白頁面。</value>
+    <value>空白頁 (WinUI)。</value>
   </data>
   <data name="1009" xml:space="preserve">
-    <value>資源字典 (WinUI 3)</value>
+    <value>資源字典</value>
   </data>
   <data name="1010" xml:space="preserve">
-    <value>[實驗性] 資源字典 (WinUI 3)</value>
+    <value>[實驗性] 資源字典</value>
   </data>
   <data name="1011" xml:space="preserve">
-    <value>使用 Windows UI 程式庫 (WinUI 3) 之應用程式的 XAML 資源空白金鑰集合。</value>
+    <value>WinUI) (XAML 資源的空白金鑰集合。</value>
   </data>
   <data name="1013" xml:space="preserve">
     <value>資源檔 (.resw)</value>
@@ -151,60 +151,105 @@
     <value>[實驗性] 資源檔 (.resw)</value>
   </data>
   <data name="1015" xml:space="preserve">
-    <value>檔案，可儲存使用 Windows UI 程式庫 (WinUI 3) 之應用程式的字串和條件式資源。</value>
+    <value>用於在 WinUI) (儲存字串和條件式資源的檔案。</value>
   </data>
   <data name="1017" xml:space="preserve">
-    <value>自訂控制項 (WinUI 3)</value>
+    <value>範本控制項</value>
   </data>
   <data name="1018" xml:space="preserve">
-    <value>[實驗性] 自訂控制項 (WinUI 3)</value>
+    <value>[實驗性] 範本控制項</value>
   </data>
   <data name="1019" xml:space="preserve">
-    <value>使用 Windows UI 程式庫 (WinUI 3) 的應用程式自訂控制項。</value>
+    <value>具有適當預設樣式的空白自定義控件 (WinUI)。</value>
   </data>
   <data name="1021" xml:space="preserve">
-    <value>使用者控制項 (WinUI 3)</value>
+    <value>使用者控制項</value>
   </data>
   <data name="1022" xml:space="preserve">
-    <value>[實驗性] 使用者控制項 (WinUI 3)</value>
+    <value>[實驗性] 使用者控制項</value>
   </data>
   <data name="1023" xml:space="preserve">
-    <value>使用 Windows UI 程式庫 (WinUI 3) 的應用程式使用者控制項。</value>
+    <value>空白使用者控制項 (WinUI)。</value>
   </data>
   <data name="1025" xml:space="preserve">
-    <value>類別庫 (桌面中的 WinUI 3)</value>
+    <value>WinUI 類別庫</value>
   </data>
   <data name="1026" xml:space="preserve">
-    <value>[實驗性] 類別庫 (桌面中的 WinUI 3)</value>
+    <value>[實驗性] WinUI 類別庫</value>
   </data>
   <data name="1027" xml:space="preserve">
-    <value>專案，可用於建立使用 Windows UI 程式庫 (WinUI 3) 之傳統型應用程式的受管理類別庫 (.dll)。</value>
+    <value>用於建立 WinUI) (.dll) (受管理類別庫的專案。</value>
   </data>
   <data name="1029" xml:space="preserve">
-    <value>空白應用程式，與 Windows 應用程式封裝專案 (電腦版 WinUI 3)</value>
+    <value>WinUI 空白應用程式 (與 Windows 應用程式封裝專案封裝)</value>
   </data>
   <data name="1030" xml:space="preserve">
-    <value>[實驗性]空白應用程式，與 Windows 應用程式封裝專案 (電腦版 WinUI 3)</value>
+    <value>[實驗性] WinUI 空白應用程式 (與 Windows 應用程式封裝專案封裝)</value>
   </data>
   <data name="1031" xml:space="preserve">
-    <value>專案範本，用於建立使用 Windows UI 程式庫 (WinUI 3) 的傳統型應用程式。會包含 Windows 應用程式封裝 (WAP) 專案，以建立 MSIX 套件，以便透過 Microsoft Store 側載或散佈。</value>
+    <value>用於建立 WinUI 應用程式的專案範本。會包含 Windows 應用程式封裝 (WAP) 專案，以建立 MSIX 套件，以便透過 Microsoft Store 側載或散佈。</value>
   </data>
   <data name="1033" xml:space="preserve">
-    <value>空白應用程式，已封裝 (桌面中的 WinUI 3)</value>
+    <value>WinUI 空白應用程式 (已封裝)</value>
   </data>
   <data name="1034" xml:space="preserve">
-    <value>[實驗性] 空白應用程式，已封裝 (桌面中的 WinUI 3)</value>
+    <value>[實驗性] WinUI 空白應用程式 (已封裝)</value>
   </data>
   <data name="1035" xml:space="preserve">
-    <value>專案範本，用於建立使用 Windows UI 程式庫 (WinUI 3) 的傳統型應用程式以及 MSIX 套件，以便透過 Microsoft Store 側載或散佈。</value>
+    <value>用於建立 WinUI 應用程式以及 MSIX 套件，以便透過 Microsoft Store 側載或發行的專案範本。</value>
   </data>
   <data name="1037" xml:space="preserve">
-    <value>單元測試應用程式 (電腦版 WinUI 3)</value>
+    <value>WinUI 單元測試應用程式</value>
   </data>
   <data name="1038" xml:space="preserve">
-    <value>[實驗性] 單元測試應用程式 (電腦版 WinUI 3)</value>
+    <value>[實驗性] WinUI 單元測試應用程式</value>
   </data>
   <data name="1039" xml:space="preserve">
-    <value>用於使用 MSTest 為 WinUI 3 應用程式建立單元測試應用程式的專案。</value>
+    <value>用於使用 MSTest 為 WinUI 建立 C# 單元測試應用程式的專案。</value>
+  </data>
+  <data name="1040" xml:space="preserve">
+    <value>WinUI 空白應用程式</value>
+  </data>
+  <data name="1041" xml:space="preserve">
+    <value>用於建立空白 WinUI 應用程式的專案。</value>
+  </data>
+  <data name="1042" xml:space="preserve">
+    <value>WinUI 的 Windows 應用程式封裝專案</value>
+  </data>
+  <data name="1043" xml:space="preserve">
+    <value>此項目範本會建立 MSIX 套件，其中包含 WinUI 應用程式以透過Microsoft Store側載或散發。</value>
+  </data>
+  <data name="1044" xml:space="preserve">
+    <value>正在將 NuGet 套件安裝到專案中...</value>
+  </data>
+  <data name="1045" xml:space="preserve">
+    <value>操作進行中...</value>
+  </data>
+  <data name="1046" xml:space="preserve">
+    <value>缺少套件參考</value>
+  </data>
+  <data name="1047" xml:space="preserve">
+    <value>無法為以下套件添加參考，{0}：{1}。請在製作前加入套件參考資料。</value>
+  </data>
+  <data name="1048" xml:space="preserve">
+    <value>[{0}]無法新增以下套件的參考：{1}。這是環境錯誤。請在建置專案前先加入套件參考。</value>
+  </data>
+  <data name="1049" xml:space="preserve">
+    <value>管理 NuGet 套件</value>
+  </data>
+  <data name="1050" xml:space="preserve">
+    <value>請參閱錯誤詳細資料</value>
+  </data>
+  <data name="1051" xml:space="preserve">
+    <value>缺少 {0} 的套件參考:</value>
+  </data>
+  <data name="1052" xml:space="preserve">
+    <value>請在建置之前手動新增套件參考。</value>
+  </data>
+  <data name="1053" xml:space="preserve">
+    <value>一般</value>
+  </data>
+  <data name="1054" xml:space="preserve">
+    <value>沒有可用的輸出資訊。</value>
   </data>
 </root>


### PR DESCRIPTION
This PR completes the localization efforts in #5989 and #6059 by updating all the language resource files to their updated versions.

Local validation:
* Uninstalled the WinUI template VSIXes on Visual Studio
* Built the Standalone VSIX files for both languages (C# and C++)
* Installed the local VSIX files
* Verified the NuGet wizard displays the localized messages when installing packages (used es-ES)
* Verified the NuGet wizard displays the localized error messages when packages fail to install (used es-ES)
* Verified that the "General" tab was localized in the output window (used zh-CN)

A microsoft employee must use /azp run to validate using the pipelines below.

WARNING:
Comments made by azure-pipelines bot maybe inaccurate.
Please see pipeline link to verify that the build is being ran.

For status checks on the main branch, please use TransportPackage-Foundation-PR
(https://microsoft.visualstudio.com/ProjectReunion/_build?definitionId=81063&_a=summary)
and run the build against your PR branch with the default parameters.
