### PR TITLE
update IXP

### DIFF
--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -27,25 +27,25 @@
     -->
 <Dependencies>
   <ProductDependencies>
-    <Dependency Name="Microsoft.FrameworkUdk" Version="2.0.0-experimental-27200.1019.260506-1335.2">
+    <Dependency Name="Microsoft.FrameworkUdk" Version="2.0.0-experimental-27200.1023.260525-0800.2">
       <Uri>https://dev.azure.com/microsoft/LiftedIXP/_git/DCPP</Uri>
-      <Sha>44e735101652d482db7e1d31ec1c7d2a0ad02ba6</Sha>
+      <Sha>bcefb53ef31cde2d4d7e97760db1970335047aed</Sha>
     </Dependency>
     <Dependency Name="Microsoft.WindowsAppSDK.AppLicensingInternal.TransportPackage" Version="2.0.0-experimental.20260403.0">
       <Uri>https://dev.azure.com/microsoft/ProjectReunion/_git/WindowsAppSDKClosed</Uri>
       <Sha>4c1df0de1a0025847b63017d0eefd6dc89d685f3</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.ProjectReunion.InteractiveExperiences.TransportPackage" Version="2.0.0-experimental-27200.1019.260506-1335.2">
+    <Dependency Name="Microsoft.ProjectReunion.InteractiveExperiences.TransportPackage" Version="2.0.0-experimental-27200.1023.260525-0800.2">
       <Uri>https://dev.azure.com/microsoft/LiftedIXP/_git/DCPP</Uri>
-      <Sha>44e735101652d482db7e1d31ec1c7d2a0ad02ba6</Sha>
+      <Sha>bcefb53ef31cde2d4d7e97760db1970335047aed</Sha>
     </Dependency>
     <Dependency Name="Microsoft.WindowsAppSDK.Base" Version="2.0.5-experimental2">
       <Uri>https://dev.azure.com/microsoft/ProjectReunion/_git/WindowsAppSDKAggregator</Uri>
       <Sha>6f349c49ec4dfe60d424d12b3ab1091c06a1428f</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.WindowsAppSDK.InteractiveExperiences" Version="2.0.14-experimental">
+    <Dependency Name="Microsoft.WindowsAppSDK.InteractiveExperiences" Version="2.0.14-experimental-Rolling.20260525.3">
       <Uri>https://dev.azure.com/microsoft/LiftedIXP/_git/DCPP</Uri>
-      <Sha>44e735101652d482db7e1d31ec1c7d2a0ad02ba6</Sha>
+      <Sha>bcefb53ef31cde2d4d7e97760db1970335047aed</Sha>
     </Dependency>
   </ProductDependencies>
   <ToolsetDependencies>


### PR DESCRIPTION
Manual IXP dependency update on release/2.0-experimental.

DCPP SHA: bcefb53ef31cde2d4d7e97760db1970335047aed

- Microsoft.FrameworkUdk: 2.0.0-experimental-27200.1019.260506-1335.2 -> 2.0.0-experimental-27200.1023.260525-0800.2
- Microsoft.ProjectReunion.InteractiveExperiences.TransportPackage: 2.0.0-experimental-27200.1019.260506-1335.2 -> 2.0.0-experimental-27200.1023.260525-0800.2
- Microsoft.WindowsAppSDK.InteractiveExperiences: 2.0.14-experimental -> 2.0.14-experimental-Rolling.20260525.3