### PR TITLE
Update build channel to stable and bump patch to 19

### DIFF
--- a/build/AzurePipelinesTemplates/WindowsAppSDK-PackTransportPackage-Stage.yml
+++ b/build/AzurePipelinesTemplates/WindowsAppSDK-PackTransportPackage-Stage.yml
@@ -168,7 +168,7 @@ stages:
         targetType: 'inline'
         script: |
           $buildType = '$(channel)'
-          $majorMinorPatchRev = '$(MajorVersion).$(MinorVersion).18'
+          $majorMinorPatchRev = '$(MajorVersion).$(MinorVersion).19'
           
           if ($env:ComponentType)
           {

--- a/build/WindowsAppSDK-CommonVariables.yml
+++ b/build/WindowsAppSDK-CommonVariables.yml
@@ -2,7 +2,7 @@ variables:
   _useBuildOutputFromPipeline: $[coalesce(variables.useBuildOutputFromPipeline, variables['System.DefinitionId'] )]
   _useBuildOutputFromBuildId: $[coalesce(variables.useBuildOutputFromBuildId, variables['Build.BuildId'] )]
 
-  channel: 'preview'
+  channel: 'stable'
   rerunPassesRequiredToAvoidFailure: 5
   versionDate: $[format('{0:yyyyMMdd}', pipeline.startTime)]
   versionMinDate: $[format('{0:yyMMdd}', pipeline.startTime)]


### PR DESCRIPTION
 ## Summary
 Fixes the 2.0-stable official build failure ([build 144588870](https://microsoft.visualstudio.com/ProjectRe
union/_build/results?buildId=144588870&view=results)).
 
 ## Root Cause
 The `channel` variable in `WindowsAppSDK-CommonVariables.yml` was set to `'preview'`, causing the 
"Determine Component Nuget Package Version" task in the Pack stage to fail with:
 > Variable VersionTag must start with preview
 
 Since `VersionTag` is empty on stable builds, the validation (`$buildType -ne "stable" -and -not 
$versionTag.StartsWith($buildType)`) triggered `##vso[task.complete result=Failed;]DONE`.
 
 ## Changes
 - **`build/WindowsAppSDK-CommonVariables.yml`** — Set `channel` from `'preview'` to `'stable'`
 - **`build/AzurePipelinesTemplates/WindowsAppSDK-PackTransportPackage-Stage.yml`** — Bump component NuGet 
package patch version from `18` to `19`