### PR TITLE
Automate Patch and Revision versions using Azure DevOps Variable Libr…

### DIFF
--- a/build/AzurePipelinesTemplates/WindowsAppSDK-PackTransportPackage-Stage.yml
+++ b/build/AzurePipelinesTemplates/WindowsAppSDK-PackTransportPackage-Stage.yml
@@ -14,6 +14,18 @@ parameters:
 - name: "BuildMockWindowsAppSDK"
   type: boolean
   default: true
+- name: PrOrNightly
+  displayName: "PR or Nightly"
+  type: string
+  default: ''
+- name: BuildType
+  displayName: "Build Type"
+  type: string
+  default: 'experimental'
+- name: RunUpdateLibraryJob
+  displayName: "Run the Update Library Variable Group Job"
+  type: boolean
+  default: false
 
 stages:
 - stage: Pack
@@ -168,18 +180,9 @@ stages:
         targetType: 'inline'
         script: |
           $buildType = '$(channel)'
-          $majorMinorPatchRev = '$(MajorVersion).$(MinorVersion).22'
-          
-          if ($env:ComponentType)
-          {
-            Write-Host "componentType " $env:ComponentType
-            $majorMinorPatchRev = $majorMinorPatchRev + $env:ComponentType
-          }
-          
-          $version = $majorMinorPatchRev + '-' + $buildType
 
-          # If using release versioning, drop the version suffix, which includes a tag & build stamp.
-          # This should only be done when prepping final release packages.
+          # All builds (PR, Nightly, Official) use Library-based versioning
+          $majorMinorPatch = '$(MajorVersion).$(FoundationMinorVersionResolved).$(FoundationPatchVersionResolved)'
 
           if ('${{ parameters.IsOfficial }}' -eq 'true')
           {
@@ -203,8 +206,37 @@ stages:
             {
               $formattedTag = '-' + $versionTag
             }
+
+            # For stable official builds with no tag: Major.Minor.Patch
+            # For non-stable official builds: Major.Minor.Patch-tag{Revision}
+            $revision = '$(Revision)'
+            if ($buildType -eq "stable" -and [String]::IsNullOrEmpty($formattedTag))
+            {
+              $version = $majorMinorPatch
+            }
+            elseif (-not [String]::IsNullOrEmpty($revision))
+            {
+              $version = $majorMinorPatch + $formattedTag + $revision
+            }
+            else
+            {
+              $version = $majorMinorPatch + $formattedTag
+            }
+
             Write-Host "Using Release Versioning"
-            $version = $majorMinorPatchRev + $formattedTag
+          }
+          else
+          {
+            # PR/Nightly: Major.Minor.Patch-{NugetBuildTypePrefix}{buildType}{Revision}
+            # Uses Library version but does NOT update it. Distinguished by prefix + revision.
+            $versionTag = '$(NugetBuildTypePrefix)' + $buildType
+            $version = $majorMinorPatch + '-' + $versionTag + '$(Revision)'
+          }
+
+          if ($env:ComponentType)
+          {
+            Write-Host "componentType " $env:ComponentType
+            $version = $version + $env:ComponentType
           }
 
           Write-Host 'Component Package Version: ' $version
@@ -262,3 +294,13 @@ stages:
           nuGetFeedType: 'internal'
           #Note: The project qualifier is always required when using a feed name. Also, do not use organization scoped feeds.
           publishVstsFeed: 'ProjectReunion/Project.Reunion.nuget.internal'
+
+- stage: UpdateFoundationLibrary
+  dependsOn: Pack
+  condition: and(succeeded('Pack'), eq(${{ parameters.RunUpdateLibraryJob }}, true))
+  jobs:
+  - template: WindowsAppSDK-UpdateLibrary-Job.yml
+    parameters:
+      jobName: 'UpdateFoundationLibraryJob'
+      BuildType: ${{ parameters.BuildType }}
+      PrOrNightly: ${{ parameters.PrOrNightly }}

