### PR TITLE
Update the right logic on replacing packages after WinAppSDK-Samples update as Centralized Nuget Management for vcxproj

### DIFF
--- a/test/ModifySampleAppsReferences.ps1
+++ b/test/ModifySampleAppsReferences.ps1
@@ -69,29 +69,14 @@ Get-ChildItem -Recurse packages.config -Path $SampleRepoRoot | foreach-object {
     Write-Host "Modified " $_.FullName 
 }
 
-Get-ChildItem -Recurse *.vcxproj -Path $SampleRepoRoot | foreach-object {
-    $newPackageReference = 'PackageReference Include="Microsoft.WindowsAppSDK.Foundation"'
-    $oldPackageReference = 'PackageReference Include="Microsoft\.WindowsAppSDK"'
-    $content = Get-Content $_.FullName -Raw
-    $content = $content -replace $oldPackageReference, $newPackageReference
-    Set-Content -Path $_.FullName -Value $content
-    Write-Host "Modified " $_.FullName 
-}
-
-Get-ChildItem -Recurse *.wapproj -Path $SampleRepoRoot | foreach-object {
-    $newPackageReference = 'PackageReference Include="Microsoft.WindowsAppSDK.Foundation"'
-    $oldPackageReference = 'PackageReference Include="Microsoft\.WindowsAppSDK"'
-    $content = Get-Content $_.FullName -Raw
-    $content = $content -replace $oldPackageReference, $newPackageReference
-    Set-Content -Path $_.FullName -Value $content
-    Write-Host "Modified " $_.FullName 
-}
-
-Get-ChildItem -Recurse *.csproj -Path $SampleRepoRoot | foreach-object {
-    $newPackageReference = 'PackageReference Include="Microsoft.WindowsAppSDK.Foundation"'
-    $oldPackageReference = 'PackageReference Include="Microsoft\.WindowsAppSDK"'
-    $content = Get-Content $_.FullName -Raw
-    $content = $content -replace $oldPackageReference, $newPackageReference
-    Set-Content -Path $_.FullName -Value $content
-    Write-Host "Modified " $_.FullName 
+$projectFileExtensions = @("*.vcxproj", "*.wapproj", "*.csproj")
+$newPackageReference = 'PackageReference Include="Microsoft.WindowsAppSDK.Foundation"'
+$oldPackageReference = 'PackageReference Include="Microsoft\.WindowsAppSDK"'
+foreach ($extension in $projectFileExtensions) {
+    Get-ChildItem -Recurse $extension -Path $SampleRepoRoot | foreach-object {
+        $content = Get-Content $_.FullName -Raw
+        $content = $content -replace $oldPackageReference, $newPackageReference
+        Set-Content -Path $_.FullName -Value $content
+        Write-Host "Modified " $_.FullName 
+    }
 }


### PR DESCRIPTION
This pull request refactors and streamlines the logic in `ModifySampleAppsReferences.ps1` for updating and removing NuGet package references across sample app repositories. The changes focus on updating the handling of different project and package configuration files, consolidating code for maintainability, and ensuring consistent package reference updates.

**Refactoring and consolidation of package reference updates:**

* The script now updates `Directory.Packages.props` files instead of `packages.config` when applying version changes, using appropriate regex patterns for `PackageVersion` elements. Removal logic for packages in this file type has been eliminated.
* The update and removal logic for `packages.config` files has been improved to use consistent regex patterns for both updating package versions and removing package references.
* The logic for updating `PackageReference` elements in project files (`*.vcxproj`, `*.wapproj`, `*.csproj`) has been consolidated into a single loop, replacing the old reference with the new `Microsoft.WindowsAppSDK.Foundation` reference using a unified regex pattern.
* Legacy, repetitive code blocks for handling individual project file types have been removed in favor of the new consolidated approach, improving maintainability and reducing duplication.
* 

The test run can be found at here: https://microsoft.visualstudio.com/ProjectReunion/_build/results?buildId=136390853&view=results