### PR TITLE
Fix UniversalBGTask crash and gracefully handle CoCreateInstance failures

### DIFF
--- a/dev/WindowsAppRuntime_UniversalBGTaskDLL/Task.cpp
+++ b/dev/WindowsAppRuntime_UniversalBGTaskDLL/Task.cpp
@@ -20,9 +20,45 @@ namespace winrt::Microsoft::Windows::ApplicationModel::Background::UniversalBGTa
         ApplicationDataContainer localSettings = ApplicationData::Current().LocalSettings();
         auto values = localSettings.Values();
         auto lookupobj = values.Lookup(lookupStr);
+
+        // LocalSettings.Lookup returns S_OK with a null IInspectable when the key is missing.
+        // Treat this as an orphaned OS task registration: log and unregister so the broker
+        // stops re-firing it. Returning cleanly is preferred over throwing because thrown
+        // exceptions are treated as transient by the broker and would be retried indefinitely.
+        if (!lookupobj)
+        {
+            LOG_HR_MSG(
+                HRESULT_FROM_WIN32(ERROR_NOT_FOUND),
+                "UniversalBGTask: no CLSID stored in LocalSettings for TaskId='%ls'. Unregistering orphaned task.",
+                lookupStr.c_str());
+            try
+            {
+                taskInstance.Task().Unregister(true);
+            }
+            CATCH_LOG_MSG("UniversalBGTask: failed to unregister orphaned task TaskId='%ls'.", lookupStr.c_str());
+            return;
+        }
+
         winrt::guid comClsId = winrt::unbox_value<winrt::guid>(lookupobj);
 
-        THROW_IF_FAILED(CoCreateInstance(comClsId, nullptr, CLSCTX_LOCAL_SERVER, winrt::guid_of<winrt::Windows::ApplicationModel::Background::IBackgroundTask>(), winrt::put_abi(m_bgTask)));
+        // CoCreateInstance can fail when the COM class isn't registered, the stored CLSID is
+        // GUID_NULL, or the impl doesn't expose IBackgroundTask. Log the HR with the CLSID
+        // for diagnostics and return; do not unregister, since the failure may be transient.
+        wchar_t comClsIdStr[40]{};
+        ::StringFromGUID2(comClsId, comClsIdStr, ARRAYSIZE(comClsIdStr));
+        HRESULT coCreateHr = CoCreateInstance(comClsId, nullptr, CLSCTX_LOCAL_SERVER,
+            winrt::guid_of<winrt::Windows::ApplicationModel::Background::IBackgroundTask>(),
+            winrt::put_abi(m_bgTask));
+        if (FAILED(coCreateHr))
+        {
+            LOG_HR_MSG(
+                coCreateHr,
+                "UniversalBGTask: CoCreateInstance failed for CLSID=%ls referenced by TaskId='%ls'.",
+                comClsIdStr,
+                lookupStr.c_str());
+            return;
+        }
+
         m_bgTask.Run(taskInstance);
     }
 }


### PR DESCRIPTION
## Issue

`UniversalBGTask::Task::Run` could crash `backgroundTaskHost.exe` in two scenarios:

1. When `LocalSettings` has no entry for the task's `TaskId`, `ApplicationDataContainerSettings::Lookup` returns `S_OK` with a null `IInspectable`. The subsequent `unbox_value<winrt::guid>` then throws `hresult_no_interface`, and because the broker treats the failure as transient it re-fires the trigger forever.
2. When `CoCreateInstance` fails (e.g. the COM class isn't registered against the package), the existing `THROW_IF_FAILED` provided no diagnostic context.

## Fix

- If `LocalSettings.Lookup` returns null, log via `wil` and `Unregister` the orphaned OS task so the broker stops re-firing it.
- If `CoCreateInstance` fails, log the HR with the CLSID and TaskId and return cleanly. The registration is left in place so the broker can retry on the next trigger in case the failure is transient.

## PR Checklist

- [x] Closes #5870 
- [x] Tests added/passed
- [x] Documentation updated
- [x] If checked, please file a Pull Request on [Microsoft Docs](https://github.com/MicrosoftDocs/winrt-api) and check it in below
- [x] Contains [NO breaking changes](https://github.com/microsoft/WindowsAppSDK/blob/main/docs/Coding-Guidelines/breaking-changes.md)
