### PR TITLE
Add 1.8.5 runtime compatibility enums

### DIFF
--- a/dev/RuntimeCompatibilityOptions/RuntimeCompatibilityOptions.idl
+++ b/dev/RuntimeCompatibilityOptions/RuntimeCompatibilityOptions.idl
@@ -26,6 +26,8 @@ namespace Microsoft.Windows.ApplicationModel.WindowsAppRuntime
         XamlRoot_FixGetHostWindowInNestedIslands = 60697780,
         DeploymentManager_PackageDowngradeFix = 60760194,
         DwmCoreI_ShutdownManipulationCrash = 60823930,
+        ModelInitialization_Insights = 60909827,
+        ModelInitialization_KnownExceptions = 60910847,
     };
 
     /// Represents a version of the Windows App Runtime.


### PR DESCRIPTION
A microsoft employee must use /azp run to validate using the pipelines below.

WARNING:
Comments made by azure-pipelines bot maybe inaccurate.
Please see pipeline link to verify that the build is being ran.

For status checks on the main branch, please use TransportPackage-Foundation-PR
(https://microsoft.visualstudio.com/ProjectReunion/_build?definitionId=81063&_a=summary)
and run the build against your PR branch with the default parameters.
