### PR TITLE
Consolidate download build scripts into shared utility

### DIFF
--- a/build/scripts/Download-Package.ps1
+++ b/build/scripts/Download-Package.ps1
@@ -1,0 +1,70 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+<#
+.SYNOPSIS
+    Downloads a file from a URL to a local directory, skipping if already present.
+
+.DESCRIPTION
+    Shared download utility used by the Windows App SDK build scripts. Downloads a file
+    from the specified URL to the output directory, creating the directory if needed.
+    If the file already exists at the output path, the download is skipped.
+
+.PARAMETER Url
+    The URL to download the file from.
+
+.PARAMETER OutputDirectory
+    The directory to save the downloaded file to. Created if it does not exist.
+
+.PARAMETER FileName
+    The name of the output file within the output directory.
+
+.EXAMPLE
+    .\Download-Package.ps1 -Url "https://aka.ms/Microsoft.VCLibs.x64.14.00.Desktop.appx" -OutputDirectory ".\redist" -FileName "Microsoft.VCLibs.x64.14.00.Desktop.appx"
+#>
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory = $true)]
+    [ValidateNotNullOrEmpty()]
+    [string]$Url,
+
+    [Parameter(Mandatory = $true)]
+    [ValidateNotNullOrEmpty()]
+    [string]$OutputDirectory,
+
+    [Parameter(Mandatory = $true)]
+    [ValidateNotNullOrEmpty()]
+    [string]$FileName
+)
+
+Set-StrictMode -Version 2.0
+$ErrorActionPreference = 'Stop'
+$ProgressPreference = 'SilentlyContinue'
+
+try
+{
+    if (-not (Test-Path $OutputDirectory))
+    {
+        $null = New-Item -ItemType Directory -Path $OutputDirectory
+    }
+
+    $outputPath = Join-Path $OutputDirectory $FileName
+
+    if (-not (Test-Path $outputPath))
+    {
+        Write-Verbose "Downloading $Url to $outputPath"
+        Write-Host "Downloading $Url to $outputPath"
+        Invoke-WebRequest $Url -OutFile $outputPath -UseBasicParsing
+    }
+    else
+    {
+        Write-Host "The file '$outputPath' already exists. Skipping download."
+    }
+
+    exit 0
+}
+catch
+{
+    Write-Error "Download failed: $_"
+    exit 1
+}

--- a/build/scripts/DownloadDotNetRuntimeInstaller.ps1
+++ b/build/scripts/DownloadDotNetRuntimeInstaller.ps1
@@ -5,32 +5,25 @@ param(
     [string]$OutputDirectory
 )
 
-$ProgressPreference = "SilentlyContinue"
 $ErrorActionPreference = "Stop"
 Set-StrictMode -Version 3.0
-
-$outputPath = Join-Path $OutputDirectory "dotnet-windowsdesktop-runtime-installer.exe"
-if(-not(Test-Path $OutputDirectory))
-{
-    $null = New-Item -ItemType Directory -Path $OutputDirectory
-}
 
 # Find direct download links at https://dotnet.microsoft.com/download/dotnet/5.0
 $downloadurlx86 = "https://download.visualstudio.microsoft.com/download/pr/c089205d-4f58-4f8d-ad84-c92eaf2f3411/5cd3f9b3bd089c09df14dbbfb64124a4/windowsdesktop-runtime-5.0.5-win-x86.exe"
 $downloadurlx64 = "https://download.visualstudio.microsoft.com/download/pr/c1ef0b3f-9663-4fc5-85eb-4a9cadacdb87/52b890f91e6bd4350d29d2482038df1c/windowsdesktop-runtime-5.0.5-win-x64.exe"
 $downloadurlArm64 = "https://download.visualstudio.microsoft.com/download/pr/1201ea91-3344-4745-9143-ad4f7eb0a88d/f04108de4f95817aa1b832061a467be0/dotnet-runtime-5.0.5-win-arm64.exe"
 
-if($Platform -eq "x86")
+if ($Platform -eq "x86")
 {
-    $downloadurl = $downloadurlx86
+    $url = $downloadurlx86
 }
-elseif($Platform -eq "x64")
+elseif ($Platform -eq "x64")
 {
-    $downloadurl = $downloadurlx64
+    $url = $downloadurlx64
 }
-elseif($Platform -eq "arm64")
+elseif ($Platform -eq "arm64")
 {
-    $downloadurl = $downloadurlArm64
+    $url = $downloadurlArm64
 }
 else
 {
@@ -38,12 +31,8 @@ else
     return
 }
 
