### PR TITLE
build(monobuild): wire Foundation tests via TestGate

### DIFF
--- a/build/AzurePipelinesTemplates/WindowsAppSDK-Build-Per-Platform-Stage.yml
+++ b/build/AzurePipelinesTemplates/WindowsAppSDK-Build-Per-Platform-Stage.yml
@@ -51,9 +51,9 @@ stages:
         value: '-|**\Release\**;-|**\packages\**'
       - name: ob_artifactBaseName
         ${{ if parameters.runPREfast }}:
-          value: "FoundationBinaries_$(buildConfiguration)_$(buildPlatform)_PREfast"
+          value: "Build-Foundation-$(buildPlatform)-$(buildConfiguration)-PREfast"
         ${{ else }}:
-          value: "FoundationBinaries_$(buildConfiguration)_$(buildPlatform)"
+          value: "Build-Foundation-$(buildPlatform)-$(buildConfiguration)"
       - name: ob_sdl_apiscan_enabled
         ${{ if parameters.runApiScan }}:
           value: true
@@ -130,9 +130,9 @@ stages:
         value: default
       - name: ob_artifactBaseName
         ${{ if parameters.runPREfast }}:
-          value: "MrtBinaries_$(buildConfiguration)_$(buildPlatform)_PREfast"
+          value: "Build-Foundation-MRT-$(buildPlatform)-$(buildConfiguration)-PREfast"
         ${{ else }}:
-          value: "MrtBinaries_$(buildConfiguration)_$(buildPlatform)"
+          value: "Build-Foundation-MRT-$(buildPlatform)-$(buildConfiguration)"
       - name: ob_sdl_apiscan_enabled
         ${{ if parameters.runApiScan }}:
           value: true

--- a/build/AzurePipelinesTemplates/WindowsAppSDK-Build-Stage.yml
+++ b/build/AzurePipelinesTemplates/WindowsAppSDK-Build-Stage.yml
@@ -42,9 +42,9 @@ stages:
       ob_outputDirectory: '$(REPOROOT)\out'
       ob_sdl_codeSignValidation_excludes: '-|**\Release\**'
       ${{ if parameters.runPREfast }}:
-        ob_artifactBaseName: "FoundationBinaries_release_anycpu_PREfast"
+        ob_artifactBaseName: "Build-Foundation-anycpu-Release-PREfast"
       ${{ if not( parameters.runPREfast ) }}:
-        ob_artifactBaseName: "FoundationBinaries_release_anycpu"
+        ob_artifactBaseName: "Build-Foundation-anycpu-Release"
       ${{ if parameters.runApiScan }}:
         ob_sdl_apiscan_enabled: true
       ${{ if not( parameters.runApiScan ) }}:

--- a/build/AzurePipelinesTemplates/WindowsAppSDK-PackTransportPackage-Stage.yml
+++ b/build/AzurePipelinesTemplates/WindowsAppSDK-PackTransportPackage-Stage.yml
@@ -46,5 +46,3 @@ stages:
         SignOutput: ${{ parameters.SignOutput }}
         IsOfficial: ${{ parameters.IsOfficial }}
         PublishPackage: ${{ parameters.PublishPackage }}
-        foundationArtifactPrefix: 'FoundationBinaries_release'
-        mrtArtifactPrefix: 'MrtBinaries_release'

--- a/build/AzurePipelinesTemplates/WindowsAppSDK-PackTransportPackage-Steps.yml
+++ b/build/AzurePipelinesTemplates/WindowsAppSDK-PackTransportPackage-Steps.yml
@@ -20,14 +20,6 @@ parameters:
   - name: PublishPackage
     type: boolean
     default: false
-  # Artifact name prefix — per-component uses FoundationBinaries_release/MrtBinaries_release,
-  # monobuild uses Build-Foundation/Build-MRT naming convention.
-  - name: foundationArtifactPrefix
-    type: string
-    default: 'FoundationBinaries_release'
-  - name: mrtArtifactPrefix
-    type: string
-    default: 'MrtBinaries_release'
   # When true, this template is being invoked from the monobuild context where
   # the WindowsAppSDK monorepo IS the self repo. Shared templates (PublishSymbol,
   # DetermineVersion, EsrpCodeSigning) are invoked WITHOUT @WinAppSDK suffix.
@@ -44,6 +36,8 @@ steps:
   # Always uses source: specific with _foundationBuildOutputBuildId.
   # The coalesce on that variable resolves to Build.BuildId (current run)
   # when no override is set, making this equivalent to source: current.
+  # Artifact names match the per-component Foundation build (FoundationBinaries_Release_<plat>,
+  # FoundationBinaries_release_anycpu) and the monobuild's Foundation-Build-Stage.yml.
   - ${{ each platform in split('x64;x86;arm64;anycpu', ';') }}:
     - task: DownloadPipelineArtifact@2
       displayName: 'Download Foundation ${{ platform }}'
@@ -53,7 +47,7 @@ steps:
         project: $(System.TeamProjectId)
         pipeline: $(_foundationBuildOutputPipeline)
         pipelineId: $(_foundationBuildOutputBuildId)
-        artifactName: "${{ parameters.foundationArtifactPrefix }}_${{ platform }}"
+        artifactName: "FoundationBinaries_release_${{ platform }}"
         ${{ if parameters.IsMonobuild }}:
           targetPath: '$(Build.SourcesDirectory)\WindowsAppSDK\BuildOutput'
         ${{ else }}:
@@ -69,7 +63,7 @@ steps:
         project: $(System.TeamProjectId)
         pipeline: $(_foundationBuildOutputPipeline)
         pipelineId: $(_foundationBuildOutputBuildId)
-        artifactName: "${{ parameters.mrtArtifactPrefix }}_${{ platform }}"
+        artifactName: "MrtBinaries_release_${{ platform }}"
         ${{ if parameters.IsMonobuild }}:
           targetPath: '$(Build.SourcesDirectory)\WindowsAppSDK\BuildOutput'
         ${{ else }}:

--- a/build/AzurePipelinesTemplates/WindowsAppSDK-PackTransportPackage-Steps.yml
+++ b/build/AzurePipelinesTemplates/WindowsAppSDK-PackTransportPackage-Steps.yml
@@ -36,8 +36,8 @@ steps:
   # Always uses source: specific with _foundationBuildOutputBuildId.
   # The coalesce on that variable resolves to Build.BuildId (current run)
   # when no override is set, making this equivalent to source: current.
-  # Artifact names match the per-component Foundation build (FoundationBinaries_Release_<plat>,
-  # FoundationBinaries_release_anycpu) and the monobuild's Foundation-Build-Stage.yml.
+  # Artifact names follow the monobuild spec (Mono-Build-Pipeline-Migration.md §6.3):
+  # Build-Foundation-<plat>-Release for native and AnyCPU, Build-Foundation-MRT-<plat>-Release for MRT.
   - ${{ each platform in split('x64;x86;arm64;anycpu', ';') }}:
     - task: DownloadPipelineArtifact@2
       displayName: 'Download Foundation ${{ platform }}'
@@ -47,7 +47,7 @@ steps:
         project: $(System.TeamProjectId)
         pipeline: $(_foundationBuildOutputPipeline)
         pipelineId: $(_foundationBuildOutputBuildId)
-        artifactName: "FoundationBinaries_release_${{ platform }}"
+        artifactName: "Build-Foundation-${{ platform }}-Release"
         ${{ if parameters.IsMonobuild }}:
           targetPath: '$(Build.SourcesDirectory)\WindowsAppSDK\BuildOutput'
         ${{ else }}:
@@ -63,7 +63,7 @@ steps:
         project: $(System.TeamProjectId)
         pipeline: $(_foundationBuildOutputPipeline)
         pipelineId: $(_foundationBuildOutputBuildId)
-        artifactName: "MrtBinaries_release_${{ platform }}"
+        artifactName: "Build-Foundation-MRT-${{ platform }}-Release"
         ${{ if parameters.IsMonobuild }}:
           targetPath: '$(Build.SourcesDirectory)\WindowsAppSDK\BuildOutput'
         ${{ else }}:

--- a/build/AzurePipelinesTemplates/WindowsAppSDK-RunTests-Steps.yml
+++ b/build/AzurePipelinesTemplates/WindowsAppSDK-RunTests-Steps.yml
@@ -29,7 +29,7 @@ steps:
       project: $(System.TeamProjectId)
       pipeline: $(_foundationBuildOutputPipeline)
       pipelineId: $(_foundationBuildOutputBuildId)
-      artifactName: "FoundationBinaries_$(buildConfiguration)_$(buildPlatform)"
+      artifactName: "Build-Foundation-$(buildPlatform)-$(buildConfiguration)"
       targetPath: '$(Build.SourcesDirectory)\BuildOutput'
 
   - task: DownloadPipelineArtifact@2
@@ -40,7 +40,7 @@ steps:
       project: $(System.TeamProjectId)
       pipeline: $(_foundationBuildOutputPipeline)
       pipelineId: $(_foundationBuildOutputBuildId)
-      artifactName: "MrtBinaries_$(buildConfiguration)_$(buildPlatform)"
+      artifactName: "Build-Foundation-MRT-$(buildPlatform)-$(buildConfiguration)"
       targetPath: '$(Build.SourcesDirectory)\BuildOutput'
 
   - task: CopyFiles@2

--- a/build/AzurePipelinesTemplates/WindowsAppSDK-Test-Stage.yml
+++ b/build/AzurePipelinesTemplates/WindowsAppSDK-Test-Stage.yml
@@ -9,6 +9,9 @@ parameters:
 # consumed standalone (e.g. WindowsAppSDK-Foundation-MonoBuild-Test.yml runs Test stages only and
 # pulls binaries from a parent monobuild run via _foundationBuildOutputBuildId, with no Build_*
 # stages in the same pipeline).
+#
+# Typically, either all platforms are using their default values, or all platforms receive the
+# empty list from the caller. Mixing the two scenarios is untested/unsupported.
 - name: buildStageDependencies_x86
   type: object
   default:

--- a/build/AzurePipelinesTemplates/WindowsAppSDK-Test-Stage.yml
+++ b/build/AzurePipelinesTemplates/WindowsAppSDK-Test-Stage.yml
@@ -5,6 +5,22 @@ parameters:
 - name: testMatrix
   type: object
   default: ''
+# Build stage names that each Test_<plat> stage must wait on. Empty list when this template is
+# consumed standalone (e.g. WindowsAppSDK-Foundation-MonoBuild-Test.yml runs Test stages only and
+# pulls binaries from a parent monobuild run via _foundationBuildOutputBuildId, with no Build_*
+# stages in the same pipeline).
+- name: buildStageDependencies_x86
+  type: object
+  default:
+  - Build_x86
+- name: buildStageDependencies_x64
+  type: object
+  default:
+  - Build_x64
+- name: buildStageDependencies_arm64
+  type: object
+  default:
+  - Build_arm64
 
 stages:
 # ExtractMatrix stages always run (no skip condition) so the test matrix
@@ -81,7 +97,8 @@ stages:
 
 - stage: Test_x86
   dependsOn:
-  - Build_x86
+  - ${{ each dep in parameters.buildStageDependencies_x86 }}:
+    - ${{ dep }}
   - ExtractMatrix_x86
   condition: not(failed())
   jobs:
@@ -93,7 +110,8 @@ stages:
 
 - stage: Test_x64
   dependsOn:
-  - Build_x64
+  - ${{ each dep in parameters.buildStageDependencies_x64 }}:
+    - ${{ dep }}
   - ExtractMatrix_x64
   condition: not(failed())
   jobs:
@@ -106,7 +124,8 @@ stages:
 - ${{ if eq(parameters.TestOnArm64, true)}}:
   - stage: Test_arm64
     dependsOn:
-    - Build_arm64
+    - ${{ each dep in parameters.buildStageDependencies_arm64 }}:
+      - ${{ dep }}
     - ExtractMatrix_arm64
     condition: not(failed())
     jobs:

--- a/build/WindowsAppSDK-Foundation-MonoBuild-Test.yml
+++ b/build/WindowsAppSDK-Foundation-MonoBuild-Test.yml
@@ -65,9 +65,11 @@ variables:
     - name: sourcePipelineId
       value: '189940'
   - template: Build/WindowsAppSDK/WindowsAppSDK-Foundation-TestConfig.yml@WinAppSDK
-  - template: Build/WindowsAppSDK/AzurePipelinesTemplates/WindowsAppSDK-Versions.yml@WinAppSDK
-    parameters:
-      PrOrNightly: 'pr'
+  # Note: WindowsAppSDK-Versions.yml is intentionally NOT included here. The test pipeline does
+  # not pack/version anything (it consumes binaries from the parent monobuild run), and the
+  # computed version variables (pipelineName, DateAndCounterSuffix, WindowsAppSDKVersion, ...)
+  # are not consumed in the test path. Pulling Versions in would also burn a counter increment
+  # on the WinAppSDK-0-Versions Variable Group every test-pipeline run for no reason.
   - template: Build/WindowsAppSDK/AzurePipelinesTemplates/WindowsAppSDK-CommonVariables.yml@WinAppSDK
   - template: WindowsAppSDK-CommonVariables.yml
   - group: WinAppSDK-Foundation-Build-Variables

--- a/build/WindowsAppSDK-Foundation-MonoBuild-Test.yml
+++ b/build/WindowsAppSDK-Foundation-MonoBuild-Test.yml
@@ -23,7 +23,7 @@
 #                                                                                                                                   #
 # Tag-back contract (see CopilotBrain/Docs/Mono-Build-Pipeline-Migration.md §8.3)                                                   #
 #   - On overall success, tags the parent monobuild with `FoundationTestSucceeded`.                                                #
-#   - On any failure, tags the parent monobuild with `FoundationTestFailed` (enables fast-fail in the monobuild's TestGate stage).  #
+#   - On failure, no tag is added; TestGate falls through to its timeout / manual-override path when the success tag is absent.    #
 #                                                                                                                                   #
 #####################################################################################################################################
 
@@ -152,20 +152,21 @@ extends:
           buildStageDependencies_x64: []
           buildStageDependencies_arm64: []
 
-      # ── Tag the parent monobuild ───────────────────────────────────────────────────────────────────────────────────────────────
-      # Single stage with two steps gated on succeeded()/failed(). The shared $(System.AccessToken) belongs to the
-      # test pipeline's Project Build Service identity, which has Tag permission on builds in the same project.
-      - stage: TagFoundationTestResult
-        displayName: 'Tag parent build: FoundationTest result'
-        condition: not(canceled())
+      # ── Tag the parent monobuild on success ───────────────────────────────────────────────────────────────────────────────────
+      # Only emit the success tag. Absence of FoundationTestSucceeded indicates failure (or no test run); TestGate's
+      # poll/timeout + manual-override path handles that case. The shared $(System.AccessToken) belongs to the test
+      # pipeline's Project Build Service identity, which has Tag permission on builds in the same project.
+      - stage: TagFoundationTestSucceeded
+        displayName: 'Tag parent build: FoundationTestSucceeded'
+        condition: succeeded()
         dependsOn:
           - Test_x86
           - Test_x64
           - ${{ if eq(parameters.TestOnArm64, true) }}:
             - Test_arm64
         jobs:
-          - job: TagResult
-            displayName: 'PUT FoundationTest{Succeeded|Failed} on parent monobuild'
+          - job: TagSucceeded
+            displayName: 'PUT FoundationTestSucceeded on parent monobuild'
             pool:
               type: windows
               isCustom: true
@@ -174,7 +175,6 @@ extends:
               - checkout: none
               - task: PowerShell@2
                 displayName: 'Tag ${{ parameters.sourceBuildId }} with FoundationTestSucceeded'
-                condition: succeeded()
                 env:
                   SYSTEM_ACCESSTOKEN: $(System.AccessToken)
                 inputs:
@@ -184,23 +184,6 @@ extends:
                     $ErrorActionPreference = 'Stop'
                     $parentBuildId = '${{ parameters.sourceBuildId }}'
                     $tag = 'FoundationTestSucceeded'
-                    $uri = "$(System.CollectionUri)$(System.TeamProject)/_apis/build/builds/$parentBuildId/tags/$tag" + '?api-version=7.1'
-                    Write-Host "PUT $uri"
-                    $headers = @{ Authorization = "Bearer $env:SYSTEM_ACCESSTOKEN" }
-                    Invoke-RestMethod -Uri $uri -Method Put -Headers $headers | Out-Null
-                    Write-Host "Tagged build $parentBuildId with $tag"
-              - task: PowerShell@2
-                displayName: 'Tag ${{ parameters.sourceBuildId }} with FoundationTestFailed'
-                condition: failed()
-                env:
-                  SYSTEM_ACCESSTOKEN: $(System.AccessToken)
-                inputs:
-                  targetType: inline
-                  script: |
-                    Set-StrictMode -Version 2.0
-                    $ErrorActionPreference = 'Stop'
-                    $parentBuildId = '${{ parameters.sourceBuildId }}'
-                    $tag = 'FoundationTestFailed'
                     $uri = "$(System.CollectionUri)$(System.TeamProject)/_apis/build/builds/$parentBuildId/tags/$tag" + '?api-version=7.1'
                     Write-Host "PUT $uri"
                     $headers = @{ Authorization = "Bearer $env:SYSTEM_ACCESSTOKEN" }

--- a/build/WindowsAppSDK-Foundation-MonoBuild-Test.yml
+++ b/build/WindowsAppSDK-Foundation-MonoBuild-Test.yml
@@ -19,7 +19,7 @@
 # Artifact reuse contract                                                                                                           #
 #   - Sets `foundationUseBuildOutputFromPipeline` / `foundationUseBuildOutputFromBuildId` to point at the parent monobuild run.     #
 #   - WindowsAppSDK-CommonVariables.yml coalesces these into `_foundationBuildOutputPipeline`/`_foundationBuildOutputBuildId`,      #
-#     which the RunTests step template consumes to download FoundationBinaries_release_*/MrtBinaries_release_* artifacts.           #
+#     which the RunTests step template consumes to download Build-Foundation-<plat>-Release/Build-Foundation-MRT-<plat>-Release artifacts. #
 #                                                                                                                                   #
 # Tag-back contract (see CopilotBrain/Docs/Mono-Build-Pipeline-Migration.md §8.3)                                                   #
 #   - On overall success, tags the parent monobuild with `TestSucceeded_Foundation`.                                                #
@@ -74,7 +74,7 @@ variables:
 
   # ── Reuse contract: pull binaries + transport packages from the source monobuild run ───────────────────────────────
   # Foundation's WindowsAppSDK-CommonVariables.yml coalesces these into _foundationBuildOutputPipeline / _foundationBuildOutputBuildId,
-  # which the RunTests step template already consumes to download FoundationBinaries_release_<plat>/MrtBinaries_release_<plat> from
+  # which the RunTests step template already consumes to download Build-Foundation-<plat>-Release/Build-Foundation-MRT-<plat>-Release from
   # the parent monobuild run.
   - name: foundationUseBuildOutputFromPipeline
     value: $(sourcePipelineId)
@@ -140,7 +140,7 @@ extends:
 
     stages:
       # ── Test stages only ───────────────────────────────────────────────────────────────────────────────────────────────────────
-      # Test_<plat> downloads FoundationBinaries_release_<plat> / MrtBinaries_release_<plat> from the parent monobuild run
+      # Test_<plat> downloads Build-Foundation-<plat>-Release / Build-Foundation-MRT-<plat>-Release from the parent monobuild run
       # via $(_foundationBuildOutputPipeline) / $(_foundationBuildOutputBuildId) and runs the TAEF test matrix.
       # buildStageDependencies_* are passed empty so Test_* don't try to reference non-existent Build_* stages.
       #

--- a/build/WindowsAppSDK-Foundation-MonoBuild-Test.yml
+++ b/build/WindowsAppSDK-Foundation-MonoBuild-Test.yml
@@ -30,26 +30,21 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
 
-# Build run name shows the source pipeline + build id so it's obvious which monobuild run
-# each test run is paired with. Examples:
-#   FoundationTest - Nightly #4567 (def 190463)
-#   FoundationTest - Official #890 (def 189940)
-name: 'FoundationTest - ${{ parameters.sourcePipelineName }} #${{ parameters.sourceBuildId }} (def ${{ parameters.sourcePipelineId }})'
+# Build run name shows the locked source pipeline label + build id so it's obvious
+# which parent run each test run is paired with.
+name: 'FoundationTest - ${{ parameters.sourcePipeline }} #${{ parameters.sourceBuildId }} (def $(sourcePipelineId))'
 
 parameters:
-  # Source monobuild pipeline metadata. The Build Completion trigger configured in the ADO UI
-  # auto-fills sourcePipelineId / sourceBuildId from the triggering run; sourcePipelineName is a
-  # free-text label for the run name only (not used for any artifact resolution).
-  # For manual queues, paste the values from the source build's URL (`buildId=...&definitionId=...`)
-  # and pick a label that makes sense in the runs list.
-  - name: sourcePipelineName
-    displayName: 'Source monobuild pipeline name (e.g. Nightly, Official) - free text label for the run name'
+  # Source pipeline is locked to known definitions and mapped below to the numeric
+  # definition id used by artifact download and tag-back.
+  - name: sourcePipeline
+    displayName: 'Source pipeline'
     type: string
-    default: 'Nightly'
-  - name: sourcePipelineId
-    displayName: 'Source monobuild pipeline definition id (e.g. 190463 = Nightly)'
-    type: string
-    default: '190463'
+    default: 'Monobuild-Nightly'
+    values:
+      - 'Monobuild-Nightly'
+      - 'Monobuild-Official'
+      - 'Foundation-PR'
   - name: sourceBuildId
     displayName: 'Source monobuild Build Id (run id of the producing build) - required'
     type: string
@@ -60,6 +55,15 @@ parameters:
     default: true
 
 variables:
+  - ${{ if eq(parameters.sourcePipeline, 'Monobuild-Nightly') }}:
+    - name: sourcePipelineId
+      value: '190463'
+  - ${{ if eq(parameters.sourcePipeline, 'Monobuild-Official') }}:
+    - name: sourcePipelineId
+      value: '190464'
+  - ${{ if eq(parameters.sourcePipeline, 'Foundation-PR') }}:
+    - name: sourcePipelineId
+      value: '189940'
   - template: Build/WindowsAppSDK/WindowsAppSDK-Foundation-TestConfig.yml@WinAppSDK
   - template: Build/WindowsAppSDK/AzurePipelinesTemplates/WindowsAppSDK-Versions.yml@WinAppSDK
     parameters:
@@ -73,7 +77,7 @@ variables:
   # which the RunTests step template already consumes to download FoundationBinaries_release_<plat>/MrtBinaries_release_<plat> from
   # the parent monobuild run.
   - name: foundationUseBuildOutputFromPipeline
-    value: ${{ parameters.sourcePipelineId }}
+    value: $(sourcePipelineId)
   - name: foundationUseBuildOutputFromBuildId
     value: ${{ parameters.sourceBuildId }}
 

