### PR TITLE
Upload localization files for Storage.Pickers in WindowsAppSDK 2.0

### DIFF
--- a/dev/Interop/StoragePickers/Strings/cs-CZ/StoragePickers.resw
+++ b/dev/Interop/StoragePickers/Strings/cs-CZ/StoragePickers.resw
@@ -135,4 +135,10 @@
   <data name="IDS_APIERROR_MAXSAVEFILELENGTHEXCEEDED" xml:space="preserve">
     <value>Navrhovaný název souboru má větší počet znaků, než je povolené maximum.</value>
   </data>
+  <data name="IDS_APIERROR_INVALIDINITIALFILETYPEINDEX" xml:space="preserve">
+    <value>InitialFileTypeIndex nemůže být menší než -1 nebo mimo rozsah.</value>
+  </data>
+  <data name="IDS_APIERROR_INVALIDAPPIDFORSETTINGSIDENTIFIER" xml:space="preserve">
+    <value>Nepovedlo se určit identitu aplikace pro SettingsIdentifier.</value>
+  </data>
 </root>

--- a/dev/Interop/StoragePickers/Strings/de-DE/StoragePickers.resw
+++ b/dev/Interop/StoragePickers/Strings/de-DE/StoragePickers.resw
@@ -135,4 +135,10 @@
   <data name="IDS_APIERROR_MAXSAVEFILELENGTHEXCEEDED" xml:space="preserve">
     <value>Der vorgeschlagene Dateiname überschreitet die maximal zulässige Zeichenanzahl.</value>
   </data>
+  <data name="IDS_APIERROR_INVALIDINITIALFILETYPEINDEX" xml:space="preserve">
+    <value>Der InitialFileTypeIndex darf nicht kleiner als -1 oder außerhalb des gültigen Bereichs sein.</value>
+  </data>
+  <data name="IDS_APIERROR_INVALIDAPPIDFORSETTINGSIDENTIFIER" xml:space="preserve">
+    <value>Die App-Identität für SettingsIdentifier kann nicht ermittelt werden.</value>
+  </data>
 </root>

--- a/dev/Interop/StoragePickers/Strings/es-ES/StoragePickers.resw
+++ b/dev/Interop/StoragePickers/Strings/es-ES/StoragePickers.resw
@@ -135,4 +135,10 @@
   <data name="IDS_APIERROR_MAXSAVEFILELENGTHEXCEEDED" xml:space="preserve">
     <value>El nombre de archivo sugerido sobrepasa el número máximo de caracteres permitido.</value>
   </data>
+  <data name="IDS_APIERROR_INVALIDINITIALFILETYPEINDEX" xml:space="preserve">
+    <value>InitialFileTypeIndex no puede ser menor que -1 ni estar fuera del intervalo.</value>
+  </data>
+  <data name="IDS_APIERROR_INVALIDAPPIDFORSETTINGSIDENTIFIER" xml:space="preserve">
+    <value>No se puede determinar la identidad de la aplicación para SettingsIdentifier.</value>
+  </data>
 </root>

--- a/dev/Interop/StoragePickers/Strings/fr-FR/StoragePickers.resw
+++ b/dev/Interop/StoragePickers/Strings/fr-FR/StoragePickers.resw
@@ -135,4 +135,10 @@
   <data name="IDS_APIERROR_MAXSAVEFILELENGTHEXCEEDED" xml:space="preserve">
     <value>Le nom de fichier suggéré dépasse le nombre maximum de caractères autorisés.</value>
   </data>
+  <data name="IDS_APIERROR_INVALIDINITIALFILETYPEINDEX" xml:space="preserve">
+    <value>InitialFileTypeIndex ne peut pas être inférieur à -1 ou hors limites.</value>
+  </data>
+  <data name="IDS_APIERROR_INVALIDAPPIDFORSETTINGSIDENTIFIER" xml:space="preserve">
+    <value>Impossible de déterminer l’identité de l’application pour SettingsIdentifier.</value>
+  </data>
 </root>

--- a/dev/Interop/StoragePickers/Strings/it-IT/StoragePickers.resw
+++ b/dev/Interop/StoragePickers/Strings/it-IT/StoragePickers.resw
@@ -135,4 +135,10 @@
   <data name="IDS_APIERROR_MAXSAVEFILELENGTHEXCEEDED" xml:space="preserve">
     <value>Il nome file suggerito supera il numero massimo di caratteri consentito.</value>
   </data>
