### PR TITLE
Removing workaround on App Notification Conferencing Config for calling IsCallingPreviewSupported

### DIFF
--- a/dev/AppNotifications/AppNotification.cpp
+++ b/dev/AppNotifications/AppNotification.cpp
@@ -129,7 +129,7 @@ namespace winrt::Microsoft::Windows::AppNotifications::implementation
 
     void AppNotification::ConferencingConfig(winrt::Microsoft::Windows::AppNotifications::AppNotificationConferencingConfig const& conferencingConfig)
     {
-        THROW_HR_IF(E_NOTIMPL, !::Microsoft::Windows::AppNotifications::AppNotificationConferencingConfig::IsCallingPreviewSupported());
+        THROW_HR_IF(E_NOTIMPL, !AppNotificationConferencingConfig::IsCallingPreviewSupported());
         auto lock{ m_lock.lock_exclusive() };
         m_conferencingConfig = conferencingConfig;
     }

--- a/dev/AppNotifications/AppNotificationBuilder/AppNotificationBuilder.cpp
+++ b/dev/AppNotifications/AppNotificationBuilder/AppNotificationBuilder.cpp
@@ -404,7 +404,7 @@ namespace winrt::Microsoft::Windows::AppNotifications::Builder::implementation
 
     winrt::Microsoft::Windows::AppNotifications::Builder::AppNotificationBuilder AppNotificationBuilder::AddCameraPreview()
     {
-        THROW_HR_IF(E_NOTIMPL, !::Microsoft::Windows::AppNotifications::AppNotificationConferencingConfig::IsCallingPreviewSupported());
+        THROW_HR_IF(E_NOTIMPL, !winrt::Microsoft::Windows::AppNotifications::implementation::AppNotificationConferencingConfig::IsCallingPreviewSupported());
 
         THROW_HR_IF_MSG(E_INVALIDARG, m_useCameraPreview, "CameraPreview element is already added, only one is allowed");
 

--- a/dev/AppNotifications/AppNotificationBuilder/AppNotificationButton.cpp
+++ b/dev/AppNotifications/AppNotificationBuilder/AppNotificationButton.cpp
@@ -139,7 +139,7 @@ namespace winrt::Microsoft::Windows::AppNotifications::Builder::implementation
 
     winrt::Microsoft::Windows::AppNotifications::Builder::AppNotificationButton AppNotificationButton::SetSettingStyle(AppNotificationButtonSettingStyle const& value)
     {
-        THROW_HR_IF(E_NOTIMPL, !::Microsoft::Windows::AppNotifications::AppNotificationConferencingConfig::IsCallingPreviewSupported());
+        THROW_HR_IF(E_NOTIMPL, !winrt::Microsoft::Windows::AppNotifications::implementation::AppNotificationConferencingConfig::IsCallingPreviewSupported());
 
         m_settingType = value;
         return *this;

--- a/dev/AppNotifications/AppNotificationConferencingConfig.cpp
+++ b/dev/AppNotifications/AppNotificationConferencingConfig.cpp
@@ -51,12 +51,3 @@ namespace winrt::Microsoft::Windows::AppNotifications::implementation
         return isSupported;
     }
 }
-
-bool Microsoft::Windows::AppNotifications::AppNotificationConferencingConfig::IsCallingPreviewSupported()
-{
-#if WINDOWSAPPRUNTIME_MICROSOFT_WINDOWS_CALLINGPREVIEWSUPPORT_FEATURE_CALLINGPREVIEWSUPPORT_ENABLED == 1
-    return winrt::Microsoft::Windows::AppNotifications::AppNotificationConferencingConfig::IsCallingPreviewSupported();
-#else
-    return false;
-#endif
-}

--- a/dev/AppNotifications/AppNotificationConferencingConfig.h
+++ b/dev/AppNotifications/AppNotificationConferencingConfig.h
@@ -35,8 +35,3 @@ namespace winrt::Microsoft::Windows::AppNotifications::factory_implementation
     {
     };
 }
-
-namespace Microsoft::Windows::AppNotifications::AppNotificationConferencingConfig
-{
-    bool IsCallingPreviewSupported();
-}

--- a/dev/AppNotifications/AppNotificationManager.cpp
+++ b/dev/AppNotifications/AppNotificationManager.cpp
@@ -55,7 +55,6 @@ namespace PushNotificationHelpers
 
 using namespace Microsoft::Windows::AppNotifications::Helpers;
 using namespace Microsoft::Windows::AppNotifications::ShellLocalization;
