### PR TITLE
Add missing AppIcon.ico entry to C# SingleProjectPackagedApp and Wapproj vstemplates

### DIFF
--- a/dev/Templates/Source/ProjectTemplates/Desktop/CSharp/PackagedApp/BlankApp/WinUI.Desktop.Cs.BlankApp.vstemplate
+++ b/dev/Templates/Source/ProjectTemplates/Desktop/CSharp/PackagedApp/BlankApp/WinUI.Desktop.Cs.BlankApp.vstemplate
@@ -34,6 +34,7 @@
       <ProjectItem ReplaceParameters="true" TargetFileName="App.xaml.cs">App.xaml.cs</ProjectItem>
       <ProjectItem ReplaceParameters="true" TargetFileName="MainWindow.xaml">MainWindow.xaml</ProjectItem>
       <ProjectItem ReplaceParameters="true" TargetFileName="MainWindow.xaml.cs">MainWindow.xaml.cs</ProjectItem>
+      <ProjectItem ReplaceParameters="false" TargetFileName="AppIcon.ico">AppIcon.ico</ProjectItem>
     </Project>      
     <CustomParameters>
       <CustomParameter Name="$NuGetPackages$" Value="Microsoft.WindowsAppSDK;Microsoft.Windows.SDK.BuildTools"/>

--- a/dev/Templates/Source/ProjectTemplates/Desktop/CSharp/SingleProjectPackagedApp/WinUI.Desktop.Cs.SingleProjectPackagedApp.vstemplate
+++ b/dev/Templates/Source/ProjectTemplates/Desktop/CSharp/SingleProjectPackagedApp/WinUI.Desktop.Cs.SingleProjectPackagedApp.vstemplate
@@ -49,6 +49,7 @@
         <ProjectItem ReplaceParameters="false" TargetFileName="Square44x44Logo.scale-200.png">Square44x44Logo.scale-200.png</ProjectItem>
         <ProjectItem ReplaceParameters="false" TargetFileName="Square44x44Logo.targetsize-24_altform-unplated.png">Square44x44Logo.targetsize-24_altform-unplated.png</ProjectItem>
         <ProjectItem ReplaceParameters="false" TargetFileName="Square44x44Logo.targetsize-48_altform-lightunplated.png">Square44x44Logo.targetsize-48_altform-lightunplated.png</ProjectItem>
+        <ProjectItem ReplaceParameters="false" TargetFileName="AppIcon.ico">AppIcon.ico</ProjectItem>
         <ProjectItem ReplaceParameters="false" TargetFileName="StoreLogo.png">StoreLogo.png</ProjectItem>
         <ProjectItem ReplaceParameters="false" TargetFileName="Wide310x150Logo.scale-200.png">Wide310x150Logo.scale-200.png</ProjectItem>
       </Folder>


### PR DESCRIPTION
The .vstemplate was missing the AppIcon.ico ProjectItem in its Assets folder, so Visual Studio never copied the icon into new projects created from this template, causing APPX0702 build errors. Verified locally.

A microsoft employee must use /azp run to validate using the pipelines below.

WARNING:
Comments made by azure-pipelines bot maybe inaccurate.
Please see pipeline link to verify that the build is being ran.

For status checks on the main branch, please use TransportPackage-Foundation-PR
(https://microsoft.visualstudio.com/ProjectReunion/_build?definitionId=81063&_a=summary)
and run the build against your PR branch with the default parameters.
