### PR TITLE
Add 1.8.9 runtime compatibility enums

### DIFF
--- a/dev/RuntimeCompatibilityOptions/RuntimeCompatibilityOptions.idl
+++ b/dev/RuntimeCompatibilityOptions/RuntimeCompatibilityOptions.idl
@@ -53,6 +53,10 @@ namespace Microsoft.Windows.ApplicationModel.WindowsAppRuntime
         LanguageModelInsights_GetPartialResultLatency = 62083654,
         UIAffinityReleaseQueue_PauseDispatchDuringCleanup = 62097119,
         PackageDependency_ResolveDynamically = 62052877,
+
+        // 1.8.9
+        ItemTemplateWrapper_RecyclePoolLeak = 61574370,
+        InputPointerSource_TouchUpScrollCrashFix = 62086608,
     };
 
     /// Represents a version of the Windows App Runtime.


### PR DESCRIPTION
A microsoft employee must use /azp run to validate using the pipelines below.

WARNING:
Comments made by azure-pipelines bot maybe inaccurate.
Please see pipeline link to verify that the build is being ran.

For status checks on the main branch, please use TransportPackage-Foundation-PR
(https://microsoft.visualstudio.com/ProjectReunion/_build?definitionId=81063&_a=summary)
and run the build against your PR branch with the default parameters.