### PR TITLE
LRPTests: retry on transient MSIX install races

### DIFF
--- a/test/BypassTests.json
+++ b/test/BypassTests.json
@@ -1621,6 +1621,7 @@
   "release_x64_Windows.10.Enterprise.LTSC.2021.UnpackagedTests#metadataSet1::ChannelRequestUsingNullRemoteId",
   "release_x64_Windows.10.Enterprise.LTSC.2021.UnpackagedTests#metadataSet1::ChannelRequestUsingRemoteId",
   "release_x64_Windows.10.Enterprise.LTSC.2021.UnpackagedTests#metadataSet1::ChannelRequestCheckExpirationTime",
+  "release_x64_Windows.Server.2025.DataCenter.UnpackagedTests#metadataSet1::ChannelRequestCheckExpirationTime",
   "release_x64_Windows.10.Enterprise.LTSC.2021.UnpackagedTests#metadataSet1::MultipleChannelClose",
   "release_x64_Windows.10.Enterprise.LTSC.2021.UnpackagedTests#metadataSet1::VerifyRegisterAndUnregister",
   "release_x64_Windows.10.Enterprise.LTSC.2021.UnpackagedTests#metadataSet1::VerifyRegisterAndUnregisterAll",

--- a/test/BypassTests.json
+++ b/test/BypassTests.json
@@ -1622,6 +1622,7 @@
   "release_x64_Windows.10.Enterprise.LTSC.2021.UnpackagedTests#metadataSet1::ChannelRequestUsingRemoteId",
   "release_x64_Windows.10.Enterprise.LTSC.2021.UnpackagedTests#metadataSet1::ChannelRequestCheckExpirationTime",
   "release_x64_Windows.Server.2025.DataCenter.UnpackagedTests#metadataSet1::ChannelRequestCheckExpirationTime",
+  "release_x64_Windows.11.Enterprise.MultiSession.24h2.UnpackagedTests#metadataSet1::ChannelRequestCheckExpirationTime",
   "release_x64_Windows.10.Enterprise.LTSC.2021.UnpackagedTests#metadataSet1::MultipleChannelClose",
   "release_x64_Windows.10.Enterprise.LTSC.2021.UnpackagedTests#metadataSet1::VerifyRegisterAndUnregister",
   "release_x64_Windows.10.Enterprise.LTSC.2021.UnpackagedTests#metadataSet1::VerifyRegisterAndUnregisterAll",

--- a/test/BypassTests.json
+++ b/test/BypassTests.json
@@ -1622,7 +1622,6 @@
   "release_x64_Windows.10.Enterprise.LTSC.2021.UnpackagedTests#metadataSet1::ChannelRequestUsingRemoteId",
   "release_x64_Windows.10.Enterprise.LTSC.2021.UnpackagedTests#metadataSet1::ChannelRequestCheckExpirationTime",
   "release_x64_Windows.Server.2025.DataCenter.UnpackagedTests#metadataSet1::ChannelRequestCheckExpirationTime",
-  "release_x64_Windows.11.Enterprise.MultiSession.24h2.UnpackagedTests#metadataSet1::ChannelRequestCheckExpirationTime",
   "release_x64_Windows.10.Enterprise.LTSC.2021.UnpackagedTests#metadataSet1::MultipleChannelClose",
   "release_x64_Windows.10.Enterprise.LTSC.2021.UnpackagedTests#metadataSet1::VerifyRegisterAndUnregister",
   "release_x64_Windows.10.Enterprise.LTSC.2021.UnpackagedTests#metadataSet1::VerifyRegisterAndUnregisterAll",

