### PR TITLE
Integration into Monobuild (Follow Up) 

### DIFF
--- a/build/AzurePipelinesTemplates/WindowsAppSDK-PackTransportPackage-Steps.yml
+++ b/build/AzurePipelinesTemplates/WindowsAppSDK-PackTransportPackage-Steps.yml
@@ -36,7 +36,7 @@ steps:
   # Always uses source: specific with _foundationBuildOutputBuildId.
   # The coalesce on that variable resolves to Build.BuildId (current run)
   # when no override is set, making this equivalent to source: current.
-  - ${{ each platform in split('x64;x86;arm64', ';') }}:
+  - ${{ each platform in split('x64;x86;arm64;anycpu', ';') }}:
     - task: DownloadPipelineArtifact@2
       displayName: 'Download Foundation ${{ platform }}'
       inputs:
@@ -47,17 +47,6 @@ steps:
         pipelineId: $(_foundationBuildOutputBuildId)
         artifactName: "${{ parameters.foundationArtifactPrefix }}_${{ platform }}"
         targetPath: '$(Build.SourcesDirectory)\BuildOutput'
-
-  - task: DownloadPipelineArtifact@2
-    displayName: 'Download Foundation anycpu'
-    inputs:
-      source: specific
-      runVersion: specific
-      project: $(System.TeamProjectId)
-      pipeline: $(_foundationBuildOutputPipeline)
-      pipelineId: $(_foundationBuildOutputBuildId)
-      artifactName: "${{ parameters.foundationArtifactPrefix }}_anycpu"
-      targetPath: '$(Build.SourcesDirectory)\BuildOutput'
 
   # ── Download MRT build artifacts ──
   - ${{ each platform in split('x64;x86;arm64', ';') }}:
@@ -140,7 +129,7 @@ steps:
   # ── Publish to feed ──
   - ${{ if eq(parameters.PublishPackage, 'true') }}:
     - task: NuGetCommand@2
-      displayName: 'NuGet push to ProjectReunion.nuget.internal'
+      displayName: 'NuGet push to Project.Reunion.nuget.internal'
       inputs:
         command: 'push'
         packagesToPush: '$(ob_outputDirectory)\*.nupkg'

--- a/build/WindowsAppSDK-CommonVariables.yml
+++ b/build/WindowsAppSDK-CommonVariables.yml
@@ -40,7 +40,7 @@ variables:
   #   - NuGet package contents (**/packages/**)
   #   - Test NetCore reference DLLs shipped with the .NET runtime (api-ms-win-core-*.dll)
   #   - The @WinAppSDK monorepo checkout (tool binaries like pdbcopy.exe, pgort140.dll)
-  ob_sdl_binskim_scannerParameters: '+:f|**.exe;+:f|**.dll;-:f|**/packages/**/*.dll;-:f|**/packages/**/*.exe;-:f|**/WindowsAppSDK.Test.NetCore/**;-:f|**/WinAppSDK/**/*.exe;-:f|**/WinAppSDK/**/*.dll'
+  ob_sdl_binskim_scannerParameters: '+:f|**.exe;+:f|**.dll;-:f|**/packages/**/*.dll;-:f|**/packages/**/*.exe;-:f|**/WindowsAppSDK.Test.NetCore/**;-:f|**/WinAppSDK/**/pdbcopy.exe;-:f|**/WinAppSDK/**/pgort140.dll'
 
   enableTestPass: true
 
@@ -48,6 +48,6 @@ variables:
   # Includes all EXEs/DLLs (+:f|**.exe, +:f|**.dll) then excludes:
   #   - NuGet package contents restored during build (**/packages/**)
   #   - .NET runtime reference DLLs in test projects (**/WindowsAppSDK.Test.NetCore/**)
-  #   - Tool binaries from the @WinAppSDK monorepo checkout (pdbcopy.exe, pgort140.dll, etc.)
+  #   - Tool binaries from the @WinAppSDK monorepo checkout (pdbcopy.exe, pgort140.dll)
   #     which are pre-built and not built from source in this repo
-  BinskimExclusionForFoundationRepo: +:f|**.exe;+:f|**.dll;-:f|**/packages/**/*.dll;-:f|**/packages/**/*.exe;-:f|**/WindowsAppSDK.Test.NetCore/**;-:f|**/WinAppSDK/**/*.exe;-:f|**/WinAppSDK/**/*.dll
+  BinskimExclusionForFoundationRepo: +:f|**.exe;+:f|**.dll;-:f|**/packages/**/*.dll;-:f|**/packages/**/*.exe;-:f|**/WindowsAppSDK.Test.NetCore/**;-:f|**/WinAppSDK/**/pdbcopy.exe;-:f|**/WinAppSDK/**/pgort140.dll


### PR DESCRIPTION
- PackTransportPackage-Steps: include anycpu in Foundation download loop (alexlamtest)
- PackTransportPackage-Steps: ProjectReunion -> Project.Reunion in displayName (alexlamtest)
- WindowsAppSDK-CommonVariables: scope BinSkim WinAppSDK exclusions from **/*.exe + **/*.dll to specific tool binaries (pdbcopy.exe, pgort140.dll) to avoid masking real BinSkim issues (alexlamtest)

A microsoft employee must use /azp run to validate using the pipelines below.

WARNING:
Comments made by azure-pipelines bot maybe inaccurate.
Please see pipeline link to verify that the build is being ran.

For status checks on the main branch, please use TransportPackage-Foundation-PR
(https://microsoft.visualstudio.com/ProjectReunion/_build?definitionId=81063&_a=summary)
and run the build against your PR branch with the default parameters.