--- a/build/AzurePipelinesTemplates/WindowsAppSDK-UpdateLibrary-Job.yml
+++ b/build/AzurePipelinesTemplates/WindowsAppSDK-UpdateLibrary-Job.yml
@@ -1,0 +1,157 @@
+# This template updates the Azure DevOps Variable Group (Library) for the Open (Foundation) repo
+# after a successful official build. It bumps PatchVersion and Revision variables.
+# This job should only run on official builds (not PR or Nightly).
+
+parameters:
+- name: jobName
+  displayName: "Job Name"
+  type: string
+  default: 'UpdateFoundationLibraryJob'
+- name: BuildType
+  displayName: "Build Type"
+  type: string
+  default: 'stable'
+- name: PrOrNightly
+  displayName: "PR or Nightly"
+  type: string
+  default: ''
+
+jobs:
+- job: ${{ parameters.jobName }}
+  variables:
+    ob_outputDirectory: '$(REPOROOT)\out'
+    ob_artifactBaseName: '${{parameters.jobName}}'
+  pool:
+    type: windows
+  displayName: "Update Foundation Variable Group"
+  steps:
+  - script: |
+      echo MajorVersion                         : $(MajorVersion)
+      echo MinorVersion                         : $(MinorVersion)
+      echo Revision                             : $(Revision)
+      echo FoundationMinorVersionResolved       : $(FoundationMinorVersionResolved)
+      echo FoundationPatchVersionResolved       : $(FoundationPatchVersionResolved)
+      echo FoundationLibraryName                : $(FoundationLibraryName)
+      echo NugetBuildTypePrefix                 : $(NugetBuildTypePrefix)
+    displayName: 'Variables'
+
+  # Create the next Variable Group if it does not already exist so that when we change the Major version,
+  # the next build will already have the variable group available.
+  - task: PowerShell@2
+    displayName: Create Next Variable Group if Necessary
+    env:
+      AZURE_DEVOPS_EXT_PAT: $(System.AccessToken)
+    inputs:
+      targetType: 'inline'
+      script: |
+        $NextMajorVersion = [int]$(MajorVersion) + 1
+        $NextLibraryName = "$NextMajorVersion-Foundation-Versions"
+
+        echo "Next Major Version will be $NextMajorVersion, so next Variable Group will be $NextLibraryName"
+        echo "Checking to see if the next Variable Group exists"
+        $groupExists = az pipelines variable-group list --query "[?name=='$NextLibraryName']" | ConvertFrom-Json
+        if ($groupExists.Count -eq 0)
+        {
+          echo "Creating Variable Group $NextLibraryName"
+          az pipelines variable-group create --name "$NextLibraryName" --description "Variable group for Windows App SDK Foundation Major Version $NextMajorVersion" --authorize --variables FoundationMinorVersion=0 FoundationPatchVersion=0 FoundationPreviewRevision=0 FoundationExperimentalRevision=0
+        }
+        else
+        {
+          echo "Variable Group $NextLibraryName already exists"
+        }
+
+  - task: PowerShell@2
+    condition: and(ne(variables.FoundationMinorVersionResolved, variables.MinorVersion), eq('${{ parameters.PrOrNightly }}', ''))
+    displayName: Update FoundationMinorVersion in Variable Group
+    env:
+      AZURE_DEVOPS_EXT_PAT: $(System.AccessToken)
+    inputs:
+      targetType: 'inline'
+      script: |
+        echo "Updating Foundation Minor Version variable in Variable Group"
+        $group_id = $(az pipelines variable-group list -p $(System.TeamProject) --group-name $(FoundationLibraryName) --query '[0].id' -o json)
+        az pipelines variable-group variable update --group-id $group_id --name FoundationMinorVersion --value $(MinorVersion)
+
+  - task: PowerShell@2
+    condition: eq('${{ parameters.PrOrNightly }}', '')
+    displayName: Update PreviewRevision in Variable Group
+    env:
+      AZURE_DEVOPS_EXT_PAT: $(System.AccessToken)
+    inputs:
+      targetType: 'inline'
+      script: |
+        echo "Determining if we need to update FoundationPreviewRevision variable in Variable Group"
+        $NextPreviewRevision = [int]$(FoundationPreviewRevisionResolved)
+        if ("${{ parameters.BuildType }}" -eq 'preview')
+        {
+          $NextPreviewRevision = $NextPreviewRevision + 1
+        }
+
+        if ($NextPreviewRevision -ne '$(FoundationPreviewRevision)')
+        {
+          echo "Updating FoundationPreviewRevision variable in Variable Group to $NextPreviewRevision"
+          $group_id = $(az pipelines variable-group list -p $(System.TeamProject) --group-name $(FoundationLibraryName) --query '[0].id' -o json)
+          az pipelines variable-group variable update --group-id $group_id --name FoundationPreviewRevision --value $NextPreviewRevision
+        }
+        else
+        {
+          echo "No update needed for FoundationPreviewRevision variable in Variable Group"
+        }
+
+  - task: PowerShell@2
+    condition: eq('${{ parameters.PrOrNightly }}', '')
+    displayName: Update ExperimentalRevision in Variable Group
+    env:
+      AZURE_DEVOPS_EXT_PAT: $(System.AccessToken)
+    inputs:
+      targetType: 'inline'
+      script: |
+        echo "Determining if we need to update FoundationExperimentalRevision variable in Variable Group"
+        $NextExperimentalRevision = [int]$(FoundationExperimentalRevisionResolved)
+        if ("${{ parameters.BuildType }}" -eq "experimental")
+        {
+          $NextExperimentalRevision = $NextExperimentalRevision + 1
+        }
+
+        if ($NextExperimentalRevision -ne '$(FoundationExperimentalRevision)')
+        {
+          echo "Updating FoundationExperimentalRevision variable in Variable Group to $NextExperimentalRevision"
+          $group_id = $(az pipelines variable-group list -p $(System.TeamProject) --group-name $(FoundationLibraryName) --query '[0].id' -o json)
+          az pipelines variable-group variable update --group-id $group_id --name FoundationExperimentalRevision --value $NextExperimentalRevision
+        }
+        else
+        {
+          echo "No update needed for FoundationExperimentalRevision variable in Variable Group"
+        }
+
+  - task: PowerShell@2
+    condition: eq('${{ parameters.PrOrNightly }}', '')
+    displayName: Update FoundationPatchVersion in Variable Group
+    env:
+      AZURE_DEVOPS_EXT_PAT: $(System.AccessToken)
+    inputs:
+      targetType: 'inline'
+      script: |
+        echo "Determining if we need to update FoundationPatchVersion variable in Variable Group"
+        $NextPatchVersion = "$(FoundationPatchVersionResolved)"
+
+        # Bump patch on stable official builds (when NugetBuildTypePrefix is empty, meaning not PR/Nightly)
+        if (("${{ parameters.BuildType }}" -eq "stable") -And ('$(NugetBuildTypePrefix)' -eq ''))
+        {
+          $NextPatchVersion = [int]$NextPatchVersion + 1
+        }
+        elseif ((($(FoundationMinorVersionResolved) -ne 0) -Or ($(FoundationPatchVersionResolved) -ne 0)) -And ('$(NugetBuildTypePrefix)' -eq ''))
+        {
+          $NextPatchVersion = [int]$NextPatchVersion + 1
+        }
+
+        if ($NextPatchVersion -ne '$(FoundationPatchVersion)')
+        {
+          echo "Updating FoundationPatchVersion variable in Variable Group to $NextPatchVersion"
+          $group_id = $(az pipelines variable-group list -p $(System.TeamProject) --group-name $(FoundationLibraryName) --query '[0].id' -o json)
+          az pipelines variable-group variable update --group-id $group_id --name FoundationPatchVersion --value $NextPatchVersion
+        }
+        else
+        {
+          echo "No update needed for FoundationPatchVersion variable in Variable Group"
+        }

