### PR TITLE
[Build] Fix artifact suffix to use correct status variable

### DIFF
--- a/build/AzurePipelinesTemplates/WindowsAppSDK-RunTestsInPipeline-Job.yml
+++ b/build/AzurePipelinesTemplates/WindowsAppSDK-RunTestsInPipeline-Job.yml
@@ -41,7 +41,7 @@ jobs:
     AZURE_PIPELINES_DEDUP_PARALLELISM: 16
     artifactAttempt: ''
     artifactStatus: 'Succeeded'
-    ob_artifactSuffix: '_$(buildConfiguration)$(buildPlatform)_$(Agent.artifactStatus)$(artifactAttempt)'
+    ob_artifactSuffix: '_$(buildConfiguration)$(buildPlatform)_$(artifactStatus)$(artifactAttempt)'
     ob_artifactBaseName: '$(System.StageName)_$(imageName)'
     # As the name of this job suggests, we currently don't build any code here, but only run tests; therefore, not bothering to enable BinSkim scans
     # here. OTOH, if we leave BinSkim enabled, then the "Guardian: BinSkim" task in the Post* jobs injected into our pipeline by OneBranch 


### PR DESCRIPTION
Fixing the OneBranch pipeline break by correcting a cut and paste error which was missed by the non-OneBranch PR validation pipeline run.

////
A microsoft employee must use /azp run to validate using the pipelines below.

WARNING:
Comments made by azure-pipelines bot maybe inaccurate.
Please see pipeline link to verify that the build is being ran.

For status checks on the main branch, please use TransportPackage-Foundation-PR
(https://microsoft.visualstudio.com/ProjectReunion/_build?definitionId=81063&_a=summary)
and run the build against your PR branch with the default parameters.
