### PR TITLE
[Build Pipeline] Create Check Api Changes Stage for Nightly and Official Build

### DIFF
--- a/build/AzurePipelinesTemplates/WindowsAppSDK-CheckApiChanges-Stage.yml
+++ b/build/AzurePipelinesTemplates/WindowsAppSDK-CheckApiChanges-Stage.yml
@@ -1,0 +1,42 @@
+parameters:
+- name: CompareAllDependencies
+  type: boolean
+  default: false
+- name: CompareAgainstStable
+  type: boolean
+  default: true
+- name: CompareAgainstExperimental
+  type: boolean
+  default: false
+
+stages:
+- stage: CheckApiChanges
+  dependsOn:
+    - Pack
+  condition: not(failed())
+  jobs:
+  - job: CheckApiChanges
+    pool:
+      type: windows
+      isCustom: true
+      name: 'ProjectReunionESPool-2022'
+    timeoutInMinutes: 120
+    steps:
+    - checkout: self
+
+    - template: AzurePipelinesTemplates\WindowsAppSDK-CheckApiChanges-Steps.yml@WindowsAppSDKConfig
+      parameters:
+        # Pattern of the component package
+        ComponentPackagePatterns: ['Microsoft.WindowsAppSDK.Foundation*.nupkg']
+        # Whether to compare against latest stable build from nuget
+        CompareAgainstStable: ${{ parameters.CompareAgainstStable }}
+        # Whether to compare against latest experimental build from nuget
+        CompareAgainstExperimental: ${{ parameters.CompareAgainstExperimental }}
+        # Parameters for DownloadPipelineArtifact step to retrieve the component packages in artifacts
+        DownloadPipelineArtifactInputs:
+          source: specific
+          runVersion: specific
+          project: $(System.TeamProjectId)
+          pipeline: $(_useBuildOutputFromPipeline)
+          pipelineId: $(_useBuildOutputFromBuildId)
+          artifactName: 'TransportPackage'

--- a/build/WindowsAppSDK-Foundation-Nightly.yml
+++ b/build/WindowsAppSDK-Foundation-Nightly.yml
@@ -49,6 +49,10 @@ parameters:
   displayName: "Whether Maestro publishing should depend on successful Sample tests"
   type: boolean
   default: false
+- name: "CheckApiChanges"
+  displayName: "Whether to run Api Diff against latest stable package"
+  type: boolean
+  default: true
 
 variables:
 - template: WindowsAppSDK-Foundation-TestConfig.yml@WindowsAppSDKConfig
@@ -158,6 +162,11 @@ extends:
       parameters:
         SignOutput: ${{ parameters.SignOutput }}
         PublishPackage: true
+
+    - ${{ if eq( parameters.CheckApiChanges, true ) }}:
+      - template: AzurePipelinesTemplates\WindowsAppSDK-CheckApiChanges-Stage.yml@self
+        parameters:
+          CompareAgainstExperimental: false
 
     - template: AzurePipelinesTemplates\WindowsAppSDK-StaticValidationTest-Stage.yml@self
       parameters:

--- a/build/WindowsAppSDK-Foundation-Official.yml
+++ b/build/WindowsAppSDK-Foundation-Official.yml
@@ -53,6 +53,10 @@ parameters:
   displayName: "Validate Runtime Compatibility Enums (Servicing builds only)"
   type: boolean
   default: true
+- name: "CheckApiChanges"
+  displayName: "Run WindowsAppSDK-CheckApiChanges stage"
+  type: boolean
+  default: true
 
 variables:
 - template: WindowsAppSDK-Foundation-TestConfig.yml@WindowsAppSDKConfig
@@ -173,6 +177,11 @@ extends:
         SignOutput: ${{ parameters.SignOutput }}
         PublishPackage: true
         IsOfficial: true
+
+    - ${{ if eq( parameters.CheckApiChanges, true ) }}:
+      - template: AzurePipelinesTemplates\WindowsAppSDK-CheckApiChanges-Stage.yml@self
+        parameters:
+          CompareAgainstExperimental: false
 
     - template: AzurePipelinesTemplates\WindowsAppSDK-StaticValidationTest-Stage.yml@self
       parameters:


### PR DESCRIPTION
With the change, by default nightly and official foundation build will leverage Tempo Diff tool to compare API differences against latest stable Foundation package from nuget - result can be seen on "Extension" tab and artifact folder "drop_CheckApiChanges_CheckApiChanges"

Test Run: https://dev.azure.com/microsoft/ProjectReunion/_build/results?buildId=138201074&view=results

Sample results on extension tab:
<img width="1104" height="1153" alt="image" src="https://github.com/user-attachments/assets/4658c7ae-c8ca-473b-8ce3-dbcc2135c57a" />


A microsoft employee must use /azp run to validate using the pipelines below.

WARNING:
Comments made by azure-pipelines bot maybe inaccurate.
Please see pipeline link to verify that the build is being ran.

For status checks on the main branch, please use TransportPackage-Foundation-PR
(https://microsoft.visualstudio.com/ProjectReunion/_build?definitionId=81063&_a=summary)
and run the build against your PR branch with the default parameters.