--- a/build/AzurePipelinesTemplates/WindowsAppSDK-VersionVariables.yml
+++ b/build/AzurePipelinesTemplates/WindowsAppSDK-VersionVariables.yml
@@ -1,0 +1,52 @@
+# This template loads version variables from a per-major-version Azure DevOps Library
+# for the Open (Foundation) repo. It mirrors the pattern from the Aggregator repo's
+# WindowsAppSDK-VersionVariables.yml but uses a separate "Foundation-Versions" library.
+#
+# Variables loaded from the library:
+#   - FoundationMinorVersion: The minor version for Foundation, tracked independently
+#   - FoundationPatchVersion: The patch version, incremented on each official build
+#   - FoundationPreviewRevision: The revision for preview official builds
+#   - FoundationExperimentalRevision: The revision for experimental official builds
+#
+# All builds (PR, Nightly, Official) use the Library-based version. Only official builds
+# update the Library values. PR/Nightly are distinguished by NugetBuildTypePrefix + Revision.
+
+parameters:
+- name: PrOrNightly
+  displayName: "PR or Nightly Identifier"
+  type: string
+  default: ''
+- name: BuildType
+  displayName: "Build Type"
+  type: string
+  default: 'experimental'
+
+variables:
+  - template: AzurePipelinesTemplates\WindowsAppSDK-Versions.yml@WindowsAppSDKVersionConfig
+  - name: FoundationLibraryName
+    value: ${{ format('{0}-Foundation-Versions', variables.MajorVersion)}}
+  - group: ${{ variables.FoundationLibraryName }}
+  - name: FoundationMinorVersionResolved
+    value: $[coalesce(variables['FoundationMinorVersion'], 0)]
+  - name: FoundationPatchVersionResolved
+    value: $[coalesce(variables['FoundationPatchVersion'], 0)]
+  - name: PRNightlyRevision
+    value: $[counter(format('{0}-{1}-{2}-{3}', variables.MajorVersion, variables.FoundationMinorVersionResolved, variables.FoundationPatchVersionResolved, variables.NugetBuildTypePrefix), 1)]
+  - name: FoundationPreviewRevisionResolved
+    value: $[coalesce(variables['FoundationPreviewRevision'], 0)]
+  - name: FoundationExperimentalRevisionResolved
+    value: $[coalesce(variables['FoundationExperimentalRevision'], 0)]
+  - ${{ if ne(parameters.PrOrNightly, '') }}:
+    - name: Revision
+      value: $[variables['PRNightlyRevision']]
+  - ${{ else }}:
+    - ${{ if eq(parameters.BuildType, 'experimental') }}:
+      - name: Revision
+        value: $[variables['FoundationExperimentalRevisionResolved']]
+    - ${{ else }}:
+      - ${{ if eq(parameters.BuildType, 'preview') }}:
+        - name: Revision
+          value: $[variables['FoundationPreviewRevisionResolved']]
+      - ${{ else }}:
+        - name: Revision
+          value: ""