+  <data name="IDS_APIERROR_INVALIDINITIALFILETYPEINDEX" xml:space="preserve">
+    <value>InitialFileTypeIndex non può essere minore di -1 o non compreso nell'intervallo.</value>
+  </data>
+  <data name="IDS_APIERROR_INVALIDAPPIDFORSETTINGSIDENTIFIER" xml:space="preserve">
+    <value>Non è possibile determinare l'identità dell'app per SettingsIdentifier.</value>
+  </data>
 </root>

--- a/dev/Interop/StoragePickers/Strings/ja-JP/StoragePickers.resw
+++ b/dev/Interop/StoragePickers/Strings/ja-JP/StoragePickers.resw
@@ -135,4 +135,10 @@
   <data name="IDS_APIERROR_MAXSAVEFILELENGTHEXCEEDED" xml:space="preserve">
     <value>候補のファイル名は、使える文字数の上限を超えています。</value>
   </data>
+  <data name="IDS_APIERROR_INVALIDINITIALFILETYPEINDEX" xml:space="preserve">
+    <value>InitialFileTypeIndex を -1 未満または範囲外にすることはできません。</value>
+  </data>
+  <data name="IDS_APIERROR_INVALIDAPPIDFORSETTINGSIDENTIFIER" xml:space="preserve">
+    <value>SettingsIdentifier のアプリ ID を特定できません。</value>
+  </data>
 </root>

--- a/dev/Interop/StoragePickers/Strings/ko-KR/StoragePickers.resw
+++ b/dev/Interop/StoragePickers/Strings/ko-KR/StoragePickers.resw
@@ -135,4 +135,10 @@
   <data name="IDS_APIERROR_MAXSAVEFILELENGTHEXCEEDED" xml:space="preserve">
     <value>제안된 파일 이름이 허용된 최대 문자 수를 초과합니다.</value>
   </data>
+  <data name="IDS_APIERROR_INVALIDINITIALFILETYPEINDEX" xml:space="preserve">
+    <value>InitialFileTypeIndex는 -1보다 작거나 범위를 벗어날 수 없습니다.</value>
+  </data>
+  <data name="IDS_APIERROR_INVALIDAPPIDFORSETTINGSIDENTIFIER" xml:space="preserve">
+    <value>SettingsIdentifier에 대한 앱 ID를 확인할 수 없습니다.</value>
+  </data>
 </root>

--- a/dev/Interop/StoragePickers/Strings/pl-PL/StoragePickers.resw
+++ b/dev/Interop/StoragePickers/Strings/pl-PL/StoragePickers.resw
@@ -135,4 +135,10 @@
   <data name="IDS_APIERROR_MAXSAVEFILELENGTHEXCEEDED" xml:space="preserve">
     <value>Sugerowana nazwa pliku przekracza maksymalną dozwoloną liczbę znaków.</value>
   </data>
+  <data name="IDS_APIERROR_INVALIDINITIALFILETYPEINDEX" xml:space="preserve">
+    <value>Wartość InitialFileTypeIndex nie może być mniejsza niż -1 ani spoza zakresu.</value>
+  </data>
+  <data name="IDS_APIERROR_INVALIDAPPIDFORSETTINGSIDENTIFIER" xml:space="preserve">
+    <value>Nie można określić tożsamości aplikacji dla ustawienia SettingsIdentifier.</value>
+  </data>
 </root>

--- a/dev/Interop/StoragePickers/Strings/pt-BR/StoragePickers.resw
+++ b/dev/Interop/StoragePickers/Strings/pt-BR/StoragePickers.resw
@@ -135,4 +135,10 @@
   <data name="IDS_APIERROR_MAXSAVEFILELENGTHEXCEEDED" xml:space="preserve">
     <value>O nome de arquivo sugerido excede o número máximo de caracteres permitidos.</value>
   </data>
+  <data name="IDS_APIERROR_INVALIDINITIALFILETYPEINDEX" xml:space="preserve">
+    <value>InitialFileTypeIndex não pode ser menor que -1 ou fora do intervalo.</value>
+  </data>
+  <data name="IDS_APIERROR_INVALIDAPPIDFORSETTINGSIDENTIFIER" xml:space="preserve">
+    <value>Não é possível determinar a identidade do aplicativo para SettingsIdentifier.</value>
+  </data>
 </root>

--- a/dev/Interop/StoragePickers/Strings/ru-RU/StoragePickers.resw
+++ b/dev/Interop/StoragePickers/Strings/ru-RU/StoragePickers.resw
@@ -135,4 +135,10 @@
   <data name="IDS_APIERROR_MAXSAVEFILELENGTHEXCEEDED" xml:space="preserve">
     <value>Предложенное имя файла превышает максимально допустимое число символов.</value>
   </data>
