### PR TITLE
Fix sparse-packaged apps unable to discover module-specific PRI files

### DIFF
--- a/dev/MRTCore/mrt/Microsoft.Windows.ApplicationModel.Resources/src/Helper.cpp
+++ b/dev/MRTCore/mrt/Microsoft.Windows.ApplicationModel.Resources/src/Helper.cpp
@@ -87,8 +87,7 @@ HRESULT GetDefaultPriFile(winrt::hstring& filePath)
     hr = GetDefaultPriFileForCurentModule(isPackaged, filePath);
 
     // Sparse-packaged apps have identity but deploy PRI files as loose files.
-    // When the PRI is not found, fall back to unpackaged discovery which also
-    // searches for "[modulename].pri".
+    // When the PRI is not found, fall back to unpackaged discovery which also searches for "[modulename].pri".
     // See: https://github.com/microsoft/microsoft-ui-xaml/issues/10856
     if (isPackaged &&
         (hr == HRESULT_FROM_WIN32(ERROR_FILE_NOT_FOUND) || hr == HRESULT_FROM_WIN32(ERROR_PATH_NOT_FOUND)))
@@ -98,9 +97,8 @@ HRESULT GetDefaultPriFile(winrt::hstring& filePath)
         {
             hr = hrFallback;
         }
-        // If the fallback also fails, preserve the original HRESULT (not the
-        // fallback's) for backward compatibility so callers checking for
-        // specific errors (e.g., ERROR_FILE_NOT_FOUND) are not broken.
+        // If the fallback also fails, preserve the original HRESULT (not the fallback's)
+        // for backward compatibility so callers checking for specific errors (e.g., ERROR_FILE_NOT_FOUND) are not broken.
     }
 
     return hr;

--- a/dev/MRTCore/mrt/Microsoft.Windows.ApplicationModel.Resources/src/Helper.cpp
+++ b/dev/MRTCore/mrt/Microsoft.Windows.ApplicationModel.Resources/src/Helper.cpp
@@ -84,5 +84,38 @@ HRESULT GetDefaultPriFile(winrt::hstring& filePath)
     // GetDefaultPriFileForCurrentPackage will not handle the new case where
     // resources.pri is in the parent folder. 
     bool isPackaged = (hr != HRESULT_FROM_WIN32(APPMODEL_ERROR_NO_PACKAGE));
-    return GetDefaultPriFileForCurentModule(isPackaged, filePath);
+    hr = GetDefaultPriFileForCurentModule(isPackaged, filePath);
+    if (SUCCEEDED(hr))
+    {
+        return S_OK;
+    }
+
+    // Sparse-packaged apps have package identity (via AddPackageByUriAsync) but
+    // deploy resources as loose files next to the executable rather than through
+    // the package system. Because they have identity, the packaged code path above
+    // passes "resources.pri" to MrmGetFilePathFromName — which only searches for
+    // that exact filename. However, sparse apps may use a custom PRI name matching
+    // their module name (e.g., "MyApp.pri" via ProjectPriFileName).
+    //
+    // The package system cannot resolve the app's original PRI filename for sparse
+    // apps, so we fall back to the unpackaged discovery path which passes nullptr
+    // to MrmGetFilePathFromName. This triggers a broader search that includes both
+    // "resources.pri" and "[modulename].pri" (derived via PathCchRenameExtension
+    // from the process executable name).
+    //
+    // This only runs for apps with identity where "resources.pri" was not found —
+    // fully packaged apps and unpackaged apps are unaffected.
+    // If this fallback also fails, return the original HRESULT so callers that
+    // check for a specific error (e.g., ERROR_FILE_NOT_FOUND) are not broken.
+    // See: https://github.com/microsoft/microsoft-ui-xaml/issues/10856
+    if (isPackaged)
+    {
+        HRESULT hrFallback = GetDefaultPriFileForCurentModule(false, filePath);
+        if (SUCCEEDED(hrFallback))
+        {
+            return S_OK;
+        }
+    }
+
+    return hr;
 }

--- a/dev/MRTCore/mrt/Microsoft.Windows.ApplicationModel.Resources/src/Helper.cpp
+++ b/dev/MRTCore/mrt/Microsoft.Windows.ApplicationModel.Resources/src/Helper.cpp
@@ -85,35 +85,18 @@ HRESULT GetDefaultPriFile(winrt::hstring& filePath)
     // resources.pri is in the parent folder. 
     bool isPackaged = (hr != HRESULT_FROM_WIN32(APPMODEL_ERROR_NO_PACKAGE));
     hr = GetDefaultPriFileForCurentModule(isPackaged, filePath);