--- a/build/WindowsAppSDK-Foundation-MonoBuild-Test.yml
+++ b/build/WindowsAppSDK-Foundation-MonoBuild-Test.yml
@@ -1,0 +1,254 @@
+#####################################################################################################################################
+#                                  Foundation MonoBuild Test Pipeline                                                               #
+#####################################################################################################################################
+#                                                                                                                                   #
+# Test pipeline that consumes Foundation build artifacts produced by the WinAppSDK MonoBuild and runs the full Foundation test      #
+# matrix (TAEF tests, sample app build/test, static validation) against them.                                                       #
+#                                                                                                                                   #
+# Trigger contract                                                                                                                  #
+#   - Configured from the ADO pipeline UI (Build Completion / Pipeline Resource trigger), not in this YAML.                         #
+#   - Source pipeline is declared as a `pipelines` resource so we can reference $(resources.pipeline.monobuild.runID).              #
+#                                                                                                                                   #
+# Artifact reuse contract                                                                                                           #
+#   - Sets `foundationUseBuildOutputFromPipeline` / `foundationUseBuildOutputFromBuildId` to point at the parent monobuild run.     #
+#   - WindowsAppSDK-CommonVariables.yml coalesces these into `_foundationBuildOutputPipeline`/`_foundationBuildOutputBuildId`,      #
+#     which the Pack steps and RunTests steps use as the artifact source.                                                           #
+#   - The same `foundationUseBuildOutputFromBuildId` setting causes per-platform Build_* stages to skip via their existing skip     #
+#     condition, so this pipeline only runs Pack/Test/StaticValidation/SampleApps against the parent's binaries.                    #
+#                                                                                                                                   #
+# Tag-back contract (see CopilotBrain/Docs/Mono-Build-Pipeline-Migration.md §8.3)                                                   #
+#   - On overall success, tags the parent monobuild with `FoundationTestSucceeded`.                                                #
+#   - On any failure, tags the parent monobuild with `FoundationTestFailed` (enables fast-fail in the monobuild's TestGate stage).  #
+#                                                                                                                                   #
+#####################################################################################################################################
+
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+name: $(pipelineName)
+
+trigger: none
+pr: none
+
+parameters:
+  - name: BuildSampleApps
+    displayName: 'Run Build Sample Apps stages'
+    type: boolean
+    default: true
+  - name: TestSampleApps
+    displayName: 'Test launch of sample apps in the TestSampleApps stages'
+    type: boolean
+    default: true
+  - name: TestOnArm64
+    displayName: 'Run tests on arm64'
+    type: boolean
+    default: true
+
+variables:
+  - template: Build/WindowsAppSDK/WindowsAppSDK-Foundation-TestConfig.yml@WinAppSDK
+  - template: Build/WindowsAppSDK/AzurePipelinesTemplates/WindowsAppSDK-Versions.yml@WinAppSDK
+    parameters:
+      PrOrNightly: 'pr'
+  - template: Build/WindowsAppSDK/AzurePipelinesTemplates/WindowsAppSDK-CommonVariables.yml@WinAppSDK
+  - template: WindowsAppSDK-CommonVariables.yml
+  - group: WinAppSDK-Foundation-Build-Variables
+  - name: maxParallelForBuildSamplesCompatJob_x64
+    value: 20
+  - name: maxParallelForBuildSamplesCompatJob_arm64
+    value: 20
+
+  # ── Reuse contract: pull binaries + transport packages from the triggering monobuild run ───────────────────────────────────────
+  # Foundation's WindowsAppSDK-CommonVariables.yml coalesces these into _foundationBuildOutputPipeline / _foundationBuildOutputBuildId,
+  # which the Pack and RunTests step templates already consume. Setting `foundationUseBuildOutputFromBuildId` also causes the
+  # per-platform Build_*/PREfast_* stages to skip via their own `condition:` guards.
+  - name: foundationUseBuildOutputFromPipeline
+    value: $(resources.pipeline.monobuild.pipelineID)
+  - name: foundationUseBuildOutputFromBuildId
+    value: $(resources.pipeline.monobuild.runID)
+
+resources:
+  repositories:
+    - repository: templates
+      type: git
+      name: OneBranch.Pipelines/GovernedTemplates
+      ref: refs/heads/main
+    - repository: WinAppSDK
+      type: git
+      name: OS/WinAppSDK
+      ref: refs/heads/release/dev/monobuild
+    - repository: WindowsAppSDKSamples
+      type: github
+      endpoint: 'WinAppSDK-Github'
+      name: microsoft/WindowsAppSDK-Samples
+      ref: $(SamplesBranch)
+
+  pipelines:
+    # The monobuild run whose artifacts we test. The trigger is configured in the ADO pipeline UI;
+    # we only need the resource declaration so we can reference $(resources.pipeline.monobuild.runID)
+    # / .pipelineID in the variables block above.
+    - pipeline: monobuild
+      source: WinAppSDK-MonoBuild-Nightly
+      project: OS
+
+extends:
+  template: v2/Microsoft.NonOfficial.yml@templates
+  parameters:
+    featureFlags:
+      EnableCDPxPAT: false
+      WindowsHostVersion:
+        Version: 2022
+        Network: R1
+
+    platform:
+      name: 'windows_undocked'
+
+    cloudvault:
+      enabled: false
+
+    globalSdl:
+      tsa:
+        enabled: $(TsaEnabled)
+      isNativeCode: false
+      suppression:
+        suppressionFile: $(Build.SourcesDirectory)\.gdn\OneBranch.gdnsuppress
+      psscriptanalyzer:
+        enable: true
+        break: true
+      binskim:
+        # Test pipeline does not produce binaries — only consumes monobuild artifacts and runs tests.
+        enabled: false
+        break: false
+      prefast:
+        enabled: false
+        break: false
+      apiscan:
+        enabled: false
+        break: false
+
+    stages:
+      # ── Build_*/PREfast_* stages from Foundation-PR.yml ─────────────────────────────────────────────────────────────────────────
+      # These stages are defined inside WindowsAppSDK-Build-Stage.yml. Each one's outer `condition:` is
+      # `eq(variables['foundationUseBuildOutputFromBuildId'],'')`, so all per-platform build jobs skip
+      # automatically when that variable is set (which we do above). They are kept in the pipeline so that
+      # downstream stages keep their `dependsOn` references valid; ADO treats skipped stages as satisfied
+      # for `not(failed())` conditions used by Pack/Test.
+      - template: AzurePipelinesTemplates\WindowsAppSDK-Build-Stage.yml@self
+        parameters:
+          SignOutput: false
+          runApiScan: false
+          runPREFast: false
+          testMatrix: ${{ variables.PipelineTests }}
+
+      # ── Pack: re-pack TransportPackage from monobuild's per-platform binaries ───────────────────────────────────────────────────
+      # WindowsAppSDK-PackTransportPackage-Steps.yml downloads from $(_foundationBuildOutputPipeline) / $(_foundationBuildOutputBuildId)
+      # using the default `FoundationBinaries_release` / `MrtBinaries_release` prefixes (case-insensitive match on
+      # the monobuild's `FoundationBinaries_Release_*` / `MrtBinaries_Release_*` artifacts).
+      - template: AzurePipelinesTemplates\WindowsAppSDK-PackTransportPackage-Stage.yml@self
+        parameters:
+          SignOutput: false
+          PublishPackage: false
+
+      - template: AzurePipelinesTemplates\WindowsAppSDK-StaticValidationTest-Stage.yml@self
+        parameters:
+          SignOutput: false
+
+      - template: AzurePipelinesTemplates\WindowsAppSDK-Test-Stage.yml@self
+        parameters:
+          testMatrix: ${{ variables.PipelineTests }}
+          TestOnArm64: ${{ parameters.TestOnArm64 }}
+
+      - ${{ if eq(parameters.BuildSampleApps, true) }}:
+        - template: AzurePipelinesTemplates\WindowsAppSDK-BuildAndTestSampleApps-Stage.yml@self
+          parameters:
+            TestSampleApps: ${{ parameters.TestSampleApps }}
+            TestOnArm64: ${{ parameters.TestOnArm64 }}
+            runStaticAnalysis: false
+            maxParallel_x64: ${{ variables.maxParallelForBuildSamplesCompatJob_x64 }}
+            maxParallel_arm64: ${{ variables.maxParallelForBuildSamplesCompatJob_arm64 }}
+
+      # ── Tag the parent monobuild ───────────────────────────────────────────────────────────────────────────────────────────────
+      # Two stages, one each for success / failure paths. The shared $(System.AccessToken) belongs to the
+      # test pipeline's Project Build Service identity, which has Tag permission on builds in the same project.
+      - stage: TagFoundationTestSucceeded
+        displayName: 'Tag parent build: FoundationTestSucceeded'
+        condition: succeeded()
+        dependsOn:
+          - Pack
+          - StaticValidationTest
+          - Test_x86
+          - Test_x64
+          - ${{ if eq(parameters.TestOnArm64, true) }}:
+            - Test_arm64
+          - ${{ if eq(parameters.BuildSampleApps, true) }}:
+            - BuildSampleApps_x64
+            - BuildSampleApps_arm64
+            - ${{ if eq(parameters.TestSampleApps, true) }}:
+              - TestSampleApps_x64
+              - TestSampleApps_arm64
+        jobs:
+          - job: TagSucceeded
+            displayName: 'PUT FoundationTestSucceeded on parent monobuild'
+            pool:
+              type: windows
+              isCustom: true
+              name: 'ProjectReunionESPool-2022'
+            steps:
+              - checkout: none
+              - task: PowerShell@2
+                displayName: 'Tag $(resources.pipeline.monobuild.runID) with FoundationTestSucceeded'
+                env:
+                  SYSTEM_ACCESSTOKEN: $(System.AccessToken)
+                inputs:
+                  targetType: inline
+                  script: |
+                    Set-StrictMode -Version 2.0
+                    $ErrorActionPreference = 'Stop'
+                    $parentBuildId = '$(resources.pipeline.monobuild.runID)'
+                    $tag = 'FoundationTestSucceeded'
+                    $uri = "$(System.CollectionUri)$(System.TeamProject)/_apis/build/builds/$parentBuildId/tags/$tag" + '?api-version=7.1'
+                    Write-Host "PUT $uri"
+                    $headers = @{ Authorization = "Bearer $env:SYSTEM_ACCESSTOKEN" }
+                    Invoke-RestMethod -Uri $uri -Method Put -Headers $headers | Out-Null
+                    Write-Host "Tagged build $parentBuildId with $tag"
+
+      - stage: TagFoundationTestFailed
+        displayName: 'Tag parent build: FoundationTestFailed'
+        condition: failed()
+        dependsOn:
+          - Pack
+          - StaticValidationTest
+          - Test_x86
+          - Test_x64
+          - ${{ if eq(parameters.TestOnArm64, true) }}:
+            - Test_arm64
+          - ${{ if eq(parameters.BuildSampleApps, true) }}:
+            - BuildSampleApps_x64
+            - BuildSampleApps_arm64
+            - ${{ if eq(parameters.TestSampleApps, true) }}:
+              - TestSampleApps_x64
+              - TestSampleApps_arm64
+        jobs:
+          - job: TagFailed
+            displayName: 'PUT FoundationTestFailed on parent monobuild'
+            pool:
+              type: windows
+              isCustom: true
+              name: 'ProjectReunionESPool-2022'
+            steps:
+              - checkout: none
+              - task: PowerShell@2
+                displayName: 'Tag $(resources.pipeline.monobuild.runID) with FoundationTestFailed'
+                env:
+                  SYSTEM_ACCESSTOKEN: $(System.AccessToken)
+                inputs:
+                  targetType: inline
+                  script: |
+                    Set-StrictMode -Version 2.0
+                    $ErrorActionPreference = 'Stop'
+                    $parentBuildId = '$(resources.pipeline.monobuild.runID)'
+                    $tag = 'FoundationTestFailed'
+                    $uri = "$(System.CollectionUri)$(System.TeamProject)/_apis/build/builds/$parentBuildId/tags/$tag" + '?api-version=7.1'
+                    Write-Host "PUT $uri"
+                    $headers = @{ Authorization = "Bearer $env:SYSTEM_ACCESSTOKEN" }
+                    Invoke-RestMethod -Uri $uri -Method Put -Headers $headers | Out-Null
+                    Write-Host "Tagged build $parentBuildId with $tag"

