### PR TITLE
Add machine-readable releases.json with lifecycle data

### DIFF
--- a/releases.json
+++ b/releases.json
@@ -1,0 +1,103 @@
+{
+  "releases": [
+    {
+      "release-version": "1.8",
+      "latest-version": "1.8.5",
+      "latest-build-version": "1.8.260101001",
+      "original-release-date": "2025-09-09",
+      "latest-patch-date": "2026-01-13",
+      "support-level": "current",
+      "eol-date": "2026-09-09"
+    },
+    {
+      "release-version": "1.7",
+      "latest-version": "1.7.7",
+      "latest-build-version": "1.7.260208005",
+      "original-release-date": "2025-03-18",
+      "latest-patch-date": "2026-02-10",
+      "support-level": "maintenance",
+      "eol-date": "2026-03-18"
+    },
+    {
+      "release-version": "1.6",
+      "latest-version": "1.6.5",
+      "latest-build-version": "1.6.250602001",
+      "original-release-date": "2024-09-04",
+      "latest-patch-date": "2025-06-10",
+      "support-level": "eol",
+      "eol-date": "2025-09-04"
+    },
+    {
+      "release-version": "1.5",
+      "latest-version": "1.5.8",
+      "latest-build-version": "1.5.250108004",
+      "original-release-date": "2024-02-29",
+      "latest-patch-date": "2025-01-15",
+      "support-level": "eol",
+      "eol-date": "2025-02-28"
+    },
+    {
+      "release-version": "1.4",
+      "latest-version": "1.4.5",
+      "latest-build-version": "1.4.240802001",
+      "original-release-date": "2023-08-29",
+      "latest-patch-date": "2024-08-13",
+      "support-level": "eol",
+      "eol-date": "2024-08-29"
+    },
+    {
+      "release-version": "1.3",
+      "latest-version": "1.3.3",
+      "latest-build-version": "1.3.230724000",
+      "original-release-date": "2023-04-12",
+      "latest-patch-date": "2023-07-25",
+      "support-level": "eol",
+      "eol-date": "2024-04-12"
+    },
+    {
+      "release-version": "1.2",
+      "latest-version": "1.2.5",
+      "latest-build-version": "1.2.230313.1",
+      "original-release-date": "2022-11-10",
+      "latest-patch-date": "2023-03-15",
+      "support-level": "eol",
+      "eol-date": "2023-11-10"
+    },
+    {
+      "release-version": "1.1",
+      "latest-version": "1.1.5",
+      "latest-build-version": "1.1.5",
+      "original-release-date": "2022-05-24",
+      "latest-patch-date": "2022-09-14",
+      "support-level": "eol",
+      "eol-date": "2023-05-24"
+    },
+    {
+      "release-version": "1.0",
+      "latest-version": "1.0.4",
+      "latest-build-version": "1.0.4",
+      "original-release-date": "2021-11-16",
+      "latest-patch-date": "2022-06-14",
+      "support-level": "eol",
+      "eol-date": "2022-11-16"
+    },
+    {
+      "release-version": "0.8",
+      "latest-version": "0.8.12",
+      "latest-build-version": "0.8.12",
+      "original-release-date": "2021-06-24",
+      "latest-patch-date": "2022-08-03",
+      "support-level": "eol",
+      "eol-date": "2022-06-24"
+    },
+    {
+      "release-version": "0.5",
+      "latest-version": "0.5.9",
+      "latest-build-version": "0.5.9",
+      "original-release-date": "2021-03-29",
+      "latest-patch-date": "2021-08-10",
+      "support-level": "eol",
+      "eol-date": "2021-11-01"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Add a machine-readable `releases.json` file at the repo root containing lifecycle data for all Windows App SDK stable releases.

## Motivation

Developers want to automatically check in CI if their referenced WindowsAppSDK version is still supported. Currently the only source is a non-machine-readable web page. This follows the pattern established by [dotnet/core releases-index.json](https://github.com/dotnet/core/blob/main/release-notes/releases-index.json).

## Data

Each release entry includes:
- `release-version` – Major.minor version
- `latest-version` – Latest patch version
- `latest-build-version` – Full build version string
- `original-release-date` – Initial release date
- `latest-patch-date` – Most recent patch date
- `support-level` – `current`, `maintenance`, or `eol`
- `eol-date` – End of servicing date

Data sourced from the [official release lifecycle page](https://learn.microsoft.com/windows/apps/windows-app-sdk/release-channels#release-lifecycle).

## Impact

New file only. Zero code impact.

Fixes #4314