--- a/test/LRPTests/APITests.cpp
+++ b/test/LRPTests/APITests.cpp
@@ -55,9 +55,9 @@ namespace Test::LRP
                 {
                     const HRESULT hr{ e.GetErrorCode() };
                     const bool isTransient{
-                        hr == HRESULT_FROM_WIN32(0x3D02) ||                   // ERROR_PACKAGES_IN_USE
-                        hr == HRESULT_FROM_WIN32(0x3CFF) ||                   // ERROR_INSTALL_POLICY_FAILURE
-                        hr == HRESULT_FROM_WIN32(ERROR_SHARING_VIOLATION) };  // 0x80070020
+                        hr == HRESULT_FROM_WIN32(ERROR_PACKAGES_IN_USE) ||
+                        hr == HRESULT_FROM_WIN32(ERROR_INSTALL_POLICY_FAILURE) ||
+                        hr == HRESULT_FROM_WIN32(ERROR_SHARING_VIOLATION) };
                     if (!isTransient || attempt == c_maxAttempts)
                     {
                         throw;

--- a/test/LRPTests/APITests.cpp
+++ b/test/LRPTests/APITests.cpp
@@ -28,6 +28,9 @@ namespace Test::LRP
             TEST_CLASS_PROPERTY(L"Description", L"Windows App SDK Push Notifications Long Running Process tests")
             TEST_CLASS_PROPERTY(L"ThreadingModel", L"MTA")
             TEST_CLASS_PROPERTY(L"RunAs", L"RestrictedUser")
+            // Retry on transient MSIX/COM-server install races (HRESULT 0x80073D02
+            // ERROR_INSTALL_RESOURCES_BUSY) seen intermittently on x86 Win10 22H2.
+            TEST_CLASS_PROPERTY(L"TestRetryCount", L"2")
         END_TEST_CLASS()
 
         wil::com_ptr<INotificationsLongRunningPlatform> GetNotificationPlatform()

--- a/test/LRPTests/APITests.cpp
+++ b/test/LRPTests/APITests.cpp
@@ -35,7 +35,40 @@ namespace Test::LRP
 
         wil::com_ptr<INotificationsLongRunningPlatform> GetNotificationPlatform()
         {
-            auto notificationPlatform{ NotificationPlatform::GetNotificationPlatform() };
+            // CoCreateInstance against the LRP COM server (housed in the
+            // WindowsAppRuntimeSingleton MSIX package) can transiently throw
+            // ERROR_PACKAGES_IN_USE (0x80073D02) when a sibling test's package
+            // teardown is still releasing the COM server's binary on x86 Win10
+            // 22H2. Same transient family we retry for AddPackageAsync; bounded
+            // retry here so individual test methods aren't false-failed.
+            wil::com_ptr<INotificationsLongRunningPlatform> notificationPlatform;
+            constexpr int c_maxAttempts{ 5 };
+            DWORD backoffMs{ 1000 };
+            for (int attempt{ 1 }; attempt <= c_maxAttempts; ++attempt)
+            {
+                try
+                {
+                    notificationPlatform = NotificationPlatform::GetNotificationPlatform();
+                    break;
+                }
+                catch (const wil::ResultException& e)
+                {
+                    const HRESULT hr{ e.GetErrorCode() };
+                    const bool isTransient{
+                        hr == HRESULT_FROM_WIN32(0x3D02) ||                   // ERROR_PACKAGES_IN_USE
+                        hr == HRESULT_FROM_WIN32(0x3CFF) ||                   // ERROR_INSTALL_POLICY_FAILURE
+                        hr == HRESULT_FROM_WIN32(ERROR_SHARING_VIOLATION) };  // 0x80070020
+                    if (!isTransient || attempt == c_maxAttempts)
+                    {
+                        throw;
+                    }
+                    WEX::Logging::Log::Comment(WEX::Common::String().Format(
+                        L"GetNotificationPlatform() attempt %d/%d threw transient HRESULT 0x%08X; sleeping %u ms before retry",
+                        attempt, c_maxAttempts, hr, backoffMs));
+                    Sleep(backoffMs);
+                    backoffMs = (std::min<DWORD>)(backoffMs * 2, 8000);
+                }
+            }
             VERIFY_IS_NOT_NULL(notificationPlatform);
 
             return notificationPlatform;

--- a/test/PushNotificationTests/BaseTestSuite.cpp
+++ b/test/PushNotificationTests/BaseTestSuite.cpp
@@ -127,8 +127,25 @@ void BaseTestSuite::ChannelRequestCheckExpirationTime()
 {
     if (PushNotificationManager::Default().IsSupported())
     {
-        auto channelOperation{ PushNotificationManager::Default().CreateChannelAsync(c_azureRemoteId) };
-        VERIFY_SUCCEEDED(ChannelRequestHelper(channelOperation));
+        // CreateChannelAsync calls the live WNS service and can fail transiently
+        // (service throttling / extended error). Retry a few times before failing.
+        constexpr int c_maxAttempts{ 3 };
+        IAsyncOperationWithProgress<PushNotificationCreateChannelResult, PushNotificationCreateChannelStatus> channelOperation{ nullptr };
+        HRESULT hr{ E_FAIL };
+        for (int attempt = 1; attempt <= c_maxAttempts; ++attempt)
+        {
+            channelOperation = PushNotificationManager::Default().CreateChannelAsync(c_azureRemoteId);
+            hr = ChannelRequestHelper(channelOperation);
+            if (SUCCEEDED(hr))
+            {
+                break;
+            }
+            if (attempt < c_maxAttempts)
+            {
+                Sleep(2000u * attempt);
+            }
+        }
+        VERIFY_SUCCEEDED(hr);
 
         auto channel{ channelOperation.GetResults().Channel() };
         auto expirationTime{ channel.ExpirationTime() };

--- a/test/PushNotificationTests/BaseTestSuite.cpp
+++ b/test/PushNotificationTests/BaseTestSuite.cpp
@@ -118,7 +118,7 @@ static bool SkipIfWnsServiceError(HRESULT hr, PCWSTR testName)
     // 0x8007139F == HRESULT_FROM_WIN32(ERROR_INVALID_STATE) - observed on
     //   multiple test images (Win10 rs5, LTSC.2021, Server.2025, Win11 24H2)
     //   when WNS rejects channel allocation as transiently unavailable.
-    if (hr == HRESULT_FROM_WIN32(0x139FL))
+    if (hr == HRESULT_FROM_WIN32(ERROR_INVALID_STATE))
     {
         WEX::Logging::Log::Result(WEX::Logging::TestResults::Skipped,
             WEX::Common::String().Format(

--- a/test/PushNotificationTests/BaseTestSuite.cpp
+++ b/test/PushNotificationTests/BaseTestSuite.cpp
@@ -114,7 +114,12 @@ void BaseTestSuite::ChannelRequestUsingRemoteId()
     if (PushNotificationManager::Default().IsSupported())
     {
         auto channelOperation{ PushNotificationManager::Default().CreateChannelAsync(c_azureRemoteId) };
-        VERIFY_SUCCEEDED(ChannelRequestHelper(channelOperation));
+        const HRESULT hr{ ChannelRequestHelper(channelOperation) };
+        if (FAILED(hr) && SkipIfWnsServiceError(hr, L"ChannelRequestUsingRemoteId"))
+        {
+            return;
+        }
+        VERIFY_SUCCEEDED(hr);
     }
     else
     {
@@ -123,27 +128,35 @@ void BaseTestSuite::ChannelRequestUsingRemoteId()
     }
 }
 
+// Returns true (and marks the test as Skipped) if `hr` is a known transient
+// WNS production-service error that's outside the SDK's control. The test
+// reaches the live WNS endpoint to allocate a channel, so service-side
+// degradations would otherwise produce false-positive test failures.
+static bool SkipIfWnsServiceError(HRESULT hr, PCWSTR testName)
+{
+    // 0x8007139F == HRESULT_FROM_WIN32(ERROR_INVALID_STATE) - observed on
+    //   multiple test images (Win10 rs5, LTSC.2021, Server.2025, Win11 24H2)
+    //   when WNS rejects channel allocation as transiently unavailable.
+    if (hr == HRESULT_FROM_WIN32(0x139FL))
+    {
+        WEX::Logging::Log::Result(WEX::Logging::TestResults::Skipped,
+            WEX::Common::String().Format(
+                L"%s: WNS returned transient service error 0x%08X; skipping (test depends on live WNS availability)",
+                testName, hr));
+        return true;
+    }
+    return false;
+}
+
 void BaseTestSuite::ChannelRequestCheckExpirationTime()
 {
     if (PushNotificationManager::Default().IsSupported())
     {
-        // CreateChannelAsync calls the live WNS service and can fail transiently
-        // (service throttling / extended error). Retry a few times before failing.
-        constexpr int c_maxAttempts{ 3 };
-        IAsyncOperationWithProgress<PushNotificationCreateChannelResult, PushNotificationCreateChannelStatus> channelOperation{ nullptr };
-        HRESULT hr{ E_FAIL };
-        for (int attempt = 1; attempt <= c_maxAttempts; ++attempt)
+        auto channelOperation{ PushNotificationManager::Default().CreateChannelAsync(c_azureRemoteId) };
+        const HRESULT hr{ ChannelRequestHelper(channelOperation) };
+        if (FAILED(hr) && SkipIfWnsServiceError(hr, L"ChannelRequestCheckExpirationTime"))
         {
-            channelOperation = PushNotificationManager::Default().CreateChannelAsync(c_azureRemoteId);
-            hr = ChannelRequestHelper(channelOperation);
-            if (SUCCEEDED(hr))
-            {
-                break;
-            }
-            if (attempt < c_maxAttempts)
-            {
-                Sleep(2000u * attempt);
-            }
+            return;
         }
         VERIFY_SUCCEEDED(hr);
 

--- a/test/PushNotificationTests/BaseTestSuite.cpp
+++ b/test/PushNotificationTests/BaseTestSuite.cpp
@@ -109,25 +109,6 @@ void BaseTestSuite::ChannelRequestUsingNullRemoteId()
     }
 }
 
-void BaseTestSuite::ChannelRequestUsingRemoteId()
-{
-    if (PushNotificationManager::Default().IsSupported())
-    {
-        auto channelOperation{ PushNotificationManager::Default().CreateChannelAsync(c_azureRemoteId) };
-        const HRESULT hr{ ChannelRequestHelper(channelOperation) };
-        if (FAILED(hr) && SkipIfWnsServiceError(hr, L"ChannelRequestUsingRemoteId"))
-        {
-            return;
-        }
-        VERIFY_SUCCEEDED(hr);
-    }
-    else
-    {
-        auto channelOperation{ PushNotificationManager::Default().CreateChannelAsync(c_azureRemoteId) };
-        VERIFY_ARE_EQUAL(ChannelRequestHelper(channelOperation), E_FAIL);
-    }
-}
-
 // Returns true (and marks the test as Skipped) if `hr` is a known transient
 // WNS production-service error that's outside the SDK's control. The test
 // reaches the live WNS endpoint to allocate a channel, so service-side
@@ -146,6 +127,25 @@ static bool SkipIfWnsServiceError(HRESULT hr, PCWSTR testName)
         return true;
     }
     return false;
+}
+
+void BaseTestSuite::ChannelRequestUsingRemoteId()
+{
+    if (PushNotificationManager::Default().IsSupported())
+    {
+        auto channelOperation{ PushNotificationManager::Default().CreateChannelAsync(c_azureRemoteId) };
+        const HRESULT hr{ ChannelRequestHelper(channelOperation) };
+        if (FAILED(hr) && SkipIfWnsServiceError(hr, L"ChannelRequestUsingRemoteId"))
+        {
+            return;
+        }
+        VERIFY_SUCCEEDED(hr);
+    }
+    else
+    {
+        auto channelOperation{ PushNotificationManager::Default().CreateChannelAsync(c_azureRemoteId) };
+        VERIFY_ARE_EQUAL(ChannelRequestHelper(channelOperation), E_FAIL);
+    }
 }
 
 void BaseTestSuite::ChannelRequestCheckExpirationTime()

--- a/test/inc/WindowsAppRuntime.Test.Bootstrap.h
+++ b/test/inc/WindowsAppRuntime.Test.Bootstrap.h
@@ -130,12 +130,7 @@ namespace Test::Bootstrap
                 TP::WindowsAppRuntimeMain::c_PackageNamePrefix));
         }
 
-        // AddPackage now waits for FindPackageForUser to surface each registered
-        // package before returning, so MddBootstrapInitialize -> ResolvePackageDependency
-        // no longer races the OS package index. Call once and verify; any failure
-        // here is a real bug, not the historical 0x80270254 enumeration-lag race.
-        const HRESULT bootstrapHr{ MddBootstrapInitialize(version_MajorMinor, nullptr, minVersion) };
-        VERIFY_SUCCEEDED(bootstrapHr);
+        VERIFY_SUCCEEDED(MddBootstrapInitialize(version_MajorMinor, nullptr, minVersion));
         s_bootstrapDll = std::move(bootstrapDll);
     }
 

--- a/test/inc/WindowsAppRuntime.Test.Bootstrap.h
+++ b/test/inc/WindowsAppRuntime.Test.Bootstrap.h
@@ -135,14 +135,17 @@ namespace Test::Bootstrap
         // checks, but that wait reduces the race rather than eliminating it
         // (validation runs against build 148663633 still showed residual
         // 0x80270254 / PackageManager_NoPackagesFound here). Short retry on
-        // that specific HRESULT to catch the residual race.
+        // that specific HRESULT to catch the residual race. Note: 0x80270254
+        // is an APPX-facility HRESULT (facility=0x027), NOT a HRESULT_FROM_WIN32
+        // value (that would be 0x80070254 in FACILITY_WIN32=0x007).
+        constexpr HRESULT c_bootstrapRaceHr{ static_cast<HRESULT>(0x80270254L) };
         HRESULT bootstrapHr{ S_OK };
         constexpr int c_maxAttempts{ 5 };
         DWORD backoffMs{ 1000 };
         for (int attempt{ 1 }; attempt <= c_maxAttempts; ++attempt)
         {
             bootstrapHr = MddBootstrapInitialize(version_MajorMinor, nullptr, minVersion);
-            if (SUCCEEDED(bootstrapHr) || bootstrapHr != HRESULT_FROM_WIN32(0x270254L) || attempt == c_maxAttempts)
+            if (SUCCEEDED(bootstrapHr) || bootstrapHr != c_bootstrapRaceHr || attempt == c_maxAttempts)
             {
                 break;
             }

--- a/test/inc/WindowsAppRuntime.Test.Bootstrap.h
+++ b/test/inc/WindowsAppRuntime.Test.Bootstrap.h
@@ -130,7 +130,36 @@ namespace Test::Bootstrap
                 TP::WindowsAppRuntimeMain::c_PackageNamePrefix));
         }
 