--- a/build/WindowsAppSDK-Foundation-MonoBuild-Test.yml
+++ b/build/WindowsAppSDK-Foundation-MonoBuild-Test.yml
@@ -2,8 +2,14 @@
 #                                  Foundation MonoBuild Test Pipeline                                                               #
 #####################################################################################################################################
 #                                                                                                                                   #
-# Test pipeline that consumes Foundation build artifacts produced by the WinAppSDK MonoBuild and runs the full Foundation test      #
-# matrix (TAEF tests, sample app build/test, static validation) against them.                                                       #
+# Test pipeline that consumes Foundation build artifacts produced by the WinAppSDK MonoBuild and runs the Foundation TAEF test    #
+# matrix against them.                                                                                                              #
+#                                                                                                                                   #
+# Scope                                                                                                                             #
+#   - Test stages only (Test_x86, Test_x64, Test_arm64).                                                                            #
+#   - Pack, StaticValidationTest, BuildAndTestSampleApps are NOT included; Pack already ran in the parent monobuild's Foundation   #
+#     stage and the other two depend on Pack outputs in the same run. Those will return as a follow-up once they're adapted to     #
+#     consume `Component-Foundation-Final` from the parent monobuild instead of the current run's Pack stage.                       #
 #                                                                                                                                   #
 # Trigger contract                                                                                                                  #
 #   - All triggers are configured in the ADO pipeline UI (Build Completion / Pipeline Resource trigger), not in this YAML.          #
@@ -13,9 +19,7 @@
 # Artifact reuse contract                                                                                                           #
 #   - Sets `foundationUseBuildOutputFromPipeline` / `foundationUseBuildOutputFromBuildId` to point at the parent monobuild run.     #
 #   - WindowsAppSDK-CommonVariables.yml coalesces these into `_foundationBuildOutputPipeline`/`_foundationBuildOutputBuildId`,      #
-#     which the Pack steps and RunTests steps use as the artifact source.                                                           #
-#   - The same `foundationUseBuildOutputFromBuildId` setting causes per-platform Build_* stages to skip via their existing skip     #
-#     condition, so this pipeline only runs Pack/Test/StaticValidation/SampleApps against the parent's binaries.                    #
+#     which the RunTests step template consumes to download FoundationBinaries_release_*/MrtBinaries_release_* artifacts.           #
 #                                                                                                                                   #
 # Tag-back contract (see CopilotBrain/Docs/Mono-Build-Pipeline-Migration.md §8.3)                                                   #
 #   - On overall success, tags the parent monobuild with `FoundationTestSucceeded`.                                                #
@@ -41,14 +45,6 @@ parameters:
     displayName: 'Source monobuild Build Id (run id of the producing build) - required'
     type: string
     default: ''
-  - name: BuildSampleApps
-    displayName: 'Run Build Sample Apps stages'
-    type: boolean
-    default: true
-  - name: TestSampleApps
-    displayName: 'Test launch of sample apps in the TestSampleApps stages'
-    type: boolean
-    default: true
   - name: TestOnArm64
     displayName: 'Run tests on arm64'
     type: boolean
@@ -62,15 +58,11 @@ variables:
   - template: Build/WindowsAppSDK/AzurePipelinesTemplates/WindowsAppSDK-CommonVariables.yml@WinAppSDK
   - template: WindowsAppSDK-CommonVariables.yml
   - group: WinAppSDK-Foundation-Build-Variables
-  - name: maxParallelForBuildSamplesCompatJob_x64
-    value: 20
-  - name: maxParallelForBuildSamplesCompatJob_arm64
-    value: 20
 
-  # ── Reuse contract: pull binaries + transport packages from the triggering monobuild run ───────────────────────────────────────
+  # ── Reuse contract: pull binaries + transport packages from the source monobuild run ───────────────────────────────
   # Foundation's WindowsAppSDK-CommonVariables.yml coalesces these into _foundationBuildOutputPipeline / _foundationBuildOutputBuildId,
-  # which the Pack and RunTests step templates already consume. Setting `foundationUseBuildOutputFromBuildId` also causes the
-  # per-platform Build_*/PREfast_* stages to skip via their own `condition:` guards.
+  # which the RunTests step template already consumes to download FoundationBinaries_release_<plat>/MrtBinaries_release_<plat> from
+  # the parent monobuild run.
   - name: foundationUseBuildOutputFromPipeline
     value: ${{ parameters.sourcePipelineId }}
   - name: foundationUseBuildOutputFromBuildId
