### PR TITLE
feat: add IsMonobuild parameter to step templates for self-ref support

### DIFF
--- a/build/AzurePipelinesTemplates/WindowsAppSDK-BuildFoundation-AnyCPU-Steps.yml
+++ b/build/AzurePipelinesTemplates/WindowsAppSDK-BuildFoundation-AnyCPU-Steps.yml
@@ -5,6 +5,12 @@ parameters:
 - name: runPREfast
   type: boolean
   default: false
+# When true, this template is being invoked from the monobuild context where
+# the WindowsAppSDK monorepo IS the self repo. EsrpCodeSigning-Steps is invoked
+# WITHOUT the @WinAppSDK suffix.
+- name: IsMonobuild
+  type: boolean
+  default: false
 
 steps:
 - task: NuGetAuthenticate@1
@@ -53,16 +59,28 @@ steps:
     failOnAlert: false #changed true to false, temporary workaround for component governance blocking pipeline due to low .NET version
 
 - ${{ if eq(parameters.SignOutput, 'true') }}:
-  - template: Build/WindowsAppSDK/AzurePipelinesTemplates/WindowsAppSDK-EsrpCodeSigning-Steps.yml@WinAppSDK
-    parameters:
-      FolderPath: '$(build.SourcesDirectory)\BuildOutput'
-      UseMinimatch: true
-      Pattern: |
-        **/*.winmd
-        **/*.dll
-        **/*.exe
-      KeyCode: 'CP-230012'
-      displayName: 'Authenticode CodeSign Binaries'
+  - ${{ if parameters.IsMonobuild }}:
+    - template: Build/WindowsAppSDK/AzurePipelinesTemplates/WindowsAppSDK-EsrpCodeSigning-Steps.yml
+      parameters:
+        FolderPath: '$(build.SourcesDirectory)\BuildOutput'
+        UseMinimatch: true
+        Pattern: |
+          **/*.winmd
+          **/*.dll
+          **/*.exe
+        KeyCode: 'CP-230012'
+        displayName: 'Authenticode CodeSign Binaries'
+  - ${{ else }}:
+    - template: Build/WindowsAppSDK/AzurePipelinesTemplates/WindowsAppSDK-EsrpCodeSigning-Steps.yml@WinAppSDK
+      parameters:
+        FolderPath: '$(build.SourcesDirectory)\BuildOutput'
+        UseMinimatch: true
+        Pattern: |
+          **/*.winmd
+          **/*.dll
+          **/*.exe
+        KeyCode: 'CP-230012'
+        displayName: 'Authenticode CodeSign Binaries'
 
 # Artifacts are uploaded via ob_outputDirectory where the each vPack Push jobs downloads from
 # so the CopyFiles below are to move all the vPack files to the right locations

--- a/build/AzurePipelinesTemplates/WindowsAppSDK-BuildFoundation-AnyCPU-Steps.yml
+++ b/build/AzurePipelinesTemplates/WindowsAppSDK-BuildFoundation-AnyCPU-Steps.yml
@@ -60,7 +60,7 @@ steps:
 
 - ${{ if eq(parameters.SignOutput, 'true') }}:
   - ${{ if parameters.IsMonobuild }}:
-    - template: Build/WindowsAppSDK/AzurePipelinesTemplates/WindowsAppSDK-EsrpCodeSigning-Steps.yml
+    - template: Build/WindowsAppSDK/AzurePipelinesTemplates/WindowsAppSDK-EsrpCodeSigning-Steps.yml@self
       parameters:
         FolderPath: '$(build.SourcesDirectory)\BuildOutput'
         UseMinimatch: true

--- a/build/AzurePipelinesTemplates/WindowsAppSDK-BuildFoundation-AnyCPU-Steps.yml
+++ b/build/AzurePipelinesTemplates/WindowsAppSDK-BuildFoundation-AnyCPU-Steps.yml
@@ -59,20 +59,10 @@ steps:
     failOnAlert: false #changed true to false, temporary workaround for component governance blocking pipeline due to low .NET version
 
 - ${{ if eq(parameters.SignOutput, 'true') }}:
-  - ${{ if parameters.IsMonobuild }}:
-    - template: Build/WindowsAppSDK/AzurePipelinesTemplates/WindowsAppSDK-EsrpCodeSigning-Steps.yml@self
-      parameters:
-        FolderPath: '$(build.SourcesDirectory)\BuildOutput'
-        UseMinimatch: true
-        Pattern: |
-          **/*.winmd
-          **/*.dll
-          **/*.exe
-        KeyCode: 'CP-230012'
-        displayName: 'Authenticode CodeSign Binaries'
-  - ${{ else }}:
-    - template: Build/WindowsAppSDK/AzurePipelinesTemplates/WindowsAppSDK-EsrpCodeSigning-Steps.yml@WinAppSDK
-      parameters:
+  - template: WindowsAppSDK-EsrpCodeSigning-Wrapper.yml
+    parameters:
+      IsMonobuild: ${{ parameters.IsMonobuild }}
+      InnerParams:
         FolderPath: '$(build.SourcesDirectory)\BuildOutput'
         UseMinimatch: true
         Pattern: |

--- a/build/AzurePipelinesTemplates/WindowsAppSDK-BuildFoundation-Steps.yml
+++ b/build/AzurePipelinesTemplates/WindowsAppSDK-BuildFoundation-Steps.yml
@@ -8,6 +8,12 @@ parameters:
 - name: runPREfast
   type: boolean
   default: false
+# When true, this template is being invoked from the monobuild context where
+# the WindowsAppSDK monorepo IS the self repo. The shared EsrpCodeSigning-Steps
+# template is invoked WITHOUT the @WinAppSDK suffix.
+- name: IsMonobuild
+  type: boolean
+  default: false
 
 steps:
 - task: NuGetAuthenticate@1
@@ -132,16 +138,28 @@ steps:
   #  continueOnError: true
 
 - ${{ if eq(parameters.SignOutput, 'true') }}:
-  - template: Build/WindowsAppSDK/AzurePipelinesTemplates/WindowsAppSDK-EsrpCodeSigning-Steps.yml@WinAppSDK
-    parameters:
-      FolderPath: '$(build.SourcesDirectory)\BuildOutput'
-      UseMinimatch: true
-      Pattern: |
-        **/*.winmd
-        **/*.dll
-        **/*.exe
-      KeyCode: 'CP-230012'
-      displayName: 'Authenticode CodeSign Binaries'
+  - ${{ if parameters.IsMonobuild }}:
+    - template: Build/WindowsAppSDK/AzurePipelinesTemplates/WindowsAppSDK-EsrpCodeSigning-Steps.yml
+      parameters:
+        FolderPath: '$(build.SourcesDirectory)\BuildOutput'
+        UseMinimatch: true
+        Pattern: |
+          **/*.winmd
+          **/*.dll
+          **/*.exe
+        KeyCode: 'CP-230012'
+        displayName: 'Authenticode CodeSign Binaries'
+  - ${{ else }}:
+    - template: Build/WindowsAppSDK/AzurePipelinesTemplates/WindowsAppSDK-EsrpCodeSigning-Steps.yml@WinAppSDK
+      parameters:
+        FolderPath: '$(build.SourcesDirectory)\BuildOutput'
+        UseMinimatch: true
+        Pattern: |
+          **/*.winmd
+          **/*.dll
+          **/*.exe
+        KeyCode: 'CP-230012'
+        displayName: 'Authenticode CodeSign Binaries'
 
 # Artifacts are uploaded via ob_outputDirectory where the each vPack Push jobs downloads from
 # so the CopyFiles below are to move all the vPack files to the right locations

--- a/build/AzurePipelinesTemplates/WindowsAppSDK-BuildFoundation-Steps.yml
+++ b/build/AzurePipelinesTemplates/WindowsAppSDK-BuildFoundation-Steps.yml
@@ -138,20 +138,10 @@ steps:
   #  continueOnError: true
 
 - ${{ if eq(parameters.SignOutput, 'true') }}:
-  - ${{ if parameters.IsMonobuild }}:
-    - template: Build/WindowsAppSDK/AzurePipelinesTemplates/WindowsAppSDK-EsrpCodeSigning-Steps.yml@self
-      parameters:
-        FolderPath: '$(build.SourcesDirectory)\BuildOutput'
-        UseMinimatch: true
-        Pattern: |
-          **/*.winmd
-          **/*.dll
-          **/*.exe
-        KeyCode: 'CP-230012'
-        displayName: 'Authenticode CodeSign Binaries'
-  - ${{ else }}:
-    - template: Build/WindowsAppSDK/AzurePipelinesTemplates/WindowsAppSDK-EsrpCodeSigning-Steps.yml@WinAppSDK
-      parameters:
+  - template: WindowsAppSDK-EsrpCodeSigning-Wrapper.yml
+    parameters:
+      IsMonobuild: ${{ parameters.IsMonobuild }}
+      InnerParams:
         FolderPath: '$(build.SourcesDirectory)\BuildOutput'
         UseMinimatch: true
         Pattern: |

--- a/build/AzurePipelinesTemplates/WindowsAppSDK-BuildFoundation-Steps.yml
+++ b/build/AzurePipelinesTemplates/WindowsAppSDK-BuildFoundation-Steps.yml
@@ -139,7 +139,7 @@ steps:
 
 - ${{ if eq(parameters.SignOutput, 'true') }}:
   - ${{ if parameters.IsMonobuild }}:
-    - template: Build/WindowsAppSDK/AzurePipelinesTemplates/WindowsAppSDK-EsrpCodeSigning-Steps.yml
+    - template: Build/WindowsAppSDK/AzurePipelinesTemplates/WindowsAppSDK-EsrpCodeSigning-Steps.yml@self
       parameters:
         FolderPath: '$(build.SourcesDirectory)\BuildOutput'
         UseMinimatch: true

--- a/build/AzurePipelinesTemplates/WindowsAppSDK-BuildInstaller-Steps.yml
+++ b/build/AzurePipelinesTemplates/WindowsAppSDK-BuildInstaller-Steps.yml
@@ -294,30 +294,19 @@ steps:
     failOnAlert: false
   condition: and(succeeded(), ne(variables.SkipInstallerBuild, true))
 
-- ${{ if parameters.IsMonobuild }}:
-  - template: Build/WindowsAppSDK/AzurePipelinesTemplates/WindowsAppSDK-PublishSymbol-Steps.yml@self
-    parameters:
-      SearchPattern: '$(foundationRepoPath)BuildOutput\$(buildConfiguration)\$(buildPlatform)\WindowsAppRuntimeInstall\*.pdb'
-      IsOfficial: ${{ parameters.IsOfficial }}
-      condition: and(succeeded(), ne(variables.SkipInstallerBuild, true))
-- ${{ else }}:
-  - template: Build/WindowsAppSDK/AzurePipelinesTemplates/WindowsAppSDK-PublishSymbol-Steps.yml@WinAppSDK
-    parameters:
+- template: WindowsAppSDK-PublishSymbol-Wrapper.yml
+  parameters:
+    IsMonobuild: ${{ parameters.IsMonobuild }}
+    InnerParams:
       SearchPattern: '$(foundationRepoPath)BuildOutput\$(buildConfiguration)\$(buildPlatform)\WindowsAppRuntimeInstall\*.pdb'
       IsOfficial: ${{ parameters.IsOfficial }}
       condition: and(succeeded(), ne(variables.SkipInstallerBuild, true))
 
 - ${{ if eq(parameters.SignOutput, 'true') }}:
-  - ${{ if parameters.IsMonobuild }}:
-    - template: Build/WindowsAppSDK/AzurePipelinesTemplates/WindowsAppSDK-EsrpCodeSigning-Steps.yml@self
-      parameters:
-        FolderPath: $(foundationRepoPath)BuildOutput\$(buildConfiguration)\$(buildPlatform)\WindowsAppRuntimeInstall
-        Pattern: WindowsAppRuntimeInstall*.exe
-        UseMinimatch: true
-        KeyCode: 'CP-230012'
-  - ${{ else }}:
-    - template: Build/WindowsAppSDK/AzurePipelinesTemplates/WindowsAppSDK-EsrpCodeSigning-Steps.yml@WinAppSDK
-      parameters:
+  - template: WindowsAppSDK-EsrpCodeSigning-Wrapper.yml
+    parameters:
+      IsMonobuild: ${{ parameters.IsMonobuild }}
+      InnerParams:
         FolderPath: $(foundationRepoPath)BuildOutput\$(buildConfiguration)\$(buildPlatform)\WindowsAppRuntimeInstall
         Pattern: WindowsAppRuntimeInstall*.exe
         UseMinimatch: true