--- a/build/WindowsAppSDK-CommonVariables.yml
+++ b/build/WindowsAppSDK-CommonVariables.yml
@@ -1,3 +1,9 @@
+parameters:
+- name: PrOrNightly
+  displayName: "PR or Nightly Identifier"
+  type: string
+  default: ''
+
 variables:
   _useBuildOutputFromPipeline: $[coalesce(variables.useBuildOutputFromPipeline, variables['System.DefinitionId'] )]
   _useBuildOutputFromBuildId: $[coalesce(variables.useBuildOutputFromBuildId, variables['Build.BuildId'] )]
@@ -9,10 +15,15 @@ variables:
   versionCounter: $[counter(variables['versionDate'], 0)]
   version: $[format('{0}.{1}.{2}-{3}.{4}', variables['MajorVersion'], variables['MinorVersion'], variables['PatchVersion'], variables['versionDate'], variables['versionCounter'])]
   SamplesBranch: "release/2.0-experimental" # Used in the Samples Build Compat Test
+
+  # Extra nuget version variables for version automation
+  ${{ if ne(parameters.PrOrNightly, '') }}:
+    NugetBuildTypePrefix: ${{ format('{0}.', parameters.PrOrNightly) }}
+  ${{ else }}:
+    NugetBuildTypePrefix: ''
   
   #OneBranch Variables
   CDP_DEFINITION_BUILD_COUNT: $[counter('', 0)] # needed for onebranch.pipeline.version task https://aka.ms/obpipelines/versioning