-    if (SUCCEEDED(hr))
-    {
-        return S_OK;
-    }
 
-    // Sparse-packaged apps have package identity (via AddPackageByUriAsync) but
-    // deploy resources as loose files next to the executable rather than through
-    // the package system. Because they have identity, the packaged code path above
-    // passes "resources.pri" to MrmGetFilePathFromName — which only searches for
-    // that exact filename. However, sparse apps may use a custom PRI name matching
-    // their module name (e.g., "MyApp.pri" via ProjectPriFileName).
-    //
-    // The package system cannot resolve the app's original PRI filename for sparse
-    // apps, so we fall back to the unpackaged discovery path which passes nullptr
-    // to MrmGetFilePathFromName. This triggers a broader search that includes both
-    // "resources.pri" and "[modulename].pri" (derived via PathCchRenameExtension
-    // from the process executable name).
-    //
-    // This only runs for apps with identity where "resources.pri" was not found —
-    // fully packaged apps and unpackaged apps are unaffected.
-    // If this fallback also fails, return the original HRESULT so callers that
-    // check for a specific error (e.g., ERROR_FILE_NOT_FOUND) are not broken.
+    // Sparse-packaged apps have identity but deploy PRI files as loose files.
+    // When the PRI is not found, fall back to unpackaged discovery which also
+    // searches for "[modulename].pri".
     // See: https://github.com/microsoft/microsoft-ui-xaml/issues/10856
-    if (isPackaged)
+    if (isPackaged &&
+        (hr == HRESULT_FROM_WIN32(ERROR_FILE_NOT_FOUND) || hr == HRESULT_FROM_WIN32(ERROR_PATH_NOT_FOUND)))
     {
         HRESULT hrFallback = GetDefaultPriFileForCurentModule(false, filePath);
         if (SUCCEEDED(hrFallback))
         {
-            return S_OK;
+            hr = hrFallback;
         }
     }
 

--- a/dev/MRTCore/mrt/Microsoft.Windows.ApplicationModel.Resources/src/Helper.cpp
+++ b/dev/MRTCore/mrt/Microsoft.Windows.ApplicationModel.Resources/src/Helper.cpp
@@ -86,9 +86,7 @@ HRESULT GetDefaultPriFile(winrt::hstring& filePath)
     bool isPackaged = (hr != HRESULT_FROM_WIN32(APPMODEL_ERROR_NO_PACKAGE));
     hr = GetDefaultPriFileForCurentModule(isPackaged, filePath);
 
-    // Sparse-packaged apps have identity but deploy PRI files as loose files.
-    // When the PRI is not found, fall back to unpackaged discovery which also searches for "[modulename].pri".
-    // See: https://github.com/microsoft/microsoft-ui-xaml/issues/10856
+    // Sparse-packaged apps have identity but deploy PRI files as loose files; fall back to unpackaged discovery which also searches for "[modulename].pri".
     if (isPackaged && IsResourceNotFound(hr))
     {
         HRESULT hrFallback = GetDefaultPriFileForCurentModule(false, filePath);

--- a/dev/MRTCore/mrt/Microsoft.Windows.ApplicationModel.Resources/src/Helper.cpp
+++ b/dev/MRTCore/mrt/Microsoft.Windows.ApplicationModel.Resources/src/Helper.cpp
@@ -98,9 +98,10 @@ HRESULT GetDefaultPriFile(winrt::hstring& filePath)
         {
             hr = hrFallback;
         }
+        // If the fallback also fails, preserve the original HRESULT (not the
+        // fallback's) for backward compatibility so callers checking for
+        // specific errors (e.g., ERROR_FILE_NOT_FOUND) are not broken.
     }
 
-    // Return original HRESULT for backward compatibility so callers that
-    // check for specific errors (e.g., ERROR_FILE_NOT_FOUND) are not broken.
     return hr;
 }

