### PR TITLE
[2.0-stable] Bump Foundation patch version to 23

### DIFF
--- a/build/AzurePipelinesTemplates/WindowsAppSDK-PackTransportPackage-Stage.yml
+++ b/build/AzurePipelinesTemplates/WindowsAppSDK-PackTransportPackage-Stage.yml
@@ -168,7 +168,7 @@ stages:
         targetType: 'inline'
         script: |
           $buildType = '$(channel)'
-          $majorMinorPatchRev = '$(MajorVersion).$(MinorVersion).21'
+          $majorMinorPatchRev = '$(MajorVersion).$(MinorVersion).23'
           
           if ($env:ComponentType)
           {


### PR DESCRIPTION
Bumps the Foundation patch version from `21` to `23`.

Currently-published Foundation packages on nuget.org are:
- `Microsoft.WindowsAppSDK.Foundation 2.0.21` (stable, matches current branch HEAD)
- `Microsoft.WindowsAppSDK.Foundation 2.0.22-experimental`

Without this bump, the next `release/2.0-stable` build would re-publish `2.0.21` and collide with the already-shipped package. Skipping to `23` clears the experimental too.

This is a manual bump because the patch-version automation (#6486) has not yet landed on `release/2.0-stable`.

Needed for the WinAppSDK 2.2.0 RC.