### PR TITLE
Set DefaultContentDialogStyle on ContentDialog item template

### DIFF
--- a/dev/VSIX/ItemTemplates/Neutral/CSharp/ContentDialog/ContentDialog.xaml
+++ b/dev/VSIX/ItemTemplates/Neutral/CSharp/ContentDialog/ContentDialog.xaml
@@ -6,6 +6,7 @@
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:local="using:$rootnamespace$"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    Style="{StaticResource DefaultContentDialogStyle}"
     Title="Title"
     PrimaryButtonClick="ContentDialog_PrimaryButtonClick"
     PrimaryButtonText="Button1"


### PR DESCRIPTION
Adds Style="{StaticResource DefaultContentDialogStyle}" to the ContentDialog XAML item template so it picks up the correct default style.