### PR TITLE
Use custom feed for VS test platform

### DIFF
--- a/build/AzurePipelinesTemplates/WindowsAppSDK-RunTests-Steps.yml
+++ b/build/AzurePipelinesTemplates/WindowsAppSDK-RunTests-Steps.yml
@@ -163,9 +163,14 @@ steps:
           Write-Host "##vso[task.setvariable variable=SAMPLES_ROOT_PATH;isOutput=true]$(Build.SourcesDirectory)\$(SamplesRepoName)\Samples"
           Write-Host "##vso[task.setvariable variable=SAMPLES_ROOT_PATH;]$(Build.SourcesDirectory)\$(SamplesRepoName)\Samples"
 
+  - task: NuGetAuthenticate@1
+    displayName: "NuGet authenticate for VSTest platform install"
+
   - task: VisualStudioTestPlatformInstaller@1
     inputs:
       versionSelector: latestStable
+      packageFeedSelector: customFeed
+      customFeed: "https://microsoft.pkgs.visualstudio.com/ProjectReunion/_packaging/Project.Reunion.nuget.internal/nuget/v3/index.json"
 
   - task: PowerShell@2
     displayName: Add test locale to User Language List


### PR DESCRIPTION
SFI breaking change, we can no longer pull these from the public nuget feed. already merged in 2.0 to unblock RC building

A microsoft employee must use /azp run to validate using the pipelines below.

WARNING:
Comments made by azure-pipelines bot maybe inaccurate.
Please see pipeline link to verify that the build is being ran.

For status checks on the main branch, please use TransportPackage-Foundation-PR
(https://microsoft.visualstudio.com/ProjectReunion/_build?definitionId=81063&_a=summary)
and run the build against your PR branch with the default parameters.
