### PR TITLE
Use IsPackagedProcess() for package detection in PRI fallback

### DIFF
--- a/dev/MRTCore/mrt/Microsoft.Windows.ApplicationModel.Resources/src/Helper.cpp
+++ b/dev/MRTCore/mrt/Microsoft.Windows.ApplicationModel.Resources/src/Helper.cpp
@@ -3,6 +3,7 @@
 
 #include "pch.h"
 #include "frameworkudk\ResourceManager.h"
+#include <AppModel.Identity.IsPackagedProcess.h>
 
 bool IsResourceNotFound(HRESULT hr)
 {
@@ -83,7 +84,7 @@ HRESULT GetDefaultPriFile(winrt::hstring& filePath)
 
     // GetDefaultPriFileForCurrentPackage will not handle the new case where
     // resources.pri is in the parent folder. 
-    bool isPackaged = (hr != HRESULT_FROM_WIN32(APPMODEL_ERROR_NO_PACKAGE));
+    bool isPackaged = AppModel::Identity::IsPackagedProcess();
     hr = GetDefaultPriFileForCurentModule(isPackaged, filePath);
 
     // Sparse-packaged apps have identity but deploy PRI files as loose files; fall back to unpackaged discovery which also searches for "[modulename].pri".


### PR DESCRIPTION
Use `AppModel::Identity::IsPackagedProcess()` instead of inferring packaged state from `GetDefaultPriFileForCurrentPackage`'s HRESULT. The old check `hr != HRESULT_FROM_WIN32(APPMODEL_ERROR_NO_PACKAGE)` silently treats other errors as packaged.