### PR TITLE
Move validateRuntimeCompatibility from condition to 'if' statement

### DIFF
--- a/build/WindowsAppSDK-Foundation-Official.yml
+++ b/build/WindowsAppSDK-Foundation-Official.yml
@@ -107,28 +107,29 @@ extends:
 
     stages:
 
-    - stage: ManualValidation_RuntimeCompatibility
-      displayName: 'Manual Validation - RuntimeCompatibilityChange Enums'
-      # Only run this validation for release branches
-      condition: and(contains(variables['Build.SourceBranch'], 'release/'), eq(parameters.validateRuntimeCompatibility, true))
-      dependsOn: []
-      jobs:
-      - job: waitForValidation
-        displayName: 'Wait for external validation'
-        pool: server
-        timeoutInMinutes: 120 # 2 hours timeout
-        steps:
-        - task: ManualValidation@0
-          displayName: 'Confirm RuntimeCompatibilityChange Enums Added'
-          inputs:
-            notifyUsers: ''
-            instructions: |
-              SERVICING BUILD - RuntimeCompatibilityChange VALIDATION
+    - ${{ if eq(parameters.validateRuntimeCompatibility, 'true') }}:
+      - stage: ManualValidation_RuntimeCompatibility
+        displayName: 'Manual Validation - RuntimeCompatibilityChange Enums'
+        # Only run this validation for release branches
+        condition: contains(variables['Build.SourceBranch'], 'release/')
+        dependsOn: []
+        jobs:
+        - job: waitForValidation
+          displayName: 'Wait for external validation'
+          pool: server
+          timeoutInMinutes: 120 # 2 hours timeout
+          steps:
+          - task: ManualValidation@0
+            displayName: 'Confirm RuntimeCompatibilityChange Enums Added'
+            inputs:
+              notifyUsers: ''
+              instructions: |
+                SERVICING BUILD - RuntimeCompatibilityChange VALIDATION
 
-              Verify dev/RuntimeCompatibilityOptions/RuntimeCompatibilityOptions.idl in Foundation
+                Verify dev/RuntimeCompatibilityOptions/RuntimeCompatibilityOptions.idl in Foundation
 
-              Unless none of the servicing changes have containment, Foundation MUST include the RuntimeCompatibilityChange
-              enum values associated with this servicing release before kicking off this official build.
+                Unless none of the servicing changes have containment, Foundation MUST include the RuntimeCompatibilityChange
+                enum values associated with this servicing release before kicking off this official build.
     
     - template: AzurePipelinesTemplates\WindowsAppSDK-Build-Stage.yml@self
       parameters:


### PR DESCRIPTION
A microsoft employee must use /azp run to validate using the pipelines below.

WARNING:
Comments made by azure-pipelines bot maybe inaccurate.
Please see pipeline link to verify that the build is being ran.

For status checks on the main branch, please use TransportPackage-Foundation-PR
(https://microsoft.visualstudio.com/ProjectReunion/_build?definitionId=81063&_a=summary)
and run the build against your PR branch with the default parameters.
