### PR TITLE
Fix WEX logging namespace in AppNotificationBuilderTests

### DIFF
--- a/test/AppNotificationBuilderTests/APITests.cpp
+++ b/test/AppNotificationBuilderTests/APITests.cpp
@@ -4,6 +4,8 @@
 #include "pch.h"
 #include "MddWin11.h"
 
+using namespace WEX::Logging;
+
 namespace winrt
 {
     using namespace winrt::Microsoft::Windows::AppNotifications::Builder;


### PR DESCRIPTION
A microsoft employee must use /azp run to validate using the pipelines below.

WARNING:
Comments made by azure-pipelines bot maybe inaccurate.
Please see pipeline link to verify that the build is being ran.

For status checks on the main branch, please use TransportPackage-Foundation-PR
(https://microsoft.visualstudio.com/ProjectReunion/_build?definitionId=81063&_a=summary)
and run the build against your PR branch with the default parameters.