--- a/dev/MRTCore/mrt/Microsoft.Windows.ApplicationModel.Resources/src/Helper.cpp
+++ b/dev/MRTCore/mrt/Microsoft.Windows.ApplicationModel.Resources/src/Helper.cpp
@@ -89,8 +89,7 @@ HRESULT GetDefaultPriFile(winrt::hstring& filePath)
     // Sparse-packaged apps have identity but deploy PRI files as loose files.
     // When the PRI is not found, fall back to unpackaged discovery which also searches for "[modulename].pri".
     // See: https://github.com/microsoft/microsoft-ui-xaml/issues/10856
-    if (isPackaged &&
-        (hr == HRESULT_FROM_WIN32(ERROR_FILE_NOT_FOUND) || hr == HRESULT_FROM_WIN32(ERROR_PATH_NOT_FOUND)))
+    if (isPackaged && IsResourceNotFound(hr))
     {
         HRESULT hrFallback = GetDefaultPriFileForCurentModule(false, filePath);
         if (SUCCEEDED(hrFallback))

--- a/dev/MRTCore/mrt/Microsoft.Windows.ApplicationModel.Resources/src/Helper.cpp
+++ b/dev/MRTCore/mrt/Microsoft.Windows.ApplicationModel.Resources/src/Helper.cpp
@@ -100,5 +100,7 @@ HRESULT GetDefaultPriFile(winrt::hstring& filePath)
         }
     }
 
+    // Return original HRESULT for backward compatibility so callers that
+    // check for specific errors (e.g., ERROR_FILE_NOT_FOUND) are not broken.
     return hr;
 }


### PR DESCRIPTION
## Summary


Fixes sparse-packaged apps (unpackaged + self-contained WinUI3 with identity via `AddPackageByUriAsync`) failing to locate module-specific PRI files (e.g., `MyApp.pri` set via `ProjectPriFileName`).



## Why This Matters

Not an regression, it doesn't work from the first day.

While unpackaged apps that need package-identity-only APIs (e.g., Windows AI APIs) must use sparse app registration (`AddPackageByUriAsync`) to acquire identity. When multiple such apps share the same output directory, each needs its own module-specific PRI (via `ProjectPriFileName`) to avoid resource conflicts. This fix unblocks that scenario - without it, any sparse-packaged app with a custom PRI name fails to load resources.


## Problem



`GetDefaultPriFile()` determines `isPackaged=true` for sparse apps because they have package identity. This causes `GetDefaultPriFileForCurentModule` to pass `"resources.pri"` to `MrmGetFilePathFromName`, which only searches for that exact filename - skipping the `[modulename].pri` fallback that unpackaged apps (the one leverage sparse app) receive.



When multiple apps share the same output directory, each needs its own module-specific PRI to avoid conflicts, but sparse apps could only find `resources.pri`.



## Fix



When the packaged `"resources.pri"` search fails for apps with identity, fall back to the unpackaged discovery path (pass `nullptr` to `MrmGetFilePathFromName`) which triggers the broader search including `"[modulename].pri"` derived from the process executable name.



The fallback is gated on `IsResourceNotFound(hr)` to ensure only genuine not-found conditions trigger it, avoiding masking real errors (e.g., `E_OUTOFMEMORY`, `E_ACCESSDENIED`). If the fallback also fails, the original HRESULT from the `"resources.pri"` search is returned for backward compatibility so callers checking for specific errors (e.g., `ERROR_FILE_NOT_FOUND`) are not broken.



### Changed file

- `dev/MRTCore/mrt/Microsoft.Windows.ApplicationModel.Resources/src/Helper.cpp`



## Existing test coverage



- `DefaultResourceManagerWithExePri` — validates the nullptr fallback mechanism

- `DefaultResourceManager` — validates error behavior when no PRI exists

- `DefaultResourceManagerWithResourcePri` — validates the normal packaged path



A full sparse-app integration test requires actual sparse package registration (`AddPackageByUriAsync`) which is beyond unit test scope.



## Validation



- [x] Builds clean with no warnings

- [ ] `/azp run` pipeline validation



---

A microsoft employee must use /azp run to validate using the pipelines below.



WARNING:

Comments made by azure-pipelines bot maybe inaccurate.

Please see pipeline link to verify that the build is being ran.



For status checks on the main branch, please use TransportPackage-Foundation-PR

(https://microsoft.visualstudio.com/ProjectReunion/_build?definitionId=81063&_a=summary)

and run the build against your PR branch with the default parameters.