-  system.debug: ${{ parameters.debug }}
   ENABLE_PRS_DELAYSIGN: 1
   ROOT: $(Build.SourcesDirectory)
   REPOROOT: $(Build.SourcesDirectory)

--- a/build/WindowsAppSDK-Foundation-DevTest.yml
+++ b/build/WindowsAppSDK-Foundation-DevTest.yml
@@ -14,8 +14,6 @@
 #                                                                                                                                   #
 #####################################################################################################################################
 
-name: $(version)
-
 # https://aka.ms/obpipelines/triggers
 trigger: none
 
@@ -51,10 +49,17 @@ variables:
 - template: WindowsAppSDK-Foundation-TestConfig.yml@WindowsAppSDKConfig
 - template: AzurePipelinesTemplates\WindowsAppSDK-Versions.yml@WindowsAppSDKVersionConfig
 - template: WindowsAppSDK-CommonVariables.yml
+  parameters:
+    PrOrNightly: 'devtest'
+- template: AzurePipelinesTemplates\WindowsAppSDK-VersionVariables.yml
+  parameters:
+    PrOrNightly: 'devtest'
 - name: maxParallelForBuildSamplesCompatJob_x64
   value: 20
 - name: maxParallelForBuildSamplesCompatJob_arm64
   value: 20
+
+name: $(MajorVersion).$(FoundationMinorVersionResolved).$(FoundationPatchVersionResolved)-$(NugetBuildTypePrefix)$(channel)$(Revision)
 
 resources:
   repositories:

--- a/build/WindowsAppSDK-Foundation-Nightly.yml
+++ b/build/WindowsAppSDK-Foundation-Nightly.yml
@@ -14,8 +14,6 @@
 #                                                                                                                                   #
 #####################################################################################################################################
 
-name: $(version)
-
 # https://aka.ms/obpipelines/triggers
 trigger: none
 
@@ -58,10 +56,17 @@ variables:
 - template: WindowsAppSDK-Foundation-TestConfig.yml@WindowsAppSDKConfig
 - template: AzurePipelinesTemplates\WindowsAppSDK-Versions.yml@WindowsAppSDKVersionConfig
 - template: WindowsAppSDK-CommonVariables.yml
+  parameters:
+    PrOrNightly: 'dev'
+- template: AzurePipelinesTemplates\WindowsAppSDK-VersionVariables.yml
+  parameters:
+    PrOrNightly: 'dev'
 - name: maxParallelForBuildSamplesCompatJob_x64
   value: 20
 - name: maxParallelForBuildSamplesCompatJob_arm64
   value: 20
+
+name: $(MajorVersion).$(FoundationMinorVersionResolved).$(FoundationPatchVersionResolved)-$(NugetBuildTypePrefix)$(channel)$(Revision)
 
 resources:
   repositories:

--- a/build/WindowsAppSDK-Foundation-Official.yml
+++ b/build/WindowsAppSDK-Foundation-Official.yml
@@ -14,8 +14,6 @@
 #                                                                                                                                   #
 #####################################################################################################################################
 
-name: $(version)
-
 # https://aka.ms/obpipelines/triggers
 trigger: none
 
@@ -57,15 +55,35 @@ parameters:
   displayName: "Run WindowsAppSDK-CheckApiChanges stage"
   type: boolean
   default: true