--- a/build/AzurePipelinesTemplates/WindowsAppSDK-BuildInstaller-Steps.yml
+++ b/build/AzurePipelinesTemplates/WindowsAppSDK-BuildInstaller-Steps.yml
@@ -295,7 +295,7 @@ steps:
   condition: and(succeeded(), ne(variables.SkipInstallerBuild, true))
 
 - ${{ if parameters.IsMonobuild }}:
-  - template: Build/WindowsAppSDK/AzurePipelinesTemplates/WindowsAppSDK-PublishSymbol-Steps.yml
+  - template: Build/WindowsAppSDK/AzurePipelinesTemplates/WindowsAppSDK-PublishSymbol-Steps.yml@self
     parameters:
       SearchPattern: '$(foundationRepoPath)BuildOutput\$(buildConfiguration)\$(buildPlatform)\WindowsAppRuntimeInstall\*.pdb'
       IsOfficial: ${{ parameters.IsOfficial }}
@@ -309,7 +309,7 @@ steps:
 
 - ${{ if eq(parameters.SignOutput, 'true') }}:
   - ${{ if parameters.IsMonobuild }}:
-    - template: Build/WindowsAppSDK/AzurePipelinesTemplates/WindowsAppSDK-EsrpCodeSigning-Steps.yml
+    - template: Build/WindowsAppSDK/AzurePipelinesTemplates/WindowsAppSDK-EsrpCodeSigning-Steps.yml@self
       parameters:
         FolderPath: $(foundationRepoPath)BuildOutput\$(buildConfiguration)\$(buildPlatform)\WindowsAppRuntimeInstall
         Pattern: WindowsAppRuntimeInstall*.exe

--- a/build/AzurePipelinesTemplates/WindowsAppSDK-BuildInstaller-Steps.yml
+++ b/build/AzurePipelinesTemplates/WindowsAppSDK-BuildInstaller-Steps.yml
@@ -11,6 +11,12 @@ parameters:
 - name: UseCurrentBuild
   type: boolean
   default: false 
+# When true, this template is being invoked from the monobuild context where
+# the WindowsAppSDK monorepo IS the self repo. PublishSymbol-Steps and
+# EsrpCodeSigning-Steps are invoked WITHOUT the @WinAppSDK suffix.
+- name: IsMonobuild
+  type: boolean
+  default: false
 
 steps:
 - task: PowerShell@2
@@ -288,19 +294,34 @@ steps:
     failOnAlert: false
   condition: and(succeeded(), ne(variables.SkipInstallerBuild, true))
 
-- template: Build/WindowsAppSDK/AzurePipelinesTemplates/WindowsAppSDK-PublishSymbol-Steps.yml@WinAppSDK
-  parameters:
-    SearchPattern: '$(foundationRepoPath)BuildOutput\$(buildConfiguration)\$(buildPlatform)\WindowsAppRuntimeInstall\*.pdb'
-    IsOfficial: ${{ parameters.IsOfficial }}
-    condition: and(succeeded(), ne(variables.SkipInstallerBuild, true))
+- ${{ if parameters.IsMonobuild }}:
+  - template: Build/WindowsAppSDK/AzurePipelinesTemplates/WindowsAppSDK-PublishSymbol-Steps.yml
+    parameters:
+      SearchPattern: '$(foundationRepoPath)BuildOutput\$(buildConfiguration)\$(buildPlatform)\WindowsAppRuntimeInstall\*.pdb'
+      IsOfficial: ${{ parameters.IsOfficial }}
+      condition: and(succeeded(), ne(variables.SkipInstallerBuild, true))
+- ${{ else }}:
+  - template: Build/WindowsAppSDK/AzurePipelinesTemplates/WindowsAppSDK-PublishSymbol-Steps.yml@WinAppSDK
+    parameters:
+      SearchPattern: '$(foundationRepoPath)BuildOutput\$(buildConfiguration)\$(buildPlatform)\WindowsAppRuntimeInstall\*.pdb'
+      IsOfficial: ${{ parameters.IsOfficial }}
+      condition: and(succeeded(), ne(variables.SkipInstallerBuild, true))
 
 - ${{ if eq(parameters.SignOutput, 'true') }}:
-  - template: Build/WindowsAppSDK/AzurePipelinesTemplates/WindowsAppSDK-EsrpCodeSigning-Steps.yml@WinAppSDK
-    parameters:
-      FolderPath: $(foundationRepoPath)BuildOutput\$(buildConfiguration)\$(buildPlatform)\WindowsAppRuntimeInstall
-      Pattern: WindowsAppRuntimeInstall*.exe
-      UseMinimatch: true
-      KeyCode: 'CP-230012'
+  - ${{ if parameters.IsMonobuild }}:
+    - template: Build/WindowsAppSDK/AzurePipelinesTemplates/WindowsAppSDK-EsrpCodeSigning-Steps.yml
+      parameters:
+        FolderPath: $(foundationRepoPath)BuildOutput\$(buildConfiguration)\$(buildPlatform)\WindowsAppRuntimeInstall
+        Pattern: WindowsAppRuntimeInstall*.exe
+        UseMinimatch: true
+        KeyCode: 'CP-230012'
+  - ${{ else }}:
+    - template: Build/WindowsAppSDK/AzurePipelinesTemplates/WindowsAppSDK-EsrpCodeSigning-Steps.yml@WinAppSDK
+      parameters:
+        FolderPath: $(foundationRepoPath)BuildOutput\$(buildConfiguration)\$(buildPlatform)\WindowsAppRuntimeInstall
+        Pattern: WindowsAppRuntimeInstall*.exe
+        UseMinimatch: true
+        KeyCode: 'CP-230012'
 
 - task: CopyFiles@2
   displayName: 'Publish Installer'

--- a/build/AzurePipelinesTemplates/WindowsAppSDK-BuildMRT-Steps.yml
+++ b/build/AzurePipelinesTemplates/WindowsAppSDK-BuildMRT-Steps.yml
@@ -80,20 +80,10 @@ steps:
 - task: ms.vss-governance-buildtask.governance-build-task-component-detection.ComponentGovernanceComponentDetection@0
 
 - ${{ if eq(parameters.SignOutput, 'true') }}:
-  - ${{ if parameters.IsMonobuild }}:
-    - template: Build/WindowsAppSDK/AzurePipelinesTemplates/WindowsAppSDK-EsrpCodeSigning-Steps.yml@self
-      parameters:
-        FolderPath: '$(build.SourcesDirectory)\BuildOutput'
-        UseMinimatch: true
-        Pattern: |
-          **/*.winmd
-          **/*.dll
-          **/*.exe
-        KeyCode: 'CP-230012'
-        displayName: 'Authenticode CodeSign Binaries'
-  - ${{ else }}:
-    - template: Build/WindowsAppSDK/AzurePipelinesTemplates/WindowsAppSDK-EsrpCodeSigning-Steps.yml@WinAppSDK
-      parameters:
+  - template: WindowsAppSDK-EsrpCodeSigning-Wrapper.yml
+    parameters:
+      IsMonobuild: ${{ parameters.IsMonobuild }}
+      InnerParams:
         FolderPath: '$(build.SourcesDirectory)\BuildOutput'
         UseMinimatch: true
         Pattern: |

--- a/build/AzurePipelinesTemplates/WindowsAppSDK-BuildMRT-Steps.yml
+++ b/build/AzurePipelinesTemplates/WindowsAppSDK-BuildMRT-Steps.yml
@@ -81,7 +81,7 @@ steps:
 
 - ${{ if eq(parameters.SignOutput, 'true') }}:
   - ${{ if parameters.IsMonobuild }}:
-    - template: Build/WindowsAppSDK/AzurePipelinesTemplates/WindowsAppSDK-EsrpCodeSigning-Steps.yml
+    - template: Build/WindowsAppSDK/AzurePipelinesTemplates/WindowsAppSDK-EsrpCodeSigning-Steps.yml@self
       parameters:
         FolderPath: '$(build.SourcesDirectory)\BuildOutput'
         UseMinimatch: true

--- a/build/AzurePipelinesTemplates/WindowsAppSDK-BuildMRT-Steps.yml
+++ b/build/AzurePipelinesTemplates/WindowsAppSDK-BuildMRT-Steps.yml
@@ -8,6 +8,12 @@ parameters:
 - name: runPREfast
   type: boolean
   default: false
+# When true, this template is being invoked from the monobuild context where
+# the WindowsAppSDK monorepo IS the self repo. EsrpCodeSigning-Steps is invoked
+# WITHOUT the @WinAppSDK suffix.
+- name: IsMonobuild
+  type: boolean
+  default: false
 
 steps:
 - template: WindowsAppSDK-SetupBuildEnvironment-Steps.yml
@@ -74,16 +80,28 @@ steps:
 - task: ms.vss-governance-buildtask.governance-build-task-component-detection.ComponentGovernanceComponentDetection@0
 
 - ${{ if eq(parameters.SignOutput, 'true') }}:
-  - template: Build/WindowsAppSDK/AzurePipelinesTemplates/WindowsAppSDK-EsrpCodeSigning-Steps.yml@WinAppSDK
-    parameters:
-      FolderPath: '$(build.SourcesDirectory)\BuildOutput'
-      UseMinimatch: true
-      Pattern: |
-        **/*.winmd
-        **/*.dll
-        **/*.exe
-      KeyCode: 'CP-230012'
-      displayName: 'Authenticode CodeSign Binaries'
+  - ${{ if parameters.IsMonobuild }}:
+    - template: Build/WindowsAppSDK/AzurePipelinesTemplates/WindowsAppSDK-EsrpCodeSigning-Steps.yml
+      parameters:
+        FolderPath: '$(build.SourcesDirectory)\BuildOutput'
+        UseMinimatch: true
+        Pattern: |
+          **/*.winmd
+          **/*.dll
+          **/*.exe
+        KeyCode: 'CP-230012'
+        displayName: 'Authenticode CodeSign Binaries'
+  - ${{ else }}:
+    - template: Build/WindowsAppSDK/AzurePipelinesTemplates/WindowsAppSDK-EsrpCodeSigning-Steps.yml@WinAppSDK
+      parameters:
+        FolderPath: '$(build.SourcesDirectory)\BuildOutput'
+        UseMinimatch: true
+        Pattern: |
+          **/*.winmd
+          **/*.dll
+          **/*.exe
+        KeyCode: 'CP-230012'
+        displayName: 'Authenticode CodeSign Binaries'
 
 - task: CopyFiles@2
   displayName: MoveToOutputDirectory

--- a/build/AzurePipelinesTemplates/WindowsAppSDK-BuildVSIX-Steps.yml
+++ b/build/AzurePipelinesTemplates/WindowsAppSDK-BuildVSIX-Steps.yml
@@ -200,7 +200,7 @@ steps:
         **/WindowsAppSDK.*.Extension.*.dll
         
 - ${{ if parameters.IsMonobuild }}:
-  - template: Build/WindowsAppSDK/AzurePipelinesTemplates/WindowsAppSDK-PublishSymbol-Steps.yml
+  - template: Build/WindowsAppSDK/AzurePipelinesTemplates/WindowsAppSDK-PublishSymbol-Steps.yml@self
     parameters:
       SearchPattern: '$(FoundationRepoPath)dev\VSIX\BuildOutput\obj\AnyCPU$(buildConfiguration)\**\WindowsAppSDK*.pdb'
       IsOfficial: ${{ parameters.IsOfficial }}

--- a/build/AzurePipelinesTemplates/WindowsAppSDK-BuildVSIX-Steps.yml
+++ b/build/AzurePipelinesTemplates/WindowsAppSDK-BuildVSIX-Steps.yml
@@ -11,6 +11,12 @@ parameters:
 - name: UseCurrentBuild
   type: boolean
   default: false 
