### PR TITLE
revert [1.8-stable CP] Fix: Deployment exceptions masked as ERROR_UNHANDLED_EXCEPTION; SetLastFailure logging single chars

### DIFF
--- a/dev/Deployment/DeploymentActivityContext.cpp
+++ b/dev/Deployment/DeploymentActivityContext.cpp
@@ -5,11 +5,6 @@
 
 #include "DeploymentActivityContext.h"
 
-#include <FrameworkUdk/Containment.h>
-
-// Bug 61543987: [1.8 servicing] Deployment exceptions masked as ERROR_UNHANDLED_EXCEPTION; SetLastFailure logging single chars
-#define WINAPPSDK_CHANGEID_61543987 61543987, WinAppSDK_1_8_7
-
 WindowsAppRuntime::Deployment::Activity::Context& WindowsAppRuntime::Deployment::Activity::Context::Get()
 {
     return g_DeploymentActivityContext;
@@ -42,14 +37,7 @@ void WindowsAppRuntime::Deployment::Activity::Context::SetLastFailure(const wil:
 
     if (failure.pszFile)
     {
-        if (WinAppSdk::Containment::IsChangeEnabled<WINAPPSDK_CHANGEID_61543987>())
-        {
-            m_lastFailure.file = failure.pszFile;
-        }
-        else
-        {
-            m_lastFailure.file = *failure.pszFile;
-        }
+        m_lastFailure.file = *failure.pszFile;
     }
     else
     {
@@ -60,14 +48,7 @@ void WindowsAppRuntime::Deployment::Activity::Context::SetLastFailure(const wil:
 
     if (failure.pszMessage)
     {
-        if (WinAppSdk::Containment::IsChangeEnabled<WINAPPSDK_CHANGEID_61543987>())
-        {
-            m_lastFailure.message = failure.pszMessage;
-        }
-        else
-        {
-            m_lastFailure.message = *failure.pszMessage;
-        }
+        m_lastFailure.message = *failure.pszMessage;
     }
     else
     {
@@ -76,14 +57,7 @@ void WindowsAppRuntime::Deployment::Activity::Context::SetLastFailure(const wil:
 
     if (failure.pszModule)
     {
-        if (WinAppSdk::Containment::IsChangeEnabled<WINAPPSDK_CHANGEID_61543987>())
-        {
-            m_lastFailure.module = failure.pszModule;
-        }
-        else
-        {
-            m_lastFailure.module = *failure.pszModule;
-        }
+        m_lastFailure.module = *failure.pszModule;
     }
     else
     {

--- a/dev/Deployment/DeploymentManager.cpp
+++ b/dev/Deployment/DeploymentManager.cpp
@@ -18,9 +18,6 @@
 // Bug 61124029: [1.8 servicing] Fixing reset activity data on deployment initialization
 #define WINAPPSDK_CHANGEID_61124029 61124029, WinAppSDK_1_8_6
 
-// Bug 61543987: [1.8 servicing] Deployment exceptions masked as ERROR_UNHANDLED_EXCEPTION; SetLastFailure logging single chars
-#define WINAPPSDK_CHANGEID_61543987 61543987, WinAppSDK_1_8_7
-
 using namespace winrt;
 using namespace winrt::Windows::Foundation;
 
@@ -212,17 +209,9 @@ namespace winrt::Microsoft::Windows::ApplicationModel::WindowsAppRuntime::implem
         {
             deploymentResult = _Initialize(initializeActivityContext, packageFullName, deploymentInitializeOptions, isRepair);
         }
-        catch (...)
+        catch (winrt::hresult_error const& e)
         {
-            const HRESULT hr = []() -> HRESULT {
-                if (WinAppSdk::Containment::IsChangeEnabled<WINAPPSDK_CHANGEID_61543987>())
-                {
-                    return wil::ResultFromCaughtException();
-                }
-                try { throw; }
-                catch (winrt::hresult_error const& e) { return e.code(); }
-                // Non-winrt::hresult_error exceptions propagate (old behavior)
-            }();
+            const HRESULT hr{ e.code() };
 
             auto packageIdentity{ AppModel::Identity::PackageIdentity::FromPackageFullName(packageFullName.c_str()) };
             PCWSTR c_packageNamePrefix{ L"microsoft.windowsappruntime." };
@@ -230,7 +219,7 @@ namespace winrt::Microsoft::Windows::ApplicationModel::WindowsAppRuntime::implem
             std::wstring release;
             if (CompareStringOrdinal(packageIdentity.Name(), -1, c_packageNamePrefix, -1, TRUE) == CSTR_EQUAL)
             {
-                release = packageIdentity.Name() + c_packageNamePrefixLength;
+                release =  packageIdentity.Name() + c_packageNamePrefixLength;
             }
             else
             {
@@ -253,7 +242,7 @@ namespace winrt::Microsoft::Windows::ApplicationModel::WindowsAppRuntime::implem
 
             THROW_HR_MSG(hr, "PackageFullName=%ls Options: ForceDeployment=%c OnErrorShowUI=%c isRepair:%c",
                          packageFullName.c_str(), deploymentInitializeOptions.ForceDeployment() ? 'Y' : 'N',
-                         deploymentInitializeOptions.OnErrorShowUI() ? 'Y' : 'N', isRepair ? 'Y' : 'N');
+                         deploymentInitializeOptions.OnErrorShowUI() ? 'Y' : 'N', isRepair ? 'Y' : 'N' );
         }
 
         // Success!

--- a/dev/RuntimeCompatibilityOptions/RuntimeCompatibilityOptions.idl
+++ b/dev/RuntimeCompatibilityOptions/RuntimeCompatibilityOptions.idl
@@ -36,7 +36,6 @@ namespace Microsoft.Windows.ApplicationModel.WindowsAppRuntime
         TextIntelligence_Insights = 61106039,
 
         // 1.8.7
-        DeploymentManager_DiagnosabilityFix = 61543987,
         LanguageModel_ProcessingFix = 61200617,
         ImageDescription_ConcurrencyFix = 61350696,
         LanguageModel_ContentErrorHandlingFix = 61352166,

--- a/dev/WindowsAppRuntime_BootstrapDLL/MddBootstrapActivity.cpp
+++ b/dev/WindowsAppRuntime_BootstrapDLL/MddBootstrapActivity.cpp
@@ -18,7 +18,7 @@ void WindowsAppRuntime::MddBootstrap::Activity::Context::SetLastFailure(const wi
 
     if (failure.pszFile)
     {
-        m_lastFailure.file = failure.pszFile;
+        m_lastFailure.file = *failure.pszFile;
     }
     else
     {
@@ -29,7 +29,7 @@ void WindowsAppRuntime::MddBootstrap::Activity::Context::SetLastFailure(const wi
 
     if (failure.pszMessage)
     {
-        m_lastFailure.message = failure.pszMessage;
+        m_lastFailure.message = *failure.pszMessage;
     }
     else
     {
@@ -38,7 +38,7 @@ void WindowsAppRuntime::MddBootstrap::Activity::Context::SetLastFailure(const wi
 
     if (failure.pszModule)
     {
-        m_lastFailure.module = failure.pszModule;
+        m_lastFailure.module = *failure.pszModule;
     }
     else
     {

--- a/dev/WindowsAppRuntime_BootstrapDLL/MddBootstrapAutoInitializer.cpp
+++ b/dev/WindowsAppRuntime_BootstrapDLL/MddBootstrapAutoInitializer.cpp
@@ -4,7 +4,6 @@
 #include <Windows.h>
 #include <stdint.h>
 #include <stdlib.h>
-
 #include <MddBootstrap.h>
 #include <WindowsAppSDK-VersionInfo.h>
 

--- a/installer/dev/InstallActivityContext.cpp
+++ b/installer/dev/InstallActivityContext.cpp
@@ -4,11 +4,6 @@
 #include "pch.h"
 #include "InstallActivityContext.h"
 
-#include <FrameworkUdk/Containment.h>
-
-// Bug 61543987: [1.8 servicing] Deployment exceptions masked as ERROR_UNHANDLED_EXCEPTION; SetLastFailure logging single chars
-#define WINAPPSDK_CHANGEID_61543987 61543987, WinAppSDK_1_8_7
-
 WindowsAppRuntimeInstaller::InstallActivity::Context& WindowsAppRuntimeInstaller::InstallActivity::Context::Get()
 {
     return g_installActivityContext;
@@ -42,14 +37,7 @@ void WindowsAppRuntimeInstaller::InstallActivity::Context::SetLastFailure(const 
 
     if (failure.pszFile)
     {
-        if (WinAppSdk::Containment::IsChangeEnabled<WINAPPSDK_CHANGEID_61543987>())
-        {
-            m_lastFailure.file = failure.pszFile;
-        }
-        else
-        {
-            m_lastFailure.file = *failure.pszFile;
-        }
+        m_lastFailure.file = *failure.pszFile;
     }
     else
     {
@@ -60,14 +48,7 @@ void WindowsAppRuntimeInstaller::InstallActivity::Context::SetLastFailure(const 
 
     if (failure.pszMessage)
     {
-        if (WinAppSdk::Containment::IsChangeEnabled<WINAPPSDK_CHANGEID_61543987>())
-        {
-            m_lastFailure.message = failure.pszMessage;
-        }
-        else
-        {
-            m_lastFailure.message = *failure.pszMessage;
-        }
+        m_lastFailure.message = *failure.pszMessage;
     }
     else
     {


### PR DESCRIPTION
…HANDLED_EXCEPTION; SetLastFailure logging single chars (#6330)"

This reverts commit 2a2a5dcaa43250f25ee01015234fe7fad67a187b.

A microsoft employee must use /azp run to validate using the pipelines below.

WARNING:
Comments made by azure-pipelines bot maybe inaccurate.
Please see pipeline link to verify that the build is being ran.

For status checks on the main branch, please use TransportPackage-Foundation-PR
(https://microsoft.visualstudio.com/ProjectReunion/_build?definitionId=81063&_a=summary)
and run the build against your PR branch with the default parameters.