+- name: BuildType
+  displayName: "Build Type"
+  type: string
+  default: 'experimental'
+  values:
+  - 'stable'
+  - 'experimental'
+  - 'preview'
+- name: RunUpdateLibraryJob
+  displayName: "Run the Update Library Variable Group Job"
+  type: boolean
+  default: true
 
 variables:
 - template: WindowsAppSDK-Foundation-TestConfig.yml@WindowsAppSDKConfig
 - template: AzurePipelinesTemplates\WindowsAppSDK-Versions.yml@WindowsAppSDKVersionConfig
 - template: WindowsAppSDK-CommonVariables.yml
+  parameters:
+    PrOrNightly: ''
+- template: AzurePipelinesTemplates\WindowsAppSDK-VersionVariables.yml
+  parameters:
+    PrOrNightly: ''
+    BuildType: ${{ parameters.BuildType }}
 - name: maxParallelForBuildSamplesCompatJob_x64
   value: 20
 - name: maxParallelForBuildSamplesCompatJob_arm64
   value: 20
+
+name: $(MajorVersion).$(FoundationMinorVersionResolved).$(FoundationPatchVersionResolved)-$(NugetBuildTypePrefix)$(channel)$(Revision)
 
 resources:
   repositories:
@@ -177,6 +195,9 @@ extends:
         SignOutput: ${{ parameters.SignOutput }}
         PublishPackage: true
         IsOfficial: true
+        PrOrNightly: ''
+        BuildType: ${{ parameters.BuildType }}
+        RunUpdateLibraryJob: ${{ parameters.RunUpdateLibraryJob }}
 
     - ${{ if eq( parameters.CheckApiChanges, true ) }}:
       - template: AzurePipelinesTemplates\WindowsAppSDK-CheckApiChanges-Stage.yml@self

--- a/build/WindowsAppSDK-Foundation-PR.yml
+++ b/build/WindowsAppSDK-Foundation-PR.yml
@@ -14,8 +14,6 @@
 #                                                                                                                                   #
 #####################################################################################################################################
 
-name: $(version)
-
 # https://aka.ms/obpipelines/triggers
 trigger: none
 
@@ -41,10 +39,17 @@ variables:
 - template: WindowsAppSDK-Foundation-TestConfig.yml@WindowsAppSDKConfig
 - template: AzurePipelinesTemplates\WindowsAppSDK-Versions.yml@WindowsAppSDKVersionConfig
 - template: WindowsAppSDK-CommonVariables.yml
+  parameters:
+    PrOrNightly: 'ci'
+- template: AzurePipelinesTemplates\WindowsAppSDK-VersionVariables.yml
+  parameters:
+    PrOrNightly: 'ci'
 - name: maxParallelForBuildSamplesCompatJob_x64
   value: 20
 - name: maxParallelForBuildSamplesCompatJob_arm64
   value: 20
+
+name: $(MajorVersion).$(FoundationMinorVersionResolved).$(FoundationPatchVersionResolved)-$(NugetBuildTypePrefix)$(channel)$(Revision)
 
 resources:
   repositories:


### PR DESCRIPTION
…ary (#6462)

* Automate Patch and Revision versions using Azure DevOps Variable Library

Add version automation to the Open (Foundation) repo, mirroring the pattern from the Aggregator repo. Uses a separate '{MajorVersion}-Foundation-Versions' Library to track PatchVersion and Revision across builds.

- Add WindowsAppSDK-VersionVariables.yml to load version vars from Library
- Add WindowsAppSDK-UpdateLibrary-Job.yml to bump versions after official builds
- Update Official/PR/Nightly pipelines to include version templates
- Update PackTransportPackage to use Library-based versioning for official builds
- Patch only bumps on official builds (not PR or Nightly)



* Remove the system.debug, since parameters.debug is empty

* Change name of pipeline run

* Respond to Agne 1

* Revert the change to depending on Publish

---------

A microsoft employee must use /azp run to validate using the pipelines below.

WARNING:
Comments made by azure-pipelines bot maybe inaccurate.
Please see pipeline link to verify that the build is being ran.

For status checks on the main branch, please use TransportPackage-Foundation-PR
(https://microsoft.visualstudio.com/ProjectReunion/_build?definitionId=81063&_a=summary)
and run the build against your PR branch with the default parameters.