@@ -128,45 +120,24 @@ extends:
         break: false
 
     stages:
-      # ── Build_*/PREfast_* stages from Foundation-PR.yml ─────────────────────────────────────────────────────────────────────────
-      # These stages are defined inside WindowsAppSDK-Build-Stage.yml. Each one's outer `condition:` is
-      # `eq(variables['foundationUseBuildOutputFromBuildId'],'')`, so all per-platform build jobs skip
-      # automatically when that variable is set (which we do above). They are kept in the pipeline so that
-      # downstream stages keep their `dependsOn` references valid; ADO treats skipped stages as satisfied
-      # for `not(failed())` conditions used by Pack/Test.
-      - template: AzurePipelinesTemplates\WindowsAppSDK-Build-Stage.yml@self
-        parameters:
-          SignOutput: false
-          runApiScan: false
-          runPREFast: false
-          testMatrix: ${{ variables.PipelineTests }}
-
-      # ── Pack: re-pack TransportPackage from monobuild's per-platform binaries ───────────────────────────────────────────────────
-      # WindowsAppSDK-PackTransportPackage-Steps.yml downloads from $(_foundationBuildOutputPipeline) / $(_foundationBuildOutputBuildId)
-      # using the default `FoundationBinaries_release` / `MrtBinaries_release` prefixes (case-insensitive match on
-      # the monobuild's `FoundationBinaries_Release_*` / `MrtBinaries_Release_*` artifacts).
-      - template: AzurePipelinesTemplates\WindowsAppSDK-PackTransportPackage-Stage.yml@self
-        parameters:
-          SignOutput: false
-          PublishPackage: false
-
-      - template: AzurePipelinesTemplates\WindowsAppSDK-StaticValidationTest-Stage.yml@self
-        parameters:
-          SignOutput: false
-
+      # ── Test stages only ───────────────────────────────────────────────────────────────────────────────────────────────────────
+      # Test_<plat> downloads FoundationBinaries_release_<plat> / MrtBinaries_release_<plat> from the parent monobuild run
+      # via $(_foundationBuildOutputPipeline) / $(_foundationBuildOutputBuildId) and runs the TAEF test matrix.
+      # buildStageDependencies_* are passed empty so Test_* don't try to reference non-existent Build_* stages.
+      #
+      # Pack, StaticValidationTest, BuildAndTestSampleApps are intentionally NOT included here:
+      #   - Pack already ran in the parent monobuild's Foundation stage; re-running it would be duplicate work.
+      #   - StaticValidationTest currently consumes the in-pipeline TransportPackage artifact (Pack output).
+      #   - BuildAndTestSampleApps reads stageDependencies.Pack.NugetPackage outputs.
+      # Both will be re-introduced in a follow-up that adapts those stages to consume `Component-Foundation-Final`
+      # from the parent monobuild run instead of the current run's Pack stage.
       - template: AzurePipelinesTemplates\WindowsAppSDK-Test-Stage.yml@self
         parameters:
           testMatrix: ${{ variables.PipelineTests }}
           TestOnArm64: ${{ parameters.TestOnArm64 }}
-
-      - ${{ if eq(parameters.BuildSampleApps, true) }}:
-        - template: AzurePipelinesTemplates\WindowsAppSDK-BuildAndTestSampleApps-Stage.yml@self
-          parameters:
-            TestSampleApps: ${{ parameters.TestSampleApps }}
-            TestOnArm64: ${{ parameters.TestOnArm64 }}
-            runStaticAnalysis: false
-            maxParallel_x64: ${{ variables.maxParallelForBuildSamplesCompatJob_x64 }}
-            maxParallel_arm64: ${{ variables.maxParallelForBuildSamplesCompatJob_arm64 }}
+          buildStageDependencies_x86: []
+          buildStageDependencies_x64: []
+          buildStageDependencies_arm64: []
 
       # ── Tag the parent monobuild ───────────────────────────────────────────────────────────────────────────────────────────────
       # Two stages, one each for success / failure paths. The shared $(System.AccessToken) belongs to the
@@ -175,18 +146,10 @@ extends:
         displayName: 'Tag parent build: FoundationTestSucceeded'
         condition: succeeded()
         dependsOn:
-          - Pack
-          - StaticValidationTest
           - Test_x86
           - Test_x64
           - ${{ if eq(parameters.TestOnArm64, true) }}:
             - Test_arm64
-          - ${{ if eq(parameters.BuildSampleApps, true) }}:
-            - BuildSampleApps_x64
-            - BuildSampleApps_arm64
-            - ${{ if eq(parameters.TestSampleApps, true) }}:
-              - TestSampleApps_x64
-              - TestSampleApps_arm64
         jobs:
           - job: TagSucceeded
             displayName: 'PUT FoundationTestSucceeded on parent monobuild'
@@ -217,18 +180,10 @@ extends:
         displayName: 'Tag parent build: FoundationTestFailed'
         condition: failed()
         dependsOn:
-          - Pack
-          - StaticValidationTest
           - Test_x86
           - Test_x64
           - ${{ if eq(parameters.TestOnArm64, true) }}:
             - Test_arm64
-          - ${{ if eq(parameters.BuildSampleApps, true) }}:
-            - BuildSampleApps_x64
-            - BuildSampleApps_arm64
-            - ${{ if eq(parameters.TestSampleApps, true) }}:
-              - TestSampleApps_x64
-              - TestSampleApps_arm64
         jobs:
           - job: TagFailed
             displayName: 'PUT FoundationTestFailed on parent monobuild'

--- a/build/WindowsAppSDK-Foundation-MonoBuild-Test.yml
+++ b/build/WindowsAppSDK-Foundation-MonoBuild-Test.yml
@@ -87,6 +87,12 @@ resources:
       type: git
       name: OneBranch.Pipelines/GovernedTemplates
       ref: refs/heads/main
+    # TODO: Pinned to the WASDK monobuild dev branch while the monobuild contract is
+    # still in flight. Once the trigger flow lands on release/main and we're ready to
+    # consume monobuild templates from the same branch the parent run is executing on,
+    # switch this to a queue-time parameter (or pass it through the trigger POST body
+    # alongside resources.repositories.self.refName) so the test pipeline picks up the
+    # exact monobuild commit that produced its input artifacts.
     - repository: WinAppSDK
       type: git
       name: OS/WinAppSDK

--- a/build/WindowsAppSDK-Foundation-MonoBuild-Test.yml
+++ b/build/WindowsAppSDK-Foundation-MonoBuild-Test.yml
@@ -32,7 +32,7 @@
 
 # Build run name shows the locked source pipeline label + build id so it's obvious
 # which parent run each test run is paired with.
-name: '${{ parameters.sourcePipeline }}-${{ parameters.sourceBuildId }}'
+name: '${{ parameters.sourcePipeline }} #${{ parameters.sourceBuildId }} (def $(sourcePipelineId))'
 
 parameters:
   # Source pipeline is locked to known definitions and mapped below to the numeric

--- a/build/WindowsAppSDK-Foundation-MonoBuild-Test.yml
+++ b/build/WindowsAppSDK-Foundation-MonoBuild-Test.yml
@@ -6,8 +6,9 @@
 # matrix (TAEF tests, sample app build/test, static validation) against them.                                                       #
 #                                                                                                                                   #
 # Trigger contract                                                                                                                  #
-#   - Configured from the ADO pipeline UI (Build Completion / Pipeline Resource trigger), not in this YAML.                         #
-#   - Source pipeline is declared as a `pipelines` resource so we can reference $(resources.pipeline.monobuild.runID).              #
+#   - All triggers are configured in the ADO pipeline UI (Build Completion / Pipeline Resource trigger), not in this YAML.          #
+#   - Source pipeline + run id are passed as queue-time parameters (`sourcePipelineId` / `sourceBuildId`) so any monobuild          #
+#     definition (Nightly, future Official, 189940, ...) can feed this pipeline without YAML edits.                                 #
 #                                                                                                                                   #
 # Artifact reuse contract                                                                                                           #
 #   - Sets `foundationUseBuildOutputFromPipeline` / `foundationUseBuildOutputFromBuildId` to point at the parent monobuild run.     #