-if(-not(Test-Path $outputPath))
-{
-    Write-Host "Downloading $downloadurl to $outputPath"
-    Invoke-WebRequest $downloadurl -OutFile $outputPath -UseBasicParsing
-}
-else
-{
-    Write-Host "The file '$outputPath' already exists. Skipping download."
-}
+$fileName = "dotnet-windowsdesktop-runtime-installer.exe"
+
+& "$PSScriptRoot\Download-Package.ps1" -Url $url -OutputDirectory $OutputDirectory -FileName $fileName
+exit $LASTEXITCODE
+

--- a/build/scripts/DownloadVCLibsDesktop.ps1
+++ b/build/scripts/DownloadVCLibsDesktop.ps1
@@ -5,25 +5,12 @@ param(
     [string]$OutputDirectory
 )
 
-$ProgressPreference = "SilentlyContinue"
 $ErrorActionPreference = "Stop"
 Set-StrictMode -Version 3.0
 
-$outputPath = Join-Path $OutputDirectory "Microsoft.VCLibs.$Platform.14.00.Desktop.appx"
-if(-not(Test-Path $OutputDirectory))
-{
-    $null = New-Item -ItemType Directory -Path $OutputDirectory
-}
+$url = "https://aka.ms/Microsoft.VCLibs.$Platform.14.00.Desktop.appx"
+$fileName = "Microsoft.VCLibs.$Platform.14.00.Desktop.appx"
 
-# Find direct download links at https://learn.microsoft.com/en-us/troubleshoot/developer/visualstudio/cpp/libraries/c-runtime-packages-desktop-bridge
-$downloadurl = "https://aka.ms/Microsoft.VCLibs.$Platform.14.00.Desktop.appx"
+& "$PSScriptRoot\Download-Package.ps1" -Url $url -OutputDirectory $OutputDirectory -FileName $fileName
+exit $LASTEXITCODE
 
-if(-not(Test-Path $outputPath))
-{
-    Write-Host "Downloading $downloadurl to $outputPath"
-    Invoke-WebRequest $downloadurl -OutFile $outputPath -UseBasicParsing
-}
-else
-{
-    Write-Host "The file '$outputPath' already exists. Skipping download."
-}

--- a/build/scripts/DownloadVCRedistInstaller.ps1
+++ b/build/scripts/DownloadVCRedistInstaller.ps1
@@ -5,25 +5,13 @@ param(
     [string]$OutputDirectory
 )
 
-$ProgressPreference = "SilentlyContinue"
 $ErrorActionPreference = "Stop"
 Set-StrictMode -Version 3.0
 
-$outputPath = Join-Path $OutputDirectory "vc_redist.$Platform.exe"
-if(-not(Test-Path $OutputDirectory))
-{
-    $null = New-Item -ItemType Directory -Path $OutputDirectory
-}
-
 # Find direct download links at https://learn.microsoft.com/en-US/cpp/windows/latest-supported-vc-redist?view=msvc-170
-$downloadurl = "https://aka.ms/vs/17/release/vc_redist.$Platform.exe"
+$url = "https://aka.ms/vs/17/release/vc_redist.$Platform.exe"
+$fileName = "vc_redist.$Platform.exe"
 
-if(-not(Test-Path $outputPath))
-{
-    Write-Host "Downloading $downloadurl to $outputPath"
-    Invoke-WebRequest $downloadurl -OutFile $outputPath -UseBasicParsing
-}
-else
-{
-    Write-Host "The file '$outputPath' already exists. Skipping download."
-}
+& "$PSScriptRoot\Download-Package.ps1" -Url $url -OutputDirectory $OutputDirectory -FileName $fileName
+exit $LASTEXITCODE
+


### PR DESCRIPTION
## Summary

Consolidates three nearly identical download scripts into a shared `Download-Package.ps1` utility, reducing code duplication in the build infrastructure.

## Changes

- **New:** `build/scripts/Download-Package.ps1` — shared download utility with `CmdletBinding`, comment-based help, parameter validation, and proper error handling (try/catch with exit codes)
- **Modified:** `DownloadVCLibsDesktop.ps1`, `DownloadVCRedistInstaller.ps1`, `DownloadDotNetRuntimeInstaller.ps1` — converted to thin wrappers that resolve their component-specific URL/filename and delegate to `Download-Package.ps1`

## Why

The three download scripts had identical structure (create output dir → build URL → skip if exists → download via `Invoke-WebRequest`). Any bug fix or improvement had to be applied three times. Now the common logic lives in one place.

## Backward Compatibility

The three wrapper scripts preserve their original `-Platform` / `-OutputDirectory` parameter interface, so the pipeline YAML (`WindowsAppSDK-SetupBuildEnvironment-Steps.yml`) requires **no changes**.