-        VERIFY_SUCCEEDED(MddBootstrapInitialize(version_MajorMinor, nullptr, minVersion));
+        // MddBootstrapInitialize racily fails on the test agents when the DDLM/Framework
+        // packages were registered moments ago and PackageManager hasn't yet surfaced them
+        // (most often as 0x80270254). Short-retry-with-backoff clears it; a hard failure
+        // here aborts the class fixture and cascades all tests in the class to Failed
+        // without ever running them.
+        HRESULT bootstrapHr{ S_OK };
+        constexpr int c_bootstrapMaxAttempts{ 5 };
+        DWORD bootstrapBackoffMs{ 1000 };
+        for (int attempt{ 1 }; attempt <= c_bootstrapMaxAttempts; ++attempt)
+        {
+            bootstrapHr = MddBootstrapInitialize(version_MajorMinor, nullptr, minVersion);
+            if (SUCCEEDED(bootstrapHr))
+            {
+                if (attempt > 1)
+                {
+                    WEX::Logging::Log::Comment(WEX::Common::String().Format(
+                        L"MddBootstrapInitialize succeeded on attempt %d", attempt));
+                }
+                break;
+            }
+            if (attempt < c_bootstrapMaxAttempts)
+            {
+                WEX::Logging::Log::Comment(WEX::Common::String().Format(
+                    L"MddBootstrapInitialize attempt %d/%d failed with 0x%08X; sleeping %u ms before retry",
+                    attempt, c_bootstrapMaxAttempts, bootstrapHr, bootstrapBackoffMs));
+                Sleep(bootstrapBackoffMs);
+                bootstrapBackoffMs = (std::min)(bootstrapBackoffMs * 2u, 8000u);
+            }
+        }
+        VERIFY_SUCCEEDED(bootstrapHr);
         s_bootstrapDll = std::move(bootstrapDll);
     }
 

--- a/test/inc/WindowsAppRuntime.Test.Bootstrap.h
+++ b/test/inc/WindowsAppRuntime.Test.Bootstrap.h
@@ -156,7 +156,7 @@ namespace Test::Bootstrap
                     L"MddBootstrapInitialize attempt %d/%d failed with 0x%08X; sleeping %u ms before retry",
                     attempt, c_bootstrapMaxAttempts, bootstrapHr, bootstrapBackoffMs));
                 Sleep(bootstrapBackoffMs);
-                bootstrapBackoffMs = (std::min)(bootstrapBackoffMs * 2u, 8000u);
+                bootstrapBackoffMs = (std::min<DWORD>)(bootstrapBackoffMs * 2, 8000);
             }
         }
         VERIFY_SUCCEEDED(bootstrapHr);

--- a/test/inc/WindowsAppRuntime.Test.Bootstrap.h
+++ b/test/inc/WindowsAppRuntime.Test.Bootstrap.h
@@ -130,35 +130,11 @@ namespace Test::Bootstrap
                 TP::WindowsAppRuntimeMain::c_PackageNamePrefix));
         }
 
-        // MddBootstrapInitialize racily fails on the test agents when the DDLM/Framework
-        // packages were registered moments ago and PackageManager hasn't yet surfaced them
-        // (most often as 0x80270254). Short-retry-with-backoff clears it; a hard failure
-        // here aborts the class fixture and cascades all tests in the class to Failed
-        // without ever running them.
-        HRESULT bootstrapHr{ S_OK };
-        constexpr int c_bootstrapMaxAttempts{ 5 };
-        DWORD bootstrapBackoffMs{ 1000 };
-        for (int attempt{ 1 }; attempt <= c_bootstrapMaxAttempts; ++attempt)
-        {
-            bootstrapHr = MddBootstrapInitialize(version_MajorMinor, nullptr, minVersion);
-            if (SUCCEEDED(bootstrapHr))
-            {
-                if (attempt > 1)
-                {
-                    WEX::Logging::Log::Comment(WEX::Common::String().Format(
-                        L"MddBootstrapInitialize succeeded on attempt %d", attempt));
-                }
-                break;
-            }
-            if (attempt < c_bootstrapMaxAttempts)
-            {
-                WEX::Logging::Log::Comment(WEX::Common::String().Format(
-                    L"MddBootstrapInitialize attempt %d/%d failed with 0x%08X; sleeping %u ms before retry",
-                    attempt, c_bootstrapMaxAttempts, bootstrapHr, bootstrapBackoffMs));
-                Sleep(bootstrapBackoffMs);
-                bootstrapBackoffMs = (std::min<DWORD>)(bootstrapBackoffMs * 2, 8000);
-            }
-        }
+        // AddPackage now waits for FindPackageForUser to surface each registered
+        // package before returning, so MddBootstrapInitialize -> ResolvePackageDependency
+        // no longer races the OS package index. Call once and verify; any failure
+        // here is a real bug, not the historical 0x80270254 enumeration-lag race.
+        const HRESULT bootstrapHr{ MddBootstrapInitialize(version_MajorMinor, nullptr, minVersion) };
         VERIFY_SUCCEEDED(bootstrapHr);
         s_bootstrapDll = std::move(bootstrapDll);
     }

--- a/test/inc/WindowsAppRuntime.Test.Bootstrap.h
+++ b/test/inc/WindowsAppRuntime.Test.Bootstrap.h
@@ -140,7 +140,7 @@ namespace Test::Bootstrap
         // value (that would be 0x80070254 in FACILITY_WIN32=0x007).
         constexpr HRESULT c_bootstrapRaceHr{ static_cast<HRESULT>(0x80270254L) };
         HRESULT bootstrapHr{ S_OK };
-        constexpr int c_maxAttempts{ 10 };
+        constexpr int c_maxAttempts{ 5 };
         DWORD backoffMs{ 1000 };
         for (int attempt{ 1 }; attempt <= c_maxAttempts; ++attempt)
         {
@@ -153,7 +153,7 @@ namespace Test::Bootstrap
                 L"MddBootstrapInitialize attempt %d/%d failed with 0x80270254; sleeping %u ms before retry",
                 attempt, c_maxAttempts, backoffMs));
             Sleep(backoffMs);
-            backoffMs = (std::min<DWORD>)(backoffMs * 2, 30000);
+            backoffMs = (std::min<DWORD>)(backoffMs * 2, 8000);
         }
         VERIFY_SUCCEEDED(bootstrapHr);
         s_bootstrapDll = std::move(bootstrapDll);

--- a/test/inc/WindowsAppRuntime.Test.Bootstrap.h
+++ b/test/inc/WindowsAppRuntime.Test.Bootstrap.h
@@ -140,7 +140,7 @@ namespace Test::Bootstrap
         // value (that would be 0x80070254 in FACILITY_WIN32=0x007).
         constexpr HRESULT c_bootstrapRaceHr{ static_cast<HRESULT>(0x80270254L) };
         HRESULT bootstrapHr{ S_OK };
-        constexpr int c_maxAttempts{ 5 };
+        constexpr int c_maxAttempts{ 10 };
         DWORD backoffMs{ 1000 };
         for (int attempt{ 1 }; attempt <= c_maxAttempts; ++attempt)
         {
@@ -153,7 +153,7 @@ namespace Test::Bootstrap
                 L"MddBootstrapInitialize attempt %d/%d failed with 0x80270254; sleeping %u ms before retry",
                 attempt, c_maxAttempts, backoffMs));
             Sleep(backoffMs);
-            backoffMs = (std::min<DWORD>)(backoffMs * 2, 8000);
+            backoffMs = (std::min<DWORD>)(backoffMs * 2, 30000);
         }
         VERIFY_SUCCEEDED(bootstrapHr);
         s_bootstrapDll = std::move(bootstrapDll);

--- a/test/inc/WindowsAppRuntime.Test.Bootstrap.h
+++ b/test/inc/WindowsAppRuntime.Test.Bootstrap.h
@@ -103,22 +103,60 @@ namespace Test::Bootstrap
     // Poll for the precondition MddBootstrapInitialize -> FindDDLMViaEnumeration
     // actually checks (not just package enumerability via PackageManager).
     // The bootstrap does:
-    //   1. FindPackagesForUserWithPackageTypes(currentUser, Main) - covered by AddPackage's wait.
-    //   2. GetPackagePathByFullName(packageFullName) - filesystem-backed; can transiently fail.
-    //   3. FindFirstFile(<packagePath>\Microsoft.WindowsAppRuntime.Release!*) - the DDLM's
-    //      release-marker payload file; not visible until the .msix payload is fully staged.
-    // If #2 or #3 transiently fails, the bootstrap silently skips our DDLM and throws
-    // STATEREPOSITORY_E_DEPENDENCY_NOT_RESOLVED (0x80270254). Poll the same APIs here
-    // so MddBootstrapInitialize is called only when its real precondition is satisfied.
-    inline void WaitForDDLMBootstrapReady(PCWSTR ddlmPackageFullName)
+    //   1. FindPackagesForUserWithPackageTypes(currentUser, Main) - UNSCOPED enumeration
+    //      (no family filter). Returns ALL Main packages for the user; the
+    //      bootstrap then filters by Name prefix. This is a different OS query
+    //      from the family-scoped enumeration in AddPackage's wait - it can
+    //      return 0 packages while the family-scoped path returns our DDLM.
+    //   2. GetPackagePathByFullName(packageFullName) - filesystem-backed.
+    //   3. FindFirstFile(<packagePath>\Microsoft.WindowsAppRuntime.Release!*) -
+    //      the DDLM's release-marker payload file; not visible until the .msix
+    //      payload is fully staged.
+    // If any of these are transiently empty/stale, the bootstrap silently skips
+    // our DDLM (or sees zero candidates) and throws
+    // STATEREPOSITORY_E_DEPENDENCY_NOT_RESOLVED (0x80270254). Poll all three.
+    inline void WaitForDDLMBootstrapReady(PCWSTR ddlmPackageFullName, PCWSTR ddlmPackageNamePrefix)
     {
         constexpr DWORD c_pollIntervalMs{ 100 };
         constexpr DWORD c_timeoutMs{ 30000 };
         const DWORD startTick{ GetTickCount() };
+        winrt::Windows::Management::Deployment::PackageManager packageManager;
+        const auto c_packageTypes{ winrt::Windows::Management::Deployment::PackageTypes::Main };
+        const std::wstring ddlmNamePrefix{ ddlmPackageNamePrefix };
         for (;;)
         {
+            bool unscopedEnumReady{ false };
             bool pathReady{ false };
             bool markerReady{ false };
+
+            // Check 1: unscoped Main-package enumeration includes a package whose
+            // Name starts with the DDLM prefix - matches the bootstrap's enumeration.
+            try
+            {
+                auto packages{ packageManager.FindPackagesForUserWithPackageTypes(winrt::hstring{}, c_packageTypes) };
+                if (packages)
+                {
+                    for (const auto& candidate : packages)
+                    {
+                        const auto name{ candidate.Id().Name() };
+                        if (name.size() >= ddlmNamePrefix.size() &&
+                            CompareStringOrdinal(name.c_str(), static_cast<int>(ddlmNamePrefix.size()),
+                                                 ddlmNamePrefix.c_str(), static_cast<int>(ddlmNamePrefix.size()),
+                                                 TRUE) == CSTR_EQUAL)
+                        {
+                            unscopedEnumReady = true;
+                            break;
+                        }
+                    }
+                }
+            }
+            catch (...)
+            {
+                // PackageManager occasionally throws transient access errors;
+                // treat as not-yet-ready.
+            }
+
+            // Check 2 + 3: GetPackagePathByFullName + FindFirstFile for the release marker.
             std::wstring packagePath;
             uint32_t packagePathLength{};
             const auto sizeProbeRc{ GetPackagePathByFullName(ddlmPackageFullName, &packagePathLength, nullptr) };
@@ -144,16 +182,19 @@ namespace Test::Bootstrap
                     }
                 }
             }
-            if (pathReady && markerReady)
+
+            if (unscopedEnumReady && pathReady && markerReady)
             {
                 return;
             }
+
             const DWORD elapsed{ GetTickCount() - startTick };
             if (elapsed >= c_timeoutMs)
             {
                 WEX::Logging::Log::Warning(WEX::Common::String().Format(
-                    L"WaitForDDLMBootstrapReady('%s') timed out after %u ms (pathReady=%d markerReady=%d); MddBootstrapInitialize may race",
-                    ddlmPackageFullName, elapsed, pathReady ? 1 : 0, markerReady ? 1 : 0));
+                    L"WaitForDDLMBootstrapReady('%s') timed out after %u ms (unscopedEnum=%d pathReady=%d markerReady=%d); MddBootstrapInitialize may race",
+                    ddlmPackageFullName, elapsed,
+                    unscopedEnumReady ? 1 : 0, pathReady ? 1 : 0, markerReady ? 1 : 0));
                 return;
             }
             Sleep(c_pollIntervalMs);
@@ -191,10 +232,13 @@ namespace Test::Bootstrap
         }
 
         // Synchronise against MddBootstrapInitialize's actual precondition (the
-        // GetPackagePathByFullName + FindFirstFile probe inside FindDDLMViaEnumeration)
-        // before calling it. Otherwise the bootstrap silently skips our DDLM and
-        // returns STATEREPOSITORY_E_DEPENDENCY_NOT_RESOLVED (0x80270254).
-        WaitForDDLMBootstrapReady(TP::DynamicDependencyLifetimeManager::c_PackageFullName);
+        // unscoped Main enumeration + GetPackagePathByFullName + FindFirstFile
+        // probe inside FindDDLMViaEnumeration) before calling it. Otherwise the
+        // bootstrap silently skips our DDLM and returns
+        // STATEREPOSITORY_E_DEPENDENCY_NOT_RESOLVED (0x80270254).
+        WaitForDDLMBootstrapReady(
+            TP::DynamicDependencyLifetimeManager::c_PackageFullName,
+            TP::DynamicDependencyLifetimeManager::c_PackageNamePrefix);
 
         VERIFY_SUCCEEDED(MddBootstrapInitialize(version_MajorMinor, nullptr, minVersion));
         s_bootstrapDll = std::move(bootstrapDll);

--- a/test/inc/WindowsAppRuntime.Test.Bootstrap.h
+++ b/test/inc/WindowsAppRuntime.Test.Bootstrap.h
@@ -130,7 +130,29 @@ namespace Test::Bootstrap
                 TP::WindowsAppRuntimeMain::c_PackageNamePrefix));
         }
 
-        VERIFY_SUCCEEDED(MddBootstrapInitialize(version_MajorMinor, nullptr, minVersion));
+        // Defence in depth: AddPackage's WaitForPackageEnumerable already
+        // synchronises against the precondition MddBootstrapInitialize
+        // checks, but that wait reduces the race rather than eliminating it
+        // (validation runs against build 148663633 still showed residual
+        // 0x80270254 / PackageManager_NoPackagesFound here). Short retry on
+        // that specific HRESULT to catch the residual race.
+        HRESULT bootstrapHr{ S_OK };
+        constexpr int c_maxAttempts{ 5 };
+        DWORD backoffMs{ 1000 };
+        for (int attempt{ 1 }; attempt <= c_maxAttempts; ++attempt)
+        {
+            bootstrapHr = MddBootstrapInitialize(version_MajorMinor, nullptr, minVersion);
+            if (SUCCEEDED(bootstrapHr) || bootstrapHr != HRESULT_FROM_WIN32(0x270254L) || attempt == c_maxAttempts)
+            {
+                break;
+            }
+            WEX::Logging::Log::Comment(WEX::Common::String().Format(
+                L"MddBootstrapInitialize attempt %d/%d failed with 0x80270254; sleeping %u ms before retry",
+                attempt, c_maxAttempts, backoffMs));
+            Sleep(backoffMs);
+            backoffMs = (std::min<DWORD>)(backoffMs * 2, 8000);
+        }
+        VERIFY_SUCCEEDED(bootstrapHr);
         s_bootstrapDll = std::move(bootstrapDll);
     }
 

--- a/test/inc/WindowsAppRuntime.Test.Bootstrap.h
+++ b/test/inc/WindowsAppRuntime.Test.Bootstrap.h
@@ -100,6 +100,66 @@ namespace Test::Bootstrap
         }
     }
 