+  <data name="IDS_APIERROR_INVALIDINITIALFILETYPEINDEX" xml:space="preserve">
+    <value>Значение InitialFileTypeIndex не может быть меньше -1 или выходит за пределы допустимого диапазона.</value>
+  </data>
+  <data name="IDS_APIERROR_INVALIDAPPIDFORSETTINGSIDENTIFIER" xml:space="preserve">
+    <value>Не удалось определить удостоверение приложения для SettingsIdentifier.</value>
+  </data>
 </root>

--- a/dev/Interop/StoragePickers/Strings/tr-TR/StoragePickers.resw
+++ b/dev/Interop/StoragePickers/Strings/tr-TR/StoragePickers.resw
@@ -135,4 +135,10 @@
   <data name="IDS_APIERROR_MAXSAVEFILELENGTHEXCEEDED" xml:space="preserve">
     <value>Önerilen dosya adı izin verilen karakter sayısı üst sınırını aşıyor.</value>
   </data>
+  <data name="IDS_APIERROR_INVALIDINITIALFILETYPEINDEX" xml:space="preserve">
+    <value>InitialFileTypeIndex -1'den küçük veya aralık dışında olamaz.</value>
+  </data>
+  <data name="IDS_APIERROR_INVALIDAPPIDFORSETTINGSIDENTIFIER" xml:space="preserve">
+    <value>SettingsIdentifier için uygulama kimliği belirlenemedi.</value>
+  </data>
 </root>

--- a/dev/Interop/StoragePickers/Strings/zh-CN/StoragePickers.resw
+++ b/dev/Interop/StoragePickers/Strings/zh-CN/StoragePickers.resw
@@ -135,4 +135,10 @@
   <data name="IDS_APIERROR_MAXSAVEFILELENGTHEXCEEDED" xml:space="preserve">
     <value>建议的文件名超出允许的最大字符数。</value>
   </data>
+  <data name="IDS_APIERROR_INVALIDINITIALFILETYPEINDEX" xml:space="preserve">
+    <value>InitialFileTypeIndex 不能小于 -1 或超出范围。</value>
+  </data>
+  <data name="IDS_APIERROR_INVALIDAPPIDFORSETTINGSIDENTIFIER" xml:space="preserve">
+    <value>无法确定 SettingsIdentifier 的应用标识。</value>
+  </data>
 </root>

--- a/dev/Interop/StoragePickers/Strings/zh-TW/StoragePickers.resw
+++ b/dev/Interop/StoragePickers/Strings/zh-TW/StoragePickers.resw
@@ -135,4 +135,10 @@
   <data name="IDS_APIERROR_MAXSAVEFILELENGTHEXCEEDED" xml:space="preserve">
     <value>建議的檔案名稱超過允許的字元數目上限。</value>
   </data>
+  <data name="IDS_APIERROR_INVALIDINITIALFILETYPEINDEX" xml:space="preserve">
+    <value>InitialFileTypeIndex 不能小於 -1 或超出範圍。</value>
+  </data>
+  <data name="IDS_APIERROR_INVALIDAPPIDFORSETTINGSIDENTIFIER" xml:space="preserve">
+    <value>無法判斷 SettingsIdentifier 的應用程式帳戶。</value>
+  </data>
 </root>


### PR DESCRIPTION
This pull request adds new localized error messages to the `StoragePickers.resw` resource files for multiple languages. These messages provide user-friendly error descriptions for invalid `InitialFileTypeIndex` values and cases where the app identity for `SettingsIdentifier` cannot be determined.

**Localization updates:**

* Added `IDS_APIERROR_INVALIDINITIALFILETYPEINDEX` and `IDS_APIERROR_INVALIDAPPIDFORSETTINGSIDENTIFIER` error messages to the following resource files:
  - `cs-CZ/StoragePickers.resw`
  - `de-DE/StoragePickers.resw`
  - `es-ES/StoragePickers.resw`
  - `fr-FR/StoragePickers.resw`
  - `it-IT/StoragePickers.resw`
  - `ja-JP/StoragePickers.resw`
  - `ko-KR/StoragePickers.resw`
  - `pl-PL/StoragePickers.resw`
  - `pt-BR/StoragePickers.resw`
  - `ru-RU/StoragePickers.resw`
  - `tr-TR/StoragePickers.resw`
  - `zh-CN/StoragePickers.resw`
  - `zh-TW/StoragePickers.resw`