### PR TITLE
Add upper bound for Foundation nuspec

### DIFF
--- a/BuildAll.ps1
+++ b/BuildAll.ps1
@@ -577,7 +577,11 @@ Try {
                 exit 1
             }
 
-            $dependency.version = $buildDependency.Version
+            $_dependencyMinVersion = $buildDependency.Version
+            $_numericVersion = $_dependencyMinVersion -replace '[-+].*$', ''  # Remove suffix
+            $_parsedVersion = [System.Version]$_numericVersion
+            $_dependencyMaxVersion = "$($_parsedVersion.Major + 1).0.0"
+            $dependency.version = "[${_dependencyMinVersion}, ${_dependencyMaxVersion})"
         }
 
         Set-Content -Value $publicNuspec.OuterXml $nuspecPath


### PR DESCRIPTION
A microsoft employee must use /azp run to validate using the pipelines below.

WARNING:
Comments made by azure-pipelines bot maybe inaccurate.
Please see pipeline link to verify that the build is being ran.

For status checks on the main branch, please use TransportPackage-Foundation-PR
(https://microsoft.visualstudio.com/ProjectReunion/_build?definitionId=81063&_a=summary)
and run the build against your PR branch with the default parameters.