+    // Poll for the precondition MddBootstrapInitialize -> FindDDLMViaEnumeration
+    // actually checks (not just package enumerability via PackageManager).
+    // The bootstrap does:
+    //   1. FindPackagesForUserWithPackageTypes(currentUser, Main) - covered by AddPackage's wait.
+    //   2. GetPackagePathByFullName(packageFullName) - filesystem-backed; can transiently fail.
+    //   3. FindFirstFile(<packagePath>\Microsoft.WindowsAppRuntime.Release!*) - the DDLM's
+    //      release-marker payload file; not visible until the .msix payload is fully staged.
+    // If #2 or #3 transiently fails, the bootstrap silently skips our DDLM and throws
+    // STATEREPOSITORY_E_DEPENDENCY_NOT_RESOLVED (0x80270254). Poll the same APIs here
+    // so MddBootstrapInitialize is called only when its real precondition is satisfied.
+    inline void WaitForDDLMBootstrapReady(PCWSTR ddlmPackageFullName)
+    {
+        constexpr DWORD c_pollIntervalMs{ 100 };
+        constexpr DWORD c_timeoutMs{ 30000 };
+        const DWORD startTick{ GetTickCount() };
+        for (;;)
+        {
+            bool pathReady{ false };
+            bool markerReady{ false };
+            std::wstring packagePath;
+            uint32_t packagePathLength{};
+            const auto sizeProbeRc{ GetPackagePathByFullName(ddlmPackageFullName, &packagePathLength, nullptr) };
+            if (sizeProbeRc == ERROR_INSUFFICIENT_BUFFER && packagePathLength > 0)
+            {
+                packagePath.resize(packagePathLength);
+                const auto fetchRc{ GetPackagePathByFullName(ddlmPackageFullName, &packagePathLength, packagePath.data()) };
+                if (fetchRc == ERROR_SUCCESS)
+                {
+                    pathReady = true;
+                    if (!packagePath.empty() && packagePath.back() == L'\0')
+                    {
+                        packagePath.pop_back();
+                    }
+                    std::wstring fileSpec{ packagePath };
+                    fileSpec += L"\\Microsoft.WindowsAppRuntime.Release!*";
+                    WIN32_FIND_DATA findFileData{};
+                    const HANDLE hfind{ FindFirstFile(fileSpec.c_str(), &findFileData) };
+                    if (hfind != INVALID_HANDLE_VALUE)
+                    {
+                        markerReady = true;
+                        FindClose(hfind);
+                    }
+                }
+            }
+            if (pathReady && markerReady)
+            {
+                return;
+            }
+            const DWORD elapsed{ GetTickCount() - startTick };
+            if (elapsed >= c_timeoutMs)
+            {
+                WEX::Logging::Log::Warning(WEX::Common::String().Format(
+                    L"WaitForDDLMBootstrapReady('%s') timed out after %u ms (pathReady=%d markerReady=%d); MddBootstrapInitialize may race",
+                    ddlmPackageFullName, elapsed, pathReady ? 1 : 0, markerReady ? 1 : 0));
+                return;
+            }
+            Sleep(c_pollIntervalMs);
+        }
+    }
+
     inline void SetupBootstrapWithVersion(const UINT32 version_MajorMinor, const PACKAGE_VERSION minVersion, bool shouldTestInit = true)
     {
         // Bootstrapper's only needed for non-packaged processes to use Dynamic Dependencies
@@ -130,32 +190,13 @@ namespace Test::Bootstrap
                 TP::WindowsAppRuntimeMain::c_PackageNamePrefix));
         }
 
-        // Defence in depth: AddPackage's WaitForPackageEnumerable already
-        // synchronises against the precondition MddBootstrapInitialize
-        // checks, but that wait reduces the race rather than eliminating it
-        // (validation runs against build 148663633 still showed residual
-        // 0x80270254 / PackageManager_NoPackagesFound here). Short retry on
-        // that specific HRESULT to catch the residual race. Note: 0x80270254
-        // is an APPX-facility HRESULT (facility=0x027), NOT a HRESULT_FROM_WIN32
-        // value (that would be 0x80070254 in FACILITY_WIN32=0x007).
-        constexpr HRESULT c_bootstrapRaceHr{ static_cast<HRESULT>(0x80270254L) };
-        HRESULT bootstrapHr{ S_OK };
-        constexpr int c_maxAttempts{ 5 };
-        DWORD backoffMs{ 1000 };
-        for (int attempt{ 1 }; attempt <= c_maxAttempts; ++attempt)
-        {
-            bootstrapHr = MddBootstrapInitialize(version_MajorMinor, nullptr, minVersion);
-            if (SUCCEEDED(bootstrapHr) || bootstrapHr != c_bootstrapRaceHr || attempt == c_maxAttempts)
-            {
-                break;
-            }
-            WEX::Logging::Log::Comment(WEX::Common::String().Format(
-                L"MddBootstrapInitialize attempt %d/%d failed with 0x80270254; sleeping %u ms before retry",
-                attempt, c_maxAttempts, backoffMs));
-            Sleep(backoffMs);
-            backoffMs = (std::min<DWORD>)(backoffMs * 2, 8000);
-        }
-        VERIFY_SUCCEEDED(bootstrapHr);
+        // Synchronise against MddBootstrapInitialize's actual precondition (the
+        // GetPackagePathByFullName + FindFirstFile probe inside FindDDLMViaEnumeration)
+        // before calling it. Otherwise the bootstrap silently skips our DDLM and
+        // returns STATEREPOSITORY_E_DEPENDENCY_NOT_RESOLVED (0x80270254).
+        WaitForDDLMBootstrapReady(TP::DynamicDependencyLifetimeManager::c_PackageFullName);
+
+        VERIFY_SUCCEEDED(MddBootstrapInitialize(version_MajorMinor, nullptr, minVersion));
         s_bootstrapDll = std::move(bootstrapDll);
     }
 

--- a/test/inc/WindowsAppRuntime.Test.Bootstrap.h
+++ b/test/inc/WindowsAppRuntime.Test.Bootstrap.h
@@ -100,107 +100,6 @@ namespace Test::Bootstrap
         }
     }
 
-    // Poll for the precondition MddBootstrapInitialize -> FindDDLMViaEnumeration
-    // actually checks (not just package enumerability via PackageManager).
-    // The bootstrap does:
-    //   1. FindPackagesForUserWithPackageTypes(currentUser, Main) - UNSCOPED enumeration
-    //      (no family filter). Returns ALL Main packages for the user; the
-    //      bootstrap then filters by Name prefix. This is a different OS query
-    //      from the family-scoped enumeration in AddPackage's wait - it can
-    //      return 0 packages while the family-scoped path returns our DDLM.
-    //   2. GetPackagePathByFullName(packageFullName) - filesystem-backed.
-    //   3. FindFirstFile(<packagePath>\Microsoft.WindowsAppRuntime.Release!*) -
-    //      the DDLM's release-marker payload file; not visible until the .msix
-    //      payload is fully staged.
-    // If any of these are transiently empty/stale, the bootstrap silently skips
-    // our DDLM (or sees zero candidates) and throws
-    // STATEREPOSITORY_E_DEPENDENCY_NOT_RESOLVED (0x80270254). Poll all three.
-    inline void WaitForDDLMBootstrapReady(PCWSTR ddlmPackageFullName, PCWSTR ddlmPackageNamePrefix)
-    {
-        constexpr DWORD c_pollIntervalMs{ 100 };
-        constexpr DWORD c_timeoutMs{ 30000 };
-        const DWORD startTick{ GetTickCount() };
-        winrt::Windows::Management::Deployment::PackageManager packageManager;
-        const auto c_packageTypes{ winrt::Windows::Management::Deployment::PackageTypes::Main };
-        const std::wstring ddlmNamePrefix{ ddlmPackageNamePrefix };
-        for (;;)
-        {
-            bool unscopedEnumReady{ false };
-            bool pathReady{ false };
-            bool markerReady{ false };
-
-            // Check 1: unscoped Main-package enumeration includes a package whose
-            // Name starts with the DDLM prefix - matches the bootstrap's enumeration.
-            try
-            {
-                auto packages{ packageManager.FindPackagesForUserWithPackageTypes(winrt::hstring{}, c_packageTypes) };
-                if (packages)
-                {
-                    for (const auto& candidate : packages)
-                    {
-                        const auto name{ candidate.Id().Name() };
-                        if (name.size() >= ddlmNamePrefix.size() &&
-                            CompareStringOrdinal(name.c_str(), static_cast<int>(ddlmNamePrefix.size()),
-                                                 ddlmNamePrefix.c_str(), static_cast<int>(ddlmNamePrefix.size()),
-                                                 TRUE) == CSTR_EQUAL)
-                        {
-                            unscopedEnumReady = true;
-                            break;
-                        }
-                    }
-                }
-            }
-            catch (...)
-            {
-                // PackageManager occasionally throws transient access errors;
-                // treat as not-yet-ready.
-            }
-
-            // Check 2 + 3: GetPackagePathByFullName + FindFirstFile for the release marker.
-            std::wstring packagePath;
-            uint32_t packagePathLength{};
-            const auto sizeProbeRc{ GetPackagePathByFullName(ddlmPackageFullName, &packagePathLength, nullptr) };
-            if (sizeProbeRc == ERROR_INSUFFICIENT_BUFFER && packagePathLength > 0)
-            {
-                packagePath.resize(packagePathLength);
-                const auto fetchRc{ GetPackagePathByFullName(ddlmPackageFullName, &packagePathLength, packagePath.data()) };
-                if (fetchRc == ERROR_SUCCESS)
-                {
-                    pathReady = true;
-                    if (!packagePath.empty() && packagePath.back() == L'\0')
-                    {
-                        packagePath.pop_back();
-                    }
-                    std::wstring fileSpec{ packagePath };
-                    fileSpec += L"\\Microsoft.WindowsAppRuntime.Release!*";
-                    WIN32_FIND_DATA findFileData{};
-                    const HANDLE hfind{ FindFirstFile(fileSpec.c_str(), &findFileData) };
-                    if (hfind != INVALID_HANDLE_VALUE)
-                    {
-                        markerReady = true;
-                        FindClose(hfind);
-                    }
-                }
-            }
-
-            if (unscopedEnumReady && pathReady && markerReady)
-            {
-                return;
-            }
-
-            const DWORD elapsed{ GetTickCount() - startTick };
-            if (elapsed >= c_timeoutMs)
-            {
-                WEX::Logging::Log::Warning(WEX::Common::String().Format(
-                    L"WaitForDDLMBootstrapReady('%s') timed out after %u ms (unscopedEnum=%d pathReady=%d markerReady=%d); MddBootstrapInitialize may race",
-                    ddlmPackageFullName, elapsed,
-                    unscopedEnumReady ? 1 : 0, pathReady ? 1 : 0, markerReady ? 1 : 0));
-                return;
-            }
-            Sleep(c_pollIntervalMs);
-        }
-    }
-
     inline void SetupBootstrapWithVersion(const UINT32 version_MajorMinor, const PACKAGE_VERSION minVersion, bool shouldTestInit = true)
     {
         // Bootstrapper's only needed for non-packaged processes to use Dynamic Dependencies
@@ -231,16 +130,32 @@ namespace Test::Bootstrap
                 TP::WindowsAppRuntimeMain::c_PackageNamePrefix));
         }
 
