### PR TITLE
Add Windows Server versions to bug report template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yaml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yaml
@@ -67,6 +67,10 @@ body:
         - "Windows 10 version 1909 (18363, November 2019 Update)"
         - "Windows 10 version 1903 (18362, May 2019 Update)"
         - "Windows 10 version 1809 (17763, October 2018 Update)"
+        - "Windows Server 2025 (26100)"
+        - "Windows Server version 23H2 (25398)"
+        - "Windows Server 2022 version 21H2 (20348)"
+        - "Windows Server 2019 version 1809 (17763)"
   - type: dropdown
     attributes:
       label: IDE


### PR DESCRIPTION
## Summary
- Adds Windows Server 2025 (26100), 23H2 (25398), 2022 (20348), and 2019 (17763) to the Windows version dropdown in the bug report issue template

Fixes #5554