-using namespace Microsoft::Windows::AppNotifications::AppNotificationConferencingConfig;
 
 namespace winrt::Microsoft::Windows::AppNotifications::implementation
 {
@@ -436,7 +435,7 @@ namespace winrt::Microsoft::Windows::AppNotifications::implementation
             notification.Payload(),
             notification.Tag(),
             notification.Group(),
-            IsCallingPreviewSupported()) };
+            AppNotificationConferencingConfig::IsCallingPreviewSupported()) };
 
         THROW_HR_IF(WPN_E_NOTIFICATION_POSTED, notification.Id() != 0);
 

--- a/dev/AppNotifications/NotificationProperties.cpp
+++ b/dev/AppNotifications/NotificationProperties.cpp
@@ -50,7 +50,7 @@ NotificationProperties::NotificationProperties(winrt::AppNotification const& toa
         m_toastProgressData = winrt::make_self<NotificationProgressData>(toastNotification.Progress());
     }
 
-    if (Microsoft::Windows::AppNotifications::AppNotificationConferencingConfig::IsCallingPreviewSupported())
+    if (winrt::implementation::AppNotificationConferencingConfig::IsCallingPreviewSupported())
     {
         if (auto config = toastNotification.ConferencingConfig())
         {


### PR DESCRIPTION
[ADO bug](https://microsoft.visualstudio.com/OS/_workitems/edit/56154668)

This PR removes the workaround on `AppNotificationConferencingConfig.cpp` that adds a `bool winrt::Microsoft::Windows::AppNotifications::AppNotificationConferencingConfig::IsCallingPreviewSupported()` when the velocity key is not enabled for that feature.

From the internal bug comment, it was suspected that the [generation of the stripped winmd files](https://github.com/microsoft/WindowsAppSDK/blob/1c2298d472786bd18ce7ae37557998e183a127d7/dev/WindowsAppRuntime_DLL/WindowsAppRuntime_DLL.vcxproj#L311-L317) was a possible reason for that inconsistency.

From my investigation, the above linked target has no influence on this issue. Removing it from the build process had no effect on fixing the linker issues when the velocity key is disabled.

According to the [documentation](https://github.com/microsoft/WindowsAppSDK/blob/1c2298d472786bd18ce7ae37557998e183a127d7/docs/Coding-Guidelines/TerminalVelocity.md), the terminal velocity features should just affect the stripped winmds generated by the target, but this is not what is happening. The terminal velocity features also affect the MIDL compilation, and the object files (and generated headers) resulted by it.

For the `AppNotificationConferencingConfig.cpp`, depending on the velocity key state, we can have these two different scenarios:

> Using `dumpbin /symbols AppNotificationConferencingConfig.obj | findstr "IsCallingPreviewSupported"`

### Key disabled

```
475 00000000 SECT123 notype ()    External    | ?IsCallingPreviewSupported@AppNotificationConferencingConfig@implementation@AppNotifications@Windows@Microsoft@winrt@@SA_NXZ (public: static bool __cdecl winrt::Microsoft::Windows::AppNotifications::implementation::AppNotificationConferencingConfig::IsCallingPreviewSupported(void))
49F 00000000 UNDEF  notype ()    External     | WnpNotifications_IsCallingPreviewSupported
95D 00000000 SECT312 notype       Static      | $unwind$?IsCallingPreviewSupported@AppNotificationConferencingConfig@implementation@AppNotifications@Windows@Microsoft@winrt@@SA_NXZ
960 00000000 SECT313 notype       Static      | $pdata$?IsCallingPreviewSupported@AppNotificationConferencingConfig@implementation@AppNotifications@Windows@Microsoft@winrt@@SA_NXZ
```

### Key enabled

```
480 00000000 SECT136 notype ()    External    | ?IsCallingPreviewSupported@AppNotificationConferencingConfig@AppNotifications@Windows@Microsoft@winrt@@SA_NXZ (public: static bool __cdecl winrt::Microsoft::Windows::AppNotifications::AppNotificationConferencingConfig::IsCallingPreviewSupported(void))
4A8 00000000 SECT138 notype ()    External    | ?IsCallingPreviewSupported@AppNotificationConferencingConfig@implementation@AppNotifications@Windows@Microsoft@winrt@@SA_NXZ (public: static bool __cdecl winrt::Microsoft::Windows::AppNotifications::implementation::AppNotificationConferencingConfig::IsCallingPreviewSupported(void))
4BA 00000000 SECT133 notype ()    External    | ?IsCallingPreviewSupported@?$produce@UAppNotificationConferencingConfig@factory_implementation@AppNotifications@Windows@Microsoft@winrt@@UIAppNotificationConferencingConfigStatics@3456@@impl@winrt@@UEAAHPEA_N@Z (public: virtual int __cdecl winrt::impl::produce<struct winrt::Microsoft::Windows::AppNotifications::factory_implementation::AppNotificationConferencingConfig,struct winrt::Microsoft::Windows::AppNotifications::IAppNotificationConferencingConfigStatics>::IsCallingPreviewSupported(bool *))
4D9 00000000 UNDEF  notype ()    External     | WnpNotifications_IsCallingPreviewSupported
4FE 00000000 SECT135 notype ()    Static      | ?catch$0@?0??IsCallingPreviewSupported@?$produce@UAppNotificationConferencingConfig@factory_implementation@AppNotifications@Windows@Microsoft@winrt@@UIAppNotificationConferencingConfigStatics@3456@@impl@winrt@@UEAAHPEA_N@Z@4HA (int `public: virtual int __cdecl winrt::impl::produce<struct winrt::Microsoft::Windows::AppNotifications::factory_implementation::AppNotificationConferencingConfig,struct winrt::Microsoft::Windows::AppNotifications::IAppNotificationConferencingConfigStatics>::IsCallingPreviewSupported(bool *)'::`1'::catch$0)
5A3 0000000D SECT135 notype ()    Static      | __catch$?IsCallingPreviewSupported@?$produce@UAppNotificationConferencingConfig@factory_implementation@AppNotifications@Windows@Microsoft@winrt@@UIAppNotificationConferencingConfigStatics@3456@@impl@winrt@@UEAAHPEA_N@Z$0
9A0 00000000 SECT32B notype       Static      | $unwind$?IsCallingPreviewSupported@AppNotificationConferencingConfig@implementation@AppNotifications@Windows@Microsoft@winrt@@SA_NXZ
9A3 00000000 SECT32C notype       Static      | $pdata$?IsCallingPreviewSupported@AppNotificationConferencingConfig@implementation@AppNotifications@Windows@Microsoft@winrt@@SA_NXZ
9F4 00000000 SECT347 notype       Static      | $unwind$?IsCallingPreviewSupported@?$produce@UAppNotificationConferencingConfig@factory_implementation@AppNotifications@Windows@Microsoft@winrt@@UIAppNotificationConferencingConfigStatics@3456@@impl@winrt@@UEAAHPEA_N@Z
9F7 00000000 SECT348 notype       Static      | $pdata$?IsCallingPreviewSupported@?$produce@UAppNotificationConferencingConfig@factory_implementation@AppNotifications@Windows@Microsoft@winrt@@UIAppNotificationConferencingConfigStatics@3456@@impl@winrt@@UEAAHPEA_N@Z
9FA 00000000 SECT349 notype       Static      | $cppxdata$?IsCallingPreviewSupported@?$produce@UAppNotificationConferencingConfig@factory_implementation@AppNotifications@Windows@Microsoft@winrt@@UIAppNotificationConferencingConfigStatics@3456@@impl@winrt@@UEAAHPEA_N@Z
9FD 00000000 SECT34A notype       Static      | $stateUnwindMap$?IsCallingPreviewSupported@?$produce@UAppNotificationConferencingConfig@factory_implementation@AppNotifications@Windows@Microsoft@winrt@@UIAppNotificationConferencingConfigStatics@3456@@impl@winrt@@UEAAHPEA_N@Z
A00 00000000 SECT34B notype       Static      | $tryMap$?IsCallingPreviewSupported@?$produce@UAppNotificationConferencingConfig@factory_implementation@AppNotifications@Windows@Microsoft@winrt@@UIAppNotificationConferencingConfigStatics@3456@@impl@winrt@@UEAAHPEA_N@Z
A03 00000000 SECT34C notype       Static      | $handlerMap$?IsCallingPreviewSupported@?$produce@UAppNotificationConferencingConfig@factory_implementation@AppNotifications@Windows@Microsoft@winrt@@UIAppNotificationConferencingConfigStatics@3456@@impl@winrt@@UEAAHPEA_N@Z
A06 00000000 SECT34D notype       Static      | $ip2state$?IsCallingPreviewSupported@?$produce@UAppNotificationConferencingConfig@factory_implementation@AppNotifications@Windows@Microsoft@winrt@@UIAppNotificationConferencingConfigStatics@3456@@impl@winrt@@UEAAHPEA_N@Z
A09 00000000 SECT34E notype       Static      | $unwind$?catch$0@?0??IsCallingPreviewSupported@?$produce@UAppNotificationConferencingConfig@factory_implementation@AppNotifications@Windows@Microsoft@winrt@@UIAppNotificationConferencingConfigStatics@3456@@impl@winrt@@UEAAHPEA_N@Z@4HA
A0C 00000000 SECT34F notype       Static      | $pdata$?catch$0@?0??IsCallingPreviewSupported@?$produce@UAppNotificationConferencingConfig@factory_implementation@AppNotifications@Windows@Microsoft@winrt@@UIAppNotificationConferencingConfigStatics@3456@@impl@winrt@@UEAAHPEA_N@Z@4HA
A0F 00000000 SECT350 notype       Static      | $cppxdata$?catch$0@?0??IsCallingPreviewSupported@?$produce@UAppNotificationConferencingConfig@factory_implementation@AppNotifications@Windows@Microsoft@winrt@@UIAppNotificationConferencingConfigStatics@3456@@impl@winrt@@UEAAHPEA_N@Z@4HA
A12 00000000 SECT351 notype       Static      | $stateUnwindMap$?catch$0@?0??IsCallingPreviewSupported@?$produce@UAppNotificationConferencingConfig@factory_implementation@AppNotifications@Windows@Microsoft@winrt@@UIAppNotificationConferencingConfigStatics@3456@@impl@winrt@@UEAAHPEA_N@Z@4HA
A15 00000000 SECT352 notype       Static      | $ip2state$?catch$0@?0??IsCallingPreviewSupported@?$produce@UAppNotificationConferencingConfig@factory_implementation@AppNotifications@Windows@Microsoft@winrt@@UIAppNotificationConferencingConfigStatics@3456@@impl@winrt@@UEAAHPEA_N@Z@4HA
```

Getting the `AppNotificationManager.obj` as example, we have:

```
2252 00000000 UNDEF  notype ()    External     | ?IsCallingPreviewSupported@AppNotificationConferencingConfig@AppNotifications@Windows@Microsoft@winrt@@SA_NXZ (public: static bool __cdecl winrt::Microsoft::Windows::AppNotifications::AppNotificationConferencingConfig::IsCallingPreviewSupported(void))
```

The symbol it tries to import is only present on the `AppNotificationConferencingConfig.obj` generated with the velocity key enabled (symbol in the first line).

On [MIDL 3.0 documentation](https://learn.microsoft.com/en-us/uwp/midl-3/reserved-keywords), there is no explanation on the detail of how the `feature` keyword works. For now, I am understanding that its behavior strips out the static method gatekept by the velocity key out of the generated headers, as that is what I saw by investigating them, as shown as following:

## Analyzing `Microsoft.Windows.AppNotifications.AppNotificationConferencingConfig.g.cpp`

### Key disabled

```c++
void* winrt_make_Microsoft_Windows_AppNotifications_AppNotificationConferencingConfig()
{
    return winrt::detach_abi(winrt::make<winrt::Microsoft::Windows::AppNotifications::factory_implementation::AppNotificationConferencingConfig>());
}
WINRT_EXPORT namespace winrt::Microsoft::Windows::AppNotifications
{
    AppNotificationConferencingConfig::AppNotificationConferencingConfig() :
        AppNotificationConferencingConfig(make<Microsoft::Windows::AppNotifications::implementation::AppNotificationConferencingConfig>())
    {
    }
}
```

### Key enabled

```c++

void* winrt_make_Microsoft_Windows_AppNotifications_AppNotificationConferencingConfig()
{
    return winrt::detach_abi(winrt::make<winrt::Microsoft::Windows::AppNotifications::factory_implementation::AppNotificationConferencingConfig>());
}
WINRT_EXPORT namespace winrt::Microsoft::Windows::AppNotifications
{
    AppNotificationConferencingConfig::AppNotificationConferencingConfig() :
        AppNotificationConferencingConfig(make<Microsoft::Windows::AppNotifications::implementation::AppNotificationConferencingConfig>())
    {
    }
    bool AppNotificationConferencingConfig::IsCallingPreviewSupported()
    {
        return Microsoft::Windows::AppNotifications::implementation::AppNotificationConferencingConfig::IsCallingPreviewSupported();
    }
}
```

That way, I think the best solution is to not have this method as a winrt method conditioned to a velocity key that is called in different parts of our code, and instead have it as a regular C++ function that implementation changes depending on the velocity key locally, making it clear where the method is defined and removing the need of a workaround.

A microsoft employee must use /azp run to validate using the pipelines below.

WARNING:
Comments made by azure-pipelines bot maybe inaccurate.
Please see pipeline link to verify that the build is being ran.

For status checks on the main branch, please use TransportPackage-Foundation-PR
(https://microsoft.visualstudio.com/ProjectReunion/_build?definitionId=81063&_a=summary)
and run the build against your PR branch with the default parameters.