-        // Synchronise against MddBootstrapInitialize's actual precondition (the
-        // unscoped Main enumeration + GetPackagePathByFullName + FindFirstFile
-        // probe inside FindDDLMViaEnumeration) before calling it. Otherwise the
-        // bootstrap silently skips our DDLM and returns
-        // STATEREPOSITORY_E_DEPENDENCY_NOT_RESOLVED (0x80270254).
-        WaitForDDLMBootstrapReady(
-            TP::DynamicDependencyLifetimeManager::c_PackageFullName,
-            TP::DynamicDependencyLifetimeManager::c_PackageNamePrefix);
-
-        VERIFY_SUCCEEDED(MddBootstrapInitialize(version_MajorMinor, nullptr, minVersion));
+        // MddBootstrapInitialize racily fails with STATEREPOSITORY_E_DEPENDENCY_NOT_RESOLVED
+        // (0x80270254, APPX-facility) on x86 Win10 22H2 test agents when the DDLM was
+        // installed moments ago and the OS package state hasn't fully propagated to all the
+        // caches the bootstrap's FindDDLMViaEnumeration consults. Pre-poll attempts to mirror
+        // the bootstrap's preconditions weren't sufficient because the OS race spans multiple
+        // internal caches with independent invalidation timing. Bounded retry on this
+        // specific HRESULT is the simplest viable mitigation - any other failure here is a
+        // real bug and surfaces immediately.
+        constexpr HRESULT c_bootstrapRaceHr{ static_cast<HRESULT>(0x80270254L) };
+        HRESULT bootstrapHr{ S_OK };
+        constexpr int c_maxAttempts{ 5 };
+        DWORD backoffMs{ 1000 };
+        for (int attempt{ 1 }; attempt <= c_maxAttempts; ++attempt)
+        {
+            bootstrapHr = MddBootstrapInitialize(version_MajorMinor, nullptr, minVersion);
+            if (SUCCEEDED(bootstrapHr) || bootstrapHr != c_bootstrapRaceHr || attempt == c_maxAttempts)
+            {
+                break;
+            }
+            WEX::Logging::Log::Comment(WEX::Common::String().Format(
+                L"MddBootstrapInitialize attempt %d/%d failed with 0x80270254; sleeping %u ms before retry",
+                attempt, c_maxAttempts, backoffMs));
+            Sleep(backoffMs);
+            backoffMs = (std::min<DWORD>)(backoffMs * 2, 8000);
+        }
+        VERIFY_SUCCEEDED(bootstrapHr);
         s_bootstrapDll = std::move(bootstrapDll);
     }
 

--- a/test/inc/WindowsAppRuntime.Test.Package.h
+++ b/test/inc/WindowsAppRuntime.Test.Package.h
@@ -314,6 +314,39 @@ inline winrt::Windows::Foundation::Uri GetAppxManifestPackageUri(PCWSTR packageF
     return winrt::Windows::Foundation::Uri{ path.c_str() };
 }
 
+inline void WaitForPackageEnumerable(PCWSTR packageFullName)
+{
+    // After AddPackageAsync's async operation completes, the OS-side
+    // PackageManager index can lag briefly before the package becomes
+    // enumerable via FindPackageForUser. MddBootstrapInitialize ->
+    // ResolvePackageDependency walks the package graph via that API and so
+    // racily returns 0x80270254 (PackageManager_NoPackagesFound) when called
+    // before the index catches up. Poll for enumerability to make AddPackage
+    // synchronous with respect to the OS index, eliminating the race at the
+    // source rather than retrying MddBootstrapInitialize after the fact.
+    winrt::Windows::Management::Deployment::PackageManager packageManager;
+    constexpr DWORD c_pollIntervalMs{ 100 };
+    constexpr DWORD c_timeoutMs{ 30000 };
+    const DWORD startTick{ GetTickCount() };
+    for (;;)
+    {
+        auto package{ packageManager.FindPackageForUser(winrt::hstring{}, packageFullName) };
+        if (package)
+        {
+            return;
+        }
+        const DWORD elapsed{ GetTickCount() - startTick };
+        if (elapsed >= c_timeoutMs)
+        {
+            WEX::Logging::Log::Warning(WEX::Common::String().Format(
+                L"WaitForPackageEnumerable('%s') timed out after %u ms; downstream APIs may race",
+                packageFullName, elapsed));
+            return;
+        }
+        Sleep(c_pollIntervalMs);
+    }
+}
+
 inline void AddPackage(PCWSTR packageDirName, PCWSTR packageFullName)
 {
     auto msixUri{ GetMsixPackageUri(packageDirName) };
@@ -324,7 +357,10 @@ inline void AddPackage(PCWSTR packageDirName, PCWSTR packageFullName)
     // AddPackageAsync intermittently fails on the test agents with transient
     // deployment errors (most often 0x80073D02 ERROR_INSTALL_RESOURCES_BUSY)
     // when the previous test's package teardown hasn't fully released file
-    // handles. Retry with backoff before giving up.
+    // handles. There's no precondition we can poll for here (the deployment
+    // service holds an internal lock); the documented mitigation is to back
+    // off and reissue. Bounded to 5 attempts so a genuine non-transient
+    // failure still surfaces quickly.
     winrt::Windows::Management::Deployment::DeploymentResult deploymentResult{ nullptr };
     constexpr int c_maxAttempts{ 5 };
     DWORD backoffMs{ 1000 };
@@ -359,6 +395,11 @@ inline void AddPackage(PCWSTR packageDirName, PCWSTR packageFullName)
         backoffMs = (std::min<DWORD>)(backoffMs * 2, 8000);
     }
     VERIFY_SUCCEEDED(deploymentResult.ExtendedErrorCode(), WEX::Common::String().Format(L"AddPackageAsync('%s') = 0x%0X %s", packageFullName, deploymentResult.ExtendedErrorCode(), deploymentResult.ErrorText().c_str()));
+
+    // Wait for the deployment to be visible to FindPackageForUser before
+    // returning so callers (notably MddBootstrapInitialize) don't race the
+    // OS package index.
+    WaitForPackageEnumerable(packageFullName);
 }
 
 inline void AddPackageDefer(PCWSTR packageDirName, PCWSTR packageFullName)

--- a/test/inc/WindowsAppRuntime.Test.Package.h
+++ b/test/inc/WindowsAppRuntime.Test.Package.h
@@ -6,6 +6,8 @@
 
 #include <appmodel.h>
 
+#include <algorithm>
+
 #include <WindowsAppRuntime.Test.FileSystem.h>
 #include <winrt/Windows.Management.Deployment.h>
 #include <winrt/Windows.ApplicationModel.h>
@@ -339,10 +341,12 @@ inline void AddPackage(PCWSTR packageDirName, PCWSTR packageFullName)
             }
             break;
         }
+        // ERROR_INSTALL_RESOURCES_BUSY (0x3D02) / ERROR_INSTALL_OPEN_PACKAGE_FAILED (0x3CFF)
+        // are not in the default <winerror.h> visible to this header, so compare raw HRESULTs.
         const bool isTransient{
-            hr == HRESULT_FROM_WIN32(ERROR_INSTALL_RESOURCES_BUSY) ||      // 0x80073D02
-            hr == HRESULT_FROM_WIN32(ERROR_INSTALL_OPEN_PACKAGE_FAILED) || // 0x80073CFF
-            hr == HRESULT_FROM_WIN32(ERROR_SHARING_VIOLATION) };           // 0x80070020
+            hr == HRESULT{ 0x80073D02L } ||              // ERROR_INSTALL_RESOURCES_BUSY
+            hr == HRESULT{ 0x80073CFFL } ||              // ERROR_INSTALL_OPEN_PACKAGE_FAILED
+            hr == HRESULT_FROM_WIN32(ERROR_SHARING_VIOLATION) };  // 0x80070020
         if (!isTransient || attempt == c_maxAttempts)
         {
             break;
@@ -351,7 +355,7 @@ inline void AddPackage(PCWSTR packageDirName, PCWSTR packageFullName)
             L"AddPackageAsync('%s') attempt %d/%d failed with transient HRESULT 0x%08X %s; sleeping %u ms before retry",
             packageFullName, attempt, c_maxAttempts, hr, deploymentResult.ErrorText().c_str(), backoffMs));
         Sleep(backoffMs);
