### PR TITLE
[release 2.0-stable] Remove wil/cppwinrt.h from NuGet-shipped auto-initializer files

### DIFF
--- a/dev/Common/WindowsAppRuntimeAutoInitializer.cpp
+++ b/dev/Common/WindowsAppRuntimeAutoInitializer.cpp
@@ -1,8 +1,6 @@
 // Copyright (c) Microsoft Corporation and Contributors.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
-#include <wil/cppwinrt.h>
-
 // Forward-declare the various AutoInitialize functions
 namespace Microsoft::Windows::ApplicationModel::DynamicDependency::Bootstrap
 {

--- a/dev/Deployment/DeploymentManagerAutoInitializer.cpp
+++ b/dev/Deployment/DeploymentManagerAutoInitializer.cpp
@@ -4,8 +4,6 @@
 #include <Windows.h>
 #include <stdlib.h>
 
-#include <wil/cppwinrt.h>
-
 #include <winrt/Windows.Foundation.h>
 #include <winrt/Windows.Foundation.Collections.h>
 

--- a/dev/UndockedRegFreeWinRT/UndockedRegFreeWinRT-AutoInitializer.cpp
+++ b/dev/UndockedRegFreeWinRT/UndockedRegFreeWinRT-AutoInitializer.cpp
@@ -4,8 +4,6 @@
 #include <Windows.h>
 #include <stdlib.h>
 
-#include <wil/cppwinrt.h>
-
 // Ensure the including PE file has an import reference to
 // the WindowsAppSDK runtime DLL and thus gets loaded when
 // the including PE file gets loaded.

--- a/dev/WindowsAppRuntime_BootstrapDLL/MddBootstrapAutoInitializer.cpp
+++ b/dev/WindowsAppRuntime_BootstrapDLL/MddBootstrapAutoInitializer.cpp
@@ -5,8 +5,6 @@
 #include <stdint.h>
 #include <stdlib.h>
 
-#include <wil/cppwinrt.h>
-
 #include <MddBootstrap.h>
 #include <WindowsAppSDK-VersionInfo.h>
 


### PR DESCRIPTION
The wil/cppwinrt.h include added in https://github.com/microsoft/WindowsAppSDK/pull/6323 breaks SamplesCompatTest because these auto-initializer .cpp files are
compiled by NuGet package consumers who don't have WIL headers available.

Removes the include from all 4 shipped auto-initializer files:

WindowsAppRuntimeAutoInitializer.cpp
UndockedRegFreeWinRT-AutoInitializer.cpp
DeploymentManagerAutoInitializer.cpp
MddBootstrapAutoInitializer.cpp
The other files in https://github.com/microsoft/WindowsAppSDK/pull/6323 (DeploymentManager.cpp, MddBootstrapActivity.cpp, etc.) are internal SDK files and
unaffected.The wil/cppwinrt.h include added in https://github.com/microsoft/WindowsAppSDK/pull/6323 breaks SamplesCompatTest because these auto-initializer .cpp files are
compiled by NuGet package consumers who don't have WIL headers available.