+# When true, this template is being invoked from the monobuild context where
+# the WindowsAppSDK monorepo IS the self repo. PublishSymbol-Steps is invoked
+# WITHOUT the @WinAppSDK suffix.
+- name: IsMonobuild
+  type: boolean
+  default: false
 - name: OptionalVSIXVersion
   # if blank, the project template will select the version matching the Windows App SDK
   # nuget. If provided, it should be a 4-part dotted version ('1.2.3.4')
@@ -193,10 +199,16 @@ steps:
       codeSignPattern: |
         **/WindowsAppSDK.*.Extension.*.dll
         
-- template: Build/WindowsAppSDK/AzurePipelinesTemplates/WindowsAppSDK-PublishSymbol-Steps.yml@WinAppSDK
-  parameters:
-    SearchPattern: '$(FoundationRepoPath)dev\VSIX\BuildOutput\obj\AnyCPU$(buildConfiguration)\**\WindowsAppSDK*.pdb'
-    IsOfficial: ${{ parameters.IsOfficial }}
+- ${{ if parameters.IsMonobuild }}:
+  - template: Build/WindowsAppSDK/AzurePipelinesTemplates/WindowsAppSDK-PublishSymbol-Steps.yml
+    parameters:
+      SearchPattern: '$(FoundationRepoPath)dev\VSIX\BuildOutput\obj\AnyCPU$(buildConfiguration)\**\WindowsAppSDK*.pdb'
+      IsOfficial: ${{ parameters.IsOfficial }}
+- ${{ else }}:
+  - template: Build/WindowsAppSDK/AzurePipelinesTemplates/WindowsAppSDK-PublishSymbol-Steps.yml@WinAppSDK
+    parameters:
+      SearchPattern: '$(FoundationRepoPath)dev\VSIX\BuildOutput\obj\AnyCPU$(buildConfiguration)\**\WindowsAppSDK*.pdb'
+      IsOfficial: ${{ parameters.IsOfficial }}
 
 - task: CopyFiles@2
   displayName: 'Stage VSIX component JSONs'

--- a/build/AzurePipelinesTemplates/WindowsAppSDK-BuildVSIX-Steps.yml
+++ b/build/AzurePipelinesTemplates/WindowsAppSDK-BuildVSIX-Steps.yml
@@ -199,14 +199,10 @@ steps:
       codeSignPattern: |
         **/WindowsAppSDK.*.Extension.*.dll
         
-- ${{ if parameters.IsMonobuild }}:
-  - template: Build/WindowsAppSDK/AzurePipelinesTemplates/WindowsAppSDK-PublishSymbol-Steps.yml@self
-    parameters:
-      SearchPattern: '$(FoundationRepoPath)dev\VSIX\BuildOutput\obj\AnyCPU$(buildConfiguration)\**\WindowsAppSDK*.pdb'
-      IsOfficial: ${{ parameters.IsOfficial }}
-- ${{ else }}:
-  - template: Build/WindowsAppSDK/AzurePipelinesTemplates/WindowsAppSDK-PublishSymbol-Steps.yml@WinAppSDK
-    parameters:
+- template: WindowsAppSDK-PublishSymbol-Wrapper.yml
+  parameters:
+    IsMonobuild: ${{ parameters.IsMonobuild }}
+    InnerParams:
       SearchPattern: '$(FoundationRepoPath)dev\VSIX\BuildOutput\obj\AnyCPU$(buildConfiguration)\**\WindowsAppSDK*.pdb'
       IsOfficial: ${{ parameters.IsOfficial }}
 

--- a/build/AzurePipelinesTemplates/WindowsAppSDK-ConvertWttLogToXUnit-Wrapper.yml
+++ b/build/AzurePipelinesTemplates/WindowsAppSDK-ConvertWttLogToXUnit-Wrapper.yml
@@ -1,0 +1,18 @@
+# Wrapper for WindowsAppSDK-ConvertWttLogToXUnit-Steps.yml that dispatches to either
+# @WinAppSDK (per-component pipelines) or @self (monobuild) at compile time.
+
+parameters:
+  - name: IsMonobuild
+    type: boolean
+    default: false
+  - name: InnerParams
+    type: object
+    default: {}
+
+steps:
+  - ${{ if parameters.IsMonobuild }}:
+    - template: Build/WindowsAppSDK/AzurePipelinesTemplates/WindowsAppSDK-ConvertWttLogToXUnit-Steps.yml@self
+      parameters: ${{ parameters.InnerParams }}
+  - ${{ else }}:
+    - template: Build/WindowsAppSDK/AzurePipelinesTemplates/WindowsAppSDK-ConvertWttLogToXUnit-Steps.yml@WinAppSDK
+      parameters: ${{ parameters.InnerParams }}

--- a/build/AzurePipelinesTemplates/WindowsAppSDK-DetermineVersion-Wrapper.yml
+++ b/build/AzurePipelinesTemplates/WindowsAppSDK-DetermineVersion-Wrapper.yml
@@ -1,0 +1,18 @@
+# Wrapper for WindowsAppSDK-DetermineVersion-Steps.yml that dispatches to either
+# @WinAppSDK (per-component pipelines) or @self (monobuild) at compile time.
+
+parameters:
+  - name: IsMonobuild
+    type: boolean
+    default: false
+  - name: InnerParams
+    type: object
+    default: {}
+
+steps:
+  - ${{ if parameters.IsMonobuild }}:
+    - template: Build/WindowsAppSDK/AzurePipelinesTemplates/WindowsAppSDK-DetermineVersion-Steps.yml@self
+      parameters: ${{ parameters.InnerParams }}
+  - ${{ else }}:
+    - template: Build/WindowsAppSDK/AzurePipelinesTemplates/WindowsAppSDK-DetermineVersion-Steps.yml@WinAppSDK
+      parameters: ${{ parameters.InnerParams }}

--- a/build/AzurePipelinesTemplates/WindowsAppSDK-EsrpCodeSigning-Wrapper.yml
+++ b/build/AzurePipelinesTemplates/WindowsAppSDK-EsrpCodeSigning-Wrapper.yml
@@ -1,0 +1,19 @@
+# Wrapper for WindowsAppSDK-EsrpCodeSigning-Steps.yml that dispatches to either
+# @WinAppSDK (per-component pipelines) or @self (monobuild) at compile time.
+# This eliminates if/else duplication at each call site.
+
+parameters:
+  - name: IsMonobuild
+    type: boolean
+    default: false
+  - name: InnerParams
+    type: object
+    default: {}
+
+steps:
+  - ${{ if parameters.IsMonobuild }}:
+    - template: Build/WindowsAppSDK/AzurePipelinesTemplates/WindowsAppSDK-EsrpCodeSigning-Steps.yml@self
+      parameters: ${{ parameters.InnerParams }}
+  - ${{ else }}:
+    - template: Build/WindowsAppSDK/AzurePipelinesTemplates/WindowsAppSDK-EsrpCodeSigning-Steps.yml@WinAppSDK
+      parameters: ${{ parameters.InnerParams }}

--- a/build/AzurePipelinesTemplates/WindowsAppSDK-PackTransportPackage-Steps.yml
+++ b/build/AzurePipelinesTemplates/WindowsAppSDK-PackTransportPackage-Steps.yml
@@ -81,43 +81,29 @@ steps:
         targetPath: '$(Build.SourcesDirectory)\BuildOutput'
 
   # ── Stage files + symbols ──
-  # In monobuild context, BuildAll.ps1 expects NuGetLicense files at the
-  # `WinAppSDK\Build\WindowsAppSDK\NuGetLicense` relative path (per-component
-  # pattern). The monobuild has them at `Build\WindowsAppSDK\NuGetLicense`
-  # because the WinAppSDK monorepo IS at $(Build.SourcesDirectory). Ensure
-  # the directory exists at the expected path so BuildAll.ps1 finds them.
+  # In monobuild context, Foundation is checked out at $(Build.SourcesDirectory)\WindowsAppSDK
+  # and self (monobuild) is at $(Build.SourcesDirectory). BuildAll.ps1 expects NuGetLicense
+  # files at WinAppSDK\Build\WindowsAppSDK\NuGetLicense relative to its working directory
+  # (Foundation root). Mirror them from the monobuild's Build\WindowsAppSDK\NuGetLicense.
   - ${{ if parameters.IsMonobuild }}:
     - task: PowerShell@2
       displayName: 'Mirror NuGetLicense files to BuildAll.ps1-expected path (monobuild)'
       inputs:
         targetType: 'inline'
         script: |
-          $base = $env:BUILD_SOURCESDIRECTORY
-          $candidates = @(
-            (Join-Path $base 'WinAppSDK\Build\WindowsAppSDK\NuGetLicense'),
-            (Join-Path $base 'Build\WindowsAppSDK\NuGetLicense')
-          )
-          $src = $candidates | Where-Object { Test-Path $_ } | Select-Object -First 1
-          if (-not $src) {
-            Write-Host "Searching for NuGetLicense under $base..."
-            Get-ChildItem -Path $base -Recurse -Filter 'license.txt' -ErrorAction SilentlyContinue |
-              Select-Object -First 10 | ForEach-Object { Write-Host "  Found: $($_.FullName)" }
-            throw "NuGetLicense path not found in any candidate location"
-          }
-          Write-Host "Found NuGetLicense source: $src"
-          $dst = Join-Path $base 'WinAppSDK\Build\WindowsAppSDK\NuGetLicense'
-          if ($src -ne $dst) {
-            New-Item -ItemType Directory -Force -Path (Split-Path $dst -Parent) | Out-Null
-            Copy-Item -Recurse -Force $src $dst
-            Write-Host "Mirrored $src -> $dst"
-          } else {
-            Write-Host "NuGetLicense already at expected path"
-          }
+          $src = Join-Path $env:BUILD_SOURCESDIRECTORY 'Build\WindowsAppSDK\NuGetLicense'
+          $dst = Join-Path $env:BUILD_SOURCESDIRECTORY 'WindowsAppSDK\WinAppSDK\Build\WindowsAppSDK\NuGetLicense'
+          if (-not (Test-Path $src)) { throw "Source NuGetLicense path not found: $src" }
+          New-Item -ItemType Directory -Force -Path (Split-Path $dst -Parent) | Out-Null
+          Copy-Item -Recurse -Force $src $dst
+          Write-Host "Mirrored $src -> $dst"
 
   - task: PowerShell@2
     name: StageFiles
     inputs:
       filePath: 'BuildAll.ps1'
+      ${{ if parameters.IsMonobuild }}:
+        workingDirectory: '$(Build.SourcesDirectory)\WindowsAppSDK'
       arguments: -Platform "x86,x64,arm64" -Configuration "release" -AzureBuildStep "StageFiles"
 
   - task: CopyFiles@2
@@ -158,6 +144,8 @@ steps:
     name: PackNuget
     inputs:
       filePath: 'BuildAll.ps1'
+      ${{ if parameters.IsMonobuild }}:
+        workingDirectory: '$(Build.SourcesDirectory)\WindowsAppSDK'
       arguments: -Platform "x64" -Configuration "release" -AzureBuildStep "PackNuget" -OutputDirectory "$(build.artifactStagingDirectory)\FullNuget" -PackageVersion "$(WindowsAppSDKFormattedVersion)" -ComponentPackageVersion "$(WindowsAppSDKFormattedVersion)" -WindowsAppSDKVersionPinned "$(WindowsAppSDKVersionPinned)"
 
   # ── Sign ──

--- a/build/AzurePipelinesTemplates/WindowsAppSDK-PackTransportPackage-Steps.yml
+++ b/build/AzurePipelinesTemplates/WindowsAppSDK-PackTransportPackage-Steps.yml
@@ -81,10 +81,31 @@ steps:
         targetPath: '$(Build.SourcesDirectory)\BuildOutput'
 
   # ── Stage files + symbols ──
