### PR TITLE
Add LICENSE at root and update make_projection.ps1 to carry it forward

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+    MIT License
+
+    Copyright (c) Microsoft Corporation.
+
+    Permission is hereby granted, free of charge, to any person obtaining a copy
+    of this software and associated documentation files (the "Software"), to deal
+    in the Software without restriction, including without limitation the rights
+    to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+    copies of the Software, and to permit persons to whom the Software is
+    furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice shall be included in all
+    copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+    AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+    OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+    SOFTWARE

--- a/inc/make_projection.ps1
+++ b/inc/make_projection.ps1
@@ -480,16 +480,19 @@ $scriptPath   = Join-Path $incDir   'make_projection.ps1'
 $testDir      = Join-Path $incDir   'test'
 $testScript   = Join-Path $testDir  'test.ps1'
 $testIgnore   = Join-Path $testDir  '.gitignore'
+$licensePath  = Join-Path $repoRoot 'LICENSE'
 
 if (-not (Test-Path $readmePath))   { throw "Source README not found: $readmePath" }
 if (-not (Test-Path $scriptPath))   { throw "Source script not found: $scriptPath" }
 if (-not (Test-Path $testScript))   { throw "Source test script not found: $testScript" }
+if (-not (Test-Path $licensePath))  { throw "Source LICENSE not found: $licensePath" }
 
-# Capture script + readme + test content NOW, before we touch the working tree.
+# Capture script + readme + test + LICENSE content NOW, before we touch the working tree.
 $savedReadme     = Get-Content -Raw -LiteralPath $readmePath
 $savedScript     = Get-Content -Raw -LiteralPath $scriptPath
 $savedTestScript = Get-Content -Raw -LiteralPath $testScript
 $savedTestIgnore = if (Test-Path $testIgnore) { Get-Content -Raw -LiteralPath $testIgnore } else { ".packages/`n" }
+$savedLicense    = [System.IO.File]::ReadAllBytes($licensePath)
 
 if (-not $NoCommit) {
     $dirty = & $gitExe -C $repoRoot status --porcelain
@@ -646,7 +649,10 @@ try {
     # ------------------------------------------------------------------
     Write-Step "Creating orphan branch release/$Version"
     if ($Force -and $existing) {
-        Invoke-Native $gitExe -C $repoRoot branch -D "release/$Version"
+        # Note: pass args as array; bare "-D" would otherwise bind to
+        # PowerShell's common -Debug parameter on Invoke-Native.
+        $delArgs = @('-C', $repoRoot, 'branch', '-D', "release/$Version")
+        Invoke-Native $gitExe @delArgs
     }
     Invoke-Native $gitExe -C $repoRoot checkout --orphan "release/$Version"
 
@@ -658,6 +664,10 @@ try {
     New-Item -ItemType Directory -Force -Path $incDir | Out-Null
     Copy-Item -Path (Join-Path $stagingIncDir '*') -Destination $incDir -Recurse -Force
 
+    # Place LICENSE at the repo root so consumers of the orphan release
+    # branch see the project's MIT license alongside the inc/ tree.
+    [System.IO.File]::WriteAllBytes($licensePath, $savedLicense)
+
     # Stamp copyright headers if the repo's helper still happens to be
     # accessible (it won't be, on a fresh orphan -- so this is best-
     # effort and silently skipped).
@@ -667,7 +677,7 @@ try {
         & $verifier -fix | Out-Null
     }
 
-    Invoke-Native $gitExe -C $repoRoot add inc/
+    Invoke-Native $gitExe -C $repoRoot add inc/ LICENSE
     Invoke-Native $gitExe -C $repoRoot commit -m "AbiWinRT projection headers for Microsoft.WindowsAppSDK $Version"
 
     if (-not $SkipTest) {


### PR DESCRIPTION
The orphan release branches produced by inc/make_projection.ps1 ship as standalone artifacts to consuming apps. Add the project's MIT LICENSE at the branch root so legal terms are visible alongside the inc/ tree, and update make_projection.ps1 to capture LICENSE from the source repo and place it at the orphan branch root on every subsequent run.

Also fixes a bug where 'Invoke-Native git branch -D <ref>' had its '-D' eaten by PowerShell parameter binding (matched the common -Debug switch); now passes args via splatted array.

A microsoft employee must use /azp run to validate using the pipelines below.

WARNING:
Comments made by azure-pipelines bot maybe inaccurate.
Please see pipeline link to verify that the build is being ran.

For status checks on the main branch, please use TransportPackage-Foundation-PR
(https://microsoft.visualstudio.com/ProjectReunion/_build?definitionId=81063&_a=summary)
and run the build against your PR branch with the default parameters.