@@ -28,6 +29,18 @@
 name: $(pipelineName)
 
 parameters:
+  # Source monobuild pipeline definition + run id. Free text so this pipeline works against
+  # any current or future monobuild definition (Nightly = 190463, Official = TBD, 189940, ...).
+  # The Build Completion trigger configured in the ADO UI auto-fills these from the triggering run;
+  # for manual queues, paste the values from the source build's URL (`buildId=...&definitionId=...`).
+  - name: sourcePipelineId
+    displayName: 'Source monobuild pipeline definition id (e.g. 190463 = Nightly)'
+    type: string
+    default: '190463'
+  - name: sourceBuildId
+    displayName: 'Source monobuild Build Id (run id of the producing build) - required'
+    type: string
+    default: ''
   - name: BuildSampleApps
     displayName: 'Run Build Sample Apps stages'
     type: boolean
@@ -59,9 +72,9 @@ variables:
   # which the Pack and RunTests step templates already consume. Setting `foundationUseBuildOutputFromBuildId` also causes the
   # per-platform Build_*/PREfast_* stages to skip via their own `condition:` guards.
   - name: foundationUseBuildOutputFromPipeline
-    value: $(resources.pipeline.monobuild.pipelineID)
+    value: ${{ parameters.sourcePipelineId }}
   - name: foundationUseBuildOutputFromBuildId
-    value: $(resources.pipeline.monobuild.runID)
+    value: ${{ parameters.sourceBuildId }}
 
 resources:
   repositories:
@@ -78,14 +91,6 @@ resources:
       endpoint: 'WinAppSDK-Github'
       name: microsoft/WindowsAppSDK-Samples
       ref: $(SamplesBranch)
-
-  pipelines:
-    # The monobuild run whose artifacts we test. The trigger is configured in the ADO pipeline UI;
-    # we only need the resource declaration so we can reference $(resources.pipeline.monobuild.runID)
-    # / .pipelineID in the variables block above.
-    - pipeline: monobuild
-      source: WinAppSDK-MonoBuild-Nightly
-      project: OS
 
 extends:
   template: v2/Microsoft.NonOfficial.yml@templates
@@ -192,7 +197,7 @@ extends:
             steps:
               - checkout: none
               - task: PowerShell@2
-                displayName: 'Tag $(resources.pipeline.monobuild.runID) with FoundationTestSucceeded'
+                displayName: 'Tag ${{ parameters.sourceBuildId }} with FoundationTestSucceeded'
                 env:
                   SYSTEM_ACCESSTOKEN: $(System.AccessToken)
                 inputs:
@@ -200,7 +205,7 @@ extends:
                   script: |
                     Set-StrictMode -Version 2.0
                     $ErrorActionPreference = 'Stop'
-                    $parentBuildId = '$(resources.pipeline.monobuild.runID)'
+                    $parentBuildId = '${{ parameters.sourceBuildId }}'
                     $tag = 'FoundationTestSucceeded'
                     $uri = "$(System.CollectionUri)$(System.TeamProject)/_apis/build/builds/$parentBuildId/tags/$tag" + '?api-version=7.1'
                     Write-Host "PUT $uri"
@@ -234,7 +239,7 @@ extends:
             steps:
               - checkout: none
               - task: PowerShell@2
-                displayName: 'Tag $(resources.pipeline.monobuild.runID) with FoundationTestFailed'
+                displayName: 'Tag ${{ parameters.sourceBuildId }} with FoundationTestFailed'
                 env:
                   SYSTEM_ACCESSTOKEN: $(System.AccessToken)
                 inputs:
@@ -242,7 +247,7 @@ extends:
                   script: |
                     Set-StrictMode -Version 2.0
                     $ErrorActionPreference = 'Stop'
-                    $parentBuildId = '$(resources.pipeline.monobuild.runID)'
+                    $parentBuildId = '${{ parameters.sourceBuildId }}'
                     $tag = 'FoundationTestFailed'
                     $uri = "$(System.CollectionUri)$(System.TeamProject)/_apis/build/builds/$parentBuildId/tags/$tag" + '?api-version=7.1'
                     Write-Host "PUT $uri"

--- a/build/WindowsAppSDK-Foundation-MonoBuild-Test.yml
+++ b/build/WindowsAppSDK-Foundation-MonoBuild-Test.yml
@@ -30,13 +30,22 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
 
-name: $(pipelineName)
+# Build run name shows the source pipeline + build id so it's obvious which monobuild run
+# each test run is paired with. Examples:
+#   FoundationTest - Nightly #4567 (def 190463)
+#   FoundationTest - Official #890 (def 189940)
+name: 'FoundationTest - ${{ parameters.sourcePipelineName }} #${{ parameters.sourceBuildId }} (def ${{ parameters.sourcePipelineId }})'
 
 parameters:
-  # Source monobuild pipeline definition + run id. Free text so this pipeline works against
-  # any current or future monobuild definition (Nightly = 190463, Official = TBD, 189940, ...).
-  # The Build Completion trigger configured in the ADO UI auto-fills these from the triggering run;
-  # for manual queues, paste the values from the source build's URL (`buildId=...&definitionId=...`).
+  # Source monobuild pipeline metadata. The Build Completion trigger configured in the ADO UI
+  # auto-fills sourcePipelineId / sourceBuildId from the triggering run; sourcePipelineName is a
+  # free-text label for the run name only (not used for any artifact resolution).
+  # For manual queues, paste the values from the source build's URL (`buildId=...&definitionId=...`)
+  # and pick a label that makes sense in the runs list.
+  - name: sourcePipelineName
+    displayName: 'Source monobuild pipeline name (e.g. Nightly, Official) - free text label for the run name'
+    type: string
+    default: 'Nightly'
   - name: sourcePipelineId
     displayName: 'Source monobuild pipeline definition id (e.g. 190463 = Nightly)'
     type: string

--- a/build/WindowsAppSDK-Foundation-MonoBuild-Test.yml
+++ b/build/WindowsAppSDK-Foundation-MonoBuild-Test.yml
@@ -65,11 +65,6 @@ variables:
     - name: sourcePipelineId
       value: '189940'
   - template: Build/WindowsAppSDK/WindowsAppSDK-Foundation-TestConfig.yml@WinAppSDK
-  # Note: WindowsAppSDK-Versions.yml is intentionally NOT included here. The test pipeline does
-  # not pack/version anything (it consumes binaries from the parent monobuild run), and the
-  # computed version variables (pipelineName, DateAndCounterSuffix, WindowsAppSDKVersion, ...)
-  # are not consumed in the test path. Pulling Versions in would also burn a counter increment
-  # on the WinAppSDK-0-Versions Variable Group every test-pipeline run for no reason.
   - template: Build/WindowsAppSDK/AzurePipelinesTemplates/WindowsAppSDK-CommonVariables.yml@WinAppSDK
   - template: WindowsAppSDK-CommonVariables.yml
   - group: WinAppSDK-Foundation-Build-Variables

--- a/build/WindowsAppSDK-Foundation-MonoBuild-Test.yml
+++ b/build/WindowsAppSDK-Foundation-MonoBuild-Test.yml
@@ -153,39 +153,15 @@ extends:
           buildStageDependencies_arm64: []
 
       # ── Tag the parent monobuild on success ───────────────────────────────────────────────────────────────────────────────────