+  # In monobuild context:
+  #   - Self (WinAppSDK monorepo) is checked out at $(Build.SourcesDirectory)\WinAppSDK
+  #   - Foundation is checked out at  $(Build.SourcesDirectory)\WindowsAppSDK
+  # BuildAll.ps1 (in Foundation root) reads the license at the relative path
+  # `WinAppSDK\Build\WindowsAppSDK\NuGetLicense\...`, resolved against its own
+  # location. Mirror it there from the monorepo's copy so BuildAll.ps1 finds it.
+  - ${{ if parameters.IsMonobuild }}:
+    - task: PowerShell@2
+      displayName: 'Mirror NuGetLicense files to BuildAll.ps1-expected path (monobuild)'
+      inputs:
+        targetType: 'inline'
+        script: |
+          $src = Join-Path $env:BUILD_SOURCESDIRECTORY 'WinAppSDK\Build\WindowsAppSDK\NuGetLicense'
+          $dst = Join-Path $env:BUILD_SOURCESDIRECTORY 'WindowsAppSDK\WinAppSDK\Build\WindowsAppSDK\NuGetLicense'
+          if (-not (Test-Path $src)) { throw "Source NuGetLicense path not found: $src" }
+          New-Item -ItemType Directory -Force -Path (Split-Path $dst -Parent) | Out-Null
+          Copy-Item -Recurse -Force $src $dst
+          Write-Host "Mirrored $src -> $dst"
+
   - task: PowerShell@2
     name: StageFiles
     inputs:
       filePath: 'BuildAll.ps1'
+      ${{ if parameters.IsMonobuild }}:
+        workingDirectory: '$(Build.SourcesDirectory)\WindowsAppSDK'
       arguments: -Platform "x86,x64,arm64" -Configuration "release" -AzureBuildStep "StageFiles"
 
   - task: CopyFiles@2
@@ -125,6 +146,8 @@ steps:
     name: PackNuget
     inputs:
       filePath: 'BuildAll.ps1'
+      ${{ if parameters.IsMonobuild }}:
+        workingDirectory: '$(Build.SourcesDirectory)\WindowsAppSDK'
       arguments: -Platform "x64" -Configuration "release" -AzureBuildStep "PackNuget" -OutputDirectory "$(build.artifactStagingDirectory)\FullNuget" -PackageVersion "$(WindowsAppSDKFormattedVersion)" -ComponentPackageVersion "$(WindowsAppSDKFormattedVersion)" -WindowsAppSDKVersionPinned "$(WindowsAppSDKVersionPinned)"
 
   # ── Sign ──

--- a/build/AzurePipelinesTemplates/WindowsAppSDK-PackTransportPackage-Steps.yml
+++ b/build/AzurePipelinesTemplates/WindowsAppSDK-PackTransportPackage-Steps.yml
@@ -83,35 +83,32 @@ steps:
   # ── Stage files + symbols ──
   # In monobuild context, BuildAll.ps1 expects NuGetLicense files at the
   # `WinAppSDK\Build\WindowsAppSDK\NuGetLicense` relative path (per-component
-  # pattern). The monobuild has them at `Build\WindowsAppSDK\NuGetLicense`
-  # because the WinAppSDK monorepo IS at $(Build.SourcesDirectory). Ensure
-  # the directory exists at the expected path so BuildAll.ps1 finds them.
+  # pattern). The monobuild repo (OS/WinAppSDK) owns these files, but the Pack
+  # job's working tree at $(Build.SourcesDirectory) is the Foundation repo.
+  # Fetch the license files directly from the monobuild repo via the ADO Git
+  # REST API (no checkout needed — avoids OneBranch's path-conflict behavior
+  # when both `self` and an alias target paths under s/).
   - ${{ if parameters.IsMonobuild }}:
     - task: PowerShell@2
-      displayName: 'Mirror NuGetLicense files to BuildAll.ps1-expected path (monobuild)'
+      displayName: 'Fetch NuGetLicense files from monobuild repo (REST API)'
+      env:
+        SYSTEM_ACCESSTOKEN: $(System.AccessToken)
       inputs:
         targetType: 'inline'
         script: |
