### PR TITLE
Dotnet Templates: use winappCli 3.0.1 (Microsoft.Windows.SDK.BuildTools.WinApp)

### DIFF
--- a/dev/Templates/Dotnet/README.md
+++ b/dev/Templates/Dotnet/README.md
@@ -4,8 +4,12 @@ Official WinUI 3 project and item templates for the
 [Windows App SDK](https://learn.microsoft.com/windows/apps/windows-app-sdk/),
 designed for use with the .NET CLI (`dotnet new`). This template pack provides
 the same starting points available in Visual Studio — blank apps, navigation
-views, class libraries, unit test projects, and common WinUI UI items — right
-from the command line.
+views, MVVM scaffolding, tab-view shells, class libraries, unit test projects,
+and common WinUI UI items — right from the command line.
+
+`dotnet run` launches the generated app with full MSIX package identity, so
+features that require it (notifications, background tasks, Windows AI APIs,
+etc.) work the same as they would in a Visual Studio F5 deploy.
 
 ## Installation
 
@@ -17,25 +21,28 @@ dotnet new install Microsoft.WindowsAppSDK.WinUI.CSharp.Templates
 
 ### Project Templates
 
-| Short Name       | Description                                              |
-|------------------|----------------------------------------------------------|
-| `winui`          | WinUI 3 blank app with single-project MSIX packaging     |
-| `winui-mvvm`     | WinUI 3 MVVM app with CommunityToolkit.Mvvm               |
-| `winui-navview`  | WinUI 3 NavigationView starter app                       |
-| `winui-lib`      | WinUI 3 class library for sharing UI components          |
-| `winui-unittest` | WinUI 3 packaged test app configured for MSTest          |
+| Short Name        | Description                                                              |
+|-------------------|--------------------------------------------------------------------------|
+| `winui`           | Minimal WinUI 3 blank app with single-project MSIX packaging. Start here if unsure |
+| `winui-mvvm`      | WinUI 3 MVVM app using `CommunityToolkit.Mvvm`                           |
+| `winui-navview`   | WinUI 3 NavigationView starter app with single-project MSIX packaging    |
+| `winui-tabview`   | WinUI 3 TabView starter app with single-project MSIX packaging           |
+| `winui-lib`       | WinUI 3 class library for sharing UI components                          |
+| `winui-unittest`  | WinUI 3 packaged test app configured for MSTest                          |
+
+> Each `winui-*` short name also has a `winui3-*` alias (e.g. `winui3-mvvm`).
 
 ### Item Templates
 
-| Short Name                 | Description                        |
-|----------------------------|------------------------------------|
-| `winui-page`               | Blank WinUI 3 Page                 |
-| `winui-window`             | Blank WinUI 3 Window               |
-| `winui-usercontrol`        | WinUI 3 UserControl                |
-| `winui-templatedcontrol`   | WinUI 3 templated control |
-| `winui-resourcedictionary` | WinUI 3 ResourceDictionary         |
-| `winui-resw`               | RESW resource file                 |
-| `winui-dialog`             | WinUI 3 ContentDialog              |
+| Short Name                 | Description                                              |
+|----------------------------|----------------------------------------------------------|
+| `winui-page`               | WinUI 3 Page (XAML + code-behind)                        |
+| `winui-window`             | WinUI 3 Window (XAML + code-behind)                      |
+| `winui-usercontrol`        | WinUI 3 UserControl (XAML + code-behind)                 |
+| `winui-templatedcontrol`   | WinUI 3 templated control                                |
+| `winui-resourcedictionary` | WinUI 3 ResourceDictionary                               |
+| `winui-resw`               | RESW resources file for localized strings                |
+| `winui-dialog`             | WinUI 3 ContentDialog (XAML + code-behind)               |
 
 Item templates are context-aware and only surface when `dotnet new` is executed
 inside a WinUI project folder or when `--project` points to one.
@@ -44,43 +51,77 @@ inside a WinUI project folder or when `--project` points to one.
 
 ### Create a new WinUI 3 app
 
-```shell
+```powershell
 dotnet new winui -n MyApp
 cd MyApp
-dotnet build -p:Platform=x64
-dotnet run -c Debug -p:Platform=x64
+
+# Detect platform once per session.
+# $env:PROCESSOR_ARCHITECTURE returns AMD64 on x64 boxes; MSBuild expects x64.
+$arch = $env:PROCESSOR_ARCHITECTURE
+$Platform = if ($arch -eq 'AMD64') { 'x64' } else { $arch }
+
+dotnet build -c Debug -p:Platform=$Platform
+dotnet run -c Debug -p:Platform=$Platform   # launches with package identity
 ```
+
+`dotnet run` registers a loose-layout MSIX, gives the app package identity,
+and launches it via AUMID activation — equivalent to F5 in Visual Studio.
 
 ### Add items to an existing project
 
-```shell
-dotnet new winui-page -n SettingsPage --project .\MyApp.csproj
-dotnet new winui-usercontrol -n ProfileCard --project .\MyApp.csproj
-dotnet new winui-window -n SecondaryWindow --project .\MyApp.csproj
+```powershell
+dotnet new winui-page         -n SettingsPage      --project .\MyApp.csproj
+dotnet new winui-usercontrol  -n ProfileCard       --project .\MyApp.csproj
+dotnet new winui-window       -n SecondaryWindow   --project .\MyApp.csproj
+dotnet new winui-dialog       -n ConfirmDialog     --project .\MyApp.csproj
 ```
 
 ### Choosing a Target Framework
 
-By default, templates automatically detect your installed .NET SDK version and
-set the target framework accordingly. For example, if you have .NET 10 SDK
-installed, the TFM will be `net10.0-windows10.0.26100.0`.
-
-To target a specific .NET version instead, pass `--dotnet-version`:
+Generated projects target `net{N}.0-windows10.0.26100.0`, where `{N}` is
+selected at scaffold time via `--dotnet-version`:
 
 ```shell
-dotnet new winui --dotnet-version net8.0 -n MyApp
+dotnet new winui --dotnet-version net8.0  -n MyApp
+dotnet new winui --dotnet-version net9.0  -n MyApp
+dotnet new winui --dotnet-version net10.0 -n MyApp
 ```
 
-You can also edit the generated `.csproj` afterward and change
-`<TargetFramework>` (and any related `<RuntimeIdentifiers>` entries) to your
-preferred TFM.
+Supported choices: `net8.0`, `net9.0`, `net10.0`. If you omit
+`--dotnet-version`, most templates default to `net10.0`; `winui-mvvm` matches
+your installed .NET SDK. You can also edit `<TargetFramework>` (and any
+related `<RuntimeIdentifiers>`) in the generated `.csproj` afterward.
+
+### Customizing `dotnet run` behavior
+
+Set any of these MSBuild properties inside a `<PropertyGroup>` in the
+generated `.csproj` to tweak how `dotnet run` launches the app:
+
+| Property                       | Default | Effect                                                                                         |
+|--------------------------------|---------|------------------------------------------------------------------------------------------------|
+| `EnableWinAppRunSupport`       | `true`  | Set to `false` to disable the packaged-launch integration and run unpackaged instead           |
+| `WinAppRunUseExecutionAlias`   | `false` | For console apps — launches via `uap5:ExecutionAlias` so stdin/stdout stay in the terminal     |
+| `WinAppRunNoLaunch`            | `false` | Register the package but don't launch (useful when attaching a different debugger first)       |
+| `WinAppRunDebugOutput`         | `false` | Capture `OutputDebugString` and crash dumps; cannot be combined with another debugger          |
+| `WinAppLaunchArgs`             | (empty) | Arguments passed to the app on launch (e.g. `--my-flag value`)                                 |
+
+These properties are provided by the
+[`Microsoft.Windows.SDK.BuildTools.WinApp`](https://www.nuget.org/packages/Microsoft.Windows.SDK.BuildTools.WinApp)
+NuGet package, which is referenced automatically by the project templates.
+
+### AI agent instructions
+
+The `winui` blank app template also unpacks an `AGENTS.md` plus a
+`.github/instructions/` set so AI coding agents (GitHub Copilot, Claude Code,
+etc.) follow the project's WinUI / accessibility / testing conventions out of
+the box. Remove or edit them if they don't fit your project.
 
 ## Prerequisites
 
-- [.NET 10 SDK](https://dotnet.microsoft.com/download/dotnet/10.0) or later
+- [.NET SDK](https://dotnet.microsoft.com/download) — `net8.0`, `net9.0`, or `net10.0`
 - Windows 10 version 1809 (build 17763) or later
-- [Windows App SDK](https://learn.microsoft.com/windows/apps/windows-app-sdk/)
-  workload
+- **Developer Mode enabled** — required for `dotnet run` to register the loose-layout package.
+  Settings → System → For developers → Developer Mode → On.
 
 ## Resources
 
@@ -95,8 +136,8 @@ This template pack is built from the
 [WindowsAppSDK](https://github.com/microsoft/WindowsAppSDK) repository under
 `dev/Templates/Dotnet/`. The templates share the same XAML, code-behind,
 and project files as the Visual Studio templates under
-`dev/Templates/Source/ProjectTemplates/` and `dev/Templates/Source/ItemTemplates/`, so there is only one
-copy to maintain.
+`dev/Templates/Source/ProjectTemplates/` and
+`dev/Templates/Source/ItemTemplates/`, so there is only one copy to maintain.
 
 ### Local Testing
 
@@ -113,9 +154,16 @@ copy to maintain.
    dotnet new install ./localpackages/Microsoft.WindowsAppSDK.WinUI.CSharp.Templates.<version>.nupkg
    ```
 
+For an automated end-to-end run that scaffolds, builds, and (optionally)
+launches every template, use the included script:
+
+```powershell
+.\dev\Templates\Dotnet\Test-DotnetNewTemplates.ps1                      # full run
+.\dev\Templates\Dotnet\Test-DotnetNewTemplates.ps1 -SkipAppLaunch       # CI-friendly
+```
+
 ### Validation Checklist
 
-- Run `dotnet pack` locally and `dotnet new install` to verify each template scaffolds and builds.
-- Run `dotnet new list | findstr winui` to confirm all templates are registered.
-- Build generated projects for x64, x86, and ARM64 in Visual Studio or VS Code.
-- Test packaged deployments on Windows 10 version 1809 or later.
+- `dotnet new list | findstr winui` lists all expected templates.
+- Each template scaffolds and `dotnet build -c Debug -p:Platform=$Platform` succeeds.
+- `dotnet run` on a project template launches the app and `Get-AppxPackage *<AppName>*` shows it as `IsDevelopmentMode = True`.

--- a/dev/Templates/Dotnet/README.md
+++ b/dev/Templates/Dotnet/README.md
@@ -54,17 +54,13 @@ inside a WinUI project folder or when `--project` points to one.
 ### Quickstart a new WinUI 3 APP
 
 ```powershell
-# Detect platform (once per session).
-$arch = $env:PROCESSOR_ARCHITECTURE
-$Platform = if ($arch -eq 'AMD64') { 'x64' } else { $arch }
-
 # create
 dotnet new winui -n MyApp
 cd MyApp
 
 # build or run
-dotnet build -c Debug -p:Platform=$Platform
-dotnet run -c Debug -p:Platform=$Platform
+dotnet build
+dotnet run
 ```
 
 `dotnet run` registers a loose-layout MSIX, gives the app package identity,
@@ -92,8 +88,8 @@ dotnet new winui --dotnet-version net10.0 -n MyApp
 
 Supported choices: `net8.0`, `net9.0`, `net10.0`. If you omit
 `--dotnet-version`, most templates default to `net10.0`; `winui-mvvm` matches
-your installed .NET SDK. You can also edit `<TargetFramework>` (and any
-related `<RuntimeIdentifiers>`) in the generated `.csproj` afterward.
+your installed .NET SDK. You can also edit `<TargetFramework>` in the
+generated `.csproj` afterward.
 
 ### Customizing `dotnet run` behavior
 
@@ -168,5 +164,5 @@ launches every template, use the included script:
 ### Validation Checklist
 
 - `dotnet new list | findstr winui` lists all expected templates.
-- Each template scaffolds and `dotnet build -c Debug -p:Platform=$Platform` succeeds.
+- Each template scaffolds and `dotnet build` succeeds.
 - `dotnet run` on a project template launches the app and `Get-AppxPackage *<AppName>*` shows it as `IsDevelopmentMode = True`.

--- a/dev/Templates/Dotnet/README.md
+++ b/dev/Templates/Dotnet/README.md
@@ -54,12 +54,10 @@ inside a WinUI project folder or when `--project` points to one.
 ### Quickstart a new WinUI 3 APP
 
 ```powershell
-# create
 dotnet new winui -n MyApp
 cd MyApp
 
-# build or run
-dotnet build
+# dotnet build
 dotnet run
 ```
 

--- a/dev/Templates/Dotnet/README.md
+++ b/dev/Templates/Dotnet/README.md
@@ -21,6 +21,8 @@ dotnet new install Microsoft.WindowsAppSDK.WinUI.CSharp.Templates
 
 ### Project Templates
 
+Get below list via `dotnet new list winui`
+
 | Short Name        | Description                                                              |
 |-------------------|--------------------------------------------------------------------------|
 | `winui`           | Minimal WinUI 3 blank app with single-project MSIX packaging. Start here if unsure |
@@ -30,7 +32,7 @@ dotnet new install Microsoft.WindowsAppSDK.WinUI.CSharp.Templates
 | `winui-lib`       | WinUI 3 class library for sharing UI components                          |
 | `winui-unittest`  | WinUI 3 packaged test app configured for MSTest                          |
 
-> Each `winui-*` short name also has a `winui3-*` alias (e.g. `winui3-mvvm`).
+Each `winui-*` short name also has a `winui3-*` alias (e.g. `winui3-mvvm`).
 
 ### Item Templates
 
@@ -49,19 +51,20 @@ inside a WinUI project folder or when `--project` points to one.
 
 ## Quick Start
 
-### Create a new WinUI 3 app
+### Quickstart a new WinUI 3 APP
 
 ```powershell
-dotnet new winui -n MyApp
-cd MyApp
-
-# Detect platform once per session.
-# $env:PROCESSOR_ARCHITECTURE returns AMD64 on x64 boxes; MSBuild expects x64.
+# Detect platform (once per session).
 $arch = $env:PROCESSOR_ARCHITECTURE
 $Platform = if ($arch -eq 'AMD64') { 'x64' } else { $arch }
 
+# create
+dotnet new winui -n MyApp
+cd MyApp
+
+# build or run
 dotnet build -c Debug -p:Platform=$Platform
-dotnet run -c Debug -p:Platform=$Platform   # launches with package identity
+dotnet run -c Debug -p:Platform=$Platform
 ```
 
 `dotnet run` registers a loose-layout MSIX, gives the app package identity,

--- a/dev/Templates/Dotnet/Test-DotnetNewTemplates.ps1
+++ b/dev/Templates/Dotnet/Test-DotnetNewTemplates.ps1
@@ -430,7 +430,12 @@ try {
         @{ ShortName = 'winui'; Kind = 'App' },
         @{ ShortName = 'winui-navview'; Kind = 'App' },
         @{ ShortName = 'winui-lib'; Kind = 'Library' },
-        @{ ShortName = 'winui-unittest'; Kind = 'Test' }
+        # winui-unittest is a self-hosted packaged test runner: tests run
+        # from inside UnitTestApp.OnLaunched (which sets DispatcherQueue and
+        # acquires package identity) via UnitTestClient.Run(), not via
+        # `dotnet test`. Validate it as an App so we still confirm the
+        # template builds cleanly.
+        @{ ShortName = 'winui-unittest'; Kind = 'App' }
     )
 
     foreach ($template in $projectTemplates) {

--- a/dev/Templates/Dotnet/WinAppSdk.CSharp.DotnetNewTemplates.csproj
+++ b/dev/Templates/Dotnet/WinAppSdk.CSharp.DotnetNewTemplates.csproj
@@ -8,7 +8,7 @@
     <IsPackable>true</IsPackable>
     <PackageType>Template</PackageType>
     <PackageId>Microsoft.WindowsAppSDK.WinUI.CSharp.Templates</PackageId>
-    <Version>0.0.4-alpha</Version>
+    <Version>0.0.5-alpha</Version>
     <Title>WinUI 3 C# Templates</Title>
     <Authors>Microsoft</Authors>
     <Company>Microsoft</Company>

--- a/dev/Templates/Dotnet/WinAppSdk.CSharp.DotnetNewTemplates.csproj
+++ b/dev/Templates/Dotnet/WinAppSdk.CSharp.DotnetNewTemplates.csproj
@@ -188,6 +188,9 @@
     <None Include="..\Source\ItemTemplates\Neutral\CSharp\TemplatedControl\CustomControl.cs"
           Pack="true"
           PackagePath="content/winui.item.templatedcontrol/CustomControl.cs" />
+    <None Include="..\Source\ItemTemplates\Neutral\CSharp\TemplatedControl\Themes\Generic.xaml"
+          Pack="true"
+          PackagePath="content/winui.item.templatedcontrol/Themes/Generic.xaml" />
   </ItemGroup>
 
   <!-- WinUI Resource Dictionary item template -->

--- a/dev/Templates/Dotnet/templates/item-content-dialog/.template.config/template.json
+++ b/dev/Templates/Dotnet/templates/item-content-dialog/.template.config/template.json
@@ -55,6 +55,14 @@
         "value": "ContentDialogButtonClickEventArgs"
       },
       "replaces": "__WINUI_CONTENT_DIALOG_BUTTON_CLICK_EVENT_ARGS__"
+    },
+    "defaultContentDialogStyleResourceKey": {
+      "type": "generated",
+      "generator": "constant",
+      "parameters": {
+        "value": "DefaultContentDialogStyle"
+      },
+      "replaces": "__WINUI_DEFAULT_CONTENT_DIALOG_STYLE__"
     }
   },
   "constraints": {

--- a/dev/Templates/Dotnet/templates/item-resw/.template.config/template.json
+++ b/dev/Templates/Dotnet/templates/item-resw/.template.config/template.json
@@ -40,6 +40,15 @@
       "args": "CSharp & Msix"
     }
   },
+  "sources": [
+    {
+      "modifiers": [
+        {
+          "copyOnly": [ "**/*.resw" ]
+        }
+      ]
+    }
+  ],
   "primaryOutputs": [
     { "path": "Resources.resw" }
   ],

--- a/dev/Templates/Dotnet/templates/item-templated-control/.template.config/template.json
+++ b/dev/Templates/Dotnet/templates/item-templated-control/.template.config/template.json
@@ -12,7 +12,7 @@
   "shortName": ["winui-templatedcontrol", "winui3-templatedcontrol"],
   "sourceName": "CustomControl",
   "defaultName": "CustomControl",
-  "description": "Adds a WinUI 3 templated control with a code-behind skeleton.",
+  "description": "Adds a WinUI 3 templated control. By default also creates Themes\\Generic.xaml with a minimal default style. If your project already has a Themes\\Generic.xaml, pass --IncludeDefaultStyle false and manually add a <Style TargetType=\"local:<Name>\"> block to it; otherwise the new control will render blank at runtime.",
   "preferNameDirectory": false,
   "symbols": {
     "rootNamespace": {
@@ -39,8 +39,24 @@
       "valueSource": "name",
       "valueTransform": "identity",
       "replaces": "$fileinputname$"
+    },
+    "IncludeDefaultStyle": {
+      "type": "parameter",
+      "datatype": "bool",
+      "defaultValue": "true",
+      "description": "Set to false when the project already has a Themes\\Generic.xaml; you must then manually add a <Style TargetType=\"local:<Name>\"> for the new control."
     }
   },
+  "sources": [
+    {
+      "modifiers": [
+        {
+          "condition": "(!IncludeDefaultStyle)",
+          "exclude": [ "Themes/**/*" ]
+        }
+      ]
+    }
+  ],
   "constraints": {
     "winuiProject": {
       "type": "project-capability",
@@ -48,7 +64,8 @@
     }
   },
   "primaryOutputs": [
-    { "path": "CustomControl.cs" }
+    { "path": "CustomControl.cs" },
+    { "condition": "(IncludeDefaultStyle)", "path": "Themes/Generic.xaml" }
   ],
   "forms": {
     "safe_name": {

--- a/dev/Templates/Dotnet/templates/mvvm-app/.template.config/template.json
+++ b/dev/Templates/Dotnet/templates/mvvm-app/.template.config/template.json
@@ -122,6 +122,13 @@
       "replaces": "$WindowsSdkBuildToolsVersion$",
       "defaultValue": "10.0.26100.7705",
       "description": "Version of the Microsoft.Windows.SDK.BuildTools NuGet package."
+    },
+    "windowsSdkBuildToolsWinAppVersion": {
+      "type": "parameter",
+      "datatype": "text",
+      "replaces": "$WindowsSdkBuildToolsWinAppVersion$",
+      "defaultValue": "0.3.1",
+      "description": "Version of the Microsoft.Windows.SDK.BuildTools.WinApp NuGet package, which adds `dotnet run` support for packaged WinUI apps via the winapp CLI."
     }
   },
   "sources": [
@@ -176,6 +183,16 @@
         "reference": "Microsoft.Windows.SDK.BuildTools"
       },
       "manualInstructions": [{ "text": "Run 'dotnet add package Microsoft.Windows.SDK.BuildTools'" }]
+    },
+    {
+      "actionId": "B17581D1-C5C9-4489-8F0A-004BE667B814",
+      "continueOnError": true,
+      "description": "Update Microsoft.Windows.SDK.BuildTools.WinApp to the latest stable version (enables `dotnet run` for packaged WinUI apps).",
+      "args": {
+        "referenceType": "package",
+        "reference": "Microsoft.Windows.SDK.BuildTools.WinApp"
+      },
+      "manualInstructions": [{ "text": "Run 'dotnet add package Microsoft.Windows.SDK.BuildTools.WinApp'" }]
     },
     {
       "actionId": "B17581D1-C5C9-4489-8F0A-004BE667B814",

--- a/dev/Templates/Dotnet/templates/navigation-app/.template.config/template.json
+++ b/dev/Templates/Dotnet/templates/navigation-app/.template.config/template.json
@@ -141,6 +141,13 @@
       "replaces": "$WindowsSdkBuildToolsVersion$",
       "defaultValue": "10.0.26100.7705",
       "description": "Version of the Microsoft.Windows.SDK.BuildTools NuGet package."
+    },
+    "windowsSdkBuildToolsWinAppVersion": {
+      "type": "parameter",
+      "datatype": "text",
+      "replaces": "$WindowsSdkBuildToolsWinAppVersion$",
+      "defaultValue": "0.3.1",
+      "description": "Version of the Microsoft.Windows.SDK.BuildTools.WinApp NuGet package, which adds `dotnet run` support for packaged WinUI apps via the winapp CLI."
     }
   },
   "sources": [
@@ -195,6 +202,16 @@
         "reference": "Microsoft.Windows.SDK.BuildTools"
       },
       "manualInstructions": [{ "text": "Run 'dotnet add package Microsoft.Windows.SDK.BuildTools'" }]
+    },
+    {
+      "actionId": "B17581D1-C5C9-4489-8F0A-004BE667B814",
+      "continueOnError": true,
+      "description": "Update Microsoft.Windows.SDK.BuildTools.WinApp to the latest stable version (enables `dotnet run` for packaged WinUI apps).",
+      "args": {
+        "referenceType": "package",
+        "reference": "Microsoft.Windows.SDK.BuildTools.WinApp"
+      },
+      "manualInstructions": [{ "text": "Run 'dotnet add package Microsoft.Windows.SDK.BuildTools.WinApp'" }]
     },
     {
       "actionId": "210D431B-A78B-4D2F-B762-4ED3E3EA9025",

--- a/dev/Templates/Dotnet/templates/single-project/.template.config/template.json
+++ b/dev/Templates/Dotnet/templates/single-project/.template.config/template.json
@@ -153,6 +153,13 @@
       "replaces": "$WindowsSdkBuildToolsVersion$",
       "defaultValue": "10.0.26100.7705",
       "description": "Version of the Microsoft.Windows.SDK.BuildTools NuGet package."
+    },
+    "windowsSdkBuildToolsWinAppVersion": {
+      "type": "parameter",
+      "datatype": "text",
+      "replaces": "$WindowsSdkBuildToolsWinAppVersion$",
+      "defaultValue": "0.3.1",
+      "description": "Version of the Microsoft.Windows.SDK.BuildTools.WinApp NuGet package, which adds `dotnet run` support for packaged WinUI apps via the winapp CLI."
     }
   },
   "sources": [
@@ -207,6 +214,16 @@
         "reference": "Microsoft.Windows.SDK.BuildTools"
       },
       "manualInstructions": [{ "text": "Run 'dotnet add package Microsoft.Windows.SDK.BuildTools'" }]
+    },
+    {
+      "actionId": "B17581D1-C5C9-4489-8F0A-004BE667B814",
+      "continueOnError": true,
+      "description": "Update Microsoft.Windows.SDK.BuildTools.WinApp to the latest stable version (enables `dotnet run` for packaged WinUI apps).",
+      "args": {
+        "referenceType": "package",
+        "reference": "Microsoft.Windows.SDK.BuildTools.WinApp"
+      },
+      "manualInstructions": [{ "text": "Run 'dotnet add package Microsoft.Windows.SDK.BuildTools.WinApp'" }]
     },
     {
       "actionId": "210D431B-A78B-4D2F-B762-4ED3E3EA9025",

--- a/dev/Templates/Dotnet/templates/single-project/Agents.md
+++ b/dev/Templates/Dotnet/templates/single-project/Agents.md
@@ -69,7 +69,7 @@ Every time you work on this codebase, follow this checklist:
 10. **Write unit tests** -- Every new public method/class needs tests. **Read** [testing](.github/instructions/testing.instructions.md) for framework setup, naming conventions (`MethodName_Scenario_ExpectedResult`), AAA pattern, and `dotnet test` commands.
 11. **Build the project** -- Detect the platform first (`$Platform = $env:PROCESSOR_ARCHITECTURE`), then run `dotnet build -c Debug -p:Platform=$Platform` from the project folder and fix all warnings/errors. **If build errors occur, follow the Troubleshooting Build Errors workflow below.**
 12. **Run tests** -- Run tests related to the change using `--filter` (see [testing](.github/instructions/testing.instructions.md)). Run the full suite only when the change is cross-cutting.
-13. **Register the MSIX package** -- See [Build, Run & Deploy](#build-run--deploy) below.
+13. **Run the app with package identity** -- Use `dotnet run` (preferred -- the project references `Microsoft.Windows.SDK.BuildTools.WinApp`, which automatically invokes `winapp run` to register a loose-layout package and launch via AUMID). See [Build, Run & Deploy](#build-run--deploy) below for advanced scenarios.
 14. **Re-review against original goal** -- Confirm the implementation matches the user's request.
 
 ### Troubleshooting Build Errors
@@ -90,7 +90,9 @@ Only if Steps 1-2 fail to resolve the issue, then inspect `.winmd` metadata file
 
 ## Build, Run & Deploy
 
-This is an MSIX-packaged WinUI 3 app. You **must** pass both `-c` (Configuration) and `-p:Platform=` to every `dotnet` command.
+This is an MSIX-packaged WinUI 3 app. You **must** pass both `-c` (Configuration) and `-p:Platform=` to every `dotnet build`/`dotnet test` command.
+
+This template references the [`Microsoft.Windows.SDK.BuildTools.WinApp`](https://www.nuget.org/packages/Microsoft.Windows.SDK.BuildTools.WinApp) NuGet package, which hooks `dotnet run` to invoke the [`winapp` CLI](https://github.com/microsoft/WinAppCli). Use `dotnet run` for everyday inner-loop development -- you do not need to call `Add-AppxPackage` or `MakeAppx.exe` by hand.
 
 ### Dotnet CLI Workflow
 
@@ -113,14 +115,20 @@ This is an MSIX-packaged WinUI 3 app. You **must** pass both `-c` (Configuration
   Get-WindowsDeveloperLicense
   # If not enabled: Settings -> System -> For developers -> Developer Mode -> On
   ```
+- **`winapp` CLI** -- installed transitively via the `Microsoft.Windows.SDK.BuildTools.WinApp` NuGet reference (no separate install needed for `dotnet run`). To use `winapp` directly from the terminal for advanced scenarios (manifest editing, certificate management, packaging), install it standalone:
+  ```powershell
+  winget install Microsoft.WinAppCli --source winget
+  ```
 
 ### Detect Platform
 
 **Always detect the machine's architecture first** -- never hardcode a platform value. Run this once at the start of every build/test session:
 
 ```powershell
-# Detect the current machine's CPU architecture (returns x64, ARM64, or x86)
-$Platform = $env:PROCESSOR_ARCHITECTURE
+# Detect the current machine's CPU architecture
+# (returns AMD64 on x64 boxes, ARM64 on ARM64 boxes, x86 on 32-bit boxes)
+$arch = $env:PROCESSOR_ARCHITECTURE
+$Platform = if ($arch -eq 'AMD64') { 'x64' } else { $arch }   # MSBuild expects x64/x86/ARM64
 ```
 
 Use `$Platform` in all subsequent `dotnet` commands.
@@ -131,8 +139,9 @@ Use `$Platform` in all subsequent `dotnet` commands.
 # Run from the project folder containing the .csproj
 cd <ProjectName>
 
-# Detect platform
-$Platform = $env:PROCESSOR_ARCHITECTURE
+# Detect platform (see above)
+$arch = $env:PROCESSOR_ARCHITECTURE
+$Platform = if ($arch -eq 'AMD64') { 'x64' } else { $arch }
 
 # Debug build (matches current machine)
 dotnet build -c Debug -p:Platform=$Platform
@@ -141,63 +150,121 @@ dotnet build -c Debug -p:Platform=$Platform
 dotnet build -c Release -p:Platform=$Platform
 ```
 
-### Register & Run the MSIX Package (Sideload)
+### Run with Package Identity (preferred)
 
-After building, register the app package so Windows can launch it:
+The template references `Microsoft.Windows.SDK.BuildTools.WinApp`, which makes `dotnet run` register a loose-layout package via `winapp run` and launch the app via AUMID activation -- giving it the same package identity it would have in production:
 
 ```powershell
-$Platform = $env:PROCESSOR_ARCHITECTURE
-$Rid = $Platform.ToLower()   # e.g. arm64, x64, x86
+$arch = $env:PROCESSOR_ARCHITECTURE
+$Platform = if ($arch -eq 'AMD64') { 'x64' } else { $arch }
+
+dotnet run -c Debug -p:Platform=$Platform
+```
+
+The CLI prints the registered package's AUMID and the launched process's PID -- attach a debugger to that PID for runtime debugging.
+
+#### Useful MSBuild knobs (set in `.csproj` `<PropertyGroup>`)
+
+| Property | When to set |
+|---|---|
+| `EnableWinAppRunSupport=false` | Disable the `dotnet run` integration entirely (e.g., to launch unpackaged) |
+| `WinAppRunUseExecutionAlias=true` | For console apps -- launches via `uap5:ExecutionAlias` so stdin/stdout stay in the terminal. Add the alias first with `winapp manifest add-alias`. |
+| `WinAppRunNoLaunch=true` | Register the package but don't launch (attach your IDE's debugger before launch) |
+| `WinAppLaunchArgs="--flag value"` | Pass arguments to the app on launch |
+
+#### Manual `winapp run` (when not using `dotnet run`)
+
+```powershell
+# Read <TargetFramework> from .csproj first; example uses net10.0-windows10.0.26100.0
+winapp run .\bin\$Platform\Debug\<TargetFramework>
+
+# Pass args after -- to avoid escaping
+winapp run .\bin\$Platform\Debug\<TargetFramework> -- --my-flag value
+
+# Console app: keep stdin/stdout in the current terminal (requires uap5:ExecutionAlias)
+winapp run .\bin\$Platform\Debug\<TargetFramework> --with-alias
+
+# Wipe LocalState/settings between runs to test first-run behavior
+winapp run .\bin\$Platform\Debug\<TargetFramework> --clean
+```
+
+#### Run Tests
+
+```powershell
+# Run from the test project folder
+cd <ProjectName>.Tests
+$arch = $env:PROCESSOR_ARCHITECTURE
+$Platform = if ($arch -eq 'AMD64') { 'x64' } else { $arch }
+dotnet test -c Debug -p:Platform=$Platform
+```
+
+### winapp CLI command reference
+
+The `winapp` CLI is the canonical entry point for app-identity, packaging, certificate, and asset operations. Reach for it instead of hand-rolling `MakeAppx`/`SignTool`/`Add-AppxPackage` invocations.
+
+| Scenario | Command | Notes |
+|---|---|---|
+| **Run/debug with identity (loose layout)** | `dotnet run` (or `winapp run <build-output>`) | Default for inner loop. Registers full loose-layout package. |
+| **Console app inner loop** | Set `WinAppRunUseExecutionAlias=true` in `.csproj`, then `dotnet run` | Requires `uap5:ExecutionAlias` -- add via `winapp manifest add-alias`. |
+| **Sparse identity on a single exe** | `winapp create-debug-identity .\bin\Debug\<TFM>\<ProjectName>.exe` | Use when the exe is outside the build folder, or for IDE F5 startup debugging. |
+| **Stop debugging / clean up** | `winapp unregister` | Removes dev packages registered for the current project. |
+| **Generate dev signing cert** | `winapp cert generate --manifest .\Package.appxmanifest --install` | Reads publisher from manifest. Stored as `devcert.pfx` in the project. |
+| **Inspect a cert** | `winapp cert info .\devcert.pfx` | Verify subject matches manifest publisher. |
+| **Sign a file** | `winapp sign .\MyApp.msix --cert .\devcert.pfx` | Wraps `signtool`. |
+| **Build distribution MSIX** | `winapp pack .\bin\$Platform\Release\<TFM>\win-<rid> --cert .\devcert.pfx` | Auto-resolves `$targetnametoken$`, registers third-party WinRT components. |
+| **Self-contained MSIX (bundles WinAppSDK)** | `winapp pack ... --self-contained` | No runtime dependency on the framework package. |
+| **Regenerate Square44/Square150/etc. icons** | `winapp manifest update-assets .\branding\logo.svg` | SVG preferred -- rendered at all 5 scale and 14 targetsize variants. |
+| **Add execution alias** | `winapp manifest add-alias` | Required for console-app inline I/O via `WinAppRunUseExecutionAlias`. |
+| **Underlying SDK tools** | `winapp tool signtool ...`, `winapp tool makeappx ...` | Falls back to the raw [`Microsoft.Windows.SDK.BuildTools`](https://www.nuget.org/packages/Microsoft.Windows.SDK.BuildTools/) tools when needed. |
+
+For full reference, see the [winapp CLI usage docs](https://github.com/microsoft/WinAppCli/blob/main/docs/usage.md) and the [Debugging Guide](https://github.com/microsoft/WinAppCli/blob/main/docs/debugging.md).
+
+### Fallback: register a loose layout manually
+
+Only use this if you've explicitly disabled the `winapp` integration (`<EnableWinAppRunSupport>false</EnableWinAppRunSupport>`) or are debugging the deployment itself. The supported path is `dotnet run` / `winapp run`.
+
+```powershell
+$arch = $env:PROCESSOR_ARCHITECTURE
+$Platform = if ($arch -eq 'AMD64') { 'x64' } else { $arch }
+$Rid = $Platform.ToLower()   # arm64, x64, x86
 
 # Register the built MSIX package from the build output
-# Read <TargetFramework> from the project .csproj to build the correct path.
+# Read <TargetFramework> from .csproj to build the correct path.
 Add-AppxPackage -Register ".\<ProjectName>\bin\$Platform\Debug\<TargetFramework>\win-$Rid\AppxManifest.xml"
 ```
 
 > **Note:** Replace `<TargetFramework>` with the actual value from `.csproj` (e.g., `net10.0-windows10.0.26100.0`).
 
-### Run from the CLI
-
-- Quick smoke tests: `dotnet run -c Debug -p:Platform=$Platform` from the
-  project folder.
-- Launch a packaged build: `winapp run .\<ProjectName>\bin\$Platform\Debug\<TargetFramework>\<ProjectName>.exe` after registering the MSIX output.
-- If the launch fails because an old instance is still running, terminate it
-  with `taskkill /IM <ProjectName>.exe /F` before re-running.
-
-### Run Tests
-
-```powershell
-# Run from the test project folder
-cd <ProjectName>.Tests
-$Platform = $env:PROCESSOR_ARCHITECTURE
-dotnet test -c Debug -p:Platform=$Platform
-```
+If the launch fails because an old instance is still running, terminate it with `taskkill /IM <ProjectName>.exe /F` before re-running.
 
 ## Key Rules (Always Enforced)
 
 - **Every change must build and pass tests** -- Run `dotnet build` and `dotnet test` (see [Build, Run & Deploy](#build-run--deploy)) before considering any task complete.
 - **Follow all instruction files** -- The detailed rules in `.github/instructions/` are authoritative. **You must actually open and read them** (not just acknowledge they exist) when working within their scope. See the trigger conditions in steps 5-8 above.
 - **Web search before decompilation** -- When facing unknown types or build errors, always search the web / API docs first. Only use WinMD/ILDASM as a last resort (see [Troubleshooting Build Errors](#troubleshooting-build-errors)).
+- **Use `winapp` for app-identity / packaging / signing** -- Don't hand-roll `MakeAppx`/`SignTool`/`Add-AppxPackage` invocations. The CLI keeps the manifest, certificate, and registration steps in sync.
 
 ## Windows AI Prerequisites
 
-When integrating Phi Silica, Windows Vision, or other Windows AI APIs (see
-[windows-apis.instructions.md](.github/instructions/windows-apis.instructions.md)):
+When integrating Windows AI APIs (Phi Silica, Windows Vision -- ImageDescription,
+TextRecognizer, ImageScaler, etc.) -- see
+[windows-apis.instructions.md](.github/instructions/windows-apis.instructions.md):
 
-1. **Manifest capabilities:** Add the required capabilities (for example
-  `internetClient`, `machineLearning`, `systemManagement`) to the app manifest
-  before calling these APIs.
-2. **LAF token:** Phi Silica endpoints need a Local API key. Acquire it via the
-  Windows AI documentation, store it securely (never in source), and document
-  the manual step in the PR.
-3. **MSBuild overrides:** Some scenarios need temporary
-  `<WindowsAppSDKSelfContained>` or package-version overrides. Capture the
-  reasoning in the PR description and remove overrides once upstream fixes
-  land.
-4. **Fallback path:** If LAF or required hardware is unavailable, use the
-  Windows Vision / AI APIs that do not require the token and describe the
-  limitations in the instruction files or README so Copilot can pick the right
-  approach.
+1. **Package identity is required.** All Windows AI APIs require the app to
+   run with package identity. The `dotnet run` flow described above already
+   provides this. If you're testing outside `dotnet run`, register identity
+   first with `winapp run` or `winapp create-debug-identity`.
+2. **Manifest capabilities.** Add the capabilities each API requires to
+   `Package.appxmanifest` (commonly `runFullTrust`; some scenarios additionally
+   need `internetClient`). Check the API's docs page for the exact list.
+3. **Hardware / OS gating.** Some APIs require a Copilot+ PC (NPU) or a
+   minimum Windows build. Always probe availability with the API's
+   `IsAvailable` / `EnsureReadyAsync` pattern (or equivalent) and provide a
+   graceful fallback for unsupported devices.
+4. **Verify locally before checking in.** After capability or manifest
+   changes, re-run `dotnet run` (or `winapp run`) so the registered identity
+   reflects the updated manifest -- a stale registration will silently use
+   the old capability set.
 
 
 

--- a/dev/Templates/Dotnet/templates/single-project/instructions/security.instructions.md
+++ b/dev/Templates/Dotnet/templates/single-project/instructions/security.instructions.md
@@ -16,7 +16,12 @@ These rules apply to **every feature and change**. They are not optional add-ons
 - Use `SecureString` or `PasswordVault` for sensitive data in memory when practical.
 - Follow the **principle of least privilege** — request only the permissions the app actually needs in `Package.appxmanifest`.
 - Keep NuGet packages up to date — run `dotnet list package --outdated` regularly.
-- Enable **code signing** for published MSIX packages.
+- Enable **code signing** for published MSIX packages. Use the `winapp` CLI rather than hand-rolling `signtool`:
+  - Generate a development certificate matching the manifest publisher: `winapp cert generate --manifest .\Package.appxmanifest --install`.
+  - Inspect a cert before signing: `winapp cert info .\devcert.pfx`.
+  - Sign an existing file: `winapp sign .\MyApp.msix --cert .\devcert.pfx`.
+  - Build + sign in one step: `winapp pack .\bin\<Platform>\Release\<TFM>\win-<rid> --cert .\devcert.pfx`.
+  - Production releases must be signed by a trusted certificate authority -- never ship the development cert.
 - When using `HttpClient`, always validate TLS certificates and use HTTPS.
 - Never log sensitive data (PII, tokens, passwords).
 

--- a/dev/Templates/Dotnet/templates/single-project/instructions/testing.instructions.md
+++ b/dev/Templates/Dotnet/templates/single-project/instructions/testing.instructions.md
@@ -167,26 +167,30 @@ public class MainViewModelTests
 
 ### Running Tests On-Demand
 
-After a change, run only the tests related to the affected area instead of the full suite:
+After a change, run only the tests related to the affected area instead of the full suite. Detect the platform first (matching the convention in `.github/agents/Agents.md`):
 
 ```powershell
 # Run from the test project folder
 cd <ProjectName>.Tests
 
+# Detect platform once per session (AMD64 -> x64; ARM64/x86 unchanged)
+$arch = $env:PROCESSOR_ARCHITECTURE
+$Platform = if ($arch -eq 'AMD64') { 'x64' } else { $arch }
+
 # Run tests for a specific class
-dotnet test -c Debug -p:Platform=x64 --filter "FullyQualifiedName~MainViewModelTests"
+dotnet test -c Debug -p:Platform=$Platform --filter "FullyQualifiedName~MainViewModelTests"
 
 # Run a single test
-dotnet test -c Debug -p:Platform=x64 --filter "FullyQualifiedName~MainViewModelTests.LoadItemsAsync_OnSuccess_PopulatesItems"
+dotnet test -c Debug -p:Platform=$Platform --filter "FullyQualifiedName~MainViewModelTests.LoadItemsAsync_OnSuccess_PopulatesItems"
 
 # Run all tests in a namespace (e.g., all ViewModel tests)
-dotnet test -c Debug -p:Platform=x64 --filter "FullyQualifiedName~Tests.ViewModels"
+dotnet test -c Debug -p:Platform=$Platform --filter "FullyQualifiedName~Tests.ViewModels"
 
 # Run tests in a subfolder namespace (e.g., only Settings ViewModels)
-dotnet test -c Debug -p:Platform=x64 --filter "FullyQualifiedName~Tests.ViewModels.Settings"
+dotnet test -c Debug -p:Platform=$Platform --filter "FullyQualifiedName~Tests.ViewModels.Settings"
 
 # Run the full suite (for cross-cutting changes)
-dotnet test -c Debug -p:Platform=x64
+dotnet test -c Debug -p:Platform=$Platform
 ```
 ```
 
@@ -203,13 +207,15 @@ Below are additional test commands:
 
 ```powershell
 cd <ProjectName>.Tests
-dotnet build -c Debug -p:Platform=x64
+$arch = $env:PROCESSOR_ARCHITECTURE
+$Platform = if ($arch -eq 'AMD64') { 'x64' } else { $arch }
+dotnet build -c Debug -p:Platform=$Platform
 ```
 
 ### Run Tests with Verbose Output
 
 ```powershell
-dotnet test -c Debug -p:Platform=x64 --verbosity normal
+dotnet test -c Debug -p:Platform=$Platform --verbosity normal
 ```
 
 ---
@@ -221,7 +227,7 @@ When you write or modify code, follow this sequence:
 1. **Implement the feature or fix** in the main project.
 2. **Write unit tests** for every new/changed public method.
 3. **Build** — see **Build, Run & Deploy** in `.github/agents/Agents.md`. Fix all errors and warnings.
-4. **Run tests** — `dotnet test -c Debug -p:Platform=x64` (from the test project folder) and ensure all pass.
+4. **Run tests** — `dotnet test -c Debug -p:Platform=$Platform` (from the test project folder; detect `$Platform` as shown above) and ensure all pass.
 5. **Review** — Confirm tests cover the happy path, edge cases, and error cases.
 
 ### When Modifying Existing Code

--- a/dev/Templates/Dotnet/templates/single-project/instructions/winui-best-practices.instructions.md
+++ b/dev/Templates/Dotnet/templates/single-project/instructions/winui-best-practices.instructions.md
@@ -342,7 +342,8 @@ Alternatives:
 | Using `Windows.UI.Xaml` namespace | Use `Microsoft.UI.Xaml` for WinUI 3 |
 | Calling `Window.Current` | Not available in WinUI 3 -- pass window reference explicitly |
 | Using `CoreDispatcher` | Use `DispatcherQueue` instead |
-| `REGDB_E_CLASSNOTREG` error | Ensure Developer Mode is enabled; re-register the MSIX package with `Add-AppxPackage -Register` |
+| `REGDB_E_CLASSNOTREG` error | Ensure Developer Mode is enabled, then re-register: run `winapp unregister` followed by `dotnet run` (or `winapp run <build-output>`) to refresh the loose-layout registration |
+| Stale package state after manifest changes | Run `winapp unregister`, then `dotnet run` -- using `winapp run --clean` additionally wipes `LocalState`/settings to test first-run behavior |
 | XAML Designer crashes | Clean & rebuild; ensure platform matches (x64 vs AnyCPU) |
 | `{Binding}` not updating | Switch to `x:Bind` with `Mode=OneWay` or `Mode=TwoWay` |
 

--- a/dev/Templates/Dotnet/templates/tabview-app/.template.config/template.json
+++ b/dev/Templates/Dotnet/templates/tabview-app/.template.config/template.json
@@ -141,6 +141,13 @@
       "replaces": "$WindowsSdkBuildToolsVersion$",
       "defaultValue": "10.0.26100.7705",
       "description": "Version of the Microsoft.Windows.SDK.BuildTools NuGet package."
+    },
+    "windowsSdkBuildToolsWinAppVersion": {
+      "type": "parameter",
+      "datatype": "text",
+      "replaces": "$WindowsSdkBuildToolsWinAppVersion$",
+      "defaultValue": "0.3.1",
+      "description": "Version of the Microsoft.Windows.SDK.BuildTools.WinApp NuGet package, which adds `dotnet run` support for packaged WinUI apps via the winapp CLI."
     }
   },
   "sources": [
@@ -195,6 +202,16 @@
         "reference": "Microsoft.Windows.SDK.BuildTools"
       },
       "manualInstructions": [{ "text": "Run 'dotnet add package Microsoft.Windows.SDK.BuildTools'" }]
+    },
+    {
+      "actionId": "B17581D1-C5C9-4489-8F0A-004BE667B814",
+      "continueOnError": true,
+      "description": "Update Microsoft.Windows.SDK.BuildTools.WinApp to the latest stable version (enables `dotnet run` for packaged WinUI apps).",
+      "args": {
+        "referenceType": "package",
+        "reference": "Microsoft.Windows.SDK.BuildTools.WinApp"
+      },
+      "manualInstructions": [{ "text": "Run 'dotnet add package Microsoft.Windows.SDK.BuildTools.WinApp'" }]
     },
     {
       "actionId": "210D431B-A78B-4D2F-B762-4ED3E3EA9025",

--- a/dev/Templates/Dotnet/templates/unit-test/.template.config/template.json
+++ b/dev/Templates/Dotnet/templates/unit-test/.template.config/template.json
@@ -135,6 +135,46 @@
       },
       "replaces": "$guid9$"
     },
+    "UseLatestWindowsAppSDK":{
+      "type": "parameter",
+      "datatype": "bool",
+      "defaultValue": "true"
+    },
+    "windowsAppSdkVersion": {
+      "type": "parameter",
+      "datatype": "text",
+      "replaces": "$WindowsAppSdkVersion$",
+      "defaultValue": "1.8.260317003",
+      "description": "Version of the Microsoft.WindowsAppSDK NuGet package."
+    },
+    "windowsSdkBuildToolsVersion": {
+      "type": "parameter",
+      "datatype": "text",
+      "replaces": "$WindowsSdkBuildToolsVersion$",
+      "defaultValue": "10.0.26100.7705",
+      "description": "Version of the Microsoft.Windows.SDK.BuildTools NuGet package."
+    },
+    "windowsSdkBuildToolsWinAppVersion": {
+      "type": "parameter",
+      "datatype": "text",
+      "replaces": "$WindowsSdkBuildToolsWinAppVersion$",
+      "defaultValue": "0.3.1",
+      "description": "Version of the Microsoft.Windows.SDK.BuildTools.WinApp NuGet package, which adds `dotnet run` support for packaged WinUI apps via the winapp CLI."
+    },
+    "mstestVersion": {
+      "type": "parameter",
+      "datatype": "text",
+      "replaces": "$MSTestVersion$",
+      "defaultValue": "3.6.4",
+      "description": "Version of the MSTest.TestFramework and MSTest.TestAdapter NuGet packages."
+    },
+    "microsoftNetTestSdkVersion": {
+      "type": "parameter",
+      "datatype": "text",
+      "replaces": "$MicrosoftNetTestSdkVersion$",
+      "defaultValue": "17.13.0",
+      "description": "Version of the Microsoft.NET.Test.Sdk and Microsoft.TestPlatform.TestHost NuGet packages."
+    }
   },
   "sources": [
     {
@@ -169,6 +209,76 @@
     }
   },
   "postActions": [
+    {
+      "actionId": "B17581D1-C5C9-4489-8F0A-004BE667B814",
+      "continueOnError": true,
+      "description": "Update Microsoft.WindowsAppSDK to the latest stable version.",
+      "args": {
+        "referenceType": "package",
+        "reference": "Microsoft.WindowsAppSDK"
+      },
+      "manualInstructions": [{ "text": "Run 'dotnet add package Microsoft.WindowsAppSDK'" }]
+    },
+    {
+      "actionId": "B17581D1-C5C9-4489-8F0A-004BE667B814",
+      "continueOnError": true,
+      "description": "Update Microsoft.Windows.SDK.BuildTools to the latest stable version.",
+      "args": {
+        "referenceType": "package",
+        "reference": "Microsoft.Windows.SDK.BuildTools"
+      },
+      "manualInstructions": [{ "text": "Run 'dotnet add package Microsoft.Windows.SDK.BuildTools'" }]
+    },
+    {
+      "actionId": "B17581D1-C5C9-4489-8F0A-004BE667B814",
+      "continueOnError": true,
+      "description": "Update Microsoft.Windows.SDK.BuildTools.WinApp to the latest stable version (enables `dotnet run` for packaged WinUI apps).",
+      "args": {
+        "referenceType": "package",
+        "reference": "Microsoft.Windows.SDK.BuildTools.WinApp"
+      },
+      "manualInstructions": [{ "text": "Run 'dotnet add package Microsoft.Windows.SDK.BuildTools.WinApp'" }]
+    },
+    {
+      "actionId": "B17581D1-C5C9-4489-8F0A-004BE667B814",
+      "continueOnError": true,
+      "description": "Update MSTest.TestFramework to the latest stable version.",
+      "args": {
+        "referenceType": "package",
+        "reference": "MSTest.TestFramework"
+      },
+      "manualInstructions": [{ "text": "Run 'dotnet add package MSTest.TestFramework'" }]
+    },
+    {
+      "actionId": "B17581D1-C5C9-4489-8F0A-004BE667B814",
+      "continueOnError": true,
+      "description": "Update MSTest.TestAdapter to the latest stable version.",
+      "args": {
+        "referenceType": "package",
+        "reference": "MSTest.TestAdapter"
+      },
+      "manualInstructions": [{ "text": "Run 'dotnet add package MSTest.TestAdapter'" }]
+    },
+    {
+      "actionId": "B17581D1-C5C9-4489-8F0A-004BE667B814",
+      "continueOnError": true,
+      "description": "Update Microsoft.NET.Test.Sdk to the latest stable version.",
+      "args": {
+        "referenceType": "package",
+        "reference": "Microsoft.NET.Test.Sdk"
+      },
+      "manualInstructions": [{ "text": "Run 'dotnet add package Microsoft.NET.Test.Sdk'" }]
+    },
+    {
+      "actionId": "B17581D1-C5C9-4489-8F0A-004BE667B814",
+      "continueOnError": true,
+      "description": "Update Microsoft.TestPlatform.TestHost to the latest stable version.",
+      "args": {
+        "referenceType": "package",
+        "reference": "Microsoft.TestPlatform.TestHost"
+      },
+      "manualInstructions": [{ "text": "Run 'dotnet add package Microsoft.TestPlatform.TestHost'" }]
+    },
     {
       "actionId": "210D431B-A78B-4D2F-B762-4ED3E3EA9025",
       "continueOnError": true,

--- a/dev/Templates/Source/ItemTemplates/Neutral/CSharp/ContentDialog/ContentDialog.xaml
+++ b/dev/Templates/Source/ItemTemplates/Neutral/CSharp/ContentDialog/ContentDialog.xaml
@@ -6,6 +6,7 @@
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:local="using:$rootnamespace$"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    Style="{StaticResource __WINUI_DEFAULT_CONTENT_DIALOG_STYLE__}"
     Title="Title"
     PrimaryButtonClick="ContentDialog_PrimaryButtonClick"
     PrimaryButtonText="Button1"

--- a/dev/Templates/Source/ItemTemplates/Neutral/CSharp/ContentDialog/ContentDialog.xaml
+++ b/dev/Templates/Source/ItemTemplates/Neutral/CSharp/ContentDialog/ContentDialog.xaml
@@ -6,7 +6,6 @@
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:local="using:$rootnamespace$"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-    Style="{StaticResource DefaultContentDialogStyle}"
     Title="Title"
     PrimaryButtonClick="ContentDialog_PrimaryButtonClick"
     PrimaryButtonText="Button1"

--- a/dev/Templates/Source/ItemTemplates/Neutral/CSharp/TemplatedControl/CustomControl.cs
+++ b/dev/Templates/Source/ItemTemplates/Neutral/CSharp/TemplatedControl/CustomControl.cs
@@ -12,6 +12,14 @@ using Microsoft.UI.Xaml.Media;
 // To learn more about WinUI, the WinUI project structure,
 // and more about our project templates, see: http://aka.ms/winui-project-info.
 
+// To add another templated control to this project (which already has a
+// Themes\Generic.xaml), run with `--IncludeDefaultStyle false` or `-I false`:
+//
+//     dotnet new winui-templatedcontrol -n NewName --IncludeDefaultStyle false
+//
+// Then open Themes\Generic.xaml and add a <Style TargetType="local:NewName">
+// block. Without it, the new control will render blank at runtime.
+
 namespace $rootnamespace$;
 
 public sealed partial class $safeitemname$ : Control

--- a/dev/Templates/Source/ItemTemplates/Neutral/CSharp/TemplatedControl/Themes/Generic.xaml
+++ b/dev/Templates/Source/ItemTemplates/Neutral/CSharp/TemplatedControl/Themes/Generic.xaml
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<ResourceDictionary
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:local="using:$rootnamespace$">
+
+    <!--
+        To add another templated control to this project, re-run with the
+        IncludeDefaultStyle option set to false so the dotnet template engine
+        does not try to overwrite this file:
+
+            dotnet new winui-templatedcontrol -n NewName -I false
+
+        (-I is the short form of IncludeDefaultStyle. Without it, the second
+         invocation fails saying it would overwrite Themes/Generic.xaml. Do
+         not pass force to bypass that; it would erase the styles below.)
+
+        Then copy the Style block below, change TargetType to local:NewName,
+        and customize it. Save and rebuild.
+    -->
+
+    <Style TargetType="local:$safeitemname$">
+        <Setter Property="HorizontalContentAlignment" Value="Stretch" />
+        <Setter Property="VerticalContentAlignment" Value="Stretch" />
+        <Setter Property="Template">
+            <Setter.Value>
+                <ControlTemplate TargetType="local:$safeitemname$">
+                    <Border Background="{TemplateBinding Background}"
+                            BorderBrush="{TemplateBinding BorderBrush}"
+                            BorderThickness="{TemplateBinding BorderThickness}"
+                            CornerRadius="{TemplateBinding CornerRadius}"
+                            Padding="{TemplateBinding Padding}">
+                        <ContentPresenter HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
+                                          VerticalAlignment="{TemplateBinding VerticalContentAlignment}" />
+                    </Border>
+                </ControlTemplate>
+            </Setter.Value>
+        </Setter>
+    </Style>
+
+</ResourceDictionary>

--- a/dev/Templates/Source/ProjectTemplates/Desktop/CSharp/MvvmApp/ProjectTemplate.csproj
+++ b/dev/Templates/Source/ProjectTemplates/Desktop/CSharp/MvvmApp/ProjectTemplate.csproj
@@ -6,8 +6,8 @@
     <RootNamespace>$safeprojectname$</RootNamespace>
     <ApplicationManifest>app.manifest</ApplicationManifest>
     <Platforms>x86;x64;ARM64</Platforms>
-    <RuntimeIdentifiers>win-x86;win-x64;win-arm64</RuntimeIdentifiers>
-    <PublishProfile>win-$(Platform).pubxml</PublishProfile>
+    <RuntimeIdentifier Condition="'$(RuntimeIdentifier)' == ''">win-$([System.Runtime.InteropServices.RuntimeInformation]::ProcessArchitecture.ToString().ToLowerInvariant())</RuntimeIdentifier>
+    <PublishProfile Condition="Exists('Properties\PublishProfiles\win-$(Platform).pubxml')">win-$(Platform).pubxml</PublishProfile>
     <UseWinUI>true</UseWinUI>
     <WinUISDKReferences>false</WinUISDKReferences>
     <EnableMsixTooling>true</EnableMsixTooling>

--- a/dev/Templates/Source/ProjectTemplates/Desktop/CSharp/MvvmApp/ProjectTemplate.csproj
+++ b/dev/Templates/Source/ProjectTemplates/Desktop/CSharp/MvvmApp/ProjectTemplate.csproj
@@ -40,11 +40,20 @@
     <ProjectCapability Include="Msix"/>
   </ItemGroup>
 
+  <!--
+    Microsoft.Windows.SDK.BuildTools.WinApp adds first-class support for
+    `dotnet run` on packaged WinUI apps: it hooks the .NET CLI Run target to
+    register a debug identity via the winapp CLI and launch the app with
+    package identity (AUMID).
+    Set <EnableWinAppRunSupport>false</EnableWinAppRunSupport> in a
+    <PropertyGroup> above to opt out.
+  -->
   <!--#if (UseLatestWindowsAppSDK)
   <ItemGroup>
     <PackageReference Include="Microsoft.Windows.SDK.BuildTools" Version="$WindowsSdkBuildToolsVersion$" />
     <PackageReference Include="Microsoft.WindowsAppSDK" Version="$WindowsAppSdkVersion$" />
     <PackageReference Include="CommunityToolkit.Mvvm" Version="8.4.2" />
+    <PackageReference Include="Microsoft.Windows.SDK.BuildTools.WinApp" Version="$WindowsSdkBuildToolsWinAppVersion$" />
   </ItemGroup>
   #endif -->
 

--- a/dev/Templates/Source/ProjectTemplates/Desktop/CSharp/MvvmApp/WinUI.Desktop.Cs.MvvmApp.vstemplate
+++ b/dev/Templates/Source/ProjectTemplates/Desktop/CSharp/MvvmApp/WinUI.Desktop.Cs.MvvmApp.vstemplate
@@ -59,7 +59,7 @@
       </Folder>
     </Project>      
     <CustomParameters>
-      <CustomParameter Name="$NuGetPackages$" Value="Microsoft.WindowsAppSDK;Microsoft.Windows.SDK.BuildTools;CommunityToolkit.Mvvm"/>
+      <CustomParameter Name="$NuGetPackages$" Value="Microsoft.WindowsAppSDK;Microsoft.Windows.SDK.BuildTools;Microsoft.Windows.SDK.BuildTools.WinApp;CommunityToolkit.Mvvm"/>
     </CustomParameters>
   </TemplateContent>
   <WizardExtension>

--- a/dev/Templates/Source/ProjectTemplates/Desktop/CSharp/NavigationApp/ProjectTemplate.csproj
+++ b/dev/Templates/Source/ProjectTemplates/Desktop/CSharp/NavigationApp/ProjectTemplate.csproj
@@ -6,8 +6,8 @@
     <RootNamespace>$safeprojectname$</RootNamespace>
     <ApplicationManifest>app.manifest</ApplicationManifest>
     <Platforms>x86;x64;ARM64</Platforms>
-    <RuntimeIdentifiers>win-x86;win-x64;win-arm64</RuntimeIdentifiers>
-    <PublishProfile>win-$(Platform).pubxml</PublishProfile>
+    <RuntimeIdentifier Condition="'$(RuntimeIdentifier)' == ''">win-$([System.Runtime.InteropServices.RuntimeInformation]::ProcessArchitecture.ToString().ToLowerInvariant())</RuntimeIdentifier>
+    <PublishProfile Condition="Exists('Properties\PublishProfiles\win-$(Platform).pubxml')">win-$(Platform).pubxml</PublishProfile>
     <UseWinUI>true</UseWinUI>
     <WinUISDKReferences>false</WinUISDKReferences>
     <EnableMsixTooling>true</EnableMsixTooling>

--- a/dev/Templates/Source/ProjectTemplates/Desktop/CSharp/NavigationApp/ProjectTemplate.csproj
+++ b/dev/Templates/Source/ProjectTemplates/Desktop/CSharp/NavigationApp/ProjectTemplate.csproj
@@ -40,10 +40,19 @@
     <ProjectCapability Include="Msix"/>
   </ItemGroup>
 
+  <!--
+    Microsoft.Windows.SDK.BuildTools.WinApp adds first-class support for
+    `dotnet run` on packaged WinUI apps: it hooks the .NET CLI Run target to
+    register a debug identity via the winapp CLI and launch the app with
+    package identity (AUMID).
+    Set <EnableWinAppRunSupport>false</EnableWinAppRunSupport> in a
+    <PropertyGroup> above to opt out.
+  -->
   <!--#if (UseLatestWindowsAppSDK)
   <ItemGroup>
     <PackageReference Include="Microsoft.Windows.SDK.BuildTools" Version="$WindowsSdkBuildToolsVersion$" />
     <PackageReference Include="Microsoft.WindowsAppSDK" Version="$WindowsAppSdkVersion$" />
+    <PackageReference Include="Microsoft.Windows.SDK.BuildTools.WinApp" Version="$WindowsSdkBuildToolsWinAppVersion$" />
   </ItemGroup>
   #endif -->
 

--- a/dev/Templates/Source/ProjectTemplates/Desktop/CSharp/NavigationApp/WinUI.Desktop.Cs.NavigationApp.vstemplate
+++ b/dev/Templates/Source/ProjectTemplates/Desktop/CSharp/NavigationApp/WinUI.Desktop.Cs.NavigationApp.vstemplate
@@ -62,7 +62,7 @@
       </Folder>
     </Project>      
     <CustomParameters>
-      <CustomParameter Name="$NuGetPackages$" Value="Microsoft.WindowsAppSDK;Microsoft.Windows.SDK.BuildTools"/>
+      <CustomParameter Name="$NuGetPackages$" Value="Microsoft.WindowsAppSDK;Microsoft.Windows.SDK.BuildTools;Microsoft.Windows.SDK.BuildTools.WinApp"/>
     </CustomParameters>
   </TemplateContent>
   <WizardExtension>

--- a/dev/Templates/Source/ProjectTemplates/Desktop/CSharp/SingleProjectPackagedApp/ProjectTemplate.csproj
+++ b/dev/Templates/Source/ProjectTemplates/Desktop/CSharp/SingleProjectPackagedApp/ProjectTemplate.csproj
@@ -6,8 +6,8 @@
     <RootNamespace>$safeprojectname$</RootNamespace>
     <ApplicationManifest>app.manifest</ApplicationManifest>
     <Platforms>x86;x64;ARM64</Platforms>
-    <RuntimeIdentifiers>win-x86;win-x64;win-arm64</RuntimeIdentifiers>
-    <PublishProfile>win-$(Platform).pubxml</PublishProfile>
+    <RuntimeIdentifier Condition="'$(RuntimeIdentifier)' == ''">win-$([System.Runtime.InteropServices.RuntimeInformation]::ProcessArchitecture.ToString().ToLowerInvariant())</RuntimeIdentifier>
+    <PublishProfile Condition="Exists('Properties\PublishProfiles\win-$(Platform).pubxml')">win-$(Platform).pubxml</PublishProfile>
     <UseWinUI>true</UseWinUI>
     <WinUISDKReferences>false</WinUISDKReferences>
     <EnableMsixTooling>true</EnableMsixTooling>

--- a/dev/Templates/Source/ProjectTemplates/Desktop/CSharp/SingleProjectPackagedApp/ProjectTemplate.csproj
+++ b/dev/Templates/Source/ProjectTemplates/Desktop/CSharp/SingleProjectPackagedApp/ProjectTemplate.csproj
@@ -40,10 +40,19 @@
     <ProjectCapability Include="Msix"/>
   </ItemGroup>
 
+  <!--
+    Microsoft.Windows.SDK.BuildTools.WinApp adds first-class support for
+    `dotnet run` on packaged WinUI apps: it hooks the .NET CLI Run target to
+    register a debug identity via the winapp CLI and launch the app with
+    package identity (AUMID).
+    Set <EnableWinAppRunSupport>false</EnableWinAppRunSupport> in a
+    <PropertyGroup> above to opt out.
+  -->
   <!--#if (UseLatestWindowsAppSDK)
   <ItemGroup>
     <PackageReference Include="Microsoft.Windows.SDK.BuildTools" Version="$WindowsSdkBuildToolsVersion$" />
     <PackageReference Include="Microsoft.WindowsAppSDK" Version="$WindowsAppSdkVersion$" />
+    <PackageReference Include="Microsoft.Windows.SDK.BuildTools.WinApp" Version="$WindowsSdkBuildToolsWinAppVersion$" />
   </ItemGroup>
   #endif -->
 

--- a/dev/Templates/Source/ProjectTemplates/Desktop/CSharp/SingleProjectPackagedApp/WinUI.Desktop.Cs.SingleProjectPackagedApp.vstemplate
+++ b/dev/Templates/Source/ProjectTemplates/Desktop/CSharp/SingleProjectPackagedApp/WinUI.Desktop.Cs.SingleProjectPackagedApp.vstemplate
@@ -55,7 +55,7 @@
       </Folder>
     </Project>      
     <CustomParameters>
-      <CustomParameter Name="$NuGetPackages$" Value="Microsoft.WindowsAppSDK;Microsoft.Windows.SDK.BuildTools"/>
+      <CustomParameter Name="$NuGetPackages$" Value="Microsoft.WindowsAppSDK;Microsoft.Windows.SDK.BuildTools;Microsoft.Windows.SDK.BuildTools.WinApp"/>
     </CustomParameters>
   </TemplateContent>
   <WizardExtension>

--- a/dev/Templates/Source/ProjectTemplates/Desktop/CSharp/TabViewApp/MainWindow.xaml
+++ b/dev/Templates/Source/ProjectTemplates/Desktop/CSharp/TabViewApp/MainWindow.xaml
@@ -28,9 +28,6 @@
                         Source="/Assets/AppIcon.ico" />
                 </Grid>
             </TabView.TabStripHeader>
-            <TabView.TabStripFooter>
-                <Grid x:Name="CustomDragRegion" />
-            </TabView.TabStripFooter>
         </TabView>
     </Grid>
 </Window>

--- a/dev/Templates/Source/ProjectTemplates/Desktop/CSharp/TabViewApp/MainWindow.xaml
+++ b/dev/Templates/Source/ProjectTemplates/Desktop/CSharp/TabViewApp/MainWindow.xaml
@@ -28,6 +28,9 @@
                         Source="/Assets/AppIcon.ico" />
                 </Grid>
             </TabView.TabStripHeader>
+            <TabView.TabStripFooter>
+                <Grid x:Name="CustomDragRegion" />
+            </TabView.TabStripFooter>
         </TabView>
     </Grid>
 </Window>

--- a/dev/Templates/Source/ProjectTemplates/Desktop/CSharp/TabViewApp/MainWindow.xaml.cs
+++ b/dev/Templates/Source/ProjectTemplates/Desktop/CSharp/TabViewApp/MainWindow.xaml.cs
@@ -16,11 +16,6 @@ public sealed partial class MainWindow : Window
     {
         InitializeComponent();
 
-        // Extend content into the title bar and use the TabView's
-        // drag region so the tab strip acts as the title bar area.
-        ExtendsContentIntoTitleBar = true;
-        SetTitleBar(CustomDragRegion);
-        AppWindow.TitleBar.PreferredHeightOption = TitleBarHeightOption.Tall;
         AppWindow.SetIcon("Assets/AppIcon.ico");
 
         // Add a few default tabs on startup.

--- a/dev/Templates/Source/ProjectTemplates/Desktop/CSharp/TabViewApp/MainWindow.xaml.cs
+++ b/dev/Templates/Source/ProjectTemplates/Desktop/CSharp/TabViewApp/MainWindow.xaml.cs
@@ -16,12 +16,42 @@ public sealed partial class MainWindow : Window
     {
         InitializeComponent();
 
+        // Extend content into the title bar and use the TabView's
+        // drag region so the tab strip acts as the title bar area.
+        ExtendsContentIntoTitleBar = true;
+        SetTitleBar(CustomDragRegion);
         AppWindow.SetIcon("Assets/AppIcon.ico");
+
+        // Reserve space at the right edge of the tab strip for the system
+        // caption buttons, scaled to the current DPI so they don't overlap
+        // tabs on high-DPI displays.
+        AppWindow.Changed += OnAppWindowChanged;
+        UpdateCaptionButtonInset();
 
         // Add a few default tabs on startup.
         AddTab("Home", typeof(HomePage));
         AddTab("About", typeof(AboutPage));
         TabControl.SelectedIndex = 0;
+    }
+
+    private void OnAppWindowChanged(AppWindow sender, AppWindowChangedEventArgs args)
+    {
+        if (args.DidSizeChange || args.DidPositionChange)
+        {
+            UpdateCaptionButtonInset();
+        }
+    }
+
+    private void UpdateCaptionButtonInset()
+    {
+        // RightInset is in physical pixels; convert to DIPs.
+        double scale = (Content as FrameworkElement)?.XamlRoot?.RasterizationScale ?? 1.0;
+        if (scale <= 0)
+        {
+            scale = 1.0;
+        }
+
+        CustomDragRegion.MinWidth = AppWindow.TitleBar.RightInset / scale;
     }
 
     /// <summary>

--- a/dev/Templates/Source/ProjectTemplates/Desktop/CSharp/TabViewApp/ProjectTemplate.csproj
+++ b/dev/Templates/Source/ProjectTemplates/Desktop/CSharp/TabViewApp/ProjectTemplate.csproj
@@ -6,8 +6,8 @@
     <RootNamespace>$safeprojectname$</RootNamespace>
     <ApplicationManifest>app.manifest</ApplicationManifest>
     <Platforms>x86;x64;ARM64</Platforms>
-    <RuntimeIdentifiers>win-x86;win-x64;win-arm64</RuntimeIdentifiers>
-    <PublishProfile>win-$(Platform).pubxml</PublishProfile>
+    <RuntimeIdentifier Condition="'$(RuntimeIdentifier)' == ''">win-$([System.Runtime.InteropServices.RuntimeInformation]::ProcessArchitecture.ToString().ToLowerInvariant())</RuntimeIdentifier>
+    <PublishProfile Condition="Exists('Properties\PublishProfiles\win-$(Platform).pubxml')">win-$(Platform).pubxml</PublishProfile>
     <UseWinUI>true</UseWinUI>
     <WinUISDKReferences>false</WinUISDKReferences>
     <EnableMsixTooling>true</EnableMsixTooling>

--- a/dev/Templates/Source/ProjectTemplates/Desktop/CSharp/TabViewApp/ProjectTemplate.csproj
+++ b/dev/Templates/Source/ProjectTemplates/Desktop/CSharp/TabViewApp/ProjectTemplate.csproj
@@ -40,10 +40,19 @@
     <ProjectCapability Include="Msix"/>
   </ItemGroup>
 
+  <!--
+    Microsoft.Windows.SDK.BuildTools.WinApp adds first-class support for
+    `dotnet run` on packaged WinUI apps: it hooks the .NET CLI Run target to
+    register a debug identity via the winapp CLI and launch the app with
+    package identity (AUMID).
+    Set <EnableWinAppRunSupport>false</EnableWinAppRunSupport> in a
+    <PropertyGroup> above to opt out.
+  -->
   <!--#if (UseLatestWindowsAppSDK)
   <ItemGroup>
     <PackageReference Include="Microsoft.Windows.SDK.BuildTools" Version="$WindowsSdkBuildToolsVersion$" />
     <PackageReference Include="Microsoft.WindowsAppSDK" Version="$WindowsAppSdkVersion$" />
+    <PackageReference Include="Microsoft.Windows.SDK.BuildTools.WinApp" Version="$WindowsSdkBuildToolsWinAppVersion$" />
   </ItemGroup>
   #endif -->
 

--- a/dev/Templates/Source/ProjectTemplates/Desktop/CSharp/TabViewApp/WinUI.Desktop.Cs.TabViewApp.vstemplate
+++ b/dev/Templates/Source/ProjectTemplates/Desktop/CSharp/TabViewApp/WinUI.Desktop.Cs.TabViewApp.vstemplate
@@ -60,7 +60,7 @@
       </Folder>
     </Project>      
     <CustomParameters>
-      <CustomParameter Name="$NuGetPackages$" Value="Microsoft.WindowsAppSDK;Microsoft.Windows.SDK.BuildTools"/>
+      <CustomParameter Name="$NuGetPackages$" Value="Microsoft.WindowsAppSDK;Microsoft.Windows.SDK.BuildTools;Microsoft.Windows.SDK.BuildTools.WinApp"/>
     </CustomParameters>
   </TemplateContent>
   <WizardExtension>

--- a/dev/Templates/Source/ProjectTemplates/Desktop/CSharp/UnitTestApp/ProjectTemplate.csproj
+++ b/dev/Templates/Source/ProjectTemplates/Desktop/CSharp/UnitTestApp/ProjectTemplate.csproj
@@ -45,6 +45,26 @@
     <ProjectCapability Include="Msix"/>
   </ItemGroup>
 
+  <!--
+    Microsoft.Windows.SDK.BuildTools.WinApp adds first-class support for
+    `dotnet run` on packaged WinUI apps: it hooks the .NET CLI Run target to
+    register a debug identity via the winapp CLI and launch the app with
+    package identity (AUMID).
+    Set <EnableWinAppRunSupport>false</EnableWinAppRunSupport> in a
+    <PropertyGroup> above to opt out.
+  -->
+  <!--#if (UseLatestWindowsAppSDK)
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Windows.SDK.BuildTools" Version="$WindowsSdkBuildToolsVersion$" />
+    <PackageReference Include="Microsoft.WindowsAppSDK" Version="$WindowsAppSdkVersion$" />
+    <PackageReference Include="Microsoft.Windows.SDK.BuildTools.WinApp" Version="$WindowsSdkBuildToolsWinAppVersion$" />
+    <PackageReference Include="MSTest.TestAdapter" Version="$MSTestVersion$" />
+    <PackageReference Include="MSTest.TestFramework" Version="$MSTestVersion$" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="$MicrosoftNetTestSdkVersion$" />
+    <PackageReference Include="Microsoft.TestPlatform.TestHost" Version="$MicrosoftNetTestSdkVersion$" />
+  </ItemGroup>
+  #endif -->
+
   <!-- 
     Defining the "HasPackageAndPublishMenuAddedByProject" property here allows the Solution 
     Explorer "Package and Publish" context menu entry to be enabled for this project even if 

--- a/dev/Templates/Source/ProjectTemplates/Desktop/CSharp/UnitTestApp/ProjectTemplate.csproj
+++ b/dev/Templates/Source/ProjectTemplates/Desktop/CSharp/UnitTestApp/ProjectTemplate.csproj
@@ -6,8 +6,8 @@
     <RootNamespace>$safeprojectname$</RootNamespace>
     <ApplicationManifest>app.manifest</ApplicationManifest>
     <Platforms>x86;x64;ARM64</Platforms>
-    <RuntimeIdentifiers>win-x86;win-x64;win-arm64</RuntimeIdentifiers>
-    <PublishProfile>win-$(Platform).pubxml</PublishProfile>
+    <RuntimeIdentifier Condition="'$(RuntimeIdentifier)' == ''">win-$([System.Runtime.InteropServices.RuntimeInformation]::ProcessArchitecture.ToString().ToLowerInvariant())</RuntimeIdentifier>
+    <PublishProfile Condition="Exists('Properties\PublishProfiles\win-$(Platform).pubxml')">win-$(Platform).pubxml</PublishProfile>
     <UseWinUI>true</UseWinUI>
     <WinUIDSKReferences>false</WinUIDSKReferences>
     <EnableMsixTooling>true</EnableMsixTooling>


### PR DESCRIPTION
## Summary

1. **Make `dotnet run` works out of box on the WinUI templates** — wire the new
   [`Microsoft.Windows.SDK.BuildTools.WinApp 0.3.1`](https://www.nuget.org/packages/Microsoft.Windows.SDK.BuildTools.WinApp)
   NuGet package into the four packaged WinUI C# templates so users get
   loose-layout package identity + AUMID launch out of the box.
2. **Modernize the agent instructions** — `Agents.md` and the
   `instructions/*.instructions.md` files now teach AI agents to use the
   public `winapp` CLI (winappCli 0.3) instead of hand-rolled
   `Add-AppxPackage -Register` / `MakeAppx` / `SignTool` invocations.
3. **Update README**
4. Extra fixes of errors in existing templates.

## Quick start

```powershell
dotnet new winui -n MyApp
cd MyApp

# dotnet build
dotnet run
```

## Extra fixes

Below are extra fixes and their manual test steps:
1. unit test
```
dotnet new winui utApp
cd utApp
dotnet run
```
after fix: successful launch, no error.

2. winui-dialog
```
dotnet new winui -n DialogHost
cd DialogHost
dotnet new winui-dialog -n MyConfirmDialog --project DialogHost.csproj
```

(manually) add a button to demo the new dialog item

in MainPage.xaml:
```xml
    <Grid>
        <Button x:Name="ShowDialogButton"
                Content="Show dialog"
                Click="ShowDialogButton_Click"
                HorizontalAlignment="Center"
                VerticalAlignment="Center" />
    </Grid>
```

in MainPage.xaml.cs:
```cs
using Microsoft.UI.Xaml;

    private async void ShowDialogButton_Click(object sender, RoutedEventArgs e)
    {
        var dialog = new MyConfirmDialog
        {
            XamlRoot = this.XamlRoot,
        };
        await dialog.ShowAsync();
    }
```

run
```powershell
dotnet run
```
after fix: successful launch, no error.
clicking the button shows the new dialog item.


3. winui-templatedcontrol
```
dotnet new winui -n TCdemo
cd TCdemo
dotnet new winui-templatedcontrol -n MyBadge --project TCdemo.csproj
```
after fix: item created with Generic.xaml:
```
|- MyBadge.cs
|- Themes/
        |- Generic.xaml
```

Note: When running `dotnet new winui-templatedcontrol -n <item name> --project <project name>.csproj`, if the Themes/Generic.xaml file already exists, the creation will be blocked with an error as below:

`dotnet new winui-templatedcontrol -n MyBadge2 --project test1.csproj`
```diff
- Creating this template will make changes to existing files:
-  Overwrite   ./Themes/Generic.xaml

- To create the template anyway, run the command with '--force' option:
```


This issue can be resolved via flag `-I false` or `--IncludeDefaultStyle false`, who skips creating the Generic.xaml file. Here is an example command:
```
dotnet new winui-templatedcontrol -n MyBadge2 --project TCdemo.csproj -I false
```

The error message is generated by the dotnet template engine, it cannot be modified from the template side. 
So we're adding hint to use `-I false` in comments of the generated code.

4. winui-resw
After fix: the "Resources" string in output *.resw file won't be replaced by brutal force.

5. winui-tabview
Fix the caption button overlap.

After fix 5:
<img width="1858" height="1171" alt="image" src="https://github.com/user-attachments/assets/5f154788-b565-4e1f-9d2c-b528e167bd89" />

Before fix 5:
<img width="1895" height="378" alt="image" src="https://github.com/user-attachments/assets/b4667086-e261-447f-ba37-9e854477d63f" />


