### PR TITLE
Add DefaultDllImportSearchPaths to WindowsAppRuntime_EnsureIsLoaded

### DIFF
--- a/dev/UndockedRegFreeWinRT/UndockedRegFreeWinRT-AutoInitializer.cs
+++ b/dev/UndockedRegFreeWinRT/UndockedRegFreeWinRT-AutoInitializer.cs
@@ -14,6 +14,7 @@ namespace Microsoft.Windows.Foundation.UndockedRegFreeWinRTCS
 {
     internal static class NativeMethods
     {
+        [DefaultDllImportSearchPaths(DllImportSearchPath.AssemblyDirectory | DllImportSearchPath.System32)]
         [DllImport("Microsoft.WindowsAppRuntime.dll", CharSet = CharSet.Unicode, ExactSpelling = true)]
         internal static extern int WindowsAppRuntime_EnsureIsLoaded();
     }


### PR DESCRIPTION
## Summary
- Adds `[DefaultDllImportSearchPaths(DllImportSearchPath.AssemblyDirectory | DllImportSearchPath.System32)]` to the `WindowsAppRuntime_EnsureIsLoaded` P/Invoke declaration
- Constrains DLL search to assembly directory and System32, suppressing CA5392 code analysis warning
- Consistent with security best practices for DLL loading

Fixes #4857