### PR TITLE
Removing runtime identifiers from class library

### DIFF
--- a/dev/VSIX/ProjectTemplates/Desktop/CSharp/ClassLibrary/ProjectTemplate.csproj
+++ b/dev/VSIX/ProjectTemplates/Desktop/CSharp/ClassLibrary/ProjectTemplate.csproj
@@ -3,9 +3,8 @@
     <TargetFramework>$DotNetVersion$-windows10.0.19041.0</TargetFramework>
     <TargetPlatformMinVersion>10.0.17763.0</TargetPlatformMinVersion>
     <RootNamespace>$safeprojectname$</RootNamespace>
-    <RuntimeIdentifiers>win-x86;win-x64;win-arm64</RuntimeIdentifiers>
     <UseWinUI>true</UseWinUI>
     <WinUISDKReferences>false</WinUISDKReferences>
+    <AppendRuntimeIdentifierToOutputPath>false</AppendRuntimeIdentifierToOutputPath>
   </PropertyGroup>
-  
 </Project>


### PR DESCRIPTION
This draft is a tentative to fix issues related to the publishing of apps that have class libraries as dependencies.

This relates to the following issues:

1. #3337
2. #4618 
3. #4596 

Class Libraries don't have the publish profiles in it, and they are not to be published. I removed the runtime identifiers from it and added the property that makes it not inherit the RID from the global scope when building/publishing, making it take the neutral files instead.

This draft is to open discussion about what is the better approach for this issues.

A microsoft employee must use /azp run to validate using the pipelines below.

WARNING:
Comments made by azure-pipelines bot maybe inaccurate.
Please see pipeline link to verify that the build is being ran.

For status checks on the main branch, please use TransportPackage-Foundation-PR
(https://microsoft.visualstudio.com/ProjectReunion/_build?definitionId=81063&_a=summary)
and run the build against your PR branch with the default parameters.
