### PR TITLE
Add -UseBasicParsing to Invoke-WebRequest calls

### DIFF
--- a/build/scripts/DownloadDotNetRuntimeInstaller.ps1
+++ b/build/scripts/DownloadDotNetRuntimeInstaller.ps1
@@ -41,7 +41,7 @@ else
 if(-not(Test-Path $outputPath))
 {
     Write-Host "Downloading $downloadurl to $outputPath"
-    Invoke-WebRequest $downloadurl -OutFile $outputPath
+    Invoke-WebRequest $downloadurl -OutFile $outputPath -UseBasicParsing
 }
 else
 {

--- a/build/scripts/DownloadVCLibsDesktop.ps1
+++ b/build/scripts/DownloadVCLibsDesktop.ps1
@@ -21,7 +21,7 @@ $downloadurl = "https://aka.ms/Microsoft.VCLibs.$Platform.14.00.Desktop.appx"
 if(-not(Test-Path $outputPath))
 {
     Write-Host "Downloading $downloadurl to $outputPath"
-    Invoke-WebRequest $downloadurl -OutFile $outputPath
+    Invoke-WebRequest $downloadurl -OutFile $outputPath -UseBasicParsing
 }
 else
 {

--- a/build/scripts/DownloadVCRedistInstaller.ps1
+++ b/build/scripts/DownloadVCRedistInstaller.ps1
@@ -21,7 +21,7 @@ $downloadurl = "https://aka.ms/vs/17/release/vc_redist.$Platform.exe"
 if(-not(Test-Path $outputPath))
 {
     Write-Host "Downloading $downloadurl to $outputPath"
-    Invoke-WebRequest $downloadurl -OutFile $outputPath
+    Invoke-WebRequest $downloadurl -OutFile $outputPath -UseBasicParsing
 }
 else
 {

--- a/build/scripts/windows-sdk.ps1
+++ b/build/scripts/windows-sdk.ps1
@@ -26,7 +26,7 @@ function Install-EXE
         Write-Host "Downloading $Name..."
         $FilePath = "${env:Temp}\$Name"
 
-        Invoke-WebRequest -Uri $Url -OutFile $FilePath
+        Invoke-WebRequest -Uri $Url -OutFile $FilePath -UseBasicParsing
 
         Write-Host "Starting Install $Name..."
         $process = Start-Process -FilePath $FilePath -ArgumentList $ArgumentList -Wait -PassThru

--- a/dev/MRTCore/build/DownloadDotNetCoreSdk.ps1
+++ b/dev/MRTCore/build/DownloadDotNetCoreSdk.ps1
@@ -154,7 +154,7 @@ Write-Host "Installing .NET SDK..."
 
 [System.Net.ServicePointManager]::SecurityProtocol = [System.Net.SecurityProtocolType]'Ssl3,Tls,Tls11,Tls12'
 
-Invoke-WebRequest https://dot.net/v1/dotnet-install.ps1 -OutFile $dotnetInstallScript
+Invoke-WebRequest https://dot.net/v1/dotnet-install.ps1 -OutFile $dotnetInstallScript -UseBasicParsing
 
 if (-not $latestAlreadyInstalled)
 {

--- a/dev/MRTCore/build/MSBuildFunctions.psm1
+++ b/dev/MRTCore/build/MSBuildFunctions.psm1
@@ -18,7 +18,7 @@ $MSBuildUninstallParams = "uninstall --norestart --quiet --wait --force --instal
 function Download-MSBuild([string]$OutFile)
 {
     Write-Host -NoNewline "Downloading $OutFile... "
-    Invoke-WebRequest -Uri $MSBuildInstallURI -OutFile $OutFile
+    Invoke-WebRequest -Uri $MSBuildInstallURI -OutFile $OutFile -UseBasicParsing
     Write-Host -ForegroundColor Green Done.
 }
 


### PR DESCRIPTION
to ensure PowerShell 5.1 compatibility and avoid IE DOM parser dependency.

A microsoft employee must use /azp run to validate using the pipelines below.

WARNING:
Comments made by azure-pipelines bot maybe inaccurate.
Please see pipeline link to verify that the build is being ran.

For status checks on the main branch, please use TransportPackage-Foundation-PR
(https://microsoft.visualstudio.com/ProjectReunion/_build?definitionId=81063&_a=summary)
and run the build against your PR branch with the default parameters.
