### PR TITLE
Fix app notifications IsSupported method to always return true

### DIFF
--- a/dev/AppNotifications/AppNotificationManager.cpp
+++ b/dev/AppNotifications/AppNotificationManager.cpp
@@ -104,7 +104,7 @@ namespace winrt::Microsoft::Windows::AppNotifications::implementation
 
     bool AppNotificationManager::IsSupported()
     {
-        static bool isSupported{ !Security::IntegrityLevel::IsElevated() };
+        static bool isSupported = true;
         return isSupported;
     }
 

--- a/dev/AppNotifications/AppNotificationManager.cpp
+++ b/dev/AppNotifications/AppNotificationManager.cpp
@@ -427,14 +427,20 @@ namespace winrt::Microsoft::Windows::AppNotifications::implementation
         {
             return;
         }
-
+        bool isCallingPreviewSupported = false;  
+        try  
+        {  
+            isCallingPreviewSupported = winrt::AppNotificationConferencingConfig::IsCallingPreviewSupported();  
+        }  
+        catch(...) {}  
+  
         auto logTelemetry{ AppNotificationTelemetry::Show::Start(
             g_telemetryHelper,
             m_appId,
             notification.Payload(),
             notification.Tag(),
             notification.Group(),
-            winrt::AppNotificationConferencingConfig::IsCallingPreviewSupported()) };
+            isCallingPreviewSupported) };
 
         THROW_HR_IF(WPN_E_NOTIFICATION_POSTED, notification.Id() != 0);
 


### PR DESCRIPTION
Fix app notifications are not supported when app is running with administrator privileges (elevated). It should work in the elevated mode.

A microsoft employee must use /azp run to validate using the pipelines below.

WARNING:
Comments made by azure-pipelines bot maybe inaccurate.
Please see pipeline link to verify that the build is being ran.

For status checks on the main branch, please use TransportPackage-Foundation-PR
(https://microsoft.visualstudio.com/ProjectReunion/_build?definitionId=81063&_a=summary)
and run the build against your PR branch with the default parameters.
