### PR TITLE
Test-VisualStudioComponent now detects missing components

### DIFF
--- a/tools/DevCheck/DevCheck.ps1
+++ b/tools/DevCheck/DevCheck.ps1
@@ -683,7 +683,10 @@ function Test-VisualStudioComponent
     try
     {
         $value = Run-Process $vswhere_exe $args -throwIfExitCodeIsFailure $true
-        $path = $path -replace [environment]::NewLine, ''
+        if ([string]::IsNullOrEmpty($value))
+        {
+            throw "Component"
+        }
         Write-Verbose "Visual Studio component $($component) = $($value)"
         return 0
     }


### PR DESCRIPTION
DevCheck.ps1 purported to check for missing VS components, but this logic is busted.

vswhere was dutifully returning an empty string when it couldn't find a VS instance with the required components. But DevCheck wasn't checking that this empty string meant something was missing.

I discovered this after standing up a new dev environment and hitting problems.

Before:
`DevCheck.cmd -CheckVisualStudio` reported no errors.

After:
`DevCheck.cmd -CheckVisualStudio` reports missing components. For example:
```
ERROR Component: Microsoft.VisualStudio.Component.VC.Runtimes.ARM64EC.Spectre not found or valid
```
