### PR TITLE
Fix condition to check for 'Type' property in testConfig

### DIFF
--- a/TestAll.ps1
+++ b/TestAll.ps1
@@ -98,7 +98,7 @@ function Get-Tests
         foreach ($testConfig in $testJson.Tests)
         {
             $testConfig | Write-Host
-            if ($testConfig -contains 'Type')
+            if ($testConfig.PSObject.Properties.Name -contains 'Type')
             {
                 $testType = $testConfig.Type
             }


### PR DESCRIPTION
A microsoft employee must use /azp run to validate using the pipelines below.

WARNING:
Comments made by azure-pipelines bot maybe inaccurate.
Please see pipeline link to verify that the build is being ran.

For status checks on the main branch, please use TransportPackage-Foundation-PR
(https://microsoft.visualstudio.com/ProjectReunion/_build?definitionId=81063&_a=summary)
and run the build against your PR branch with the default parameters.
