### PR TITLE
feat: create Foundation-Build-Stage.yml reusable template

### DIFF
--- a/build/AzurePipelinesTemplates/Foundation-Build-Stage.yml
+++ b/build/AzurePipelinesTemplates/Foundation-Build-Stage.yml
@@ -1,0 +1,82 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+# Foundation Build Stage Template — Reusable stages for building Foundation + MRT Core
+# and packaging the transport + component NuGet packages.
+#
+# Emits the following stages:
+#   Build_AnyCPU   — AnyCPU build (Bootstrap.Net) + copyright verification
+#   Build_x64      — x64 Foundation + MRT build
+#   Build_x86      — x86 Foundation + MRT build
+#   Build_arm64    — arm64 Foundation + MRT build
+#   Pack           — Downloads all build artifacts, packs transport + component NuGet
+#
+# Optionally also emits PREfast stages when runStaticAnalysis is true:
+#   PREfast_AnyCPU — PREfast analysis (AnyCPU)
+#   PREfast_x64    — PREfast analysis (x64)
+#
+# Usage (mono-build):
+#   - template: build/AzurePipelinesTemplates/Foundation-Build-Stage.yml@WindowsAppSDKFoundation
+#     parameters:
+#       SignOutput: true
+#       BuildType: ${{ parameters.BuildType }}
+#
+# Usage (per-component pipeline):
+#   - template: AzurePipelinesTemplates/Foundation-Build-Stage.yml
+#     parameters:
+#       SignOutput: false
+#       runStaticAnalysis: ${{ parameters.runStaticAnalysis }}
+#
+# See: CopilotBrain/Docs/Mono-Build-Pipeline-Migration.md Section 6.12.5
+
+parameters:
+  - name: SignOutput
+    type: boolean
+    default: false
+  - name: IsOfficial
+    type: boolean
+    default: false
+  - name: BuildType
+    type: string
+    default: 'experimental'
+  - name: runStaticAnalysis
+    type: boolean
+    default: true
+  - name: PublishPackage
+    type: boolean
+    default: false
+  - name: testMatrix
+    type: string
+    default: ''
+
+stages:
+  #───────────────────────────────────────────────────────────────────────────
+  # Build stages — Foundation + MRT Core (all platforms + AnyCPU)
+  #───────────────────────────────────────────────────────────────────────────
+  - template: WindowsAppSDK-Build-Stage.yml
+    parameters:
+      SignOutput: ${{ parameters.SignOutput }}
+      runApiScan: ${{ parameters.runStaticAnalysis }}
+      runPREfast: false
+      testMatrix: ${{ parameters.testMatrix }}
+
+  #───────────────────────────────────────────────────────────────────────────
+  # PREfast stages (conditional — only when runStaticAnalysis is true)
+  #───────────────────────────────────────────────────────────────────────────
+  - ${{ if eq(parameters.runStaticAnalysis, true) }}:
+    - template: WindowsAppSDK-Build-Stage.yml
+      parameters:
+        SignOutput: ${{ parameters.SignOutput }}
+        runApiScan: false
+        runPREfast: true
+        testMatrix: ${{ parameters.testMatrix }}
+
+  #───────────────────────────────────────────────────────────────────────────
+  # Pack stage — assembles transport + component NuGet packages
+  # Depends on all build stages completing.
+  #───────────────────────────────────────────────────────────────────────────
+  - template: WindowsAppSDK-PackTransportPackage-Stage.yml
+    parameters:
+      SignOutput: ${{ parameters.SignOutput }}
+      IsOfficial: ${{ parameters.IsOfficial }}
+      PublishPackage: ${{ parameters.PublishPackage }}

--- a/build/WindowsAppSDK-Foundation-DevTest.yml
+++ b/build/WindowsAppSDK-Foundation-DevTest.yml
@@ -135,25 +135,13 @@ extends:
         break: false
 
     stages:
-    - template: AzurePipelinesTemplates\WindowsAppSDK-Build-Stage.yml@self
+    # Foundation Build + Pack stages
+    - template: AzurePipelinesTemplates/Foundation-Build-Stage.yml@self
       parameters:
         SignOutput: ${{ parameters.SignOutput }}
-        runApiScan: ${{ parameters.runStaticAnalysis }}
-        runPREFast: false
-        testMatrix: ${{ variables.PipelineTests }}
-    
-    - ${{ if eq(parameters.runStaticAnalysis, 'true') }}:
-      - template: AzurePipelinesTemplates\WindowsAppSDK-Build-Stage.yml@self
-        parameters:
-          SignOutput: ${{ parameters.SignOutput }}
-          runApiScan: false
-          runPREFast: true
-          testMatrix: ${{ variables.PipelineTests }}
-
-    - template: AzurePipelinesTemplates\WindowsAppSDK-PackTransportPackage-Stage.yml@self
-      parameters:
-        SignOutput: ${{ parameters.SignOutput }}
+        runStaticAnalysis: ${{ parameters.runStaticAnalysis }}
         PublishPackage: true
+        testMatrix: ${{ variables.PipelineTests }}
 
     - template: AzurePipelinesTemplates\WindowsAppSDK-StaticValidationTest-Stage.yml@self
       parameters:

--- a/build/WindowsAppSDK-Foundation-Nightly.yml
+++ b/build/WindowsAppSDK-Foundation-Nightly.yml
@@ -143,25 +143,13 @@ extends:
         break: false
 
     stages:
-    - template: AzurePipelinesTemplates\WindowsAppSDK-Build-Stage.yml@self
+    # Foundation Build + Pack stages
+    - template: AzurePipelinesTemplates/Foundation-Build-Stage.yml@self
       parameters:
         SignOutput: ${{ parameters.SignOutput }}
-        runApiScan: ${{ parameters.runStaticAnalysis }}
-        runPREFast: false
-        testMatrix: ${{ variables.PipelineTests }}
-    
-    - ${{ if eq(parameters.runStaticAnalysis, 'true') }}:
-      - template: AzurePipelinesTemplates\WindowsAppSDK-Build-Stage.yml@self
-        parameters:
-          SignOutput: ${{ parameters.SignOutput }}
-          runApiScan: false
-          runPREFast: true
-          testMatrix: ${{ variables.PipelineTests }}
-
-    - template: AzurePipelinesTemplates\WindowsAppSDK-PackTransportPackage-Stage.yml@self
-      parameters:
-        SignOutput: ${{ parameters.SignOutput }}
+        runStaticAnalysis: ${{ parameters.runStaticAnalysis }}
         PublishPackage: true
+        testMatrix: ${{ variables.PipelineTests }}
 
     - ${{ if eq( parameters.CheckApiChanges, true ) }}:
       - template: AzurePipelinesTemplates\WindowsAppSDK-CheckApiChanges-Stage.yml@self

--- a/build/WindowsAppSDK-Foundation-Official.yml
+++ b/build/WindowsAppSDK-Foundation-Official.yml
@@ -155,26 +155,14 @@ extends:
                 Unless none of the servicing changes have containment, Foundation MUST include the RuntimeCompatibilityChange
                 enum values associated with this servicing release before kicking off this official build.
     
-    - template: AzurePipelinesTemplates\WindowsAppSDK-Build-Stage.yml@self
+    # Foundation Build + Pack stages
+    - template: AzurePipelinesTemplates/Foundation-Build-Stage.yml@self
       parameters:
         SignOutput: ${{ parameters.SignOutput }}
-        runApiScan: ${{ parameters.runStaticAnalysis }}
-        runPREFast: false
-        testMatrix: ${{ variables.PipelineTests }}
-    
-    - ${{ if eq(parameters.runStaticAnalysis, 'true') }}:
-      - template: AzurePipelinesTemplates\WindowsAppSDK-Build-Stage.yml@self
-        parameters:
-          SignOutput: ${{ parameters.SignOutput }}
-          runApiScan: false
-          runPREFast: true
-          testMatrix: ${{ variables.PipelineTests }}
-
-    - template: AzurePipelinesTemplates\WindowsAppSDK-PackTransportPackage-Stage.yml@self
-      parameters:
-        SignOutput: ${{ parameters.SignOutput }}
-        PublishPackage: true
         IsOfficial: true
+        runStaticAnalysis: ${{ parameters.runStaticAnalysis }}
+        PublishPackage: true
+        testMatrix: ${{ variables.PipelineTests }}
 
     - ${{ if eq( parameters.CheckApiChanges, true ) }}:
       - template: AzurePipelinesTemplates\WindowsAppSDK-CheckApiChanges-Stage.yml@self

--- a/build/WindowsAppSDK-Foundation-PR.yml
+++ b/build/WindowsAppSDK-Foundation-PR.yml
@@ -112,25 +112,12 @@ extends:
         break: false
 
     stages:
-    - template: AzurePipelinesTemplates\WindowsAppSDK-Build-Stage.yml@self
+    # Foundation Build + Pack stages (Build_AnyCPU, Build_x64/x86/arm64, PREfast, Pack)
+    - template: AzurePipelinesTemplates/Foundation-Build-Stage.yml@self
       parameters:
         SignOutput: false
-        runApiScan: ${{ parameters.runStaticAnalysis }}
-        runPREFast: false
+        runStaticAnalysis: ${{ parameters.runStaticAnalysis }}
         testMatrix: ${{ variables.PipelineTests }}
-    
-    - ${{ if eq(parameters.runStaticAnalysis, 'true') }}:
-      - template: AzurePipelinesTemplates\WindowsAppSDK-Build-Stage.yml@self
-        parameters:
-          SignOutput: false
-          runApiScan: false
-          runPREFast: true
-          testMatrix: ${{ variables.PipelineTests }}
-
-    - template: AzurePipelinesTemplates\WindowsAppSDK-PackTransportPackage-Stage.yml@self
-      parameters:
-        SignOutput: false
-        PublishPackage: false
         
     - template: AzurePipelinesTemplates\WindowsAppSDK-StaticValidationTest-Stage.yml@self
       parameters:


### PR DESCRIPTION
Extract Build + PREfast + Pack stages into a single reusable stages template. All 4 per-component pipelines (PR, Nightly, Official, DevTest) now reference Foundation-Build-Stage.yml instead of separately including WindowsAppSDK-Build-Stage.yml (twice for PREfast) and WindowsAppSDK-PackTransportPackage-Stage.yml.

The same template will be referenced by the monobuild via @WindowsAppSDKFoundation.

Parameters: SignOutput, IsOfficial, BuildType, runStaticAnalysis, PublishPackage, testMatrix.

A microsoft employee must use /azp run to validate using the pipelines below.

WARNING:
Comments made by azure-pipelines bot maybe inaccurate.
Please see pipeline link to verify that the build is being ran.

For status checks on the main branch, please use TransportPackage-Foundation-PR
(https://microsoft.visualstudio.com/ProjectReunion/_build?definitionId=81063&_a=summary)
and run the build against your PR branch with the default parameters.