-          $base = $env:BUILD_SOURCESDIRECTORY
-          $candidates = @(
-            (Join-Path $base 'WinAppSDK\Build\WindowsAppSDK\NuGetLicense'),
-            (Join-Path $base 'Build\WindowsAppSDK\NuGetLicense')
-          )
-          $src = $candidates | Where-Object { Test-Path $_ } | Select-Object -First 1
-          if (-not $src) {
-            Write-Host "Searching for NuGetLicense under $base..."
-            Get-ChildItem -Path $base -Recurse -Filter 'license.txt' -ErrorAction SilentlyContinue |
-              Select-Object -First 10 | ForEach-Object { Write-Host "  Found: $($_.FullName)" }
-            throw "NuGetLicense path not found in any candidate location"
-          }
-          Write-Host "Found NuGetLicense source: $src"
-          $dst = Join-Path $base 'WinAppSDK\Build\WindowsAppSDK\NuGetLicense'
-          if ($src -ne $dst) {
-            New-Item -ItemType Directory -Force -Path (Split-Path $dst -Parent) | Out-Null
-            Copy-Item -Recurse -Force $src $dst
-            Write-Host "Mirrored $src -> $dst"
-          } else {
-            Write-Host "NuGetLicense already at expected path"
+          $dstRoot = Join-Path $env:BUILD_SOURCESDIRECTORY 'WinAppSDK\Build\WindowsAppSDK\NuGetLicense'
+          $apiBase = "$($env:SYSTEM_COLLECTIONURI.TrimEnd('/'))/$($env:SYSTEM_TEAMPROJECTID)/_apis/git/repositories/WinAppSDK/items"
+          $headers = @{ Authorization = "Bearer $env:SYSTEM_ACCESSTOKEN" }
+          foreach ($channel in @('preview','release')) {
+            $dstDir = Join-Path $dstRoot $channel
+            New-Item -ItemType Directory -Force -Path $dstDir | Out-Null
+            $dst = Join-Path $dstDir 'license.txt'
+            $url = "$apiBase`?path=/Build/WindowsAppSDK/NuGetLicense/$channel/license.txt&versionDescriptor.version=release/dev/monobuild&versionDescriptor.versionType=branch&api-version=7.1"
+            Write-Host "Fetching $channel/license.txt from monobuild..."
+            Invoke-WebRequest -Uri $url -Headers $headers -OutFile $dst -UseBasicParsing
+            $size = (Get-Item $dst).Length
+            if ($size -lt 100) { throw "Downloaded file too small ($size bytes), likely an error response: $(Get-Content $dst -Raw)" }
+            Write-Host "  -> $dst ($size bytes)"
           }
 
   - task: PowerShell@2

--- a/build/AzurePipelinesTemplates/WindowsAppSDK-PackTransportPackage-Steps.yml
+++ b/build/AzurePipelinesTemplates/WindowsAppSDK-PackTransportPackage-Steps.yml
@@ -81,43 +81,17 @@ steps:
         targetPath: '$(Build.SourcesDirectory)\BuildOutput'
 
   # ── Stage files + symbols ──
-  # In monobuild context:
-  #   - Self (WinAppSDK monorepo) is checked out at $(Build.SourcesDirectory)\WinAppSDK
-  #   - Foundation is checked out at  $(Build.SourcesDirectory)\WindowsAppSDK
-  # BuildAll.ps1 (in Foundation root) reads the license at the relative path
-  # `WinAppSDK\Build\WindowsAppSDK\NuGetLicense\...`, resolved against its own
-  # location. Mirror it there from the monorepo's copy so BuildAll.ps1 finds it.
-  - ${{ if parameters.IsMonobuild }}:
-    - task: PowerShell@2
-      displayName: 'Mirror NuGetLicense files to BuildAll.ps1-expected path (monobuild)'
-      inputs:
-        targetType: 'inline'
-        script: |
-          $src = Join-Path $env:BUILD_SOURCESDIRECTORY 'WinAppSDK\Build\WindowsAppSDK\NuGetLicense'
-          $dst = Join-Path $env:BUILD_SOURCESDIRECTORY 'WindowsAppSDK\WinAppSDK\Build\WindowsAppSDK\NuGetLicense'
-          if (-not (Test-Path $src)) { throw "Source NuGetLicense path not found: $src" }
-          New-Item -ItemType Directory -Force -Path (Split-Path $dst -Parent) | Out-Null
-          Copy-Item -Recurse -Force $src $dst
-          Write-Host "Mirrored $src -> $dst"
-
   - task: PowerShell@2
     name: StageFiles
     inputs:
-      ${{ if parameters.IsMonobuild }}:
-        filePath: '$(Build.SourcesDirectory)\WindowsAppSDK\BuildAll.ps1'
-        workingDirectory: '$(Build.SourcesDirectory)\WindowsAppSDK'
-      ${{ else }}:
-        filePath: 'BuildAll.ps1'
+      filePath: 'BuildAll.ps1'
       arguments: -Platform "x86,x64,arm64" -Configuration "release" -AzureBuildStep "StageFiles"
 
   - task: CopyFiles@2
     displayName: 'Copy symbols to artifact staging directory'
     condition: always()
     inputs:
-      ${{ if parameters.IsMonobuild }}:
-        sourceFolder: $(Build.SourcesDirectory)\WindowsAppSDK\BuildOutput\FullNuget
-      ${{ else }}:
-        sourceFolder: $(Build.SourcesDirectory)\BuildOutput\FullNuget
+      sourceFolder: $(Build.SourcesDirectory)\BuildOutput\FullNuget
       contents: |
         **\*.pdb
       targetFolder: $(Build.ArtifactStagingDirectory)\symbols
@@ -141,27 +115,16 @@ steps:
     displayName: Update metapackage version
     inputs:
       targetType: 'inline'
-      ${{ if parameters.IsMonobuild }}:
-        script: |
-          $packageVersion = '$(WindowsAppSDKFormattedVersion)'
-          [xml]$publicNuspec = Get-Content -Path $(Build.SourcesDirectory)\WindowsAppSDK\build\NuSpecs\Microsoft.WindowsAppSDK.Foundation.TransportPackage.nuspec
-          $publicNuspec.package.metadata.version = $packageVersion
-          Set-Content -Value $publicNuspec.OuterXml $(Build.SourcesDirectory)\WindowsAppSDK\build\NuSpecs\Microsoft.WindowsAppSDK.Foundation.TransportPackage.nuspec
-      ${{ else }}:
-        script: |
-          $packageVersion = '$(WindowsAppSDKFormattedVersion)'
-          [xml]$publicNuspec = Get-Content -Path $(Build.SourcesDirectory)\build\NuSpecs\Microsoft.WindowsAppSDK.Foundation.TransportPackage.nuspec
-          $publicNuspec.package.metadata.version = $packageVersion
-          Set-Content -Value $publicNuspec.OuterXml $(Build.SourcesDirectory)\build\NuSpecs\Microsoft.WindowsAppSDK.Foundation.TransportPackage.nuspec
+      script: |
+        $packageVersion = '$(WindowsAppSDKFormattedVersion)'
+        [xml]$publicNuspec = Get-Content -Path $(Build.SourcesDirectory)\build\NuSpecs\Microsoft.WindowsAppSDK.Foundation.TransportPackage.nuspec
+        $publicNuspec.package.metadata.version = $packageVersion
+        Set-Content -Value $publicNuspec.OuterXml $(Build.SourcesDirectory)\build\NuSpecs\Microsoft.WindowsAppSDK.Foundation.TransportPackage.nuspec
 
   - task: PowerShell@2
     name: PackNuget
     inputs:
-      ${{ if parameters.IsMonobuild }}:
-        filePath: '$(Build.SourcesDirectory)\WindowsAppSDK\BuildAll.ps1'
-        workingDirectory: '$(Build.SourcesDirectory)\WindowsAppSDK'
-      ${{ else }}:
-        filePath: 'BuildAll.ps1'
+      filePath: 'BuildAll.ps1'
       arguments: -Platform "x64" -Configuration "release" -AzureBuildStep "PackNuget" -OutputDirectory "$(build.artifactStagingDirectory)\FullNuget" -PackageVersion "$(WindowsAppSDKFormattedVersion)" -ComponentPackageVersion "$(WindowsAppSDKFormattedVersion)" -WindowsAppSDKVersionPinned "$(WindowsAppSDKVersionPinned)"
 
   # ── Sign ──
@@ -179,10 +142,7 @@ steps:
   - task: CopyFiles@2
     displayName: MoveToOutputDirectory
     inputs:
-      ${{ if parameters.IsMonobuild }}:
-        SourceFolder: '$(Build.SourcesDirectory)\WindowsAppSDK\BuildOutput\FullNuget'
-      ${{ else }}:
-        SourceFolder: '$(Build.SourcesDirectory)\BuildOutput\FullNuget'
+      SourceFolder: '$(Build.SourcesDirectory)\BuildOutput\FullNuget'
       TargetFolder: '$(ob_outputDirectory)\NugetContent'
 
   - task: CopyFiles@2

--- a/build/AzurePipelinesTemplates/WindowsAppSDK-PackTransportPackage-Steps.yml
+++ b/build/AzurePipelinesTemplates/WindowsAppSDK-PackTransportPackage-Steps.yml
@@ -81,6 +81,24 @@ steps:
         targetPath: '$(Build.SourcesDirectory)\BuildOutput'
 
   # ── Stage files + symbols ──
+  # In monobuild context, BuildAll.ps1 expects NuGetLicense files at the
+  # `WinAppSDK\Build\WindowsAppSDK\NuGetLicense` relative path (per-component
+  # pattern). The monobuild has them at `Build\WindowsAppSDK\NuGetLicense`
+  # because the WinAppSDK monorepo IS at $(Build.SourcesDirectory). Mirror
+  # them to the expected path so BuildAll.ps1 finds them unchanged.
+  - ${{ if parameters.IsMonobuild }}:
+    - task: PowerShell@2
+      displayName: 'Mirror NuGetLicense files to BuildAll.ps1-expected path (monobuild)'
+      inputs:
+        targetType: 'inline'
+        script: |
+          $src = Join-Path $env:BUILD_SOURCESDIRECTORY 'Build\WindowsAppSDK\NuGetLicense'
+          $dst = Join-Path $env:BUILD_SOURCESDIRECTORY 'WinAppSDK\Build\WindowsAppSDK\NuGetLicense'
+          if (-not (Test-Path $src)) { throw "Source NuGetLicense path not found: $src" }
+          New-Item -ItemType Directory -Force -Path (Split-Path $dst -Parent) | Out-Null
+          Copy-Item -Recurse -Force $src $dst
+          Write-Host "Mirrored $src -> $dst"
+
   - task: PowerShell@2
     name: StageFiles
     inputs:

--- a/build/AzurePipelinesTemplates/WindowsAppSDK-PackTransportPackage-Steps.yml
+++ b/build/AzurePipelinesTemplates/WindowsAppSDK-PackTransportPackage-Steps.yml
@@ -28,6 +28,14 @@ parameters:
   - name: mrtArtifactPrefix
     type: string
     default: 'MrtBinaries_release'
+  # When true, this template is being invoked from the monobuild context where
+  # the WindowsAppSDK monorepo IS the self repo. Shared templates (PublishSymbol,
+  # DetermineVersion, EsrpCodeSigning) are invoked WITHOUT @WinAppSDK suffix.
+  # When false (default, per-component pipeline context), shared templates are
+  # invoked via @WinAppSDK to reach the monobuild repo as a cross-repo resource.
+  - name: IsMonobuild
+    type: boolean
+    default: false
 
 steps:
   - task: NuGetAuthenticate@1
@@ -88,15 +96,26 @@ steps:
         **\*.pdb
       targetFolder: $(Build.ArtifactStagingDirectory)\symbols
 
-  - template: Build/WindowsAppSDK/AzurePipelinesTemplates/WindowsAppSDK-PublishSymbol-Steps.yml@WinAppSDK
-    parameters:
-      SearchPattern: '$(Build.ArtifactStagingDirectory)\symbols\**\*.pdb'
-      IsOfficial: ${{ parameters.IsOfficial }}
+  - ${{ if parameters.IsMonobuild }}:
+    - template: Build/WindowsAppSDK/AzurePipelinesTemplates/WindowsAppSDK-PublishSymbol-Steps.yml
+      parameters:
+        SearchPattern: '$(Build.ArtifactStagingDirectory)\symbols\**\*.pdb'
+        IsOfficial: ${{ parameters.IsOfficial }}
+  - ${{ else }}:
+    - template: Build/WindowsAppSDK/AzurePipelinesTemplates/WindowsAppSDK-PublishSymbol-Steps.yml@WinAppSDK
+      parameters:
+        SearchPattern: '$(Build.ArtifactStagingDirectory)\symbols\**\*.pdb'
+        IsOfficial: ${{ parameters.IsOfficial }}
 
   # ── Determine version + pack NuGet ──
-  - template: Build/WindowsAppSDK/AzurePipelinesTemplates/WindowsAppSDK-DetermineVersion-Steps.yml@WinAppSDK
-    parameters:
-      IsOfficial: ${{ parameters.IsOfficial }}
+  - ${{ if parameters.IsMonobuild }}:
+    - template: Build/WindowsAppSDK/AzurePipelinesTemplates/WindowsAppSDK-DetermineVersion-Steps.yml
+      parameters:
+        IsOfficial: ${{ parameters.IsOfficial }}
+  - ${{ else }}:
+    - template: Build/WindowsAppSDK/AzurePipelinesTemplates/WindowsAppSDK-DetermineVersion-Steps.yml@WinAppSDK
+      parameters:
+        IsOfficial: ${{ parameters.IsOfficial }}
 
   - task: PowerShell@2
     name: SetVersion
@@ -117,12 +136,20 @@ steps:
 
   # ── Sign ──
   - ${{ if eq(parameters.SignOutput, 'true') }}:
-    - template: Build/WindowsAppSDK/AzurePipelinesTemplates/WindowsAppSDK-EsrpCodeSigning-Steps.yml@WinAppSDK
-      parameters:
-        FolderPath: $(build.artifactStagingDirectory)\FullNuget
-        Pattern: 'Microsoft.WindowsAppSDK.Foundation*.nupkg'
-        KeyCode: 'CP-401405'
-        UseMinimatch: true
+    - ${{ if parameters.IsMonobuild }}:
+      - template: Build/WindowsAppSDK/AzurePipelinesTemplates/WindowsAppSDK-EsrpCodeSigning-Steps.yml
+        parameters:
+          FolderPath: $(build.artifactStagingDirectory)\FullNuget
+          Pattern: 'Microsoft.WindowsAppSDK.Foundation*.nupkg'
+          KeyCode: 'CP-401405'
+          UseMinimatch: true
+    - ${{ else }}:
+      - template: Build/WindowsAppSDK/AzurePipelinesTemplates/WindowsAppSDK-EsrpCodeSigning-Steps.yml@WinAppSDK
+        parameters:
+          FolderPath: $(build.artifactStagingDirectory)\FullNuget
+          Pattern: 'Microsoft.WindowsAppSDK.Foundation*.nupkg'
+          KeyCode: 'CP-401405'
+          UseMinimatch: true
 
   # ── Stage output ──
   - task: CopyFiles@2

--- a/build/AzurePipelinesTemplates/WindowsAppSDK-PackTransportPackage-Steps.yml
+++ b/build/AzurePipelinesTemplates/WindowsAppSDK-PackTransportPackage-Steps.yml
@@ -97,7 +97,7 @@ steps:
       targetFolder: $(Build.ArtifactStagingDirectory)\symbols
 
   - ${{ if parameters.IsMonobuild }}:
-    - template: Build/WindowsAppSDK/AzurePipelinesTemplates/WindowsAppSDK-PublishSymbol-Steps.yml
+    - template: Build/WindowsAppSDK/AzurePipelinesTemplates/WindowsAppSDK-PublishSymbol-Steps.yml@self
       parameters:
         SearchPattern: '$(Build.ArtifactStagingDirectory)\symbols\**\*.pdb'
         IsOfficial: ${{ parameters.IsOfficial }}
@@ -109,7 +109,7 @@ steps:
 
   # ── Determine version + pack NuGet ──
   - ${{ if parameters.IsMonobuild }}:
-    - template: Build/WindowsAppSDK/AzurePipelinesTemplates/WindowsAppSDK-DetermineVersion-Steps.yml
+    - template: Build/WindowsAppSDK/AzurePipelinesTemplates/WindowsAppSDK-DetermineVersion-Steps.yml@self
       parameters:
         IsOfficial: ${{ parameters.IsOfficial }}
   - ${{ else }}:
@@ -137,7 +137,7 @@ steps:
   # ── Sign ──
   - ${{ if eq(parameters.SignOutput, 'true') }}:
     - ${{ if parameters.IsMonobuild }}:
-      - template: Build/WindowsAppSDK/AzurePipelinesTemplates/WindowsAppSDK-EsrpCodeSigning-Steps.yml
+      - template: Build/WindowsAppSDK/AzurePipelinesTemplates/WindowsAppSDK-EsrpCodeSigning-Steps.yml@self
         parameters:
           FolderPath: $(build.artifactStagingDirectory)\FullNuget
           Pattern: 'Microsoft.WindowsAppSDK.Foundation*.nupkg'

--- a/build/AzurePipelinesTemplates/WindowsAppSDK-PackTransportPackage-Steps.yml
+++ b/build/AzurePipelinesTemplates/WindowsAppSDK-PackTransportPackage-Steps.yml
@@ -83,32 +83,35 @@ steps:
   # ── Stage files + symbols ──
   # In monobuild context, BuildAll.ps1 expects NuGetLicense files at the
   # `WinAppSDK\Build\WindowsAppSDK\NuGetLicense` relative path (per-component
-  # pattern). The monobuild repo (OS/WinAppSDK) owns these files, but the Pack
-  # job's working tree at $(Build.SourcesDirectory) is the Foundation repo.
-  # Fetch the license files directly from the monobuild repo via the ADO Git
-  # REST API (no checkout needed — avoids OneBranch's path-conflict behavior
-  # when both `self` and an alias target paths under s/).
+  # pattern). The monobuild has them at `Build\WindowsAppSDK\NuGetLicense`
+  # because the WinAppSDK monorepo IS at $(Build.SourcesDirectory). Ensure
+  # the directory exists at the expected path so BuildAll.ps1 finds them.
   - ${{ if parameters.IsMonobuild }}:
     - task: PowerShell@2
-      displayName: 'Fetch NuGetLicense files from monobuild repo (REST API)'
-      env:
-        SYSTEM_ACCESSTOKEN: $(System.AccessToken)
+      displayName: 'Mirror NuGetLicense files to BuildAll.ps1-expected path (monobuild)'
       inputs:
         targetType: 'inline'
         script: |
-          $dstRoot = Join-Path $env:BUILD_SOURCESDIRECTORY 'WinAppSDK\Build\WindowsAppSDK\NuGetLicense'
-          $apiBase = "$($env:SYSTEM_COLLECTIONURI.TrimEnd('/'))/$($env:SYSTEM_TEAMPROJECTID)/_apis/git/repositories/WinAppSDK/items"
-          $headers = @{ Authorization = "Bearer $env:SYSTEM_ACCESSTOKEN" }
-          foreach ($channel in @('preview','release')) {
-            $dstDir = Join-Path $dstRoot $channel
-            New-Item -ItemType Directory -Force -Path $dstDir | Out-Null
-            $dst = Join-Path $dstDir 'license.txt'
-            $url = "$apiBase`?path=/Build/WindowsAppSDK/NuGetLicense/$channel/license.txt&versionDescriptor.version=release/dev/monobuild&versionDescriptor.versionType=branch&api-version=7.1"
-            Write-Host "Fetching $channel/license.txt from monobuild..."
-            Invoke-WebRequest -Uri $url -Headers $headers -OutFile $dst -UseBasicParsing
-            $size = (Get-Item $dst).Length
-            if ($size -lt 100) { throw "Downloaded file too small ($size bytes), likely an error response: $(Get-Content $dst -Raw)" }
-            Write-Host "  -> $dst ($size bytes)"
+          $base = $env:BUILD_SOURCESDIRECTORY
+          $candidates = @(
+            (Join-Path $base 'WinAppSDK\Build\WindowsAppSDK\NuGetLicense'),
+            (Join-Path $base 'Build\WindowsAppSDK\NuGetLicense')
+          )
+          $src = $candidates | Where-Object { Test-Path $_ } | Select-Object -First 1
+          if (-not $src) {
+            Write-Host "Searching for NuGetLicense under $base..."
+            Get-ChildItem -Path $base -Recurse -Filter 'license.txt' -ErrorAction SilentlyContinue |
+              Select-Object -First 10 | ForEach-Object { Write-Host "  Found: $($_.FullName)" }
+            throw "NuGetLicense path not found in any candidate location"
+          }
+          Write-Host "Found NuGetLicense source: $src"
+          $dst = Join-Path $base 'WinAppSDK\Build\WindowsAppSDK\NuGetLicense'
+          if ($src -ne $dst) {
+            New-Item -ItemType Directory -Force -Path (Split-Path $dst -Parent) | Out-Null
+            Copy-Item -Recurse -Force $src $dst
+            Write-Host "Mirrored $src -> $dst"
+          } else {
+            Write-Host "NuGetLicense already at expected path"
           }
 
   - task: PowerShell@2

--- a/build/AzurePipelinesTemplates/WindowsAppSDK-PackTransportPackage-Steps.yml
+++ b/build/AzurePipelinesTemplates/WindowsAppSDK-PackTransportPackage-Steps.yml
@@ -84,20 +84,35 @@ steps:
   # In monobuild context, BuildAll.ps1 expects NuGetLicense files at the
   # `WinAppSDK\Build\WindowsAppSDK\NuGetLicense` relative path (per-component
   # pattern). The monobuild has them at `Build\WindowsAppSDK\NuGetLicense`
-  # because the WinAppSDK monorepo IS at $(Build.SourcesDirectory). Mirror
-  # them to the expected path so BuildAll.ps1 finds them unchanged.
+  # because the WinAppSDK monorepo IS at $(Build.SourcesDirectory). Ensure
+  # the directory exists at the expected path so BuildAll.ps1 finds them.
   - ${{ if parameters.IsMonobuild }}:
     - task: PowerShell@2
       displayName: 'Mirror NuGetLicense files to BuildAll.ps1-expected path (monobuild)'
       inputs:
         targetType: 'inline'
         script: |
-          $src = Join-Path $env:BUILD_SOURCESDIRECTORY 'Build\WindowsAppSDK\NuGetLicense'
-          $dst = Join-Path $env:BUILD_SOURCESDIRECTORY 'WinAppSDK\Build\WindowsAppSDK\NuGetLicense'
-          if (-not (Test-Path $src)) { throw "Source NuGetLicense path not found: $src" }
-          New-Item -ItemType Directory -Force -Path (Split-Path $dst -Parent) | Out-Null
-          Copy-Item -Recurse -Force $src $dst
-          Write-Host "Mirrored $src -> $dst"
+          $base = $env:BUILD_SOURCESDIRECTORY
+          $candidates = @(
+            (Join-Path $base 'WinAppSDK\Build\WindowsAppSDK\NuGetLicense'),
+            (Join-Path $base 'Build\WindowsAppSDK\NuGetLicense')
+          )
+          $src = $candidates | Where-Object { Test-Path $_ } | Select-Object -First 1
+          if (-not $src) {
+            Write-Host "Searching for NuGetLicense under $base..."
+            Get-ChildItem -Path $base -Recurse -Filter 'license.txt' -ErrorAction SilentlyContinue |
+              Select-Object -First 10 | ForEach-Object { Write-Host "  Found: $($_.FullName)" }
+            throw "NuGetLicense path not found in any candidate location"
+          }
+          Write-Host "Found NuGetLicense source: $src"
+          $dst = Join-Path $base 'WinAppSDK\Build\WindowsAppSDK\NuGetLicense'
+          if ($src -ne $dst) {
+            New-Item -ItemType Directory -Force -Path (Split-Path $dst -Parent) | Out-Null
+            Copy-Item -Recurse -Force $src $dst
+            Write-Host "Mirrored $src -> $dst"
+          } else {
+            Write-Host "NuGetLicense already at expected path"
+          }
 
   - task: PowerShell@2
     name: StageFiles

--- a/build/AzurePipelinesTemplates/WindowsAppSDK-PackTransportPackage-Steps.yml
+++ b/build/AzurePipelinesTemplates/WindowsAppSDK-PackTransportPackage-Steps.yml
@@ -81,29 +81,43 @@ steps:
         targetPath: '$(Build.SourcesDirectory)\BuildOutput'
 
   # ── Stage files + symbols ──
-  # In monobuild context, Foundation is checked out at $(Build.SourcesDirectory)\WindowsAppSDK
-  # and self (monobuild) is at $(Build.SourcesDirectory). BuildAll.ps1 expects NuGetLicense
-  # files at WinAppSDK\Build\WindowsAppSDK\NuGetLicense relative to its working directory
-  # (Foundation root). Mirror them from the monobuild's Build\WindowsAppSDK\NuGetLicense.
+  # In monobuild context, BuildAll.ps1 expects NuGetLicense files at the
+  # `WinAppSDK\Build\WindowsAppSDK\NuGetLicense` relative path (per-component
+  # pattern). The monobuild has them at `Build\WindowsAppSDK\NuGetLicense`
+  # because the WinAppSDK monorepo IS at $(Build.SourcesDirectory). Ensure
+  # the directory exists at the expected path so BuildAll.ps1 finds them.
   - ${{ if parameters.IsMonobuild }}:
     - task: PowerShell@2
       displayName: 'Mirror NuGetLicense files to BuildAll.ps1-expected path (monobuild)'
       inputs:
         targetType: 'inline'
         script: |
-          $src = Join-Path $env:BUILD_SOURCESDIRECTORY 'Build\WindowsAppSDK\NuGetLicense'
-          $dst = Join-Path $env:BUILD_SOURCESDIRECTORY 'WindowsAppSDK\WinAppSDK\Build\WindowsAppSDK\NuGetLicense'
-          if (-not (Test-Path $src)) { throw "Source NuGetLicense path not found: $src" }
-          New-Item -ItemType Directory -Force -Path (Split-Path $dst -Parent) | Out-Null
-          Copy-Item -Recurse -Force $src $dst
-          Write-Host "Mirrored $src -> $dst"
+          $base = $env:BUILD_SOURCESDIRECTORY
+          $candidates = @(
+            (Join-Path $base 'WinAppSDK\Build\WindowsAppSDK\NuGetLicense'),
+            (Join-Path $base 'Build\WindowsAppSDK\NuGetLicense')
+          )
+          $src = $candidates | Where-Object { Test-Path $_ } | Select-Object -First 1
+          if (-not $src) {
+            Write-Host "Searching for NuGetLicense under $base..."
+            Get-ChildItem -Path $base -Recurse -Filter 'license.txt' -ErrorAction SilentlyContinue |
+              Select-Object -First 10 | ForEach-Object { Write-Host "  Found: $($_.FullName)" }
+            throw "NuGetLicense path not found in any candidate location"
+          }
+          Write-Host "Found NuGetLicense source: $src"
+          $dst = Join-Path $base 'WinAppSDK\Build\WindowsAppSDK\NuGetLicense'
+          if ($src -ne $dst) {
+            New-Item -ItemType Directory -Force -Path (Split-Path $dst -Parent) | Out-Null
+            Copy-Item -Recurse -Force $src $dst
+            Write-Host "Mirrored $src -> $dst"
+          } else {
+            Write-Host "NuGetLicense already at expected path"
+          }
 
   - task: PowerShell@2
     name: StageFiles
     inputs:
       filePath: 'BuildAll.ps1'
-      ${{ if parameters.IsMonobuild }}:
-        workingDirectory: '$(Build.SourcesDirectory)\WindowsAppSDK'
       arguments: -Platform "x86,x64,arm64" -Configuration "release" -AzureBuildStep "StageFiles"
 
   - task: CopyFiles@2
@@ -144,8 +158,6 @@ steps:
     name: PackNuget
     inputs:
       filePath: 'BuildAll.ps1'
-      ${{ if parameters.IsMonobuild }}:
-        workingDirectory: '$(Build.SourcesDirectory)\WindowsAppSDK'
       arguments: -Platform "x64" -Configuration "release" -AzureBuildStep "PackNuget" -OutputDirectory "$(build.artifactStagingDirectory)\FullNuget" -PackageVersion "$(WindowsAppSDKFormattedVersion)" -ComponentPackageVersion "$(WindowsAppSDKFormattedVersion)" -WindowsAppSDKVersionPinned "$(WindowsAppSDKVersionPinned)"
 
   # ── Sign ──

--- a/build/AzurePipelinesTemplates/WindowsAppSDK-PackTransportPackage-Steps.yml
+++ b/build/AzurePipelinesTemplates/WindowsAppSDK-PackTransportPackage-Steps.yml
@@ -81,17 +81,43 @@ steps:
         targetPath: '$(Build.SourcesDirectory)\BuildOutput'
 
   # ── Stage files + symbols ──
+  # In monobuild context:
+  #   - Self (WinAppSDK monorepo) is checked out at $(Build.SourcesDirectory)\WinAppSDK
+  #   - Foundation is checked out at  $(Build.SourcesDirectory)\WindowsAppSDK
+  # BuildAll.ps1 (in Foundation root) reads the license at the relative path
+  # `WinAppSDK\Build\WindowsAppSDK\NuGetLicense\...`, resolved against its own
+  # location. Mirror it there from the monorepo's copy so BuildAll.ps1 finds it.
+  - ${{ if parameters.IsMonobuild }}:
+    - task: PowerShell@2
+      displayName: 'Mirror NuGetLicense files to BuildAll.ps1-expected path (monobuild)'
+      inputs:
+        targetType: 'inline'
+        script: |
+          $src = Join-Path $env:BUILD_SOURCESDIRECTORY 'WinAppSDK\Build\WindowsAppSDK\NuGetLicense'
+          $dst = Join-Path $env:BUILD_SOURCESDIRECTORY 'WindowsAppSDK\WinAppSDK\Build\WindowsAppSDK\NuGetLicense'
+          if (-not (Test-Path $src)) { throw "Source NuGetLicense path not found: $src" }
+          New-Item -ItemType Directory -Force -Path (Split-Path $dst -Parent) | Out-Null
+          Copy-Item -Recurse -Force $src $dst
+          Write-Host "Mirrored $src -> $dst"
+
   - task: PowerShell@2
     name: StageFiles
     inputs:
-      filePath: 'BuildAll.ps1'
+      ${{ if parameters.IsMonobuild }}:
+        filePath: '$(Build.SourcesDirectory)\WindowsAppSDK\BuildAll.ps1'
+        workingDirectory: '$(Build.SourcesDirectory)\WindowsAppSDK'
+      ${{ else }}:
+        filePath: 'BuildAll.ps1'
       arguments: -Platform "x86,x64,arm64" -Configuration "release" -AzureBuildStep "StageFiles"
 
   - task: CopyFiles@2
     displayName: 'Copy symbols to artifact staging directory'
     condition: always()
     inputs:
-      sourceFolder: $(Build.SourcesDirectory)\BuildOutput\FullNuget
+      ${{ if parameters.IsMonobuild }}:
+        sourceFolder: $(Build.SourcesDirectory)\WindowsAppSDK\BuildOutput\FullNuget
+      ${{ else }}:
+        sourceFolder: $(Build.SourcesDirectory)\BuildOutput\FullNuget
       contents: |
         **\*.pdb
       targetFolder: $(Build.ArtifactStagingDirectory)\symbols
@@ -115,16 +141,27 @@ steps:
     displayName: Update metapackage version
     inputs:
       targetType: 'inline'
-      script: |
-        $packageVersion = '$(WindowsAppSDKFormattedVersion)'
-        [xml]$publicNuspec = Get-Content -Path $(Build.SourcesDirectory)\build\NuSpecs\Microsoft.WindowsAppSDK.Foundation.TransportPackage.nuspec
-        $publicNuspec.package.metadata.version = $packageVersion
-        Set-Content -Value $publicNuspec.OuterXml $(Build.SourcesDirectory)\build\NuSpecs\Microsoft.WindowsAppSDK.Foundation.TransportPackage.nuspec
+      ${{ if parameters.IsMonobuild }}:
+        script: |
+          $packageVersion = '$(WindowsAppSDKFormattedVersion)'
+          [xml]$publicNuspec = Get-Content -Path $(Build.SourcesDirectory)\WindowsAppSDK\build\NuSpecs\Microsoft.WindowsAppSDK.Foundation.TransportPackage.nuspec
+          $publicNuspec.package.metadata.version = $packageVersion
+          Set-Content -Value $publicNuspec.OuterXml $(Build.SourcesDirectory)\WindowsAppSDK\build\NuSpecs\Microsoft.WindowsAppSDK.Foundation.TransportPackage.nuspec
+      ${{ else }}:
+        script: |
+          $packageVersion = '$(WindowsAppSDKFormattedVersion)'
+          [xml]$publicNuspec = Get-Content -Path $(Build.SourcesDirectory)\build\NuSpecs\Microsoft.WindowsAppSDK.Foundation.TransportPackage.nuspec
+          $publicNuspec.package.metadata.version = $packageVersion
+          Set-Content -Value $publicNuspec.OuterXml $(Build.SourcesDirectory)\build\NuSpecs\Microsoft.WindowsAppSDK.Foundation.TransportPackage.nuspec
 
   - task: PowerShell@2
     name: PackNuget
     inputs:
-      filePath: 'BuildAll.ps1'
+      ${{ if parameters.IsMonobuild }}:
+        filePath: '$(Build.SourcesDirectory)\WindowsAppSDK\BuildAll.ps1'
+        workingDirectory: '$(Build.SourcesDirectory)\WindowsAppSDK'
+      ${{ else }}:
+        filePath: 'BuildAll.ps1'
       arguments: -Platform "x64" -Configuration "release" -AzureBuildStep "PackNuget" -OutputDirectory "$(build.artifactStagingDirectory)\FullNuget" -PackageVersion "$(WindowsAppSDKFormattedVersion)" -ComponentPackageVersion "$(WindowsAppSDKFormattedVersion)" -WindowsAppSDKVersionPinned "$(WindowsAppSDKVersionPinned)"
 
   # ── Sign ──
@@ -142,7 +179,10 @@ steps:
   - task: CopyFiles@2
     displayName: MoveToOutputDirectory
     inputs:
-      SourceFolder: '$(Build.SourcesDirectory)\BuildOutput\FullNuget'
+      ${{ if parameters.IsMonobuild }}:
+        SourceFolder: '$(Build.SourcesDirectory)\WindowsAppSDK\BuildOutput\FullNuget'
+      ${{ else }}:
+        SourceFolder: '$(Build.SourcesDirectory)\BuildOutput\FullNuget'
       TargetFolder: '$(ob_outputDirectory)\NugetContent'
 
   - task: CopyFiles@2

--- a/build/AzurePipelinesTemplates/WindowsAppSDK-PackTransportPackage-Steps.yml
+++ b/build/AzurePipelinesTemplates/WindowsAppSDK-PackTransportPackage-Steps.yml
@@ -81,39 +81,6 @@ steps:
         targetPath: '$(Build.SourcesDirectory)\BuildOutput'
 
   # ── Stage files + symbols ──
-  # In monobuild context, BuildAll.ps1 expects NuGetLicense files at the
-  # `WinAppSDK\Build\WindowsAppSDK\NuGetLicense` relative path (per-component
-  # pattern). The monobuild has them at `Build\WindowsAppSDK\NuGetLicense`
-  # because the WinAppSDK monorepo IS at $(Build.SourcesDirectory). Ensure
-  # the directory exists at the expected path so BuildAll.ps1 finds them.
-  - ${{ if parameters.IsMonobuild }}:
-    - task: PowerShell@2
-      displayName: 'Mirror NuGetLicense files to BuildAll.ps1-expected path (monobuild)'
-      inputs:
-        targetType: 'inline'
-        script: |
-          $base = $env:BUILD_SOURCESDIRECTORY
-          $candidates = @(
-            (Join-Path $base 'WinAppSDK\Build\WindowsAppSDK\NuGetLicense'),
-            (Join-Path $base 'Build\WindowsAppSDK\NuGetLicense')
-          )
-          $src = $candidates | Where-Object { Test-Path $_ } | Select-Object -First 1
-          if (-not $src) {
-            Write-Host "Searching for NuGetLicense under $base..."
-            Get-ChildItem -Path $base -Recurse -Filter 'license.txt' -ErrorAction SilentlyContinue |
-              Select-Object -First 10 | ForEach-Object { Write-Host "  Found: $($_.FullName)" }
-            throw "NuGetLicense path not found in any candidate location"
-          }
-          Write-Host "Found NuGetLicense source: $src"
-          $dst = Join-Path $base 'WinAppSDK\Build\WindowsAppSDK\NuGetLicense'
-          if ($src -ne $dst) {
-            New-Item -ItemType Directory -Force -Path (Split-Path $dst -Parent) | Out-Null
-            Copy-Item -Recurse -Force $src $dst
-            Write-Host "Mirrored $src -> $dst"
-          } else {
-            Write-Host "NuGetLicense already at expected path"
-          }
-
   - task: PowerShell@2
     name: StageFiles
     inputs:

--- a/build/AzurePipelinesTemplates/WindowsAppSDK-PackTransportPackage-Steps.yml
+++ b/build/AzurePipelinesTemplates/WindowsAppSDK-PackTransportPackage-Steps.yml
@@ -129,25 +129,18 @@ steps:
         **\*.pdb
       targetFolder: $(Build.ArtifactStagingDirectory)\symbols
 
-  - ${{ if parameters.IsMonobuild }}:
-    - template: Build/WindowsAppSDK/AzurePipelinesTemplates/WindowsAppSDK-PublishSymbol-Steps.yml@self
-      parameters:
-        SearchPattern: '$(Build.ArtifactStagingDirectory)\symbols\**\*.pdb'
-        IsOfficial: ${{ parameters.IsOfficial }}
-  - ${{ else }}:
-    - template: Build/WindowsAppSDK/AzurePipelinesTemplates/WindowsAppSDK-PublishSymbol-Steps.yml@WinAppSDK
-      parameters:
+  - template: WindowsAppSDK-PublishSymbol-Wrapper.yml
+    parameters:
+      IsMonobuild: ${{ parameters.IsMonobuild }}
+      InnerParams:
         SearchPattern: '$(Build.ArtifactStagingDirectory)\symbols\**\*.pdb'
         IsOfficial: ${{ parameters.IsOfficial }}
 
   # ── Determine version + pack NuGet ──
-  - ${{ if parameters.IsMonobuild }}:
-    - template: Build/WindowsAppSDK/AzurePipelinesTemplates/WindowsAppSDK-DetermineVersion-Steps.yml@self
-      parameters:
-        IsOfficial: ${{ parameters.IsOfficial }}
-  - ${{ else }}:
-    - template: Build/WindowsAppSDK/AzurePipelinesTemplates/WindowsAppSDK-DetermineVersion-Steps.yml@WinAppSDK
-      parameters:
+  - template: WindowsAppSDK-DetermineVersion-Wrapper.yml
+    parameters:
+      IsMonobuild: ${{ parameters.IsMonobuild }}
+      InnerParams:
         IsOfficial: ${{ parameters.IsOfficial }}
 
   - task: PowerShell@2
@@ -169,16 +162,10 @@ steps:
 
   # ── Sign ──
   - ${{ if eq(parameters.SignOutput, 'true') }}:
-    - ${{ if parameters.IsMonobuild }}:
-      - template: Build/WindowsAppSDK/AzurePipelinesTemplates/WindowsAppSDK-EsrpCodeSigning-Steps.yml@self
-        parameters:
-          FolderPath: $(build.artifactStagingDirectory)\FullNuget
-          Pattern: 'Microsoft.WindowsAppSDK.Foundation*.nupkg'
-          KeyCode: 'CP-401405'
-          UseMinimatch: true
-    - ${{ else }}:
-      - template: Build/WindowsAppSDK/AzurePipelinesTemplates/WindowsAppSDK-EsrpCodeSigning-Steps.yml@WinAppSDK
-        parameters:
+    - template: WindowsAppSDK-EsrpCodeSigning-Wrapper.yml
+      parameters:
+        IsMonobuild: ${{ parameters.IsMonobuild }}
+        InnerParams:
           FolderPath: $(build.artifactStagingDirectory)\FullNuget
           Pattern: 'Microsoft.WindowsAppSDK.Foundation*.nupkg'
           KeyCode: 'CP-401405'

--- a/build/AzurePipelinesTemplates/WindowsAppSDK-PackTransportPackage-Steps.yml
+++ b/build/AzurePipelinesTemplates/WindowsAppSDK-PackTransportPackage-Steps.yml
@@ -54,7 +54,10 @@ steps:
         pipeline: $(_foundationBuildOutputPipeline)
         pipelineId: $(_foundationBuildOutputBuildId)
         artifactName: "${{ parameters.foundationArtifactPrefix }}_${{ platform }}"
-        targetPath: '$(Build.SourcesDirectory)\BuildOutput'
+        ${{ if parameters.IsMonobuild }}:
+          targetPath: '$(Build.SourcesDirectory)\WindowsAppSDK\BuildOutput'
+        ${{ else }}:
+          targetPath: '$(Build.SourcesDirectory)\BuildOutput'
 
   - task: DownloadPipelineArtifact@2
     displayName: 'Download Foundation anycpu'
@@ -65,7 +68,10 @@ steps:
       pipeline: $(_foundationBuildOutputPipeline)
       pipelineId: $(_foundationBuildOutputBuildId)
       artifactName: "${{ parameters.foundationArtifactPrefix }}_anycpu"
-      targetPath: '$(Build.SourcesDirectory)\BuildOutput'
+      ${{ if parameters.IsMonobuild }}:
+        targetPath: '$(Build.SourcesDirectory)\WindowsAppSDK\BuildOutput'
+      ${{ else }}:
+        targetPath: '$(Build.SourcesDirectory)\BuildOutput'
 
   # ── Download MRT build artifacts ──
   - ${{ each platform in split('x64;x86;arm64', ';') }}:
@@ -78,7 +84,10 @@ steps:
         pipeline: $(_foundationBuildOutputPipeline)
         pipelineId: $(_foundationBuildOutputBuildId)
         artifactName: "${{ parameters.mrtArtifactPrefix }}_${{ platform }}"
-        targetPath: '$(Build.SourcesDirectory)\BuildOutput'
+        ${{ if parameters.IsMonobuild }}:
+          targetPath: '$(Build.SourcesDirectory)\WindowsAppSDK\BuildOutput'
+        ${{ else }}:
+          targetPath: '$(Build.SourcesDirectory)\BuildOutput'
 
   # ── Stage files + symbols ──
   # In monobuild context:

--- a/build/AzurePipelinesTemplates/WindowsAppSDK-PackTransportPackage-Steps.yml
+++ b/build/AzurePipelinesTemplates/WindowsAppSDK-PackTransportPackage-Steps.yml
@@ -103,16 +103,21 @@ steps:
   - task: PowerShell@2
     name: StageFiles
     inputs:
-      filePath: 'BuildAll.ps1'
       ${{ if parameters.IsMonobuild }}:
+        filePath: '$(Build.SourcesDirectory)\WindowsAppSDK\BuildAll.ps1'
         workingDirectory: '$(Build.SourcesDirectory)\WindowsAppSDK'
+      ${{ else }}:
+        filePath: 'BuildAll.ps1'
       arguments: -Platform "x86,x64,arm64" -Configuration "release" -AzureBuildStep "StageFiles"
 
   - task: CopyFiles@2
     displayName: 'Copy symbols to artifact staging directory'
     condition: always()
     inputs:
-      sourceFolder: $(Build.SourcesDirectory)\BuildOutput\FullNuget
+      ${{ if parameters.IsMonobuild }}:
+        sourceFolder: $(Build.SourcesDirectory)\WindowsAppSDK\BuildOutput\FullNuget
+      ${{ else }}:
+        sourceFolder: $(Build.SourcesDirectory)\BuildOutput\FullNuget
       contents: |
         **\*.pdb
       targetFolder: $(Build.ArtifactStagingDirectory)\symbols
@@ -136,18 +141,27 @@ steps:
     displayName: Update metapackage version
     inputs:
       targetType: 'inline'
-      script: |
-        $packageVersion = '$(WindowsAppSDKFormattedVersion)'
-        [xml]$publicNuspec = Get-Content -Path $(Build.SourcesDirectory)\build\NuSpecs\Microsoft.WindowsAppSDK.Foundation.TransportPackage.nuspec
-        $publicNuspec.package.metadata.version = $packageVersion
-        Set-Content -Value $publicNuspec.OuterXml $(Build.SourcesDirectory)\build\NuSpecs\Microsoft.WindowsAppSDK.Foundation.TransportPackage.nuspec
+      ${{ if parameters.IsMonobuild }}:
+        script: |
+          $packageVersion = '$(WindowsAppSDKFormattedVersion)'
+          [xml]$publicNuspec = Get-Content -Path $(Build.SourcesDirectory)\WindowsAppSDK\build\NuSpecs\Microsoft.WindowsAppSDK.Foundation.TransportPackage.nuspec
+          $publicNuspec.package.metadata.version = $packageVersion
+          Set-Content -Value $publicNuspec.OuterXml $(Build.SourcesDirectory)\WindowsAppSDK\build\NuSpecs\Microsoft.WindowsAppSDK.Foundation.TransportPackage.nuspec
+      ${{ else }}:
+        script: |
+          $packageVersion = '$(WindowsAppSDKFormattedVersion)'
+          [xml]$publicNuspec = Get-Content -Path $(Build.SourcesDirectory)\build\NuSpecs\Microsoft.WindowsAppSDK.Foundation.TransportPackage.nuspec
+          $publicNuspec.package.metadata.version = $packageVersion
+          Set-Content -Value $publicNuspec.OuterXml $(Build.SourcesDirectory)\build\NuSpecs\Microsoft.WindowsAppSDK.Foundation.TransportPackage.nuspec
 
   - task: PowerShell@2
     name: PackNuget
     inputs:
-      filePath: 'BuildAll.ps1'
       ${{ if parameters.IsMonobuild }}:
+        filePath: '$(Build.SourcesDirectory)\WindowsAppSDK\BuildAll.ps1'
         workingDirectory: '$(Build.SourcesDirectory)\WindowsAppSDK'
+      ${{ else }}:
+        filePath: 'BuildAll.ps1'
       arguments: -Platform "x64" -Configuration "release" -AzureBuildStep "PackNuget" -OutputDirectory "$(build.artifactStagingDirectory)\FullNuget" -PackageVersion "$(WindowsAppSDKFormattedVersion)" -ComponentPackageVersion "$(WindowsAppSDKFormattedVersion)" -WindowsAppSDKVersionPinned "$(WindowsAppSDKVersionPinned)"
 
   # ── Sign ──
@@ -165,7 +179,10 @@ steps:
   - task: CopyFiles@2
     displayName: MoveToOutputDirectory
     inputs:
-      SourceFolder: '$(Build.SourcesDirectory)\BuildOutput\FullNuget'
+      ${{ if parameters.IsMonobuild }}:
+        SourceFolder: '$(Build.SourcesDirectory)\WindowsAppSDK\BuildOutput\FullNuget'
+      ${{ else }}:
+        SourceFolder: '$(Build.SourcesDirectory)\BuildOutput\FullNuget'
       TargetFolder: '$(ob_outputDirectory)\NugetContent'
 
   - task: CopyFiles@2

--- a/build/AzurePipelinesTemplates/WindowsAppSDK-PublishSymbol-Wrapper.yml
+++ b/build/AzurePipelinesTemplates/WindowsAppSDK-PublishSymbol-Wrapper.yml
@@ -1,0 +1,18 @@
+# Wrapper for WindowsAppSDK-PublishSymbol-Steps.yml that dispatches to either
+# @WinAppSDK (per-component pipelines) or @self (monobuild) at compile time.
+
+parameters:
+  - name: IsMonobuild
+    type: boolean
+    default: false
+  - name: InnerParams
+    type: object
+    default: {}
+
+steps:
+  - ${{ if parameters.IsMonobuild }}:
+    - template: Build/WindowsAppSDK/AzurePipelinesTemplates/WindowsAppSDK-PublishSymbol-Steps.yml@self
+      parameters: ${{ parameters.InnerParams }}
+  - ${{ else }}:
+    - template: Build/WindowsAppSDK/AzurePipelinesTemplates/WindowsAppSDK-PublishSymbol-Steps.yml@WinAppSDK
+      parameters: ${{ parameters.InnerParams }}

--- a/build/AzurePipelinesTemplates/WindowsAppSDK-RunTests-Steps.yml
+++ b/build/AzurePipelinesTemplates/WindowsAppSDK-RunTests-Steps.yml
@@ -236,7 +236,7 @@ steps:
         -callingStage "${{ parameters.callingStage }}"
 
   - ${{ if eq(parameters.IsMonobuild, 'true') }}:
-    - template: Build/WindowsAppSDK/AzurePipelinesTemplates/WindowsAppSDK-ConvertWttLogToXUnit-Steps.yml
+    - template: Build/WindowsAppSDK/AzurePipelinesTemplates/WindowsAppSDK-ConvertWttLogToXUnit-Steps.yml@self
       parameters:
         WttInputPath: '$(Build.SourcesDirectory)\TestOutput\$(buildConfiguration)\$(buildPlatform)\Te.wtl'
         xunitOutputPath: '$(Build.SourcesDirectory)\TestOutput\$(buildConfiguration)\$(buildPlatform)\testResults-$(buildConfiguration)_$(buildPlatform)_${{ parameters.ImageName }}.xml'

--- a/build/AzurePipelinesTemplates/WindowsAppSDK-RunTests-Steps.yml
+++ b/build/AzurePipelinesTemplates/WindowsAppSDK-RunTests-Steps.yml
@@ -7,6 +7,10 @@ parameters:
   testLocale: ''
   SamplesArtifactName: ''
   callingStage: ''
+  # When 'true', this template is being invoked from the monobuild context where
+  # the WindowsAppSDK monorepo IS the self repo. ConvertWttLogToXUnit-Steps is
+  # invoked WITHOUT the @WinAppSDK suffix.
+  IsMonobuild: 'false'
 
 steps:
   - task: powershell@2
@@ -231,13 +235,22 @@ steps:
         -wprProfilePath "$(Build.SourcesDirectory)\WinAppSDK\Build\WindowsAppSDK\src\test\AppModelProviders.wprp"
         -callingStage "${{ parameters.callingStage }}"
 
-  - template: Build/WindowsAppSDK/AzurePipelinesTemplates/WindowsAppSDK-ConvertWttLogToXUnit-Steps.yml@WinAppSDK
-    parameters:
-      WttInputPath: '$(Build.SourcesDirectory)\TestOutput\$(buildConfiguration)\$(buildPlatform)\Te.wtl'
-      xunitOutputPath: '$(Build.SourcesDirectory)\TestOutput\$(buildConfiguration)\$(buildPlatform)\testResults-$(buildConfiguration)_$(buildPlatform)_${{ parameters.ImageName }}.xml'
-      TestNamePrefix: '$(buildConfiguration)_$(buildPlatform)_${{ parameters.ImageName }}'
-      BypassTests: '$(Build.SourcesDirectory)\test\BypassTests.json'
-      CheckoutPath: '$(Build.SourcesDirectory)\WinAppSDK\Build\WindowsAppSDK'
+  - ${{ if eq(parameters.IsMonobuild, 'true') }}:
+    - template: Build/WindowsAppSDK/AzurePipelinesTemplates/WindowsAppSDK-ConvertWttLogToXUnit-Steps.yml
+      parameters:
+        WttInputPath: '$(Build.SourcesDirectory)\TestOutput\$(buildConfiguration)\$(buildPlatform)\Te.wtl'
+        xunitOutputPath: '$(Build.SourcesDirectory)\TestOutput\$(buildConfiguration)\$(buildPlatform)\testResults-$(buildConfiguration)_$(buildPlatform)_${{ parameters.ImageName }}.xml'
+        TestNamePrefix: '$(buildConfiguration)_$(buildPlatform)_${{ parameters.ImageName }}'
+        BypassTests: '$(Build.SourcesDirectory)\test\BypassTests.json'
+        CheckoutPath: '$(Build.SourcesDirectory)\WinAppSDK\Build\WindowsAppSDK'
+  - ${{ else }}:
+    - template: Build/WindowsAppSDK/AzurePipelinesTemplates/WindowsAppSDK-ConvertWttLogToXUnit-Steps.yml@WinAppSDK
+      parameters:
+        WttInputPath: '$(Build.SourcesDirectory)\TestOutput\$(buildConfiguration)\$(buildPlatform)\Te.wtl'
+        xunitOutputPath: '$(Build.SourcesDirectory)\TestOutput\$(buildConfiguration)\$(buildPlatform)\testResults-$(buildConfiguration)_$(buildPlatform)_${{ parameters.ImageName }}.xml'
+        TestNamePrefix: '$(buildConfiguration)_$(buildPlatform)_${{ parameters.ImageName }}'
+        BypassTests: '$(Build.SourcesDirectory)\test\BypassTests.json'
+        CheckoutPath: '$(Build.SourcesDirectory)\WinAppSDK\Build\WindowsAppSDK'
 
   - task: PublishTestResults@2
     displayName: 'Publish test results'

--- a/build/AzurePipelinesTemplates/WindowsAppSDK-RunTests-Steps.yml
+++ b/build/AzurePipelinesTemplates/WindowsAppSDK-RunTests-Steps.yml
@@ -235,17 +235,10 @@ steps:
         -wprProfilePath "$(Build.SourcesDirectory)\WinAppSDK\Build\WindowsAppSDK\src\test\AppModelProviders.wprp"
         -callingStage "${{ parameters.callingStage }}"
 
-  - ${{ if eq(parameters.IsMonobuild, 'true') }}:
-    - template: Build/WindowsAppSDK/AzurePipelinesTemplates/WindowsAppSDK-ConvertWttLogToXUnit-Steps.yml@self
-      parameters:
-        WttInputPath: '$(Build.SourcesDirectory)\TestOutput\$(buildConfiguration)\$(buildPlatform)\Te.wtl'
-        xunitOutputPath: '$(Build.SourcesDirectory)\TestOutput\$(buildConfiguration)\$(buildPlatform)\testResults-$(buildConfiguration)_$(buildPlatform)_${{ parameters.ImageName }}.xml'
-        TestNamePrefix: '$(buildConfiguration)_$(buildPlatform)_${{ parameters.ImageName }}'
-        BypassTests: '$(Build.SourcesDirectory)\test\BypassTests.json'
-        CheckoutPath: '$(Build.SourcesDirectory)\WinAppSDK\Build\WindowsAppSDK'
-  - ${{ else }}:
-    - template: Build/WindowsAppSDK/AzurePipelinesTemplates/WindowsAppSDK-ConvertWttLogToXUnit-Steps.yml@WinAppSDK
-      parameters:
+  - template: WindowsAppSDK-ConvertWttLogToXUnit-Wrapper.yml
+    parameters:
+      IsMonobuild: ${{ eq(parameters.IsMonobuild, 'true') }}
+      InnerParams:
         WttInputPath: '$(Build.SourcesDirectory)\TestOutput\$(buildConfiguration)\$(buildPlatform)\Te.wtl'
         xunitOutputPath: '$(Build.SourcesDirectory)\TestOutput\$(buildConfiguration)\$(buildPlatform)\testResults-$(buildConfiguration)_$(buildPlatform)_${{ parameters.ImageName }}.xml'
         TestNamePrefix: '$(buildConfiguration)_$(buildPlatform)_${{ parameters.ImageName }}'


### PR DESCRIPTION
In the monobuild context, the WindowsAppSDK monorepo IS the self repo, so @WinAppSDK template references would require declaring a self-ref repository resource (which has compile-time-only ref limitations).

Add an IsMonobuild parameter (default false) to all 7 step templates. When true, shared templates (PublishSymbol, DetermineVersion, EsrpCodeSigning, ConvertWttLogToXUnit) are invoked WITHOUT the @WinAppSDK suffix, resolving from self.

Per-component pipelines work unchanged (default IsMonobuild=false preserves @WinAppSDK cross-repo behavior). The monobuild caller (Foundation-Build-Stage.yml) passes IsMonobuild=true.

A microsoft employee must use /azp run to validate using the pipelines below.

WARNING:
Comments made by azure-pipelines bot maybe inaccurate.
Please see pipeline link to verify that the build is being ran.

For status checks on the main branch, please use TransportPackage-Foundation-PR
(https://microsoft.visualstudio.com/ProjectReunion/_build?definitionId=81063&_a=summary)
and run the build against your PR branch with the default parameters.
