### PR TITLE
Fix #6452: dotnet new winui-mvvm now creates Properties\PublishProfiles\

### DIFF
--- a/dev/Templates/Source/ProjectTemplates/Desktop/CSharp/MvvmApp/Properties/PublishProfiles/win-arm64.pubxml
+++ b/dev/Templates/Source/ProjectTemplates/Desktop/CSharp/MvvmApp/Properties/PublishProfiles/win-arm64.pubxml
@@ -1,0 +1,14 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<!--
+https://go.microsoft.com/fwlink/?LinkID=208121.
+-->
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <PublishProtocol>FileSystem</PublishProtocol>
+    <Platform>ARM64</Platform>
+    <RuntimeIdentifier>win-arm64</RuntimeIdentifier>
+    <PublishDir>bin\$(Configuration)\$(TargetFramework)\$(RuntimeIdentifier)\publish\</PublishDir>
+    <SelfContained>true</SelfContained>
+    <PublishSingleFile>False</PublishSingleFile>
+  </PropertyGroup>
+</Project>

--- a/dev/Templates/Source/ProjectTemplates/Desktop/CSharp/MvvmApp/Properties/PublishProfiles/win-x64.pubxml
+++ b/dev/Templates/Source/ProjectTemplates/Desktop/CSharp/MvvmApp/Properties/PublishProfiles/win-x64.pubxml
@@ -1,0 +1,14 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<!--
+https://go.microsoft.com/fwlink/?LinkID=208121.
+-->
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <PublishProtocol>FileSystem</PublishProtocol>
+    <Platform>x64</Platform>
+    <RuntimeIdentifier>win-x64</RuntimeIdentifier>
+    <PublishDir>bin\$(Configuration)\$(TargetFramework)\$(RuntimeIdentifier)\publish\</PublishDir>
+    <SelfContained>true</SelfContained>
+    <PublishSingleFile>False</PublishSingleFile>
+  </PropertyGroup>
+</Project>

--- a/dev/Templates/Source/ProjectTemplates/Desktop/CSharp/MvvmApp/Properties/PublishProfiles/win-x86.pubxml
+++ b/dev/Templates/Source/ProjectTemplates/Desktop/CSharp/MvvmApp/Properties/PublishProfiles/win-x86.pubxml
@@ -1,0 +1,14 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<!--
+https://go.microsoft.com/fwlink/?LinkID=208121.
+-->
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <PublishProtocol>FileSystem</PublishProtocol>
+    <Platform>x86</Platform>
+    <RuntimeIdentifier>win-x86</RuntimeIdentifier>
+    <PublishDir>bin\$(Configuration)\$(TargetFramework)\$(RuntimeIdentifier)\publish\</PublishDir>
+    <SelfContained>true</SelfContained>
+    <PublishSingleFile>False</PublishSingleFile>
+  </PropertyGroup>
+</Project>


### PR DESCRIPTION
This is a fix for 
- #6452 

Adding the pubxml files.

## Verification

```powershell
dotnet pack dev/Templates/Dotnet/WinAppSdk.CSharp.DotnetNewTemplates.csproj -c Release -o localpackages
# nupkg now contains:
#   content/winui.mvvmapp/Properties/PublishProfiles/win-arm64.pubxml
#   content/winui.mvvmapp/Properties/PublishProfiles/win-x64.pubxml
#   content/winui.mvvmapp/Properties/PublishProfiles/win-x86.pubxml

dotnet new install ./localpackages/Microsoft.WindowsAppSDK.WinUI.CSharp.Templates.<version>.nupkg
dotnet new winui-mvvm -n TestMvvm
# TestMvvm/Properties/PublishProfiles/ now exists with the 3 .pubxml files.
```

