### PR TITLE
Set <GenerateProgramFile> to false in UnitTest project template to fix CS0017 when building in Visual Studio

### DIFF
--- a/dev/Templates/Source/ProjectTemplates/Desktop/CSharp/UnitTestApp/ProjectTemplate.csproj
+++ b/dev/Templates/Source/ProjectTemplates/Desktop/CSharp/UnitTestApp/ProjectTemplate.csproj
@@ -13,6 +13,7 @@
     <EnableMsixTooling>true</EnableMsixTooling>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
+    <GenerateProgramFile>false</GenerateProgramFile>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
This is a temporary workaround for CS0017 in the winui-unittest project when built using Visual Studio.

The error is CS0017: Program has more than one entry point defined. Compile with /main to specify the type that contains the entry point.

From my understanding, this error occurs because WinUI apps define their own entry point and if `GenerateProgramFiles` is true, Microsoft.NET.Test.Sdk.Program.cs is auto-generated with its own entry point.

If the [`UseWinUI` property is not intended to automatically disable the Microsoft.NET.Test.Sdk's auto-generated `Microsoft.NET.Test.Sdk.Program.cs` with a second entry point](https://github.com/microsoft/vstest/issues/16071), setting `GenerateProgramFile` to false will do the same thing.

I'm making this PR to unblock other template work. If the targets file changes are made in vstest, I'll remove this later.

Steps to verify:
* Pull down the branch
*  Run  `.\dev\Templates\VSIX\build-local-VSIX-package\build-install-localdev-vsix.ps1`
* Open Visual Studio and select "Create a new project"
* Find the .NET C# WinUI Unit Test template (the one under MVVM, NavigationView, etc.)
* Create a Unit Test project
* Build and run using F5

A microsoft employee must use /azp run to validate using the pipelines below.

WARNING:
Comments made by azure-pipelines bot maybe inaccurate.
Please see pipeline link to verify that the build is being ran.

For status checks on the main branch, please use TransportPackage-Foundation-PR
(https://microsoft.visualstudio.com/ProjectReunion/_build?definitionId=81063&_a=summary)
and run the build against your PR branch with the default parameters.