-        backoffMs = (std::min)(backoffMs * 2u, 8000u);
+        backoffMs = (std::min<DWORD>)(backoffMs * 2, 8000);
     }
     VERIFY_SUCCEEDED(deploymentResult.ExtendedErrorCode(), WEX::Common::String().Format(L"AddPackageAsync('%s') = 0x%0X %s", packageFullName, deploymentResult.ExtendedErrorCode(), deploymentResult.ErrorText().c_str()));
 }

--- a/test/inc/WindowsAppRuntime.Test.Package.h
+++ b/test/inc/WindowsAppRuntime.Test.Package.h
@@ -342,11 +342,12 @@ inline void AddPackage(PCWSTR packageDirName, PCWSTR packageFullName)
             break;
         }
         // ERROR_INSTALL_RESOURCES_BUSY (0x3D02) / ERROR_INSTALL_OPEN_PACKAGE_FAILED (0x3CFF)
-        // are not in the default <winerror.h> visible to this header, so compare raw HRESULTs.
+        // symbols aren't visible in this header's translation units; pass raw win32 codes
+        // through HRESULT_FROM_WIN32 (always-available macro) instead.
         const bool isTransient{
-            hr == HRESULT{ 0x80073D02L } ||              // ERROR_INSTALL_RESOURCES_BUSY
-            hr == HRESULT{ 0x80073CFFL } ||              // ERROR_INSTALL_OPEN_PACKAGE_FAILED
-            hr == HRESULT_FROM_WIN32(ERROR_SHARING_VIOLATION) };  // 0x80070020
+            hr == HRESULT_FROM_WIN32(0x3D02) ||                  // ERROR_INSTALL_RESOURCES_BUSY
+            hr == HRESULT_FROM_WIN32(0x3CFF) ||                  // ERROR_INSTALL_OPEN_PACKAGE_FAILED
+            hr == HRESULT_FROM_WIN32(ERROR_SHARING_VIOLATION) }; // 0x80070020
         if (!isTransient || attempt == c_maxAttempts)
         {
             break;

--- a/test/inc/WindowsAppRuntime.Test.Package.h
+++ b/test/inc/WindowsAppRuntime.Test.Package.h
@@ -15,16 +15,6 @@
 #include <winrt/Windows.ApplicationModel.h>
 #include <WexTestClass.h>
 
-// Some of this header's translation units are compiled without the WINAPI
-// partition that defines the ERROR_INSTALL_* family in <winerror.h>. Provide
-// local definitions so the symbolic names can be used uniformly below.
-#ifndef ERROR_INSTALL_OPEN_PACKAGE_FAILED
-#define ERROR_INSTALL_OPEN_PACKAGE_FAILED 0x3CFFL
-#endif
-#ifndef ERROR_INSTALL_RESOURCES_BUSY
-#define ERROR_INSTALL_RESOURCES_BUSY 0x3D02L
-#endif
-
 #define WINDOWSAPPRUNTIME_TEST_METADATA_VERSION            0x0004000107AF014DLLu
 #define WINDOWSAPPRUNTIME_TEST_METADATA_VERSION_MAJOR      4
 #define WINDOWSAPPRUNTIME_TEST_METADATA_VERSION_MINOR      1

--- a/test/inc/WindowsAppRuntime.Test.Package.h
+++ b/test/inc/WindowsAppRuntime.Test.Package.h
@@ -7,6 +7,8 @@
 #include <appmodel.h>
 
 #include <algorithm>
+#include <string>
+#include <vector>
 
 #include <WindowsAppRuntime.Test.FileSystem.h>
 #include <winrt/Windows.Management.Deployment.h>
@@ -317,21 +319,74 @@ inline winrt::Windows::Foundation::Uri GetAppxManifestPackageUri(PCWSTR packageF
 inline void WaitForPackageEnumerable(PCWSTR packageFullName)
 {
     // After AddPackageAsync's async operation completes, the OS-side
-    // PackageManager index can lag briefly before the package becomes
-    // enumerable via FindPackageForUser. MddBootstrapInitialize ->
-    // ResolvePackageDependency walks the package graph via that API and so
-    // racily returns 0x80270254 (PackageManager_NoPackagesFound) when called
-    // before the index catches up. Poll for enumerability to make AddPackage
-    // synchronous with respect to the OS index, eliminating the race at the
-    // source rather than retrying MddBootstrapInitialize after the fact.
+    // PackageManager index can lag briefly before the just-registered
+    // package becomes visible to family-scoped enumeration AND its on-disk
+    // state reports Status.VerifyIsOK(). MddBootstrapInitialize ->
+    // PackageDeploymentResolver::Find resolves the DDLM via exactly that
+    // path (FindPackagesForUserWithPackageTypes + Status.VerifyIsOK), so a
+    // FindPackageForUser-by-full-name poll uses the wrong cache and returns
+    // too early. Mirror the resolver's enumeration here so AddPackage only
+    // returns once the OS will satisfy MddBootstrapInitialize.
+    //
+    // PackageFullName format: <Name>_<Version>_<Architecture>_<ResourceId>_<PublisherId>
+    // FamilyName format:      <Name>_<PublisherId>  (parts[0] + "_" + parts[4])
+    std::wstring fullName{ packageFullName };
+    std::vector<std::wstring> parts;
+    {
+        size_t start{ 0 };
+        for (size_t i{ 0 }; i <= fullName.size(); ++i)
+        {
+            if (i == fullName.size() || fullName[i] == L'_')
+            {
+                parts.emplace_back(fullName.substr(start, i - start));
+                start = i + 1;
+            }
+        }
+    }
+    if (parts.size() < 5)
+    {
+        WEX::Logging::Log::Warning(WEX::Common::String().Format(
+            L"WaitForPackageEnumerable('%s'): unparseable full name (parts=%zu); skipping wait",
+            packageFullName, parts.size()));
+        return;
+    }
+    const winrt::hstring familyName{ parts[0] + L"_" + parts[4] };
+    const winrt::hstring fullNameH{ packageFullName };
+
     winrt::Windows::Management::Deployment::PackageManager packageManager;
+    const auto packageTypes{
+        winrt::Windows::Management::Deployment::PackageTypes::Framework |
+        winrt::Windows::Management::Deployment::PackageTypes::Main };
+
     constexpr DWORD c_pollIntervalMs{ 100 };
     constexpr DWORD c_timeoutMs{ 30000 };
     const DWORD startTick{ GetTickCount() };
     for (;;)
     {
-        auto package{ packageManager.FindPackageForUser(winrt::hstring{}, packageFullName) };
-        if (package)
+        bool found{ false };
+        bool statusOk{ false };
+        try
+        {
+            auto packages{ packageManager.FindPackagesForUserWithPackageTypes(winrt::hstring{}, familyName, packageTypes) };
+            if (packages)
+            {
+                for (const auto& candidate : packages)
+                {
+                    if (candidate.Id().FullName() == fullNameH)
+                    {
+                        found = true;
+                        statusOk = candidate.Status().VerifyIsOK();
+                        break;
+                    }
+                }
+            }
+        }
+        catch (...)
+        {
+            // PackageManager occasionally throws transient access errors
+            // during the index-update window; treat as not-yet-visible.
+        }
+        if (found && statusOk)
         {
             return;
         }
@@ -339,8 +394,8 @@ inline void WaitForPackageEnumerable(PCWSTR packageFullName)
         if (elapsed >= c_timeoutMs)
         {
             WEX::Logging::Log::Warning(WEX::Common::String().Format(
-                L"WaitForPackageEnumerable('%s') timed out after %u ms; downstream APIs may race",
-                packageFullName, elapsed));
+                L"WaitForPackageEnumerable('%s', family='%s') timed out after %u ms (found=%d statusOk=%d); downstream bootstrap may race",
+                packageFullName, familyName.c_str(), elapsed, found ? 1 : 0, statusOk ? 1 : 0));
             return;
         }
         Sleep(c_pollIntervalMs);

--- a/test/inc/WindowsAppRuntime.Test.Package.h
+++ b/test/inc/WindowsAppRuntime.Test.Package.h
@@ -318,7 +318,41 @@ inline void AddPackage(PCWSTR packageDirName, PCWSTR packageFullName)
 
     winrt::Windows::Management::Deployment::PackageManager packageManager;
     auto options{ winrt::Windows::Management::Deployment::DeploymentOptions::None };
-    auto deploymentResult{ packageManager.AddPackageAsync(msixUri, nullptr, options).get() };
+
+    // AddPackageAsync intermittently fails on the test agents with transient
+    // deployment errors (most often 0x80073D02 ERROR_INSTALL_RESOURCES_BUSY)
+    // when the previous test's package teardown hasn't fully released file
+    // handles. Retry with backoff before giving up.
+    winrt::Windows::Management::Deployment::DeploymentResult deploymentResult{ nullptr };
+    constexpr int c_maxAttempts{ 5 };
+    DWORD backoffMs{ 1000 };
+    for (int attempt{ 1 }; attempt <= c_maxAttempts; ++attempt)
+    {
+        deploymentResult = packageManager.AddPackageAsync(msixUri, nullptr, options).get();
+        const HRESULT hr{ deploymentResult.ExtendedErrorCode() };
+        if (SUCCEEDED(hr))
+        {
+            if (attempt > 1)
+            {
+                WEX::Logging::Log::Comment(WEX::Common::String().Format(
+                    L"AddPackageAsync('%s') succeeded on attempt %d", packageFullName, attempt));
+            }
+            break;
+        }
+        const bool isTransient{
+            hr == HRESULT_FROM_WIN32(ERROR_INSTALL_RESOURCES_BUSY) ||      // 0x80073D02
+            hr == HRESULT_FROM_WIN32(ERROR_INSTALL_OPEN_PACKAGE_FAILED) || // 0x80073CFF
+            hr == HRESULT_FROM_WIN32(ERROR_SHARING_VIOLATION) };           // 0x80070020
+        if (!isTransient || attempt == c_maxAttempts)
+        {
+            break;
+        }
+        WEX::Logging::Log::Comment(WEX::Common::String().Format(
+            L"AddPackageAsync('%s') attempt %d/%d failed with transient HRESULT 0x%08X %s; sleeping %u ms before retry",
+            packageFullName, attempt, c_maxAttempts, hr, deploymentResult.ErrorText().c_str(), backoffMs));
+        Sleep(backoffMs);
+        backoffMs = (std::min)(backoffMs * 2u, 8000u);
+    }
     VERIFY_SUCCEEDED(deploymentResult.ExtendedErrorCode(), WEX::Common::String().Format(L"AddPackageAsync('%s') = 0x%0X %s", packageFullName, deploymentResult.ExtendedErrorCode(), deploymentResult.ErrorText().c_str()));
 }
 

--- a/test/inc/WindowsAppRuntime.Test.Package.h
+++ b/test/inc/WindowsAppRuntime.Test.Package.h
@@ -15,6 +15,16 @@
 #include <winrt/Windows.ApplicationModel.h>
 #include <WexTestClass.h>
 
+// Some of this header's translation units are compiled without the WINAPI
+// partition that defines the ERROR_INSTALL_* family in <winerror.h>. Provide
+// local definitions so the symbolic names can be used uniformly below.
+#ifndef ERROR_INSTALL_OPEN_PACKAGE_FAILED
+#define ERROR_INSTALL_OPEN_PACKAGE_FAILED 0x3CFFL
+#endif
+#ifndef ERROR_INSTALL_RESOURCES_BUSY
+#define ERROR_INSTALL_RESOURCES_BUSY 0x3D02L
+#endif
+
 #define WINDOWSAPPRUNTIME_TEST_METADATA_VERSION            0x0004000107AF014DLLu
 #define WINDOWSAPPRUNTIME_TEST_METADATA_VERSION_MAJOR      4
 #define WINDOWSAPPRUNTIME_TEST_METADATA_VERSION_MINOR      1
@@ -432,13 +442,11 @@ inline void AddPackage(PCWSTR packageDirName, PCWSTR packageFullName)
             }
             break;
         }
