### PR TITLE
Fix missing headers in Foundation NuGet package

### DIFF
--- a/build/CopyFilesToStagingDir.ps1
+++ b/build/CopyFilesToStagingDir.ps1
@@ -165,6 +165,8 @@ PublishFile $FullBuildOutput\WindowsAppRuntime_DLL\decimalcppwinrt.h $NugetDir\i
 PublishFile $FullBuildOutput\WindowsAppRuntime_DLL\MsixDynamicDependency.h $NugetDir\include
 PublishFile $FullBuildOutput\WindowsAppRuntime_DLL\wil_msixdynamicdependency.h $NugetDir\include
 PublishFile $FullBuildOutput\WindowsAppRuntime_DLL\WindowsAppRuntimeInsights.h $NugetDir\include\
+PublishFile $FullBuildOutput\WindowsAppRuntime_DLL\AppModel.Identity.IsPackagedProcess.h $NugetDir\include\
+PublishFile $FullBuildOutput\WindowsAppRuntime_DLL\WindowsAppRuntime.SelfContained.h $NugetDir\include\
 PublishFile $FullBuildOutput\WindowsAppRuntime_DLL\Security.AccessControl.h $NugetDir\include\
 #
 # Libraries (*.lib)

--- a/dev/Common/Common.vcxitems
+++ b/dev/Common/Common.vcxitems
@@ -20,6 +20,7 @@
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="$(MSBuildThisFileDirectory)AppModel.Identity.h" />
+    <ClInclude Include="$(MSBuildThisFileDirectory)AppModel.Identity.IsPackagedProcess.h" />
     <ClInclude Include="$(MSBuildThisFileDirectory)AppModel.Package.h" />
     <ClInclude Include="$(MSBuildThisFileDirectory)AppModel.PackageGraph.h" />
     <ClInclude Include="$(MSBuildThisFileDirectory)Microsoft.Foundation.String.h" />
@@ -35,5 +36,7 @@
   <ItemGroup>
     <PublicHeaders Include="$(MSBuildThisFileDirectory)WindowsAppRuntimeAutoInitializer.cs" />
     <PublicHeaders Include="$(MSBuildThisFileDirectory)WindowsAppRuntimeAutoInitializer.cpp" />
+    <PublicHeaders Include="$(MSBuildThisFileDirectory)AppModel.Identity.IsPackagedProcess.h" />
+    <PublicHeaders Include="$(MSBuildThisFileDirectory)WindowsAppRuntime.SelfContained.h" />
   </ItemGroup>
 </Project>

--- a/dev/Common/Common.vcxitems.filters
+++ b/dev/Common/Common.vcxitems.filters
@@ -14,6 +14,9 @@
     <ClInclude Include="$(MSBuildThisFileDirectory)AppModel.Identity.h">
       <Filter>Header Files</Filter>
     </ClInclude>
+    <ClInclude Include="$(MSBuildThisFileDirectory)AppModel.Identity.IsPackagedProcess.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
     <ClInclude Include="$(MSBuildThisFileDirectory)AppModel.Package.h">
       <Filter>Header Files</Filter>
     </ClInclude>


### PR DESCRIPTION
follow-up to https://github.com/microsoft/WindowsAppSDK/pull/6233/changes