-      # Only emit the success tag. Absence of FoundationTestSucceeded indicates failure (or no test run); TestGate's
-      # poll/timeout + manual-override path handles that case. The shared $(System.AccessToken) belongs to the test
-      # pipeline's Project Build Service identity, which has Tag permission on builds in the same project.
-      - stage: TagFoundationTestSucceeded
-        displayName: 'Tag parent build: FoundationTestSucceeded'
-        condition: succeeded()
-        dependsOn:
-          - Test_x86
-          - Test_x64
-          - ${{ if eq(parameters.TestOnArm64, true) }}:
-            - Test_arm64
-        jobs:
-          - job: TagSucceeded
-            displayName: 'PUT FoundationTestSucceeded on parent monobuild'
-            pool:
-              type: windows
-              isCustom: true
-              name: 'ProjectReunionESPool-2022'
-            steps:
-              - checkout: none
-              - task: PowerShell@2
-                displayName: 'Tag ${{ parameters.sourceBuildId }} with FoundationTestSucceeded'
-                env:
-                  SYSTEM_ACCESSTOKEN: $(System.AccessToken)
-                inputs:
-                  targetType: inline
-                  script: |
-                    Set-StrictMode -Version 2.0
-                    $ErrorActionPreference = 'Stop'
-                    $parentBuildId = '${{ parameters.sourceBuildId }}'
-                    $tag = 'FoundationTestSucceeded'
-                    $uri = "$(System.CollectionUri)$(System.TeamProject)/_apis/build/builds/$parentBuildId/tags/$tag" + '?api-version=7.1'
-                    Write-Host "PUT $uri"
-                    $headers = @{ Authorization = "Bearer $env:SYSTEM_ACCESSTOKEN" }
-                    Invoke-RestMethod -Uri $uri -Method Put -Headers $headers | Out-Null
-                    Write-Host "Tagged build $parentBuildId with $tag"
+      # Delegated to the shared monorepo template so every component uses the same
+      # tag-back contract (`<componentName>TestSucceeded`). See
+      # Build/WindowsAppSDK/AzurePipelinesTemplates/WinAppSDK-TagTestResult-Stage.yml.
+      - template: Build/WindowsAppSDK/AzurePipelinesTemplates/WinAppSDK-TagTestResult-Stage.yml@WinAppSDK
+        parameters:
+          componentName: 'Foundation'
+          sourceBuildId: ${{ parameters.sourceBuildId }}
+          dependsOn:
+            - Test_x86
+            - Test_x64
+            - ${{ if eq(parameters.TestOnArm64, true) }}:
+              - Test_arm64

--- a/build/WindowsAppSDK-Foundation-MonoBuild-Test.yml
+++ b/build/WindowsAppSDK-Foundation-MonoBuild-Test.yml
@@ -32,7 +32,7 @@
 
 # Build run name shows the locked source pipeline label + build id so it's obvious
 # which parent run each test run is paired with.
-name: 'FoundationTest - ${{ parameters.sourcePipeline }} #${{ parameters.sourceBuildId }} (def $(sourcePipelineId))'
+name: '${{ parameters.sourcePipeline }}-${{ parameters.sourceBuildId }}'
 
 parameters:
   # Source pipeline is locked to known definitions and mapped below to the numeric

--- a/build/WindowsAppSDK-Foundation-MonoBuild-Test.yml
+++ b/build/WindowsAppSDK-Foundation-MonoBuild-Test.yml
@@ -27,9 +27,6 @@
 
 name: $(pipelineName)
 
-trigger: none
-pr: none
-
 parameters:
   - name: BuildSampleApps
     displayName: 'Run Build Sample Apps stages'

--- a/build/WindowsAppSDK-Foundation-MonoBuild-Test.yml
+++ b/build/WindowsAppSDK-Foundation-MonoBuild-Test.yml
@@ -153,19 +153,19 @@ extends:
           buildStageDependencies_arm64: []
 
       # ── Tag the parent monobuild ───────────────────────────────────────────────────────────────────────────────────────────────
-      # Two stages, one each for success / failure paths. The shared $(System.AccessToken) belongs to the
+      # Single stage with two steps gated on succeeded()/failed(). The shared $(System.AccessToken) belongs to the
       # test pipeline's Project Build Service identity, which has Tag permission on builds in the same project.
-      - stage: TagFoundationTestSucceeded
-        displayName: 'Tag parent build: FoundationTestSucceeded'
-        condition: succeeded()
+      - stage: TagFoundationTestResult
+        displayName: 'Tag parent build: FoundationTest result'
+        condition: not(canceled())
         dependsOn:
           - Test_x86
           - Test_x64
           - ${{ if eq(parameters.TestOnArm64, true) }}:
             - Test_arm64
         jobs:
-          - job: TagSucceeded
-            displayName: 'PUT FoundationTestSucceeded on parent monobuild'
+          - job: TagResult
+            displayName: 'PUT FoundationTest{Succeeded|Failed} on parent monobuild'
             pool:
               type: windows
               isCustom: true
@@ -174,6 +174,7 @@ extends:
               - checkout: none
               - task: PowerShell@2
                 displayName: 'Tag ${{ parameters.sourceBuildId }} with FoundationTestSucceeded'
+                condition: succeeded()
                 env:
                   SYSTEM_ACCESSTOKEN: $(System.AccessToken)
                 inputs:
@@ -188,26 +189,9 @@ extends:
                     $headers = @{ Authorization = "Bearer $env:SYSTEM_ACCESSTOKEN" }
                     Invoke-RestMethod -Uri $uri -Method Put -Headers $headers | Out-Null
                     Write-Host "Tagged build $parentBuildId with $tag"
-
-      - stage: TagFoundationTestFailed
-        displayName: 'Tag parent build: FoundationTestFailed'
-        condition: failed()
-        dependsOn:
-          - Test_x86
-          - Test_x64
-          - ${{ if eq(parameters.TestOnArm64, true) }}:
-            - Test_arm64
-        jobs:
-          - job: TagFailed
-            displayName: 'PUT FoundationTestFailed on parent monobuild'
-            pool:
-              type: windows
-              isCustom: true
-              name: 'ProjectReunionESPool-2022'
-            steps:
-              - checkout: none
               - task: PowerShell@2
                 displayName: 'Tag ${{ parameters.sourceBuildId }} with FoundationTestFailed'
+                condition: failed()
                 env:
                   SYSTEM_ACCESSTOKEN: $(System.AccessToken)
                 inputs:

--- a/build/WindowsAppSDK-Foundation-MonoBuild-Test.yml
+++ b/build/WindowsAppSDK-Foundation-MonoBuild-Test.yml
@@ -22,7 +22,7 @@
 #     which the RunTests step template consumes to download FoundationBinaries_release_*/MrtBinaries_release_* artifacts.           #
 #                                                                                                                                   #
 # Tag-back contract (see CopilotBrain/Docs/Mono-Build-Pipeline-Migration.md §8.3)                                                   #
-#   - On overall success, tags the parent monobuild with `FoundationTestSucceeded`.                                                #
+#   - On overall success, tags the parent monobuild with `TestSucceeded_Foundation`.                                                #
 #   - On failure, no tag is added; TestGate falls through to its timeout / manual-override path when the success tag is absent.    #
 #                                                                                                                                   #
 #####################################################################################################################################
@@ -160,7 +160,7 @@ extends:
 
       # ── Tag the parent monobuild on success ───────────────────────────────────────────────────────────────────────────────────
       # Delegated to the shared monorepo template so every component uses the same
-      # tag-back contract (`<componentName>TestSucceeded`). See
+      # tag-back contract (`TestSucceeded_<componentName>`). See
       # Build/WindowsAppSDK/AzurePipelinesTemplates/WinAppSDK-TagTestResult-Stage.yml.
       - template: Build/WindowsAppSDK/AzurePipelinesTemplates/WinAppSDK-TagTestResult-Stage.yml@WinAppSDK
         parameters:


### PR DESCRIPTION
Stands up new standalone test pipeline for Foundation to be used with the monobuild
https://dev.azure.com/microsoft/OS/_build?definitionId=192441

A microsoft employee must use /azp run to validate using the pipelines below.

WARNING:
Comments made by azure-pipelines bot maybe inaccurate.
Please see pipeline link to verify that the build is being ran.

For status checks on the main branch, please use TransportPackage-Foundation-PR
(https://microsoft.visualstudio.com/ProjectReunion/_build?definitionId=81063&_a=summary)
and run the build against your PR branch with the default parameters.
