### PR TITLE
Add testMatrix parameter to build stages

### DIFF
--- a/build/WindowsAppSDK-Foundation-PR.yml
+++ b/build/WindowsAppSDK-Foundation-PR.yml
@@ -117,6 +117,7 @@ extends:
         SignOutput: false
         runApiScan: ${{ parameters.runStaticAnalysis }}
         runPREFast: false
+        testMatrix: ${{ variables.PipelineTests }}
     
     - ${{ if eq(parameters.runStaticAnalysis, 'true') }}:
       - template: AzurePipelinesTemplates\WindowsAppSDK-Build-Stage.yml@self
@@ -124,6 +125,7 @@ extends:
           SignOutput: false
           runApiScan: false
           runPREFast: true
+          testMatrix: ${{ variables.PipelineTests }}          
 
     - template: AzurePipelinesTemplates\WindowsAppSDK-PackTransportPackage-Stage.yml@self
       parameters:


### PR DESCRIPTION
A microsoft employee must use /azp run to validate using the pipelines below.

WARNING:
Comments made by azure-pipelines bot maybe inaccurate.
Please see pipeline link to verify that the build is being ran.

For status checks on the main branch, please use TransportPackage-Foundation-PR
(https://microsoft.visualstudio.com/ProjectReunion/_build?definitionId=81063&_a=summary)
and run the build against your PR branch with the default parameters.