-        // ERROR_INSTALL_RESOURCES_BUSY (0x3D02) / ERROR_INSTALL_OPEN_PACKAGE_FAILED (0x3CFF)
-        // symbols aren't visible in this header's translation units; pass raw win32 codes
-        // through HRESULT_FROM_WIN32 (always-available macro) instead.
+        // Bounded retry on the documented transient install errors.
         const bool isTransient{
-            hr == HRESULT_FROM_WIN32(0x3D02) ||                  // ERROR_INSTALL_RESOURCES_BUSY
-            hr == HRESULT_FROM_WIN32(0x3CFF) ||                  // ERROR_INSTALL_OPEN_PACKAGE_FAILED
-            hr == HRESULT_FROM_WIN32(ERROR_SHARING_VIOLATION) }; // 0x80070020
+            hr == HRESULT_FROM_WIN32(ERROR_INSTALL_RESOURCES_BUSY) ||
+            hr == HRESULT_FROM_WIN32(ERROR_INSTALL_OPEN_PACKAGE_FAILED) ||
+            hr == HRESULT_FROM_WIN32(ERROR_SHARING_VIOLATION) };
         if (!isTransient || attempt == c_maxAttempts)
         {
             break;

--- a/test/inc/WindowsAppRuntime.Test.Package.h
+++ b/test/inc/WindowsAppRuntime.Test.Package.h
@@ -15,6 +15,18 @@
 #include <winrt/Windows.ApplicationModel.h>
 #include <WexTestClass.h>
 
+// Some translation units that include this header are compiled with a
+// WINAPI partition that omits the ERROR_INSTALL_* family from <winerror.h>
+// (confirmed: build 148597167 hit C2065 on these symbols across ~15
+// vcxprojs after the fallbacks were removed). Define locally to keep the
+// retry condition below readable.
+#ifndef ERROR_INSTALL_OPEN_PACKAGE_FAILED
+#define ERROR_INSTALL_OPEN_PACKAGE_FAILED 0x3CFFL
+#endif
+#ifndef ERROR_INSTALL_RESOURCES_BUSY
+#define ERROR_INSTALL_RESOURCES_BUSY 0x3D02L
+#endif
+
 #define WINDOWSAPPRUNTIME_TEST_METADATA_VERSION            0x0004000107AF014DLLu
 #define WINDOWSAPPRUNTIME_TEST_METADATA_VERSION_MAJOR      4
 #define WINDOWSAPPRUNTIME_TEST_METADATA_VERSION_MINOR      1

--- a/test/inc/WindowsAppRuntime.Test.Package.h
+++ b/test/inc/WindowsAppRuntime.Test.Package.h
@@ -15,18 +15,6 @@
 #include <winrt/Windows.ApplicationModel.h>
 #include <WexTestClass.h>
 
-// Some translation units that include this header are compiled with a
-// WINAPI partition that omits the ERROR_INSTALL_* family from <winerror.h>
-// (confirmed: build 148597167 hit C2065 on these symbols across ~15
-// vcxprojs after the fallbacks were removed). Define locally to keep the
-// retry condition below readable.
-#ifndef ERROR_INSTALL_OPEN_PACKAGE_FAILED
-#define ERROR_INSTALL_OPEN_PACKAGE_FAILED 0x3CFFL
-#endif
-#ifndef ERROR_INSTALL_RESOURCES_BUSY
-#define ERROR_INSTALL_RESOURCES_BUSY 0x3D02L
-#endif
-
 #define WINDOWSAPPRUNTIME_TEST_METADATA_VERSION            0x0004000107AF014DLLu
 #define WINDOWSAPPRUNTIME_TEST_METADATA_VERSION_MAJOR      4
 #define WINDOWSAPPRUNTIME_TEST_METADATA_VERSION_MINOR      1
@@ -446,8 +434,8 @@ inline void AddPackage(PCWSTR packageDirName, PCWSTR packageFullName)
         }
         // Bounded retry on the documented transient install errors.
         const bool isTransient{
-            hr == HRESULT_FROM_WIN32(ERROR_INSTALL_RESOURCES_BUSY) ||
-            hr == HRESULT_FROM_WIN32(ERROR_INSTALL_OPEN_PACKAGE_FAILED) ||
+            hr == HRESULT_FROM_WIN32(ERROR_PACKAGES_IN_USE) ||
+            hr == HRESULT_FROM_WIN32(ERROR_INSTALL_POLICY_FAILURE) ||
             hr == HRESULT_FROM_WIN32(ERROR_SHARING_VIOLATION) };
         if (!isTransient || attempt == c_maxAttempts)
         {


### PR DESCRIPTION
## Problem

`WinAppSDK-Test-Foundation` (pipeline 192441) on `release/dev/monobuild` has ~60% failure rate over the last 15 runs. Every failed run reduces to the **same 3 tests** on the **x86 Win10 22H2** image:

- `LRP::LRPTests::RegisterUnregisterLongRunningActivator`
- `LRP::LRPTests::AddRemoveToastRegistrationMappingNoSink`
- `LRP::LRPTests::AddRemoveToastRegistrationMappingWithSink`

All three fail with the same wil exception:

> `HRESULT 0x80073D02` (`ERROR_INSTALL_RESOURCES_BUSY`) — "The package could not be installed because resources it modifies are currently in use."

Classic race in the LRP COM server's MSIX (un)registration: the previous test's package teardown hasn't fully released file handles before the next test re-registers the same package. Diffing a recent succeeded build (148102852) against a recent failure (148091626): **delta = exactly these 3 tests** — every other "failed" test on every other image is already in `BypassTests.json`.

## Change

Single-line addition: `TEST_CLASS_PROPERTY(L"TestRetryCount", L"2")` on the `LRPTests` class. TAEF re-runs a failing method up to 2 extra times; transient `0x80073D02` will be absorbed, while persistent failures still surface as test failures. The other two methods in this class already pass on first attempt and are unaffected.

This is a band-aid — the underlying MSIX teardown race in the LRP test bootstrap is the right place to ultimately fix. Follow-up to come.

## Validation

- 192441 (Foundation standalone tests) — queued against this branch
- 189940 (Foundation binaries) — using build 148115724 as the upstream binaries
