### PR TITLE
Add ability to specify Windows App SDK version in C# dotnet and VSIX templates

### DIFF
--- a/build/AzurePipelinesTemplates/WindowsAppSDK-BuildVSIX-Steps.yml
+++ b/build/AzurePipelinesTemplates/WindowsAppSDK-BuildVSIX-Steps.yml
@@ -12,9 +12,8 @@ parameters:
   type: boolean
   default: false 
 - name: OptionalVSIXVersion
-  value: "2.0.27"
   type: string
-  default: 'default'
+  default: '2.0.27'
 - name: EnableExperimentalVSIXFeatures
   type: boolean
   default: false

--- a/build/AzurePipelinesTemplates/WindowsAppSDK-BuildVSIX-Steps.yml
+++ b/build/AzurePipelinesTemplates/WindowsAppSDK-BuildVSIX-Steps.yml
@@ -12,8 +12,7 @@ parameters:
   type: boolean
   default: false 
 - name: OptionalVSIXVersion
-  # if blank, the project template will select the version matching the Windows App SDK
-  # nuget. If provided, it should be a 4-part dotted version ('1.2.3.4')
+  value: "2.0.27"
   type: string
   default: 'default'
 - name: EnableExperimentalVSIXFeatures

--- a/build/AzurePipelinesTemplates/WindowsAppSDK-BuildVSIX-Steps.yml
+++ b/build/AzurePipelinesTemplates/WindowsAppSDK-BuildVSIX-Steps.yml
@@ -10,10 +10,13 @@ parameters:
   default: true
 - name: UseCurrentBuild
   type: boolean
-  default: false 
+  default: false
+# To override OptionalVSIXVersion's default, add 
+# OptionalVSIXVersion: 'x.y.z' to the parameters of
+# the stage that calls this template in the aggregator pipeline.
 - name: OptionalVSIXVersion
   type: string
-  default: '2.0.27'
+  default: 'default'
 - name: EnableExperimentalVSIXFeatures
   type: boolean
   default: false

--- a/dev/Templates/Dotnet/Test-DotnetNewTemplates.ps1
+++ b/dev/Templates/Dotnet/Test-DotnetNewTemplates.ps1
@@ -378,6 +378,24 @@ function Test-ItemTemplates {
     Add-Result -Template 'winui (item host)' -Platform $Platform -Step 'build' -Status 'Succeeded' -Path $projectFile
 }
 
+function Assert-CsprojPackageVersion {
+    param(
+        [string]$CsprojPath,
+        [string]$PackageName,
+        [string]$ExpectedVersion
+    )
+
+    [xml]$csproj = Get-Content -Path $CsprojPath
+    $ref = $csproj.Project.ItemGroup.PackageReference |
+        Where-Object { $_.Include -eq $PackageName }
+    if (-not $ref) {
+        throw "PackageReference '$PackageName' not found in '$CsprojPath'"
+    }
+    if ($ref.Version -ne $ExpectedVersion) {
+        throw "PackageReference '$PackageName' has Version='$($ref.Version)' but expected '$ExpectedVersion' in '$CsprojPath'"
+    }
+}
+
 try {
     $repoRoot = (Resolve-Path -Path (Join-Path -Path $PSScriptRoot -ChildPath '..\..\..')).Path
     $templateProject = Join-Path -Path $repoRoot -ChildPath 'dev\Templates\Dotnet\WinAppSdk.CSharp.DotnetNewTemplates.csproj'
@@ -488,6 +506,82 @@ try {
     }
 
     Test-ItemTemplates -WorkingRoot $workingRoot -Platform $Platforms[0]
+
+    # ─── Version parameter test scenarios ───
+    Write-Step 'Running version parameter test scenarios...'
+
+    # Scenario 1: Default (no version passed) — verify Version="*"
+    $defaultPath = Join-Path -Path $workingRoot -ChildPath 'VersionDefault'
+    New-ProjectFromTemplate -TemplateShortName 'winui' -ProjectName 'VersionDefault' -OutputPath $defaultPath -WorkingDirectory $workingRoot
+    $defaultCsproj = Join-Path -Path $defaultPath -ChildPath 'VersionDefault.csproj'
+    Assert-CsprojPackageVersion -CsprojPath $defaultCsproj -PackageName 'Microsoft.WindowsAppSDK' -ExpectedVersion '*'
+    Assert-CsprojPackageVersion -CsprojPath $defaultCsproj -PackageName 'Microsoft.Windows.SDK.BuildTools' -ExpectedVersion '*'
+    Assert-CsprojPackageVersion -CsprojPath $defaultCsproj -PackageName 'Microsoft.Windows.SDK.BuildTools.WinApp' -ExpectedVersion '*'
+    Add-Result -Template 'winui' -Platform 'N/A' -Step 'default version content' -Status 'Succeeded' -Path $defaultPath
+
+    # Scenario 2: Pinned WindowsAppSDK version only
+    $pinnedPath = Join-Path -Path $workingRoot -ChildPath 'VersionPinned'
+    Invoke-DotnetCommand -Arguments @('new', 'winui', '-n', 'VersionPinned', '-o', $pinnedPath, '--wasdk-version', '1.7.250127002', '--force', '--no-update-check') -WorkingDirectory $workingRoot -Description 'create winui with pinned WASDK version'
+    $pinnedCsproj = Join-Path -Path $pinnedPath -ChildPath 'VersionPinned.csproj'
+    Assert-CsprojPackageVersion -CsprojPath $pinnedCsproj -PackageName 'Microsoft.WindowsAppSDK' -ExpectedVersion '1.7.250127002'
+    Assert-CsprojPackageVersion -CsprojPath $pinnedCsproj -PackageName 'Microsoft.Windows.SDK.BuildTools' -ExpectedVersion '*'
+    Assert-CsprojPackageVersion -CsprojPath $pinnedCsproj -PackageName 'Microsoft.Windows.SDK.BuildTools.WinApp' -ExpectedVersion '*'
+    Add-Result -Template 'winui' -Platform 'N/A' -Step 'pinned version content' -Status 'Succeeded' -Path $pinnedPath
+
+    # Scenario 3: All versions pinned
+    $allPinnedPath = Join-Path -Path $workingRoot -ChildPath 'VersionAllPinned'
+    Invoke-DotnetCommand -Arguments @('new', 'winui', '-n', 'VersionAllPinned', '-o', $allPinnedPath, '--wasdk-version', '1.7.250127002', '--build-tools-version', '10.0.26100.1742', '--winapp-version', '0.3.1', '--force', '--no-update-check') -WorkingDirectory $workingRoot -Description 'create winui with all versions pinned'
+    $allPinnedCsproj = Join-Path -Path $allPinnedPath -ChildPath 'VersionAllPinned.csproj'
+    Assert-CsprojPackageVersion -CsprojPath $allPinnedCsproj -PackageName 'Microsoft.WindowsAppSDK' -ExpectedVersion '1.7.250127002'
+    Assert-CsprojPackageVersion -CsprojPath $allPinnedCsproj -PackageName 'Microsoft.Windows.SDK.BuildTools' -ExpectedVersion '10.0.26100.1742'
+    Assert-CsprojPackageVersion -CsprojPath $allPinnedCsproj -PackageName 'Microsoft.Windows.SDK.BuildTools.WinApp' -ExpectedVersion '0.3.1'
+    Add-Result -Template 'winui' -Platform 'N/A' -Step 'all pinned version content' -Status 'Succeeded' -Path $allPinnedPath
+
+    # Scenario 4: Pre-release version string
+    $preReleasePath = Join-Path -Path $workingRoot -ChildPath 'VersionPreRelease'
+    Invoke-DotnetCommand -Arguments @('new', 'winui', '-n', 'VersionPreRelease', '-o', $preReleasePath, '--wasdk-version', '1.8.0-preview1', '--force', '--no-update-check') -WorkingDirectory $workingRoot -Description 'create winui with pre-release version'
+    $preReleaseCsproj = Join-Path -Path $preReleasePath -ChildPath 'VersionPreRelease.csproj'
+    Assert-CsprojPackageVersion -CsprojPath $preReleaseCsproj -PackageName 'Microsoft.WindowsAppSDK' -ExpectedVersion '1.8.0-preview1'
+    Add-Result -Template 'winui' -Platform 'N/A' -Step 'pre-release version content' -Status 'Succeeded' -Path $preReleasePath
+
+    # Scenario 5: Invalid version — scaffold succeeds but NuGet restore fails
+    Write-Step 'Testing invalid version handling...'
+    $invalidPath = Join-Path -Path $workingRoot -ChildPath 'VersionInvalid'
+    Invoke-DotnetCommand -Arguments @('new', 'winui', '-n', 'VersionInvalid', '-o', $invalidPath, '--wasdk-version', 'not-a-version', '--force', '--no-update-check') -WorkingDirectory $workingRoot -Description 'create winui with invalid version'
+    $invalidCsproj = Join-Path -Path $invalidPath -ChildPath 'VersionInvalid.csproj'
+    Assert-CsprojPackageVersion -CsprojPath $invalidCsproj -PackageName 'Microsoft.WindowsAppSDK' -ExpectedVersion 'not-a-version'
+    # Build should fail because NuGet can't parse an invalid version string
+    $invalidBuildFailed = $false
+    try {
+        Invoke-DotnetCommand -Arguments @('build', $invalidCsproj, '-p:Configuration=Debug', '-p:Platform=x64', '-p:WindowsPackageType=None') -WorkingDirectory $invalidPath -Description 'build with invalid version (should fail)'
+    }
+    catch {
+        $invalidBuildFailed = $true
+    }
+    if (-not $invalidBuildFailed) {
+        throw "Expected build to fail for invalid WASDK version 'not-a-version'"
+    }
+    Add-Result -Template 'winui' -Platform 'N/A' -Step 'invalid version: scaffold OK, build fails' -Status 'Succeeded' -Path $invalidPath
+
+    # Scenario 6: Valid version format but nonexistent package
+    $nonexistentPath = Join-Path -Path $workingRoot -ChildPath 'VersionNonexistent'
+    Invoke-DotnetCommand -Arguments @('new', 'winui', '-n', 'VersionNonexistent', '-o', $nonexistentPath, '--wasdk-version', '99.99.99', '--force', '--no-update-check') -WorkingDirectory $workingRoot -Description 'create winui with nonexistent version'
+    $nonexistentCsproj = Join-Path -Path $nonexistentPath -ChildPath 'VersionNonexistent.csproj'
+    Assert-CsprojPackageVersion -CsprojPath $nonexistentCsproj -PackageName 'Microsoft.WindowsAppSDK' -ExpectedVersion '99.99.99'
+    # Build should fail because NuGet can't find this package version
+    $buildFailed = $false
+    try {
+        Invoke-DotnetCommand -Arguments @('build', $nonexistentCsproj, '-p:Configuration=Debug', '-p:Platform=x64', '-p:WindowsPackageType=None') -WorkingDirectory $nonexistentPath -Description 'build with nonexistent version (should fail)'
+    }
+    catch {
+        $buildFailed = $true
+    }
+    if (-not $buildFailed) {
+        throw "Expected build to fail for nonexistent WASDK version 99.99.99"
+    }
+    Add-Result -Template 'winui' -Platform 'N/A' -Step 'nonexistent version: scaffold OK, build fails' -Status 'Succeeded' -Path $nonexistentPath
+
+    Write-Step 'Version parameter test scenarios completed.'
 
     if ($appExecutables.Count -gt 0) {
         if ($SkipAppLaunch.IsPresent) {

--- a/dev/Templates/Dotnet/Test-DotnetNewTemplates.ps1
+++ b/dev/Templates/Dotnet/Test-DotnetNewTemplates.ps1
@@ -575,10 +575,10 @@ try {
         throw "Expected restore to fail for invalid WASDK version 'not-a-version'"
     }
     $restoreText = $restoreOutput -join "`n"
-    # Finds NU1105, NETSDK1005, etc.
-    $errorCodes = [regex]::Matches($restoreText, '\b(?:NU|NETSDK|MSB)\d{4,}\b') |
+    # Finds NU1105, NETSDK1004, etc.
+    $errorCodes = @([regex]::Matches($restoreText, '\b(?:NU|NETSDK|MSB)\d{4,}\b') |
         ForEach-Object { $_.Value } |
-        Select-Object -Unique
+        Select-Object -Unique)
     if ($errorCodes.Count -gt 0) {
         if ($errorCodes -notcontains 'NU1105') {
             throw "Expected NU1105, got: $($errorCodes -join ', ')"
@@ -614,10 +614,10 @@ try {
         throw "Expected build to fail for invalid WASDK version 'not-a-version'"
     }
     $buildText = $buildOutput -join "`n"
-    if ($buildText -notmatch 'NETSDK1005') {
-        throw "Expected NETSDK1005 (assets file missing, please run restore) for invalid WASDK version 'not-a-version', but got:`n$buildText"
+    if ($buildText -notmatch 'NETSDK1004') {
+        throw "Expected NETSDK1004 (assets file missing, please run restore) for invalid WASDK version 'not-a-version', but got:`n$buildText"
     }
-    Add-Result -Template 'winui' -Platform 'N/A' -Step 'invalid version: build fails with NETSDK1005' -Status 'Succeeded' -Path $invalidPath
+    Add-Result -Template 'winui' -Platform 'N/A' -Step 'invalid version: build fails with NETSDK1004' -Status 'Succeeded' -Path $invalidPath
 
     # Scenario 6: Valid version format but nonexistent package
     $nonexistentPath = Join-Path -Path $workingRoot -ChildPath 'VersionNonexistent'

--- a/dev/Templates/Dotnet/Test-DotnetNewTemplates.ps1
+++ b/dev/Templates/Dotnet/Test-DotnetNewTemplates.ps1
@@ -553,6 +553,7 @@ try {
     # Restore should fail with NU1105 because NuGet can't parse an invalid version string
     $restoreFailed = $false
     $restoreOutput = $null
+    $restoreText = $null
     try {
         Push-Location -Path $invalidPath
         $savedEAP = $ErrorActionPreference
@@ -561,6 +562,8 @@ try {
         $restoreExitCode = $LASTEXITCODE
         $ErrorActionPreference = $savedEAP
         Pop-Location
+        $restoreText = $restoreOutput -join "`n"
+
         if ($restoreExitCode -ne 0) {
             $restoreFailed = $true
         }
@@ -572,8 +575,20 @@ try {
         throw "Expected restore to fail for invalid WASDK version 'not-a-version'"
     }
     $restoreText = $restoreOutput -join "`n"
-    if ($restoreText -notmatch 'NU1105') {
-        throw "Expected NuGet error NU1105 (unable to read project information) for invalid WASDK version 'not-a-version', but got:`n$restoreText"
+    # Finds NU1105, NETSDK1005, etc.
+    $errorCodes = [regex]::Matches($restoreText, '\b(?:NU|NETSDK|MSB)\d{4,}\b') |
+        ForEach-Object { $_.Value } |
+        Select-Object -Unique
+    if ($errorCodes.Count -gt 0) {
+        if ($errorCodes -notcontains 'NU1105') {
+            throw "Expected NU1105, got: $($errorCodes -join ', ')"
+        }
+    }
+    else {
+        # No machine-readable code surfaced; use narrow fallback
+        if ($restoreText -notmatch 'not a valid version string') {
+            throw "Expected invalid version failure, got:`n$restoreText"
+        }
     }
     Add-Result -Template 'winui' -Platform 'N/A' -Step 'invalid version: scaffold OK, restore fails with NU1105' -Status 'Succeeded' -Path $invalidPath
 

--- a/dev/Templates/Dotnet/Test-DotnetNewTemplates.ps1
+++ b/dev/Templates/Dotnet/Test-DotnetNewTemplates.ps1
@@ -544,24 +544,65 @@ try {
     Assert-CsprojPackageVersion -CsprojPath $preReleaseCsproj -PackageName 'Microsoft.WindowsAppSDK' -ExpectedVersion '1.8.0-preview1'
     Add-Result -Template 'winui' -Platform 'N/A' -Step 'pre-release version content' -Status 'Succeeded' -Path $preReleasePath
 
-    # Scenario 5: Invalid version — scaffold succeeds but NuGet restore fails
+    # Scenario 5: Invalid version — scaffold succeeds but NuGet restore fails with NU1105
     Write-Step 'Testing invalid version handling...'
     $invalidPath = Join-Path -Path $workingRoot -ChildPath 'VersionInvalid'
     Invoke-DotnetCommand -Arguments @('new', 'winui', '-n', 'VersionInvalid', '-o', $invalidPath, '--wasdk-version', 'not-a-version', '--force', '--no-update-check') -WorkingDirectory $workingRoot -Description 'create winui with invalid version'
     $invalidCsproj = Join-Path -Path $invalidPath -ChildPath 'VersionInvalid.csproj'
     Assert-CsprojPackageVersion -CsprojPath $invalidCsproj -PackageName 'Microsoft.WindowsAppSDK' -ExpectedVersion 'not-a-version'
-    # Build should fail because NuGet can't parse an invalid version string
-    $invalidBuildFailed = $false
+    # Restore should fail with NU1105 because NuGet can't parse an invalid version string
+    $restoreFailed = $false
+    $restoreOutput = $null
     try {
-        Invoke-DotnetCommand -Arguments @('build', $invalidCsproj, '-p:Configuration=Debug', '-p:Platform=x64', '-p:WindowsPackageType=None') -WorkingDirectory $invalidPath -Description 'build with invalid version (should fail)'
+        Push-Location -Path $invalidPath
+        $savedEAP = $ErrorActionPreference
+        $ErrorActionPreference = 'Continue'
+        $restoreOutput = & $dotnetPath restore $invalidCsproj 2>&1
+        $restoreExitCode = $LASTEXITCODE
+        $ErrorActionPreference = $savedEAP
+        Pop-Location
+        if ($restoreExitCode -ne 0) {
+            $restoreFailed = $true
+        }
     }
     catch {
-        $invalidBuildFailed = $true
+        $restoreFailed = $true
     }
-    if (-not $invalidBuildFailed) {
+    if (-not $restoreFailed) {
+        throw "Expected restore to fail for invalid WASDK version 'not-a-version'"
+    }
+    $restoreText = $restoreOutput -join "`n"
+    if ($restoreText -notmatch 'NU1105') {
+        throw "Expected NuGet error NU1105 (unable to read project information) for invalid WASDK version 'not-a-version', but got:`n$restoreText"
+    }
+    Add-Result -Template 'winui' -Platform 'N/A' -Step 'invalid version: scaffold OK, restore fails with NU1105' -Status 'Succeeded' -Path $invalidPath
+
+    # Build (with --no-restore) should fail with NETSDK1005 since restore never succeeded
+    $buildFailed = $false
+    $buildOutput = $null
+    try {
+        Push-Location -Path $invalidPath
+        $savedEAP = $ErrorActionPreference
+        $ErrorActionPreference = 'Continue'
+        $buildOutput = & $dotnetPath build $invalidCsproj --no-restore '-p:Configuration=Debug' '-p:Platform=x64' '-p:WindowsPackageType=None' 2>&1
+        $buildExitCode = $LASTEXITCODE
+        $ErrorActionPreference = $savedEAP
+        Pop-Location
+        if ($buildExitCode -ne 0) {
+            $buildFailed = $true
+        }
+    }
+    catch {
+        $buildFailed = $true
+    }
+    if (-not $buildFailed) {
         throw "Expected build to fail for invalid WASDK version 'not-a-version'"
     }
-    Add-Result -Template 'winui' -Platform 'N/A' -Step 'invalid version: scaffold OK, build fails' -Status 'Succeeded' -Path $invalidPath
+    $buildText = $buildOutput -join "`n"
+    if ($buildText -notmatch 'NETSDK1005') {
+        throw "Expected NETSDK1005 (assets file missing, please run restore) for invalid WASDK version 'not-a-version', but got:`n$buildText"
+    }
+    Add-Result -Template 'winui' -Platform 'N/A' -Step 'invalid version: build fails with NETSDK1005' -Status 'Succeeded' -Path $invalidPath
 
     # Scenario 6: Valid version format but nonexistent package
     $nonexistentPath = Join-Path -Path $workingRoot -ChildPath 'VersionNonexistent'

--- a/dev/Templates/Dotnet/Test-DotnetNewTemplates.ps1
+++ b/dev/Templates/Dotnet/Test-DotnetNewTemplates.ps1
@@ -386,7 +386,7 @@ function Assert-CsprojPackageVersion {
     )
 
     [xml]$csproj = Get-Content -Path $CsprojPath
-    $ref = $csproj.Project.ItemGroup.PackageReference |
+    $ref = $csproj.SelectNodes('//PackageReference') |
         Where-Object { $_.Include -eq $PackageName }
     if (-not $ref) {
         throw "PackageReference '$PackageName' not found in '$CsprojPath'"

--- a/dev/Templates/Dotnet/Test-DotnetNewTemplates.ps1
+++ b/dev/Templates/Dotnet/Test-DotnetNewTemplates.ps1
@@ -568,10 +568,20 @@ try {
     Invoke-DotnetCommand -Arguments @('new', 'winui', '-n', 'VersionNonexistent', '-o', $nonexistentPath, '--wasdk-version', '99.99.99', '--force', '--no-update-check') -WorkingDirectory $workingRoot -Description 'create winui with nonexistent version'
     $nonexistentCsproj = Join-Path -Path $nonexistentPath -ChildPath 'VersionNonexistent.csproj'
     Assert-CsprojPackageVersion -CsprojPath $nonexistentCsproj -PackageName 'Microsoft.WindowsAppSDK' -ExpectedVersion '99.99.99'
-    # Build should fail because NuGet can't find this package version
+    # Build should fail with NU1102 because NuGet can't find this package version
     $buildFailed = $false
+    $buildOutput = $null
     try {
-        Invoke-DotnetCommand -Arguments @('build', $nonexistentCsproj, '-p:Configuration=Debug', '-p:Platform=x64', '-p:WindowsPackageType=None') -WorkingDirectory $nonexistentPath -Description 'build with nonexistent version (should fail)'
+        Push-Location -Path $nonexistentPath
+        $savedEAP = $ErrorActionPreference
+        $ErrorActionPreference = 'Continue'
+        $buildOutput = & $dotnetPath build $nonexistentCsproj '-p:Configuration=Debug' '-p:Platform=x64' '-p:WindowsPackageType=None' 2>&1
+        $buildExitCode = $LASTEXITCODE
+        $ErrorActionPreference = $savedEAP
+        Pop-Location
+        if ($buildExitCode -ne 0) {
+            $buildFailed = $true
+        }
     }
     catch {
         $buildFailed = $true
@@ -579,7 +589,11 @@ try {
     if (-not $buildFailed) {
         throw "Expected build to fail for nonexistent WASDK version 99.99.99"
     }
-    Add-Result -Template 'winui' -Platform 'N/A' -Step 'nonexistent version: scaffold OK, build fails' -Status 'Succeeded' -Path $nonexistentPath
+    $buildText = $buildOutput -join "`n"
+    if ($buildText -notmatch 'NU1102') {
+        throw "Expected NuGet error NU1102 (package not found) for nonexistent WASDK version 99.99.99, but got:`n$buildText"
+    }
+    Add-Result -Template 'winui' -Platform 'N/A' -Step 'nonexistent version: scaffold OK, build fails with NU1102' -Status 'Succeeded' -Path $nonexistentPath
 
     Write-Step 'Version parameter test scenarios completed.'
 

--- a/dev/Templates/Dotnet/Test-DotnetNewTemplates.ps1
+++ b/dev/Templates/Dotnet/Test-DotnetNewTemplates.ps1
@@ -443,7 +443,7 @@ try {
     # Generate a NuGet.config so scaffolded projects resolve packages from
     # internal feeds only. The repo's NuGet.config has relative local-source
     # paths (tools/nuget, localpackages) that don't exist under the temp
-    # directory, and nuget.org is blocked by OneBranch network isolation.
+    # directory, and nuget.org may be blocked by CI network isolation.
     # We extract only the remote (https) feeds from the repo config.
     $repoNugetConfig = Join-Path -Path $repoRoot -ChildPath 'NuGet.config'
     $workNugetConfig = Join-Path -Path $workingRoot -ChildPath 'NuGet.config'
@@ -650,6 +650,110 @@ try {
         throw "Expected NuGet error NU1102 (package not found) for nonexistent WASDK version 99.99.99, but got:`n$buildText"
     }
     Add-Result -Template 'winui' -Platform 'N/A' -Step 'nonexistent version: scaffold OK, build fails with NU1102' -Status 'Succeeded' -Path $nonexistentPath
+
+    # Scenario 7: Unreachable NuGet source — scaffold succeeds but restore fails
+    # Simulates a developer working offline (e.g. no Wi-Fi, airplane mode, or
+    # misconfigured NuGet sources) where package feeds are unreachable. The
+    # template engine creates the project files but the post-action restore
+    # cannot reach any feed.
+    Write-Step 'Testing unreachable NuGet source handling...'
+    $unreachablePath = Join-Path -Path $workingRoot -ChildPath 'UnreachableSource'
+
+    # Write a NuGet.config that points to a nonexistent local path and no other
+    # sources, so restore has nowhere to fetch packages from.
+    New-Item -ItemType Directory -Path $unreachablePath -Force | Out-Null
+    $bogusNugetConfig = Join-Path -Path $unreachablePath -ChildPath 'NuGet.config'
+    @(
+        '<?xml version="1.0" encoding="utf-8"?>'
+        '<configuration>'
+        '  <packageSources>'
+        '    <clear />'
+        '    <add key="bogus" value="C:\nonexistent_feed_path" />'
+        '  </packageSources>'
+        '</configuration>'
+    ) | Set-Content -Path $bogusNugetConfig -Encoding UTF8
+
+    # Scaffold: dotnet new writes project files regardless of restore outcome.
+    # The post-action restore will fail, but dotnet new still exits 0 and emits
+    # the project files, so Invoke-DotnetCommand (which checks $LASTEXITCODE)
+    # will not throw.
+    Push-Location -Path $unreachablePath
+    $savedEAP = $ErrorActionPreference
+    $ErrorActionPreference = 'Continue'
+    & $dotnetPath new winui -n UnreachableSource -o $unreachablePath --force --no-update-check 2>&1 | ForEach-Object { Write-Host $_ }
+    $ErrorActionPreference = $savedEAP
+    Pop-Location
+
+    $unreachableCsproj = Join-Path -Path $unreachablePath -ChildPath 'UnreachableSource.csproj'
+    if (-not (Test-Path -Path $unreachableCsproj)) {
+        throw "Template scaffold did not produce a .csproj at '$unreachableCsproj'"
+    }
+    Add-Result -Template 'winui' -Platform 'N/A' -Step 'unreachable source: scaffold produces files' -Status 'Succeeded' -Path $unreachablePath
+
+    # Build should fail because no packages could be restored.
+    $buildFailed = $false
+    $buildOutput = $null
+    try {
+        Push-Location -Path $unreachablePath
+        $savedEAP = $ErrorActionPreference
+        $ErrorActionPreference = 'Continue'
+        $buildOutput = & $dotnetPath build $unreachableCsproj '-p:Configuration=Debug' '-p:Platform=x64' '-p:WindowsPackageType=None' 2>&1
+        $buildExitCode = $LASTEXITCODE
+        $ErrorActionPreference = $savedEAP
+        Pop-Location
+        if ($buildExitCode -ne 0) {
+            $buildFailed = $true
+        }
+    }
+    catch {
+        $buildFailed = $true
+    }
+    if (-not $buildFailed) {
+        throw "Expected build to fail when NuGet sources are unreachable"
+    }
+    $buildText = $buildOutput -join "`n"
+    # Expect NU1301 (unable to load source) or NU1102 (package not found) or
+    # NETSDK1004 (assets file missing because restore never succeeded).
+    if ($buildText -notmatch 'NU1301|NU1102|NETSDK1004') {
+        throw "Expected NuGet resolution error (NU1301, NU1102, or NETSDK1004) when sources are unreachable, but got:`n$buildText"
+    }
+    Add-Result -Template 'winui' -Platform 'N/A' -Step 'unreachable source: build fails with NuGet error' -Status 'Succeeded' -Path $unreachablePath
+
+    # Scenario 7b: Working NuGet source — restore resolves up-to-date packages
+    # and the project builds successfully. Complements 7a by proving that when
+    # pointed at valid feeds the default Version="*" wildcard pulls the latest
+    # stable packages and produces a clean build.
+    Write-Step 'Testing working NuGet source resolves packages and builds...'
+    $workingSourcePath = Join-Path -Path $workingRoot -ChildPath 'WorkingSource'
+    New-ProjectFromTemplate -TemplateShortName 'winui' -ProjectName 'WorkingSource' -OutputPath $workingSourcePath -WorkingDirectory $workingRoot
+
+    $workingSourceCsproj = Join-Path -Path $workingSourcePath -ChildPath 'WorkingSource.csproj'
+
+    # Verify the csproj uses wildcard versions (the default)
+    Assert-CsprojPackageVersion -CsprojPath $workingSourceCsproj -PackageName 'Microsoft.WindowsAppSDK' -ExpectedVersion '*'
+    Assert-CsprojPackageVersion -CsprojPath $workingSourceCsproj -PackageName 'Microsoft.Windows.SDK.BuildTools' -ExpectedVersion '*'
+
+    # Explicit restore to confirm packages are fetched from the working feeds
+    Invoke-DotnetCommand -Arguments @('restore', $workingSourceCsproj) -WorkingDirectory $workingSourcePath -Description 'restore with working NuGet source'
+
+    # Verify the assets file was created (proves restore actually resolved packages)
+    $assetsFile = Join-Path -Path $workingSourcePath -ChildPath 'obj\project.assets.json'
+    if (-not (Test-Path -Path $assetsFile)) {
+        throw "Expected project.assets.json after restore but file was not found at '$assetsFile'"
+    }
+
+    # Verify resolved packages are real versions (not still wildcards)
+    $assetsJson = Get-Content -Path $assetsFile -Raw | ConvertFrom-Json
+    $resolvedWasdk = $assetsJson.libraries.PSObject.Properties.Name | Where-Object { $_ -match '^Microsoft\.WindowsAppSDK/' }
+    if (-not $resolvedWasdk) {
+        throw "Microsoft.WindowsAppSDK was not resolved in project.assets.json"
+    }
+    Write-Step "Resolved: $resolvedWasdk"
+    Add-Result -Template 'winui' -Platform 'N/A' -Step 'working source: restore resolves packages' -Status 'Succeeded' -Path $workingSourcePath
+
+    # Build the project
+    Invoke-DotnetCommand -Arguments @('build', $workingSourceCsproj, '-p:Configuration=Debug', "-p:Platform=$($Platforms[0])", '-p:WindowsPackageType=None', '--no-restore') -WorkingDirectory $workingSourcePath -Description 'build with working NuGet source'
+    Add-Result -Template 'winui' -Platform $Platforms[0] -Step 'working source: build succeeds' -Status 'Succeeded' -Path $workingSourceCsproj
 
     Write-Step 'Version parameter test scenarios completed.'
 

--- a/dev/Templates/Dotnet/templates/blank-app/.template.config/dotnetcli.host.json
+++ b/dev/Templates/Dotnet/templates/blank-app/.template.config/dotnetcli.host.json
@@ -20,6 +20,21 @@
       "longName": "publisher-display",
       "shortName": "publisherName",
       "description": "Publisher display name stored in Package.appxmanifest."
+    },
+    "windowsAppSdkVersion": {
+      "longName": "wasdk-version",
+      "shortName": "wasdkv",
+      "description": "Pin to a specific Windows App SDK NuGet version. Leave empty for latest."
+    },
+    "windowsSdkBuildToolsVersion": {
+      "longName": "build-tools-version",
+      "shortName": "btv",
+      "description": "Pin to a specific Windows SDK BuildTools NuGet version. Leave empty for latest."
+    },
+    "windowsSdkBuildToolsWinAppVersion": {
+      "longName": "winapp-version",
+      "shortName": "wav",
+      "description": "Pin to a specific Windows SDK BuildTools WinApp NuGet version. Leave empty for latest."
     }
   }
 }

--- a/dev/Templates/Dotnet/templates/blank-app/.template.config/ide.host.json
+++ b/dev/Templates/Dotnet/templates/blank-app/.template.config/ide.host.json
@@ -39,21 +39,21 @@
     {
       "id": "windowsAppSdkVersion",
       "name": {
-        "text": "Windows App SDK version (empty = latest)"
+        "text": "Windows App SDK version (* = latest)"
       },
       "isVisible": "true"
     },
     {
       "id": "windowsSdkBuildToolsVersion",
       "name": {
-        "text": "Windows SDK BuildTools version (empty = latest)"
+        "text": "Windows SDK BuildTools version (* = latest)"
       },
       "isVisible": "true"
     },
     {
       "id": "windowsSdkBuildToolsWinAppVersion",
       "name": {
-        "text": "Windows SDK BuildTools WinApp version (empty = latest)"
+        "text": "Windows SDK BuildTools WinApp version (* = latest)"
       },
       "isVisible": "true"
     }

--- a/dev/Templates/Dotnet/templates/blank-app/.template.config/ide.host.json
+++ b/dev/Templates/Dotnet/templates/blank-app/.template.config/ide.host.json
@@ -37,32 +37,25 @@
       "isVisible": "true"
     },
     {
-      "id": "useLatestDependencies",
+      "id": "windowsAppSdkVersion",
       "name": {
-        "text": "Use latest project dependencies"
+        "text": "Windows App SDK version (empty = latest)"
       },
       "isVisible": "true"
     },
     {
-      "id": "windowsAppSdkVersion",
-      "name": {
-        "text": "Windows App SDK version"
-      },
-      "isVisible": "!useLatestDependencies"
-    },
-    {
       "id": "windowsSdkBuildToolsVersion",
       "name": {
-        "text": "Windows SDK BuildTools version"
+        "text": "Windows SDK BuildTools version (empty = latest)"
       },
-      "isVisible": "!useLatestDependencies"
+      "isVisible": "true"
     },
     {
       "id": "windowsSdkBuildToolsWinAppVersion",
       "name": {
-        "text": "Windows SDK BuildTools WinApp version"
+        "text": "Windows SDK BuildTools WinApp version (empty = latest)"
       },
-      "isVisible": "!useLatestDependencies"
+      "isVisible": "true"
     }
   ]
 }

--- a/dev/Templates/Dotnet/templates/blank-app/.template.config/ide.host.json
+++ b/dev/Templates/Dotnet/templates/blank-app/.template.config/ide.host.json
@@ -37,9 +37,23 @@
       "isVisible": "true"
     },
     {
-      "id": "UseLatestWindowsAppSDK",
+      "id": "windowsAppSdkVersion",
       "name": {
-        "text": "Use latest Windows App SDK version"
+        "text": "Windows App SDK version (empty = latest)"
+      },
+      "isVisible": "true"
+    },
+    {
+      "id": "windowsSdkBuildToolsVersion",
+      "name": {
+        "text": "Windows SDK BuildTools version (empty = latest)"
+      },
+      "isVisible": "true"
+    },
+    {
+      "id": "windowsSdkBuildToolsWinAppVersion",
+      "name": {
+        "text": "Windows SDK BuildTools WinApp version (empty = latest)"
       },
       "isVisible": "true"
     }

--- a/dev/Templates/Dotnet/templates/blank-app/.template.config/ide.host.json
+++ b/dev/Templates/Dotnet/templates/blank-app/.template.config/ide.host.json
@@ -37,25 +37,32 @@
       "isVisible": "true"
     },
     {
-      "id": "windowsAppSdkVersion",
+      "id": "useLatestDependencies",
       "name": {
-        "text": "Windows App SDK version (empty = latest)"
+        "text": "Use latest project dependencies"
       },
       "isVisible": "true"
+    },
+    {
+      "id": "windowsAppSdkVersion",
+      "name": {
+        "text": "Windows App SDK version"
+      },
+      "isVisible": "!useLatestDependencies"
     },
     {
       "id": "windowsSdkBuildToolsVersion",
       "name": {
-        "text": "Windows SDK BuildTools version (empty = latest)"
+        "text": "Windows SDK BuildTools version"
       },
-      "isVisible": "true"
+      "isVisible": "!useLatestDependencies"
     },
     {
       "id": "windowsSdkBuildToolsWinAppVersion",
       "name": {
-        "text": "Windows SDK BuildTools WinApp version (empty = latest)"
+        "text": "Windows SDK BuildTools WinApp version"
       },
-      "isVisible": "true"
+      "isVisible": "!useLatestDependencies"
     }
   ]
 }

--- a/dev/Templates/Dotnet/templates/blank-app/.template.config/template.json
+++ b/dev/Templates/Dotnet/templates/blank-app/.template.config/template.json
@@ -135,31 +135,26 @@
       },
       "replaces": "$guid9$"
     },
-    "UseLatestWindowsAppSDK":{
-      "type": "parameter",
-      "datatype": "bool",
-      "defaultValue": "true"
-    },
     "windowsAppSdkVersion": {
       "type": "parameter",
       "datatype": "text",
-      "replaces": "$WindowsAppSdkVersion$",
-      "defaultValue": "1.8.260317003",
-      "description": "Version of the Microsoft.WindowsAppSDK NuGet package."
+      "defaultValue": "*",
+      "replaces": "$ResolvedWindowsAppSdkVersion$",
+      "description": "Microsoft.WindowsAppSDK NuGet version. Use * for the latest stable."
     },
     "windowsSdkBuildToolsVersion": {
       "type": "parameter",
       "datatype": "text",
-      "replaces": "$WindowsSdkBuildToolsVersion$",
-      "defaultValue": "10.0.26100.7705",
-      "description": "Version of the Microsoft.Windows.SDK.BuildTools NuGet package."
+      "defaultValue": "*",
+      "replaces": "$ResolvedWindowsSdkBuildToolsVersion$",
+      "description": "Microsoft.Windows.SDK.BuildTools NuGet version. Use * for the latest stable."
     },
     "windowsSdkBuildToolsWinAppVersion": {
       "type": "parameter",
       "datatype": "text",
-      "replaces": "$WindowsSdkBuildToolsWinAppVersion$",
-      "defaultValue": "0.3.1",
-      "description": "Version of the Microsoft.Windows.SDK.BuildTools.WinApp NuGet package, which adds `dotnet run` support for packaged WinUI apps via the winapp CLI."
+      "defaultValue": "*",
+      "replaces": "$ResolvedWindowsSdkBuildToolsWinAppVersion$",
+      "description": "Microsoft.Windows.SDK.BuildTools.WinApp NuGet version. Use * for the latest stable."
     }
   },
   "sources": [
@@ -195,36 +190,6 @@
     }
   },
   "postActions": [
-    {
-      "actionId": "B17581D1-C5C9-4489-8F0A-004BE667B814",
-      "continueOnError": true,
-      "description": "Update Microsoft.WindowsAppSDK to the latest stable version.",
-      "args": {
-        "referenceType": "package",
-        "reference": "Microsoft.WindowsAppSDK"
-      },
-      "manualInstructions": [{ "text": "Run 'dotnet add package Microsoft.WindowsAppSDK'" }]
-    },
-    {
-      "actionId": "B17581D1-C5C9-4489-8F0A-004BE667B814",
-      "continueOnError": true,
-      "description": "Update Microsoft.Windows.SDK.BuildTools to the latest stable version.",
-      "args": {
-        "referenceType": "package",
-        "reference": "Microsoft.Windows.SDK.BuildTools"
-      },
-      "manualInstructions": [{ "text": "Run 'dotnet add package Microsoft.Windows.SDK.BuildTools'" }]
-    },
-    {
-      "actionId": "B17581D1-C5C9-4489-8F0A-004BE667B814",
-      "continueOnError": true,
-      "description": "Update Microsoft.Windows.SDK.BuildTools.WinApp to the latest stable version (enables `dotnet run` for packaged WinUI apps).",
-      "args": {
-        "referenceType": "package",
-        "reference": "Microsoft.Windows.SDK.BuildTools.WinApp"
-      },
-      "manualInstructions": [{ "text": "Run 'dotnet add package Microsoft.Windows.SDK.BuildTools.WinApp'" }]
-    },
     {
       "actionId": "210D431B-A78B-4D2F-B762-4ED3E3EA9025",
       "continueOnError": true,

--- a/dev/Templates/Dotnet/templates/blank-app/.template.config/template.json
+++ b/dev/Templates/Dotnet/templates/blank-app/.template.config/template.json
@@ -139,21 +139,21 @@
       "type": "parameter",
       "datatype": "text",
       "defaultValue": "*",
-      "replaces": "$ResolvedWindowsAppSdkVersion$",
+      "replaces": "$WindowsAppSdkVersion$",
       "description": "Microsoft.WindowsAppSDK NuGet version. Use * for the latest stable."
     },
     "windowsSdkBuildToolsVersion": {
       "type": "parameter",
       "datatype": "text",
       "defaultValue": "*",
-      "replaces": "$ResolvedWindowsSdkBuildToolsVersion$",
+      "replaces": "$WindowsSdkBuildToolsVersion$",
       "description": "Microsoft.Windows.SDK.BuildTools NuGet version. Use * for the latest stable."
     },
     "windowsSdkBuildToolsWinAppVersion": {
       "type": "parameter",
       "datatype": "text",
       "defaultValue": "*",
-      "replaces": "$ResolvedWindowsSdkBuildToolsWinAppVersion$",
+      "replaces": "$WindowsSdkBuildToolsWinAppVersion$",
       "description": "Microsoft.Windows.SDK.BuildTools.WinApp NuGet version. Use * for the latest stable."
     }
   },

--- a/dev/Templates/Dotnet/templates/blank-app/.template.config/template.json
+++ b/dev/Templates/Dotnet/templates/blank-app/.template.config/template.json
@@ -135,6 +135,12 @@
       },
       "replaces": "$guid9$"
     },
+    "useLatestDependencies": {
+      "type": "parameter",
+      "datatype": "bool",
+      "defaultValue": "true",
+      "description": "Use the latest available NuGet package versions for all project dependencies."
+    },
     "windowsAppSdkVersion": {
       "type": "parameter",
       "datatype": "text",

--- a/dev/Templates/Dotnet/templates/blank-app/.template.config/template.json
+++ b/dev/Templates/Dotnet/templates/blank-app/.template.config/template.json
@@ -135,12 +135,6 @@
       },
       "replaces": "$guid9$"
     },
-    "useLatestDependencies": {
-      "type": "parameter",
-      "datatype": "bool",
-      "defaultValue": "true",
-      "description": "Use the latest available NuGet package versions for all project dependencies."
-    },
     "windowsAppSdkVersion": {
       "type": "parameter",
       "datatype": "text",

--- a/dev/Templates/Dotnet/templates/class-library/.template.config/dotnetcli.host.json
+++ b/dev/Templates/Dotnet/templates/class-library/.template.config/dotnetcli.host.json
@@ -5,6 +5,16 @@
       "longName": "dotnet-version",
       "shortName": "tfm",
       "description": "Base TFM for the WinUI project (for example net10.0)."
+    },
+    "windowsAppSdkVersion": {
+      "longName": "wasdk-version",
+      "shortName": "wasdkv",
+      "description": "Pin to a specific Windows App SDK NuGet version. Leave empty for latest."
+    },
+    "windowsSdkBuildToolsVersion": {
+      "longName": "build-tools-version",
+      "shortName": "btv",
+      "description": "Pin to a specific Windows SDK BuildTools NuGet version. Leave empty for latest."
     }
   }
 }

--- a/dev/Templates/Dotnet/templates/class-library/.template.config/ide.host.json
+++ b/dev/Templates/Dotnet/templates/class-library/.template.config/ide.host.json
@@ -16,18 +16,25 @@
       "isVisible": "true"
     },
     {
-      "id": "windowsAppSdkVersion",
+      "id": "useLatestDependencies",
       "name": {
-        "text": "Windows App SDK version (empty = latest)"
+        "text": "Use latest project dependencies"
       },
       "isVisible": "true"
     },
     {
+      "id": "windowsAppSdkVersion",
+      "name": {
+        "text": "Windows App SDK version"
+      },
+      "isVisible": "!useLatestDependencies"
+    },
+    {
       "id": "windowsSdkBuildToolsVersion",
       "name": {
-        "text": "Windows SDK BuildTools version (empty = latest)"
+        "text": "Windows SDK BuildTools version"
       },
-      "isVisible": "true"
+      "isVisible": "!useLatestDependencies"
     }
   ]
 }

--- a/dev/Templates/Dotnet/templates/class-library/.template.config/ide.host.json
+++ b/dev/Templates/Dotnet/templates/class-library/.template.config/ide.host.json
@@ -14,6 +14,20 @@
         "text": "Framework"
       },
       "isVisible": "true"
+    },
+    {
+      "id": "windowsAppSdkVersion",
+      "name": {
+        "text": "Windows App SDK version (empty = latest)"
+      },
+      "isVisible": "true"
+    },
+    {
+      "id": "windowsSdkBuildToolsVersion",
+      "name": {
+        "text": "Windows SDK BuildTools version (empty = latest)"
+      },
+      "isVisible": "true"
     }
   ]
 }

--- a/dev/Templates/Dotnet/templates/class-library/.template.config/ide.host.json
+++ b/dev/Templates/Dotnet/templates/class-library/.template.config/ide.host.json
@@ -18,14 +18,14 @@
     {
       "id": "windowsAppSdkVersion",
       "name": {
-        "text": "Windows App SDK version (empty = latest)"
+        "text": "Windows App SDK version (* = latest)"
       },
       "isVisible": "true"
     },
     {
       "id": "windowsSdkBuildToolsVersion",
       "name": {
-        "text": "Windows SDK BuildTools version (empty = latest)"
+        "text": "Windows SDK BuildTools version (* = latest)"
       },
       "isVisible": "true"
     }

--- a/dev/Templates/Dotnet/templates/class-library/.template.config/ide.host.json
+++ b/dev/Templates/Dotnet/templates/class-library/.template.config/ide.host.json
@@ -16,25 +16,18 @@
       "isVisible": "true"
     },
     {
-      "id": "useLatestDependencies",
+      "id": "windowsAppSdkVersion",
       "name": {
-        "text": "Use latest project dependencies"
+        "text": "Windows App SDK version (empty = latest)"
       },
       "isVisible": "true"
     },
     {
-      "id": "windowsAppSdkVersion",
-      "name": {
-        "text": "Windows App SDK version"
-      },
-      "isVisible": "!useLatestDependencies"
-    },
-    {
       "id": "windowsSdkBuildToolsVersion",
       "name": {
-        "text": "Windows SDK BuildTools version"
+        "text": "Windows SDK BuildTools version (empty = latest)"
       },
-      "isVisible": "!useLatestDependencies"
+      "isVisible": "true"
     }
   ]
 }

--- a/dev/Templates/Dotnet/templates/class-library/.template.config/template.json
+++ b/dev/Templates/Dotnet/templates/class-library/.template.config/template.json
@@ -75,6 +75,20 @@
         "fallbackVariableName": "autoDetectedTfm"
       },
       "replaces": "$DotNetVersion$"
+    },
+    "windowsAppSdkVersion": {
+      "type": "parameter",
+      "datatype": "text",
+      "defaultValue": "*",
+      "replaces": "$ResolvedWindowsAppSdkVersion$",
+      "description": "Microsoft.WindowsAppSDK NuGet version. Use * for the latest stable."
+    },
+    "windowsSdkBuildToolsVersion": {
+      "type": "parameter",
+      "datatype": "text",
+      "defaultValue": "*",
+      "replaces": "$ResolvedWindowsSdkBuildToolsVersion$",
+      "description": "Microsoft.Windows.SDK.BuildTools NuGet version. Use * for the latest stable."
     }
   },
   "sources": [

--- a/dev/Templates/Dotnet/templates/class-library/.template.config/template.json
+++ b/dev/Templates/Dotnet/templates/class-library/.template.config/template.json
@@ -80,14 +80,14 @@
       "type": "parameter",
       "datatype": "text",
       "defaultValue": "*",
-      "replaces": "$ResolvedWindowsAppSdkVersion$",
+      "replaces": "$WindowsAppSdkVersion$",
       "description": "Microsoft.WindowsAppSDK NuGet version. Use * for the latest stable."
     },
     "windowsSdkBuildToolsVersion": {
       "type": "parameter",
       "datatype": "text",
       "defaultValue": "*",
-      "replaces": "$ResolvedWindowsSdkBuildToolsVersion$",
+      "replaces": "$WindowsSdkBuildToolsVersion$",
       "description": "Microsoft.Windows.SDK.BuildTools NuGet version. Use * for the latest stable."
     }
   },

--- a/dev/Templates/Dotnet/templates/class-library/.template.config/template.json
+++ b/dev/Templates/Dotnet/templates/class-library/.template.config/template.json
@@ -76,6 +76,12 @@
       },
       "replaces": "$DotNetVersion$"
     },
+    "useLatestDependencies": {
+      "type": "parameter",
+      "datatype": "bool",
+      "defaultValue": "true",
+      "description": "Use the latest available NuGet package versions for all project dependencies."
+    },
     "windowsAppSdkVersion": {
       "type": "parameter",
       "datatype": "text",

--- a/dev/Templates/Dotnet/templates/class-library/.template.config/template.json
+++ b/dev/Templates/Dotnet/templates/class-library/.template.config/template.json
@@ -76,12 +76,6 @@
       },
       "replaces": "$DotNetVersion$"
     },
-    "useLatestDependencies": {
-      "type": "parameter",
-      "datatype": "bool",
-      "defaultValue": "true",
-      "description": "Use the latest available NuGet package versions for all project dependencies."
-    },
     "windowsAppSdkVersion": {
       "type": "parameter",
       "datatype": "text",

--- a/dev/Templates/Dotnet/templates/mvvm-app/.template.config/dotnetcli.host.json
+++ b/dev/Templates/Dotnet/templates/mvvm-app/.template.config/dotnetcli.host.json
@@ -20,6 +20,26 @@
       "longName": "publisher-display",
       "shortName": "publisherName",
       "description": "Publisher display name stored in Package.appxmanifest."
+    },
+    "windowsAppSdkVersion": {
+      "longName": "wasdk-version",
+      "shortName": "wasdkv",
+      "description": "Pin to a specific Windows App SDK NuGet version. Leave empty for latest."
+    },
+    "windowsSdkBuildToolsVersion": {
+      "longName": "build-tools-version",
+      "shortName": "btv",
+      "description": "Pin to a specific Windows SDK BuildTools NuGet version. Leave empty for latest."
+    },
+    "windowsSdkBuildToolsWinAppVersion": {
+      "longName": "winapp-version",
+      "shortName": "wav",
+      "description": "Pin to a specific Windows SDK BuildTools WinApp NuGet version. Leave empty for latest."
+    },
+    "communityToolkitMvvmVersion": {
+      "longName": "mvvm-toolkit-version",
+      "shortName": "mtv",
+      "description": "Pin to a specific CommunityToolkit.Mvvm NuGet version. Leave empty for latest."
     }
   }
 }

--- a/dev/Templates/Dotnet/templates/mvvm-app/.template.config/ide.host.json
+++ b/dev/Templates/Dotnet/templates/mvvm-app/.template.config/ide.host.json
@@ -37,39 +37,32 @@
       "isVisible": "true"
     },
     {
-      "id": "useLatestDependencies",
+      "id": "windowsAppSdkVersion",
       "name": {
-        "text": "Use latest project dependencies"
+        "text": "Windows App SDK version (empty = latest)"
       },
       "isVisible": "true"
     },
     {
-      "id": "windowsAppSdkVersion",
-      "name": {
-        "text": "Windows App SDK version"
-      },
-      "isVisible": "!useLatestDependencies"
-    },
-    {
       "id": "windowsSdkBuildToolsVersion",
       "name": {
-        "text": "Windows SDK BuildTools version"
+        "text": "Windows SDK BuildTools version (empty = latest)"
       },
-      "isVisible": "!useLatestDependencies"
+      "isVisible": "true"
     },
     {
       "id": "windowsSdkBuildToolsWinAppVersion",
       "name": {
-        "text": "Windows SDK BuildTools WinApp version"
+        "text": "Windows SDK BuildTools WinApp version (empty = latest)"
       },
-      "isVisible": "!useLatestDependencies"
+      "isVisible": "true"
     },
     {
       "id": "communityToolkitMvvmVersion",
       "name": {
-        "text": "CommunityToolkit.Mvvm version"
+        "text": "CommunityToolkit.Mvvm version (empty = latest)"
       },
-      "isVisible": "!useLatestDependencies"
+      "isVisible": "true"
     }
   ]
 }

--- a/dev/Templates/Dotnet/templates/mvvm-app/.template.config/ide.host.json
+++ b/dev/Templates/Dotnet/templates/mvvm-app/.template.config/ide.host.json
@@ -39,28 +39,28 @@
     {
       "id": "windowsAppSdkVersion",
       "name": {
-        "text": "Windows App SDK version (empty = latest)"
+        "text": "Windows App SDK version (* = latest)"
       },
       "isVisible": "true"
     },
     {
       "id": "windowsSdkBuildToolsVersion",
       "name": {
-        "text": "Windows SDK BuildTools version (empty = latest)"
+        "text": "Windows SDK BuildTools version (* = latest)"
       },
       "isVisible": "true"
     },
     {
       "id": "windowsSdkBuildToolsWinAppVersion",
       "name": {
-        "text": "Windows SDK BuildTools WinApp version (empty = latest)"
+        "text": "Windows SDK BuildTools WinApp version (* = latest)"
       },
       "isVisible": "true"
     },
     {
       "id": "communityToolkitMvvmVersion",
       "name": {
-        "text": "CommunityToolkit.Mvvm version (empty = latest)"
+        "text": "CommunityToolkit.Mvvm version (* = latest)"
       },
       "isVisible": "true"
     }

--- a/dev/Templates/Dotnet/templates/mvvm-app/.template.config/ide.host.json
+++ b/dev/Templates/Dotnet/templates/mvvm-app/.template.config/ide.host.json
@@ -37,9 +37,30 @@
       "isVisible": "true"
     },
     {
-      "id": "UseLatestWindowsAppSDK",
+      "id": "windowsAppSdkVersion",
       "name": {
-        "text": "Use latest Windows App SDK version"
+        "text": "Windows App SDK version (empty = latest)"
+      },
+      "isVisible": "true"
+    },
+    {
+      "id": "windowsSdkBuildToolsVersion",
+      "name": {
+        "text": "Windows SDK BuildTools version (empty = latest)"
+      },
+      "isVisible": "true"
+    },
+    {
+      "id": "windowsSdkBuildToolsWinAppVersion",
+      "name": {
+        "text": "Windows SDK BuildTools WinApp version (empty = latest)"
+      },
+      "isVisible": "true"
+    },
+    {
+      "id": "communityToolkitMvvmVersion",
+      "name": {
+        "text": "CommunityToolkit.Mvvm version (empty = latest)"
       },
       "isVisible": "true"
     }

--- a/dev/Templates/Dotnet/templates/mvvm-app/.template.config/ide.host.json
+++ b/dev/Templates/Dotnet/templates/mvvm-app/.template.config/ide.host.json
@@ -37,32 +37,39 @@
       "isVisible": "true"
     },
     {
-      "id": "windowsAppSdkVersion",
+      "id": "useLatestDependencies",
       "name": {
-        "text": "Windows App SDK version (empty = latest)"
+        "text": "Use latest project dependencies"
       },
       "isVisible": "true"
+    },
+    {
+      "id": "windowsAppSdkVersion",
+      "name": {
+        "text": "Windows App SDK version"
+      },
+      "isVisible": "!useLatestDependencies"
     },
     {
       "id": "windowsSdkBuildToolsVersion",
       "name": {
-        "text": "Windows SDK BuildTools version (empty = latest)"
+        "text": "Windows SDK BuildTools version"
       },
-      "isVisible": "true"
+      "isVisible": "!useLatestDependencies"
     },
     {
       "id": "windowsSdkBuildToolsWinAppVersion",
       "name": {
-        "text": "Windows SDK BuildTools WinApp version (empty = latest)"
+        "text": "Windows SDK BuildTools WinApp version"
       },
-      "isVisible": "true"
+      "isVisible": "!useLatestDependencies"
     },
     {
       "id": "communityToolkitMvvmVersion",
       "name": {
-        "text": "CommunityToolkit.Mvvm version (empty = latest)"
+        "text": "CommunityToolkit.Mvvm version"
       },
-      "isVisible": "true"
+      "isVisible": "!useLatestDependencies"
     }
   ]
 }

--- a/dev/Templates/Dotnet/templates/mvvm-app/.template.config/template.json
+++ b/dev/Templates/Dotnet/templates/mvvm-app/.template.config/template.json
@@ -139,28 +139,28 @@
       "type": "parameter",
       "datatype": "text",
       "defaultValue": "*",
-      "replaces": "$ResolvedWindowsAppSdkVersion$",
+      "replaces": "$WindowsAppSdkVersion$",
       "description": "Microsoft.WindowsAppSDK NuGet version. Use * for the latest stable."
     },
     "windowsSdkBuildToolsVersion": {
       "type": "parameter",
       "datatype": "text",
       "defaultValue": "*",
-      "replaces": "$ResolvedWindowsSdkBuildToolsVersion$",
+      "replaces": "$WindowsSdkBuildToolsVersion$",
       "description": "Microsoft.Windows.SDK.BuildTools NuGet version. Use * for the latest stable."
     },
     "windowsSdkBuildToolsWinAppVersion": {
       "type": "parameter",
       "datatype": "text",
       "defaultValue": "*",
-      "replaces": "$ResolvedWindowsSdkBuildToolsWinAppVersion$",
+      "replaces": "$WindowsSdkBuildToolsWinAppVersion$",
       "description": "Microsoft.Windows.SDK.BuildTools.WinApp NuGet version. Use * for the latest stable."
     },
     "communityToolkitMvvmVersion": {
       "type": "parameter",
       "datatype": "text",
       "defaultValue": "*",
-      "replaces": "$ResolvedCommunityToolkitMvvmVersion$",
+      "replaces": "$CommunityToolkitMvvmVersion$",
       "description": "CommunityToolkit.Mvvm NuGet version. Use * for the latest stable."
     }
   },

--- a/dev/Templates/Dotnet/templates/mvvm-app/.template.config/template.json
+++ b/dev/Templates/Dotnet/templates/mvvm-app/.template.config/template.json
@@ -135,6 +135,12 @@
       },
       "replaces": "$guid9$"
     },
+    "useLatestDependencies": {
+      "type": "parameter",
+      "datatype": "bool",
+      "defaultValue": "true",
+      "description": "Use the latest available NuGet package versions for all project dependencies."
+    },
     "windowsAppSdkVersion": {
       "type": "parameter",
       "datatype": "text",

--- a/dev/Templates/Dotnet/templates/mvvm-app/.template.config/template.json
+++ b/dev/Templates/Dotnet/templates/mvvm-app/.template.config/template.json
@@ -135,31 +135,33 @@
       },
       "replaces": "$guid9$"
     },
-    "UseLatestWindowsAppSDK":{
-      "type": "parameter",
-      "datatype": "bool",
-      "defaultValue": "true"
-    },
     "windowsAppSdkVersion": {
       "type": "parameter",
       "datatype": "text",
-      "replaces": "$WindowsAppSdkVersion$",
-      "defaultValue": "1.8.260317003",
-      "description": "Version of the Microsoft.WindowsAppSDK NuGet package."
+      "defaultValue": "*",
+      "replaces": "$ResolvedWindowsAppSdkVersion$",
+      "description": "Microsoft.WindowsAppSDK NuGet version. Use * for the latest stable."
     },
     "windowsSdkBuildToolsVersion": {
       "type": "parameter",
       "datatype": "text",
-      "replaces": "$WindowsSdkBuildToolsVersion$",
-      "defaultValue": "10.0.26100.7705",
-      "description": "Version of the Microsoft.Windows.SDK.BuildTools NuGet package."
+      "defaultValue": "*",
+      "replaces": "$ResolvedWindowsSdkBuildToolsVersion$",
+      "description": "Microsoft.Windows.SDK.BuildTools NuGet version. Use * for the latest stable."
     },
     "windowsSdkBuildToolsWinAppVersion": {
       "type": "parameter",
       "datatype": "text",
-      "replaces": "$WindowsSdkBuildToolsWinAppVersion$",
-      "defaultValue": "0.3.1",
-      "description": "Version of the Microsoft.Windows.SDK.BuildTools.WinApp NuGet package, which adds `dotnet run` support for packaged WinUI apps via the winapp CLI."
+      "defaultValue": "*",
+      "replaces": "$ResolvedWindowsSdkBuildToolsWinAppVersion$",
+      "description": "Microsoft.Windows.SDK.BuildTools.WinApp NuGet version. Use * for the latest stable."
+    },
+    "communityToolkitMvvmVersion": {
+      "type": "parameter",
+      "datatype": "text",
+      "defaultValue": "*",
+      "replaces": "$ResolvedCommunityToolkitMvvmVersion$",
+      "description": "CommunityToolkit.Mvvm NuGet version. Use * for the latest stable."
     }
   },
   "sources": [
@@ -195,46 +197,6 @@
     }
   },
   "postActions": [
-    {
-      "actionId": "B17581D1-C5C9-4489-8F0A-004BE667B814",
-      "continueOnError": true,
-      "description": "Update Microsoft.WindowsAppSDK to the latest stable version.",
-      "args": {
-        "referenceType": "package",
-        "reference": "Microsoft.WindowsAppSDK"
-      },
-      "manualInstructions": [{ "text": "Run 'dotnet add package Microsoft.WindowsAppSDK'" }]
-    },
-    {
-      "actionId": "B17581D1-C5C9-4489-8F0A-004BE667B814",
-      "continueOnError": true,
-      "description": "Update Microsoft.Windows.SDK.BuildTools to the latest stable version.",
-      "args": {
-        "referenceType": "package",
-        "reference": "Microsoft.Windows.SDK.BuildTools"
-      },
-      "manualInstructions": [{ "text": "Run 'dotnet add package Microsoft.Windows.SDK.BuildTools'" }]
-    },
-    {
-      "actionId": "B17581D1-C5C9-4489-8F0A-004BE667B814",
-      "continueOnError": true,
-      "description": "Update Microsoft.Windows.SDK.BuildTools.WinApp to the latest stable version (enables `dotnet run` for packaged WinUI apps).",
-      "args": {
-        "referenceType": "package",
-        "reference": "Microsoft.Windows.SDK.BuildTools.WinApp"
-      },
-      "manualInstructions": [{ "text": "Run 'dotnet add package Microsoft.Windows.SDK.BuildTools.WinApp'" }]
-    },
-    {
-      "actionId": "B17581D1-C5C9-4489-8F0A-004BE667B814",
-      "continueOnError": true,
-      "description": "Update CommunityToolkit.Mvvm to the latest stable version.",
-      "args": {
-        "referenceType": "package",
-        "reference": "CommunityToolkit.Mvvm"
-      },
-      "manualInstructions": [{ "text": "Run 'dotnet add package CommunityToolkit.Mvvm'" }]
-    },
     {
       "actionId": "210D431B-A78B-4D2F-B762-4ED3E3EA9025",
       "continueOnError": true,

--- a/dev/Templates/Dotnet/templates/mvvm-app/.template.config/template.json
+++ b/dev/Templates/Dotnet/templates/mvvm-app/.template.config/template.json
@@ -135,12 +135,6 @@
       },
       "replaces": "$guid9$"
     },
-    "useLatestDependencies": {
-      "type": "parameter",
-      "datatype": "bool",
-      "defaultValue": "true",
-      "description": "Use the latest available NuGet package versions for all project dependencies."
-    },
     "windowsAppSdkVersion": {
       "type": "parameter",
       "datatype": "text",

--- a/dev/Templates/Dotnet/templates/navigation-app/.template.config/dotnetcli.host.json
+++ b/dev/Templates/Dotnet/templates/navigation-app/.template.config/dotnetcli.host.json
@@ -16,6 +16,18 @@
     "publisherDisplay": {
       "longName": "publisher-display",
       "shortName": "publisherName"
+    },
+    "windowsAppSdkVersion": {
+      "longName": "wasdk-version",
+      "shortName": "wasdkv"
+    },
+    "windowsSdkBuildToolsVersion": {
+      "longName": "build-tools-version",
+      "shortName": "btv"
+    },
+    "windowsSdkBuildToolsWinAppVersion": {
+      "longName": "winapp-version",
+      "shortName": "wav"
     }
   }
 }

--- a/dev/Templates/Dotnet/templates/navigation-app/.template.config/ide.host.json
+++ b/dev/Templates/Dotnet/templates/navigation-app/.template.config/ide.host.json
@@ -39,21 +39,21 @@
     {
       "id": "windowsAppSdkVersion",
       "name": {
-        "text": "Windows App SDK version (empty = latest)"
+        "text": "Windows App SDK version (* = latest)"
       },
       "isVisible": "true"
     },
     {
       "id": "windowsSdkBuildToolsVersion",
       "name": {
-        "text": "Windows SDK BuildTools version (empty = latest)"
+        "text": "Windows SDK BuildTools version (* = latest)"
       },
       "isVisible": "true"
     },
     {
       "id": "windowsSdkBuildToolsWinAppVersion",
       "name": {
-        "text": "Windows SDK BuildTools WinApp version (empty = latest)"
+        "text": "Windows SDK BuildTools WinApp version (* = latest)"
       },
       "isVisible": "true"
     }

--- a/dev/Templates/Dotnet/templates/navigation-app/.template.config/ide.host.json
+++ b/dev/Templates/Dotnet/templates/navigation-app/.template.config/ide.host.json
@@ -37,32 +37,25 @@
       "isVisible": "true"
     },
     {
-      "id": "useLatestDependencies",
+      "id": "windowsAppSdkVersion",
       "name": {
-        "text": "Use latest project dependencies"
+        "text": "Windows App SDK version (empty = latest)"
       },
       "isVisible": "true"
     },
     {
-      "id": "windowsAppSdkVersion",
-      "name": {
-        "text": "Windows App SDK version"
-      },
-      "isVisible": "!useLatestDependencies"
-    },
-    {
       "id": "windowsSdkBuildToolsVersion",
       "name": {
-        "text": "Windows SDK BuildTools version"
+        "text": "Windows SDK BuildTools version (empty = latest)"
       },
-      "isVisible": "!useLatestDependencies"
+      "isVisible": "true"
     },
     {
       "id": "windowsSdkBuildToolsWinAppVersion",
       "name": {
-        "text": "Windows SDK BuildTools WinApp version"
+        "text": "Windows SDK BuildTools WinApp version (empty = latest)"
       },
-      "isVisible": "!useLatestDependencies"
+      "isVisible": "true"
     }
   ]
 }

--- a/dev/Templates/Dotnet/templates/navigation-app/.template.config/ide.host.json
+++ b/dev/Templates/Dotnet/templates/navigation-app/.template.config/ide.host.json
@@ -37,9 +37,23 @@
       "isVisible": "true"
     },
     {
-      "id": "UseLatestWindowsAppSDK",
+      "id": "windowsAppSdkVersion",
       "name": {
-        "text": "Use latest Windows App SDK version"
+        "text": "Windows App SDK version (empty = latest)"
+      },
+      "isVisible": "true"
+    },
+    {
+      "id": "windowsSdkBuildToolsVersion",
+      "name": {
+        "text": "Windows SDK BuildTools version (empty = latest)"
+      },
+      "isVisible": "true"
+    },
+    {
+      "id": "windowsSdkBuildToolsWinAppVersion",
+      "name": {
+        "text": "Windows SDK BuildTools WinApp version (empty = latest)"
       },
       "isVisible": "true"
     }

--- a/dev/Templates/Dotnet/templates/navigation-app/.template.config/ide.host.json
+++ b/dev/Templates/Dotnet/templates/navigation-app/.template.config/ide.host.json
@@ -37,25 +37,32 @@
       "isVisible": "true"
     },
     {
-      "id": "windowsAppSdkVersion",
+      "id": "useLatestDependencies",
       "name": {
-        "text": "Windows App SDK version (empty = latest)"
+        "text": "Use latest project dependencies"
       },
       "isVisible": "true"
+    },
+    {
+      "id": "windowsAppSdkVersion",
+      "name": {
+        "text": "Windows App SDK version"
+      },
+      "isVisible": "!useLatestDependencies"
     },
     {
       "id": "windowsSdkBuildToolsVersion",
       "name": {
-        "text": "Windows SDK BuildTools version (empty = latest)"
+        "text": "Windows SDK BuildTools version"
       },
-      "isVisible": "true"
+      "isVisible": "!useLatestDependencies"
     },
     {
       "id": "windowsSdkBuildToolsWinAppVersion",
       "name": {
-        "text": "Windows SDK BuildTools WinApp version (empty = latest)"
+        "text": "Windows SDK BuildTools WinApp version"
       },
-      "isVisible": "true"
+      "isVisible": "!useLatestDependencies"
     }
   ]
 }

--- a/dev/Templates/Dotnet/templates/navigation-app/.template.config/template.json
+++ b/dev/Templates/Dotnet/templates/navigation-app/.template.config/template.json
@@ -127,21 +127,21 @@
       "type": "parameter",
       "datatype": "text",
       "defaultValue": "*",
-      "replaces": "$ResolvedWindowsAppSdkVersion$",
+      "replaces": "$WindowsAppSdkVersion$",
       "description": "Microsoft.WindowsAppSDK NuGet version. Use * for the latest stable."
     },
     "windowsSdkBuildToolsVersion": {
       "type": "parameter",
       "datatype": "text",
       "defaultValue": "*",
-      "replaces": "$ResolvedWindowsSdkBuildToolsVersion$",
+      "replaces": "$WindowsSdkBuildToolsVersion$",
       "description": "Microsoft.Windows.SDK.BuildTools NuGet version. Use * for the latest stable."
     },
     "windowsSdkBuildToolsWinAppVersion": {
       "type": "parameter",
       "datatype": "text",
       "defaultValue": "*",
-      "replaces": "$ResolvedWindowsSdkBuildToolsWinAppVersion$",
+      "replaces": "$WindowsSdkBuildToolsWinAppVersion$",
       "description": "Microsoft.Windows.SDK.BuildTools.WinApp NuGet version. Use * for the latest stable."
     }
   },

--- a/dev/Templates/Dotnet/templates/navigation-app/.template.config/template.json
+++ b/dev/Templates/Dotnet/templates/navigation-app/.template.config/template.json
@@ -123,6 +123,12 @@
       },
       "replaces": "$guid9$"
     },
+    "useLatestDependencies": {
+      "type": "parameter",
+      "datatype": "bool",
+      "defaultValue": "true",
+      "description": "Use the latest available NuGet package versions for all project dependencies."
+    },
     "windowsAppSdkVersion": {
       "type": "parameter",
       "datatype": "text",

--- a/dev/Templates/Dotnet/templates/navigation-app/.template.config/template.json
+++ b/dev/Templates/Dotnet/templates/navigation-app/.template.config/template.json
@@ -123,12 +123,6 @@
       },
       "replaces": "$guid9$"
     },
-    "useLatestDependencies": {
-      "type": "parameter",
-      "datatype": "bool",
-      "defaultValue": "true",
-      "description": "Use the latest available NuGet package versions for all project dependencies."
-    },
     "windowsAppSdkVersion": {
       "type": "parameter",
       "datatype": "text",

--- a/dev/Templates/Dotnet/templates/navigation-app/.template.config/template.json
+++ b/dev/Templates/Dotnet/templates/navigation-app/.template.config/template.json
@@ -123,31 +123,26 @@
       },
       "replaces": "$guid9$"
     },
-    "UseLatestWindowsAppSDK":{
-      "type": "parameter",
-      "datatype": "bool",
-      "defaultValue": "true"
-    },
     "windowsAppSdkVersion": {
       "type": "parameter",
       "datatype": "text",
-      "replaces": "$WindowsAppSdkVersion$",
-      "defaultValue": "1.8.260317003",
-      "description": "Version of the Microsoft.WindowsAppSDK NuGet package."
+      "defaultValue": "*",
+      "replaces": "$ResolvedWindowsAppSdkVersion$",
+      "description": "Microsoft.WindowsAppSDK NuGet version. Use * for the latest stable."
     },
     "windowsSdkBuildToolsVersion": {
       "type": "parameter",
       "datatype": "text",
-      "replaces": "$WindowsSdkBuildToolsVersion$",
-      "defaultValue": "10.0.26100.7705",
-      "description": "Version of the Microsoft.Windows.SDK.BuildTools NuGet package."
+      "defaultValue": "*",
+      "replaces": "$ResolvedWindowsSdkBuildToolsVersion$",
+      "description": "Microsoft.Windows.SDK.BuildTools NuGet version. Use * for the latest stable."
     },
     "windowsSdkBuildToolsWinAppVersion": {
       "type": "parameter",
       "datatype": "text",
-      "replaces": "$WindowsSdkBuildToolsWinAppVersion$",
-      "defaultValue": "0.3.1",
-      "description": "Version of the Microsoft.Windows.SDK.BuildTools.WinApp NuGet package, which adds `dotnet run` support for packaged WinUI apps via the winapp CLI."
+      "defaultValue": "*",
+      "replaces": "$ResolvedWindowsSdkBuildToolsWinAppVersion$",
+      "description": "Microsoft.Windows.SDK.BuildTools.WinApp NuGet version. Use * for the latest stable."
     }
   },
   "sources": [
@@ -183,36 +178,6 @@
     }
   },
   "postActions": [
-    {
-      "actionId": "B17581D1-C5C9-4489-8F0A-004BE667B814",
-      "continueOnError": true,
-      "description": "Update Microsoft.WindowsAppSDK to the latest stable version.",
-      "args": {
-        "referenceType": "package",
-        "reference": "Microsoft.WindowsAppSDK"
-      },
-      "manualInstructions": [{ "text": "Run 'dotnet add package Microsoft.WindowsAppSDK'" }]
-    },
-    {
-      "actionId": "B17581D1-C5C9-4489-8F0A-004BE667B814",
-      "continueOnError": true,
-      "description": "Update Microsoft.Windows.SDK.BuildTools to the latest stable version.",
-      "args": {
-        "referenceType": "package",
-        "reference": "Microsoft.Windows.SDK.BuildTools"
-      },
-      "manualInstructions": [{ "text": "Run 'dotnet add package Microsoft.Windows.SDK.BuildTools'" }]
-    },
-    {
-      "actionId": "B17581D1-C5C9-4489-8F0A-004BE667B814",
-      "continueOnError": true,
-      "description": "Update Microsoft.Windows.SDK.BuildTools.WinApp to the latest stable version (enables `dotnet run` for packaged WinUI apps).",
-      "args": {
-        "referenceType": "package",
-        "reference": "Microsoft.Windows.SDK.BuildTools.WinApp"
-      },
-      "manualInstructions": [{ "text": "Run 'dotnet add package Microsoft.Windows.SDK.BuildTools.WinApp'" }]
-    },
     {
       "actionId": "210D431B-A78B-4D2F-B762-4ED3E3EA9025",
       "continueOnError": true,

--- a/dev/Templates/Dotnet/templates/tabview-app/.template.config/dotnetcli.host.json
+++ b/dev/Templates/Dotnet/templates/tabview-app/.template.config/dotnetcli.host.json
@@ -20,6 +20,21 @@
       "longName": "publisher-display",
       "shortName": "publisherName",
       "description": "Publisher display name stored in Package.appxmanifest."
+    },
+    "windowsAppSdkVersion": {
+      "longName": "wasdk-version",
+      "shortName": "wasdkv",
+      "description": "Pin to a specific Windows App SDK NuGet version. Leave empty for latest."
+    },
+    "windowsSdkBuildToolsVersion": {
+      "longName": "build-tools-version",
+      "shortName": "btv",
+      "description": "Pin to a specific Windows SDK BuildTools NuGet version. Leave empty for latest."
+    },
+    "windowsSdkBuildToolsWinAppVersion": {
+      "longName": "winapp-version",
+      "shortName": "wav",
+      "description": "Pin to a specific Windows SDK BuildTools WinApp NuGet version. Leave empty for latest."
     }
   }
 }

--- a/dev/Templates/Dotnet/templates/tabview-app/.template.config/ide.host.json
+++ b/dev/Templates/Dotnet/templates/tabview-app/.template.config/ide.host.json
@@ -39,21 +39,21 @@
     {
       "id": "windowsAppSdkVersion",
       "name": {
-        "text": "Windows App SDK version (empty = latest)"
+        "text": "Windows App SDK version (* = latest)"
       },
       "isVisible": "true"
     },
     {
       "id": "windowsSdkBuildToolsVersion",
       "name": {
-        "text": "Windows SDK BuildTools version (empty = latest)"
+        "text": "Windows SDK BuildTools version (* = latest)"
       },
       "isVisible": "true"
     },
     {
       "id": "windowsSdkBuildToolsWinAppVersion",
       "name": {
-        "text": "Windows SDK BuildTools WinApp version (empty = latest)"
+        "text": "Windows SDK BuildTools WinApp version (* = latest)"
       },
       "isVisible": "true"
     }

--- a/dev/Templates/Dotnet/templates/tabview-app/.template.config/ide.host.json
+++ b/dev/Templates/Dotnet/templates/tabview-app/.template.config/ide.host.json
@@ -37,32 +37,25 @@
       "isVisible": "true"
     },
     {
-      "id": "useLatestDependencies",
+      "id": "windowsAppSdkVersion",
       "name": {
-        "text": "Use latest project dependencies"
+        "text": "Windows App SDK version (empty = latest)"
       },
       "isVisible": "true"
     },
     {
-      "id": "windowsAppSdkVersion",
-      "name": {
-        "text": "Windows App SDK version"
-      },
-      "isVisible": "!useLatestDependencies"
-    },
-    {
       "id": "windowsSdkBuildToolsVersion",
       "name": {
-        "text": "Windows SDK BuildTools version"
+        "text": "Windows SDK BuildTools version (empty = latest)"
       },
-      "isVisible": "!useLatestDependencies"
+      "isVisible": "true"
     },
     {
       "id": "windowsSdkBuildToolsWinAppVersion",
       "name": {
-        "text": "Windows SDK BuildTools WinApp version"
+        "text": "Windows SDK BuildTools WinApp version (empty = latest)"
       },
-      "isVisible": "!useLatestDependencies"
+      "isVisible": "true"
     }
   ]
 }

--- a/dev/Templates/Dotnet/templates/tabview-app/.template.config/ide.host.json
+++ b/dev/Templates/Dotnet/templates/tabview-app/.template.config/ide.host.json
@@ -37,9 +37,23 @@
       "isVisible": "true"
     },
     {
-      "id": "UseLatestWindowsAppSDK",
+      "id": "windowsAppSdkVersion",
       "name": {
-        "text": "Use latest Windows App SDK version"
+        "text": "Windows App SDK version (empty = latest)"
+      },
+      "isVisible": "true"
+    },
+    {
+      "id": "windowsSdkBuildToolsVersion",
+      "name": {
+        "text": "Windows SDK BuildTools version (empty = latest)"
+      },
+      "isVisible": "true"
+    },
+    {
+      "id": "windowsSdkBuildToolsWinAppVersion",
+      "name": {
+        "text": "Windows SDK BuildTools WinApp version (empty = latest)"
       },
       "isVisible": "true"
     }

--- a/dev/Templates/Dotnet/templates/tabview-app/.template.config/ide.host.json
+++ b/dev/Templates/Dotnet/templates/tabview-app/.template.config/ide.host.json
@@ -37,25 +37,32 @@
       "isVisible": "true"
     },
     {
-      "id": "windowsAppSdkVersion",
+      "id": "useLatestDependencies",
       "name": {
-        "text": "Windows App SDK version (empty = latest)"
+        "text": "Use latest project dependencies"
       },
       "isVisible": "true"
+    },
+    {
+      "id": "windowsAppSdkVersion",
+      "name": {
+        "text": "Windows App SDK version"
+      },
+      "isVisible": "!useLatestDependencies"
     },
     {
       "id": "windowsSdkBuildToolsVersion",
       "name": {
-        "text": "Windows SDK BuildTools version (empty = latest)"
+        "text": "Windows SDK BuildTools version"
       },
-      "isVisible": "true"
+      "isVisible": "!useLatestDependencies"
     },
     {
       "id": "windowsSdkBuildToolsWinAppVersion",
       "name": {
-        "text": "Windows SDK BuildTools WinApp version (empty = latest)"
+        "text": "Windows SDK BuildTools WinApp version"
       },
-      "isVisible": "true"
+      "isVisible": "!useLatestDependencies"
     }
   ]
 }

--- a/dev/Templates/Dotnet/templates/tabview-app/.template.config/template.json
+++ b/dev/Templates/Dotnet/templates/tabview-app/.template.config/template.json
@@ -135,31 +135,26 @@
       },
       "replaces": "$guid9$"
     },
-    "UseLatestWindowsAppSDK":{
-      "type": "parameter",
-      "datatype": "bool",
-      "defaultValue": "true"
-    },
     "windowsAppSdkVersion": {
       "type": "parameter",
       "datatype": "text",
-      "replaces": "$WindowsAppSdkVersion$",
-      "defaultValue": "1.8.260317003",
-      "description": "Version of the Microsoft.WindowsAppSDK NuGet package."
+      "defaultValue": "*",
+      "replaces": "$ResolvedWindowsAppSdkVersion$",
+      "description": "Microsoft.WindowsAppSDK NuGet version. Use * for the latest stable."
     },
     "windowsSdkBuildToolsVersion": {
       "type": "parameter",
       "datatype": "text",
-      "replaces": "$WindowsSdkBuildToolsVersion$",
-      "defaultValue": "10.0.26100.7705",
-      "description": "Version of the Microsoft.Windows.SDK.BuildTools NuGet package."
+      "defaultValue": "*",
+      "replaces": "$ResolvedWindowsSdkBuildToolsVersion$",
+      "description": "Microsoft.Windows.SDK.BuildTools NuGet version. Use * for the latest stable."
     },
     "windowsSdkBuildToolsWinAppVersion": {
       "type": "parameter",
       "datatype": "text",
-      "replaces": "$WindowsSdkBuildToolsWinAppVersion$",
-      "defaultValue": "0.3.1",
-      "description": "Version of the Microsoft.Windows.SDK.BuildTools.WinApp NuGet package, which adds `dotnet run` support for packaged WinUI apps via the winapp CLI."
+      "defaultValue": "*",
+      "replaces": "$ResolvedWindowsSdkBuildToolsWinAppVersion$",
+      "description": "Microsoft.Windows.SDK.BuildTools.WinApp NuGet version. Use * for the latest stable."
     }
   },
   "sources": [
@@ -195,36 +190,6 @@
     }
   },
   "postActions": [
-    {
-      "actionId": "B17581D1-C5C9-4489-8F0A-004BE667B814",
-      "continueOnError": true,
-      "description": "Update Microsoft.WindowsAppSDK to the latest stable version.",
-      "args": {
-        "referenceType": "package",
-        "reference": "Microsoft.WindowsAppSDK"
-      },
-      "manualInstructions": [{ "text": "Run 'dotnet add package Microsoft.WindowsAppSDK'" }]
-    },
-    {
-      "actionId": "B17581D1-C5C9-4489-8F0A-004BE667B814",
-      "continueOnError": true,
-      "description": "Update Microsoft.Windows.SDK.BuildTools to the latest stable version.",
-      "args": {
-        "referenceType": "package",
-        "reference": "Microsoft.Windows.SDK.BuildTools"
-      },
-      "manualInstructions": [{ "text": "Run 'dotnet add package Microsoft.Windows.SDK.BuildTools'" }]
-    },
-    {
-      "actionId": "B17581D1-C5C9-4489-8F0A-004BE667B814",
-      "continueOnError": true,
-      "description": "Update Microsoft.Windows.SDK.BuildTools.WinApp to the latest stable version (enables `dotnet run` for packaged WinUI apps).",
-      "args": {
-        "referenceType": "package",
-        "reference": "Microsoft.Windows.SDK.BuildTools.WinApp"
-      },
-      "manualInstructions": [{ "text": "Run 'dotnet add package Microsoft.Windows.SDK.BuildTools.WinApp'" }]
-    },
     {
       "actionId": "210D431B-A78B-4D2F-B762-4ED3E3EA9025",
       "continueOnError": true,

--- a/dev/Templates/Dotnet/templates/tabview-app/.template.config/template.json
+++ b/dev/Templates/Dotnet/templates/tabview-app/.template.config/template.json
@@ -139,21 +139,21 @@
       "type": "parameter",
       "datatype": "text",
       "defaultValue": "*",
-      "replaces": "$ResolvedWindowsAppSdkVersion$",
+      "replaces": "$WindowsAppSdkVersion$",
       "description": "Microsoft.WindowsAppSDK NuGet version. Use * for the latest stable."
     },
     "windowsSdkBuildToolsVersion": {
       "type": "parameter",
       "datatype": "text",
       "defaultValue": "*",
-      "replaces": "$ResolvedWindowsSdkBuildToolsVersion$",
+      "replaces": "$WindowsSdkBuildToolsVersion$",
       "description": "Microsoft.Windows.SDK.BuildTools NuGet version. Use * for the latest stable."
     },
     "windowsSdkBuildToolsWinAppVersion": {
       "type": "parameter",
       "datatype": "text",
       "defaultValue": "*",
-      "replaces": "$ResolvedWindowsSdkBuildToolsWinAppVersion$",
+      "replaces": "$WindowsSdkBuildToolsWinAppVersion$",
       "description": "Microsoft.Windows.SDK.BuildTools.WinApp NuGet version. Use * for the latest stable."
     }
   },

--- a/dev/Templates/Dotnet/templates/tabview-app/.template.config/template.json
+++ b/dev/Templates/Dotnet/templates/tabview-app/.template.config/template.json
@@ -135,6 +135,12 @@
       },
       "replaces": "$guid9$"
     },
+    "useLatestDependencies": {
+      "type": "parameter",
+      "datatype": "bool",
+      "defaultValue": "true",
+      "description": "Use the latest available NuGet package versions for all project dependencies."
+    },
     "windowsAppSdkVersion": {
       "type": "parameter",
       "datatype": "text",

--- a/dev/Templates/Dotnet/templates/tabview-app/.template.config/template.json
+++ b/dev/Templates/Dotnet/templates/tabview-app/.template.config/template.json
@@ -135,12 +135,6 @@
       },
       "replaces": "$guid9$"
     },
-    "useLatestDependencies": {
-      "type": "parameter",
-      "datatype": "bool",
-      "defaultValue": "true",
-      "description": "Use the latest available NuGet package versions for all project dependencies."
-    },
     "windowsAppSdkVersion": {
       "type": "parameter",
       "datatype": "text",

--- a/dev/Templates/Dotnet/templates/unit-test/.template.config/dotnetcli.host.json
+++ b/dev/Templates/Dotnet/templates/unit-test/.template.config/dotnetcli.host.json
@@ -20,6 +20,31 @@
       "longName": "publisher-display",
       "shortName": "publisherName",
       "description": "Publisher display name stored in Package.appxmanifest."
+    },
+    "windowsAppSdkVersion": {
+      "longName": "wasdk-version",
+      "shortName": "wasdkv",
+      "description": "Pin to a specific Windows App SDK NuGet version. Leave empty for latest."
+    },
+    "windowsSdkBuildToolsVersion": {
+      "longName": "build-tools-version",
+      "shortName": "btv",
+      "description": "Pin to a specific Windows SDK BuildTools NuGet version. Leave empty for latest."
+    },
+    "windowsSdkBuildToolsWinAppVersion": {
+      "longName": "winapp-version",
+      "shortName": "wav",
+      "description": "Pin to a specific Windows SDK BuildTools WinApp NuGet version. Leave empty for latest."
+    },
+    "mstestVersion": {
+      "longName": "mstest-version",
+      "shortName": "mv",
+      "description": "Pin to a specific MSTest NuGet version. Leave empty for latest."
+    },
+    "microsoftNetTestSdkVersion": {
+      "longName": "test-sdk-version",
+      "shortName": "tsv",
+      "description": "Pin to a specific Microsoft.NET.Test.Sdk NuGet version. Leave empty for latest."
     }
   }
 }

--- a/dev/Templates/Dotnet/templates/unit-test/.template.config/ide.host.json
+++ b/dev/Templates/Dotnet/templates/unit-test/.template.config/ide.host.json
@@ -37,9 +37,37 @@
       "isVisible": "true"
     },
     {
-      "id": "UseLatestWindowsAppSDK",
+      "id": "windowsAppSdkVersion",
       "name": {
-        "text": "Use latest Windows App SDK version"
+        "text": "Windows App SDK version (empty = latest)"
+      },
+      "isVisible": "true"
+    },
+    {
+      "id": "windowsSdkBuildToolsVersion",
+      "name": {
+        "text": "Windows SDK BuildTools version (empty = latest)"
+      },
+      "isVisible": "true"
+    },
+    {
+      "id": "windowsSdkBuildToolsWinAppVersion",
+      "name": {
+        "text": "Windows SDK BuildTools WinApp version (empty = latest)"
+      },
+      "isVisible": "true"
+    },
+    {
+      "id": "mstestVersion",
+      "name": {
+        "text": "MSTest version (empty = latest)"
+      },
+      "isVisible": "true"
+    },
+    {
+      "id": "microsoftNetTestSdkVersion",
+      "name": {
+        "text": "Microsoft.NET.Test.Sdk version (empty = latest)"
       },
       "isVisible": "true"
     }

--- a/dev/Templates/Dotnet/templates/unit-test/.template.config/ide.host.json
+++ b/dev/Templates/Dotnet/templates/unit-test/.template.config/ide.host.json
@@ -37,46 +37,39 @@
       "isVisible": "true"
     },
     {
-      "id": "useLatestDependencies",
+      "id": "windowsAppSdkVersion",
       "name": {
-        "text": "Use latest project dependencies"
+        "text": "Windows App SDK version (empty = latest)"
       },
       "isVisible": "true"
     },
     {
-      "id": "windowsAppSdkVersion",
-      "name": {
-        "text": "Windows App SDK version"
-      },
-      "isVisible": "!useLatestDependencies"
-    },
-    {
       "id": "windowsSdkBuildToolsVersion",
       "name": {
-        "text": "Windows SDK BuildTools version"
+        "text": "Windows SDK BuildTools version (empty = latest)"
       },
-      "isVisible": "!useLatestDependencies"
+      "isVisible": "true"
     },
     {
       "id": "windowsSdkBuildToolsWinAppVersion",
       "name": {
-        "text": "Windows SDK BuildTools WinApp version"
+        "text": "Windows SDK BuildTools WinApp version (empty = latest)"
       },
-      "isVisible": "!useLatestDependencies"
+      "isVisible": "true"
     },
     {
       "id": "mstestVersion",
       "name": {
-        "text": "MSTest version"
+        "text": "MSTest version (empty = latest)"
       },
-      "isVisible": "!useLatestDependencies"
+      "isVisible": "true"
     },
     {
       "id": "microsoftNetTestSdkVersion",
       "name": {
-        "text": "Microsoft.NET.Test.Sdk version"
+        "text": "Microsoft.NET.Test.Sdk version (empty = latest)"
       },
-      "isVisible": "!useLatestDependencies"
+      "isVisible": "true"
     }
   ]
 }

--- a/dev/Templates/Dotnet/templates/unit-test/.template.config/ide.host.json
+++ b/dev/Templates/Dotnet/templates/unit-test/.template.config/ide.host.json
@@ -39,35 +39,35 @@
     {
       "id": "windowsAppSdkVersion",
       "name": {
-        "text": "Windows App SDK version (empty = latest)"
+        "text": "Windows App SDK version (* = latest)"
       },
       "isVisible": "true"
     },
     {
       "id": "windowsSdkBuildToolsVersion",
       "name": {
-        "text": "Windows SDK BuildTools version (empty = latest)"
+        "text": "Windows SDK BuildTools version (* = latest)"
       },
       "isVisible": "true"
     },
     {
       "id": "windowsSdkBuildToolsWinAppVersion",
       "name": {
-        "text": "Windows SDK BuildTools WinApp version (empty = latest)"
+        "text": "Windows SDK BuildTools WinApp version (* = latest)"
       },
       "isVisible": "true"
     },
     {
       "id": "mstestVersion",
       "name": {
-        "text": "MSTest version (empty = latest)"
+        "text": "MSTest version (* = latest)"
       },
       "isVisible": "true"
     },
     {
       "id": "microsoftNetTestSdkVersion",
       "name": {
-        "text": "Microsoft.NET.Test.Sdk version (empty = latest)"
+        "text": "Microsoft.NET.Test.Sdk version (* = latest)"
       },
       "isVisible": "true"
     }

--- a/dev/Templates/Dotnet/templates/unit-test/.template.config/ide.host.json
+++ b/dev/Templates/Dotnet/templates/unit-test/.template.config/ide.host.json
@@ -37,39 +37,46 @@
       "isVisible": "true"
     },
     {
-      "id": "windowsAppSdkVersion",
+      "id": "useLatestDependencies",
       "name": {
-        "text": "Windows App SDK version (empty = latest)"
+        "text": "Use latest project dependencies"
       },
       "isVisible": "true"
+    },
+    {
+      "id": "windowsAppSdkVersion",
+      "name": {
+        "text": "Windows App SDK version"
+      },
+      "isVisible": "!useLatestDependencies"
     },
     {
       "id": "windowsSdkBuildToolsVersion",
       "name": {
-        "text": "Windows SDK BuildTools version (empty = latest)"
+        "text": "Windows SDK BuildTools version"
       },
-      "isVisible": "true"
+      "isVisible": "!useLatestDependencies"
     },
     {
       "id": "windowsSdkBuildToolsWinAppVersion",
       "name": {
-        "text": "Windows SDK BuildTools WinApp version (empty = latest)"
+        "text": "Windows SDK BuildTools WinApp version"
       },
-      "isVisible": "true"
+      "isVisible": "!useLatestDependencies"
     },
     {
       "id": "mstestVersion",
       "name": {
-        "text": "MSTest version (empty = latest)"
+        "text": "MSTest version"
       },
-      "isVisible": "true"
+      "isVisible": "!useLatestDependencies"
     },
     {
       "id": "microsoftNetTestSdkVersion",
       "name": {
-        "text": "Microsoft.NET.Test.Sdk version (empty = latest)"
+        "text": "Microsoft.NET.Test.Sdk version"
       },
-      "isVisible": "true"
+      "isVisible": "!useLatestDependencies"
     }
   ]
 }

--- a/dev/Templates/Dotnet/templates/unit-test/.template.config/template.json
+++ b/dev/Templates/Dotnet/templates/unit-test/.template.config/template.json
@@ -135,45 +135,40 @@
       },
       "replaces": "$guid9$"
     },
-    "UseLatestWindowsAppSDK":{
-      "type": "parameter",
-      "datatype": "bool",
-      "defaultValue": "true"
-    },
     "windowsAppSdkVersion": {
       "type": "parameter",
       "datatype": "text",
-      "replaces": "$WindowsAppSdkVersion$",
-      "defaultValue": "1.8.260317003",
-      "description": "Version of the Microsoft.WindowsAppSDK NuGet package."
+      "defaultValue": "*",
+      "replaces": "$ResolvedWindowsAppSdkVersion$",
+      "description": "Microsoft.WindowsAppSDK NuGet version. Use * for the latest stable."
     },
     "windowsSdkBuildToolsVersion": {
       "type": "parameter",
       "datatype": "text",
-      "replaces": "$WindowsSdkBuildToolsVersion$",
-      "defaultValue": "10.0.26100.7705",
-      "description": "Version of the Microsoft.Windows.SDK.BuildTools NuGet package."
+      "defaultValue": "*",
+      "replaces": "$ResolvedWindowsSdkBuildToolsVersion$",
+      "description": "Microsoft.Windows.SDK.BuildTools NuGet version. Use * for the latest stable."
     },
     "windowsSdkBuildToolsWinAppVersion": {
       "type": "parameter",
       "datatype": "text",
-      "replaces": "$WindowsSdkBuildToolsWinAppVersion$",
-      "defaultValue": "0.3.1",
-      "description": "Version of the Microsoft.Windows.SDK.BuildTools.WinApp NuGet package, which adds `dotnet run` support for packaged WinUI apps via the winapp CLI."
+      "defaultValue": "*",
+      "replaces": "$ResolvedWindowsSdkBuildToolsWinAppVersion$",
+      "description": "Microsoft.Windows.SDK.BuildTools.WinApp NuGet version. Use * for the latest stable."
     },
     "mstestVersion": {
       "type": "parameter",
       "datatype": "text",
-      "replaces": "$MSTestVersion$",
-      "defaultValue": "3.6.4",
-      "description": "Version of the MSTest.TestFramework and MSTest.TestAdapter NuGet packages."
+      "defaultValue": "*",
+      "replaces": "$ResolvedMSTestVersion$",
+      "description": "MSTest NuGet version. Use * for the latest stable."
     },
     "microsoftNetTestSdkVersion": {
       "type": "parameter",
       "datatype": "text",
-      "replaces": "$MicrosoftNetTestSdkVersion$",
-      "defaultValue": "17.13.0",
-      "description": "Version of the Microsoft.NET.Test.Sdk and Microsoft.TestPlatform.TestHost NuGet packages."
+      "defaultValue": "*",
+      "replaces": "$ResolvedMicrosoftNetTestSdkVersion$",
+      "description": "Microsoft.NET.Test.Sdk NuGet version. Use * for the latest stable."
     }
   },
   "sources": [
@@ -209,76 +204,6 @@
     }
   },
   "postActions": [
-    {
-      "actionId": "B17581D1-C5C9-4489-8F0A-004BE667B814",
-      "continueOnError": true,
-      "description": "Update Microsoft.WindowsAppSDK to the latest stable version.",
-      "args": {
-        "referenceType": "package",
-        "reference": "Microsoft.WindowsAppSDK"
-      },
-      "manualInstructions": [{ "text": "Run 'dotnet add package Microsoft.WindowsAppSDK'" }]
-    },
-    {
-      "actionId": "B17581D1-C5C9-4489-8F0A-004BE667B814",
-      "continueOnError": true,
-      "description": "Update Microsoft.Windows.SDK.BuildTools to the latest stable version.",
-      "args": {
-        "referenceType": "package",
-        "reference": "Microsoft.Windows.SDK.BuildTools"
-      },
-      "manualInstructions": [{ "text": "Run 'dotnet add package Microsoft.Windows.SDK.BuildTools'" }]
-    },
-    {
-      "actionId": "B17581D1-C5C9-4489-8F0A-004BE667B814",
-      "continueOnError": true,
-      "description": "Update Microsoft.Windows.SDK.BuildTools.WinApp to the latest stable version (enables `dotnet run` for packaged WinUI apps).",
-      "args": {
-        "referenceType": "package",
-        "reference": "Microsoft.Windows.SDK.BuildTools.WinApp"
-      },
-      "manualInstructions": [{ "text": "Run 'dotnet add package Microsoft.Windows.SDK.BuildTools.WinApp'" }]
-    },
-    {
-      "actionId": "B17581D1-C5C9-4489-8F0A-004BE667B814",
-      "continueOnError": true,
-      "description": "Update MSTest.TestFramework to the latest stable version.",
-      "args": {
-        "referenceType": "package",
-        "reference": "MSTest.TestFramework"
-      },
-      "manualInstructions": [{ "text": "Run 'dotnet add package MSTest.TestFramework'" }]
-    },
-    {
-      "actionId": "B17581D1-C5C9-4489-8F0A-004BE667B814",
-      "continueOnError": true,
-      "description": "Update MSTest.TestAdapter to the latest stable version.",
-      "args": {
-        "referenceType": "package",
-        "reference": "MSTest.TestAdapter"
-      },
-      "manualInstructions": [{ "text": "Run 'dotnet add package MSTest.TestAdapter'" }]
-    },
-    {
-      "actionId": "B17581D1-C5C9-4489-8F0A-004BE667B814",
-      "continueOnError": true,
-      "description": "Update Microsoft.NET.Test.Sdk to the latest stable version.",
-      "args": {
-        "referenceType": "package",
-        "reference": "Microsoft.NET.Test.Sdk"
-      },
-      "manualInstructions": [{ "text": "Run 'dotnet add package Microsoft.NET.Test.Sdk'" }]
-    },
-    {
-      "actionId": "B17581D1-C5C9-4489-8F0A-004BE667B814",
-      "continueOnError": true,
-      "description": "Update Microsoft.TestPlatform.TestHost to the latest stable version.",
-      "args": {
-        "referenceType": "package",
-        "reference": "Microsoft.TestPlatform.TestHost"
-      },
-      "manualInstructions": [{ "text": "Run 'dotnet add package Microsoft.TestPlatform.TestHost'" }]
-    },
     {
       "actionId": "210D431B-A78B-4D2F-B762-4ED3E3EA9025",
       "continueOnError": true,

--- a/dev/Templates/Dotnet/templates/unit-test/.template.config/template.json
+++ b/dev/Templates/Dotnet/templates/unit-test/.template.config/template.json
@@ -135,6 +135,12 @@
       },
       "replaces": "$guid9$"
     },
+    "useLatestDependencies": {
+      "type": "parameter",
+      "datatype": "bool",
+      "defaultValue": "true",
+      "description": "Use the latest available NuGet package versions for all project dependencies."
+    },
     "windowsAppSdkVersion": {
       "type": "parameter",
       "datatype": "text",

--- a/dev/Templates/Dotnet/templates/unit-test/.template.config/template.json
+++ b/dev/Templates/Dotnet/templates/unit-test/.template.config/template.json
@@ -139,35 +139,35 @@
       "type": "parameter",
       "datatype": "text",
       "defaultValue": "*",
-      "replaces": "$ResolvedWindowsAppSdkVersion$",
+      "replaces": "$WindowsAppSdkVersion$",
       "description": "Microsoft.WindowsAppSDK NuGet version. Use * for the latest stable."
     },
     "windowsSdkBuildToolsVersion": {
       "type": "parameter",
       "datatype": "text",
       "defaultValue": "*",
-      "replaces": "$ResolvedWindowsSdkBuildToolsVersion$",
+      "replaces": "$WindowsSdkBuildToolsVersion$",
       "description": "Microsoft.Windows.SDK.BuildTools NuGet version. Use * for the latest stable."
     },
     "windowsSdkBuildToolsWinAppVersion": {
       "type": "parameter",
       "datatype": "text",
       "defaultValue": "*",
-      "replaces": "$ResolvedWindowsSdkBuildToolsWinAppVersion$",
+      "replaces": "$WindowsSdkBuildToolsWinAppVersion$",
       "description": "Microsoft.Windows.SDK.BuildTools.WinApp NuGet version. Use * for the latest stable."
     },
     "mstestVersion": {
       "type": "parameter",
       "datatype": "text",
       "defaultValue": "*",
-      "replaces": "$ResolvedMSTestVersion$",
+      "replaces": "$MSTestVersion$",
       "description": "MSTest NuGet version. Use * for the latest stable."
     },
     "microsoftNetTestSdkVersion": {
       "type": "parameter",
       "datatype": "text",
       "defaultValue": "*",
-      "replaces": "$ResolvedMicrosoftNetTestSdkVersion$",
+      "replaces": "$MicrosoftNetTestSdkVersion$",
       "description": "Microsoft.NET.Test.Sdk NuGet version. Use * for the latest stable."
     }
   },

--- a/dev/Templates/Dotnet/templates/unit-test/.template.config/template.json
+++ b/dev/Templates/Dotnet/templates/unit-test/.template.config/template.json
@@ -135,12 +135,6 @@
       },
       "replaces": "$guid9$"
     },
-    "useLatestDependencies": {
-      "type": "parameter",
-      "datatype": "bool",
-      "defaultValue": "true",
-      "description": "Use the latest available NuGet package versions for all project dependencies."
-    },
     "windowsAppSdkVersion": {
       "type": "parameter",
       "datatype": "text",

--- a/dev/Templates/Source/ProjectTemplates/Desktop/CSharp/ClassLibrary/ProjectTemplate.csproj
+++ b/dev/Templates/Source/ProjectTemplates/Desktop/CSharp/ClassLibrary/ProjectTemplate.csproj
@@ -10,7 +10,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Windows.SDK.BuildTools" Version="$ResolvedWindowsSdkBuildToolsVersion$" />
-    <PackageReference Include="Microsoft.WindowsAppSDK" Version="$ResolvedWindowsAppSdkVersion$" />
+    <PackageReference Include="Microsoft.Windows.SDK.BuildTools" Version="$WindowsSdkBuildToolsVersion$" />
+    <PackageReference Include="Microsoft.WindowsAppSDK" Version="$WindowsAppSdkVersion$" />
   </ItemGroup>
 </Project>

--- a/dev/Templates/Source/ProjectTemplates/Desktop/CSharp/ClassLibrary/ProjectTemplate.csproj
+++ b/dev/Templates/Source/ProjectTemplates/Desktop/CSharp/ClassLibrary/ProjectTemplate.csproj
@@ -10,7 +10,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Windows.SDK.BuildTools" Version="*" />
-    <PackageReference Include="Microsoft.WindowsAppSDK" Version="*" />
+    <PackageReference Include="Microsoft.Windows.SDK.BuildTools" Version="$ResolvedWindowsSdkBuildToolsVersion$" />
+    <PackageReference Include="Microsoft.WindowsAppSDK" Version="$ResolvedWindowsAppSdkVersion$" />
   </ItemGroup>
 </Project>

--- a/dev/Templates/Source/ProjectTemplates/Desktop/CSharp/ClassLibrary/ProjectTemplate.csproj
+++ b/dev/Templates/Source/ProjectTemplates/Desktop/CSharp/ClassLibrary/ProjectTemplate.csproj
@@ -8,4 +8,9 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <AppendRuntimeIdentifierToOutputPath>false</AppendRuntimeIdentifierToOutputPath>
   </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Windows.SDK.BuildTools" Version="*" />
+    <PackageReference Include="Microsoft.WindowsAppSDK" Version="*" />
+  </ItemGroup>
 </Project>

--- a/dev/Templates/Source/ProjectTemplates/Desktop/CSharp/ClassLibrary/WinUI.Desktop.Cs.ClassLibrary.vstemplate
+++ b/dev/Templates/Source/ProjectTemplates/Desktop/CSharp/ClassLibrary/WinUI.Desktop.Cs.ClassLibrary.vstemplate
@@ -30,6 +30,8 @@
     <CustomParameters>
       <CustomParameter Name="$NuGetPackages$" Value="Microsoft.WindowsAppSDK;Microsoft.Windows.SDK.BuildTools"/>
       <CustomParameter Name="$DotNetVersion$" Value="FIXME-Verify-Directory.Build.Targets-XmlPoke-Queries"/>        
+      <CustomParameter Name="$ResolvedWindowsAppSdkVersion$" Value="*" />
+      <CustomParameter Name="$ResolvedWindowsSdkBuildToolsVersion$" Value="*" />
     </CustomParameters>
   </TemplateContent>
   <WizardExtension>

--- a/dev/Templates/Source/ProjectTemplates/Desktop/CSharp/ClassLibrary/WinUI.Desktop.Cs.ClassLibrary.vstemplate
+++ b/dev/Templates/Source/ProjectTemplates/Desktop/CSharp/ClassLibrary/WinUI.Desktop.Cs.ClassLibrary.vstemplate
@@ -30,8 +30,8 @@
     <CustomParameters>
       <CustomParameter Name="$NuGetPackages$" Value="Microsoft.WindowsAppSDK;Microsoft.Windows.SDK.BuildTools"/>
       <CustomParameter Name="$DotNetVersion$" Value="FIXME-Verify-Directory.Build.Targets-XmlPoke-Queries"/>        
-      <CustomParameter Name="$ResolvedWindowsAppSdkVersion$" Value="*" />
-      <CustomParameter Name="$ResolvedWindowsSdkBuildToolsVersion$" Value="*" />
+      <CustomParameter Name="$WindowsAppSdkVersion$" Value="*" />
+      <CustomParameter Name="$WindowsSdkBuildToolsVersion$" Value="*" />
     </CustomParameters>
   </TemplateContent>
   <WizardExtension>

--- a/dev/Templates/Source/ProjectTemplates/Desktop/CSharp/MvvmApp/ProjectTemplate.csproj
+++ b/dev/Templates/Source/ProjectTemplates/Desktop/CSharp/MvvmApp/ProjectTemplate.csproj
@@ -49,10 +49,10 @@
     <PropertyGroup> above to opt out.
   -->
   <ItemGroup>
-    <PackageReference Include="Microsoft.Windows.SDK.BuildTools" Version="*" />
-    <PackageReference Include="Microsoft.WindowsAppSDK" Version="*" />
-    <PackageReference Include="CommunityToolkit.Mvvm" Version="*" />
-    <PackageReference Include="Microsoft.Windows.SDK.BuildTools.WinApp" Version="*" />
+    <PackageReference Include="Microsoft.Windows.SDK.BuildTools" Version="$ResolvedWindowsSdkBuildToolsVersion$" />
+    <PackageReference Include="Microsoft.WindowsAppSDK" Version="$ResolvedWindowsAppSdkVersion$" />
+    <PackageReference Include="CommunityToolkit.Mvvm" Version="$ResolvedCommunityToolkitMvvmVersion$" />
+    <PackageReference Include="Microsoft.Windows.SDK.BuildTools.WinApp" Version="$ResolvedWindowsSdkBuildToolsWinAppVersion$" />
   </ItemGroup>
 
   <!--

--- a/dev/Templates/Source/ProjectTemplates/Desktop/CSharp/MvvmApp/ProjectTemplate.csproj
+++ b/dev/Templates/Source/ProjectTemplates/Desktop/CSharp/MvvmApp/ProjectTemplate.csproj
@@ -48,14 +48,12 @@
     Set <EnableWinAppRunSupport>false</EnableWinAppRunSupport> in a
     <PropertyGroup> above to opt out.
   -->
-  <!--#if (UseLatestWindowsAppSDK)
   <ItemGroup>
-    <PackageReference Include="Microsoft.Windows.SDK.BuildTools" Version="$WindowsSdkBuildToolsVersion$" />
-    <PackageReference Include="Microsoft.WindowsAppSDK" Version="$WindowsAppSdkVersion$" />
-    <PackageReference Include="CommunityToolkit.Mvvm" Version="8.4.2" />
-    <PackageReference Include="Microsoft.Windows.SDK.BuildTools.WinApp" Version="$WindowsSdkBuildToolsWinAppVersion$" />
+    <PackageReference Include="Microsoft.Windows.SDK.BuildTools" Version="*" />
+    <PackageReference Include="Microsoft.WindowsAppSDK" Version="*" />
+    <PackageReference Include="CommunityToolkit.Mvvm" Version="*" />
+    <PackageReference Include="Microsoft.Windows.SDK.BuildTools.WinApp" Version="*" />
   </ItemGroup>
-  #endif -->
 
   <!--
     Defining the "HasPackageAndPublishMenuAddedByProject" property here allows the Solution

--- a/dev/Templates/Source/ProjectTemplates/Desktop/CSharp/MvvmApp/ProjectTemplate.csproj
+++ b/dev/Templates/Source/ProjectTemplates/Desktop/CSharp/MvvmApp/ProjectTemplate.csproj
@@ -49,10 +49,10 @@
     <PropertyGroup> above to opt out.
   -->
   <ItemGroup>
-    <PackageReference Include="Microsoft.Windows.SDK.BuildTools" Version="$ResolvedWindowsSdkBuildToolsVersion$" />
-    <PackageReference Include="Microsoft.WindowsAppSDK" Version="$ResolvedWindowsAppSdkVersion$" />
-    <PackageReference Include="CommunityToolkit.Mvvm" Version="$ResolvedCommunityToolkitMvvmVersion$" />
-    <PackageReference Include="Microsoft.Windows.SDK.BuildTools.WinApp" Version="$ResolvedWindowsSdkBuildToolsWinAppVersion$" />
+    <PackageReference Include="Microsoft.Windows.SDK.BuildTools" Version="$WindowsSdkBuildToolsVersion$" />
+    <PackageReference Include="Microsoft.WindowsAppSDK" Version="$WindowsAppSdkVersion$" />
+    <PackageReference Include="CommunityToolkit.Mvvm" Version="$CommunityToolkitMvvmVersion$" />
+    <PackageReference Include="Microsoft.Windows.SDK.BuildTools.WinApp" Version="$WindowsSdkBuildToolsWinAppVersion$" />
   </ItemGroup>
 
   <!--

--- a/dev/Templates/Source/ProjectTemplates/Desktop/CSharp/MvvmApp/WinUI.Desktop.Cs.MvvmApp.vstemplate
+++ b/dev/Templates/Source/ProjectTemplates/Desktop/CSharp/MvvmApp/WinUI.Desktop.Cs.MvvmApp.vstemplate
@@ -28,10 +28,10 @@
       <CustomParameter Name="$WindowsAppSDKNupkgVersion$" Value="FIXME-Verify-Directory.Build.Targets-XmlPoke-Queries" />
       <CustomParameter Name="$WindowsSDKBuildToolsNupkgVersion$" Value="FIXME-Verify-Directory.Build.Targets-XmlPoke-Queries" />
       <CustomParameter Name="$DotNetVersion$" Value="FIXME-Verify-Directory.Build.Targets-XmlPoke-Queries"/>
-      <CustomParameter Name="$ResolvedWindowsAppSdkVersion$" Value="*" />
-      <CustomParameter Name="$ResolvedWindowsSdkBuildToolsVersion$" Value="*" />
-      <CustomParameter Name="$ResolvedWindowsSdkBuildToolsWinAppVersion$" Value="*" />
-      <CustomParameter Name="$ResolvedCommunityToolkitMvvmVersion$" Value="*" />
+      <CustomParameter Name="$WindowsAppSdkVersion$" Value="*" />
+      <CustomParameter Name="$WindowsSdkBuildToolsVersion$" Value="*" />
+      <CustomParameter Name="$WindowsSdkBuildToolsWinAppVersion$" Value="*" />
+      <CustomParameter Name="$CommunityToolkitMvvmVersion$" Value="*" />
     </CustomParameters>
     <Project File="ProjectTemplate.csproj" ReplaceParameters="true">
       <ProjectItem ReplaceParameters="true" TargetFileName="launchSettings.json">Properties\launchSettings.json</ProjectItem>

--- a/dev/Templates/Source/ProjectTemplates/Desktop/CSharp/MvvmApp/WinUI.Desktop.Cs.MvvmApp.vstemplate
+++ b/dev/Templates/Source/ProjectTemplates/Desktop/CSharp/MvvmApp/WinUI.Desktop.Cs.MvvmApp.vstemplate
@@ -28,6 +28,10 @@
       <CustomParameter Name="$WindowsAppSDKNupkgVersion$" Value="FIXME-Verify-Directory.Build.Targets-XmlPoke-Queries" />
       <CustomParameter Name="$WindowsSDKBuildToolsNupkgVersion$" Value="FIXME-Verify-Directory.Build.Targets-XmlPoke-Queries" />
       <CustomParameter Name="$DotNetVersion$" Value="FIXME-Verify-Directory.Build.Targets-XmlPoke-Queries"/>
+      <CustomParameter Name="$ResolvedWindowsAppSdkVersion$" Value="*" />
+      <CustomParameter Name="$ResolvedWindowsSdkBuildToolsVersion$" Value="*" />
+      <CustomParameter Name="$ResolvedWindowsSdkBuildToolsWinAppVersion$" Value="*" />
+      <CustomParameter Name="$ResolvedCommunityToolkitMvvmVersion$" Value="*" />
     </CustomParameters>
     <Project File="ProjectTemplate.csproj" ReplaceParameters="true">
       <ProjectItem ReplaceParameters="true" TargetFileName="launchSettings.json">Properties\launchSettings.json</ProjectItem>

--- a/dev/Templates/Source/ProjectTemplates/Desktop/CSharp/NavigationApp/ProjectTemplate.csproj
+++ b/dev/Templates/Source/ProjectTemplates/Desktop/CSharp/NavigationApp/ProjectTemplate.csproj
@@ -49,9 +49,9 @@
     <PropertyGroup> above to opt out.
   -->
   <ItemGroup>
-    <PackageReference Include="Microsoft.Windows.SDK.BuildTools" Version="*" />
-    <PackageReference Include="Microsoft.WindowsAppSDK" Version="*" />
-    <PackageReference Include="Microsoft.Windows.SDK.BuildTools.WinApp" Version="*" />
+    <PackageReference Include="Microsoft.Windows.SDK.BuildTools" Version="$ResolvedWindowsSdkBuildToolsVersion$" />
+    <PackageReference Include="Microsoft.WindowsAppSDK" Version="$ResolvedWindowsAppSdkVersion$" />
+    <PackageReference Include="Microsoft.Windows.SDK.BuildTools.WinApp" Version="$ResolvedWindowsSdkBuildToolsWinAppVersion$" />
   </ItemGroup>
 
   <!--

--- a/dev/Templates/Source/ProjectTemplates/Desktop/CSharp/NavigationApp/ProjectTemplate.csproj
+++ b/dev/Templates/Source/ProjectTemplates/Desktop/CSharp/NavigationApp/ProjectTemplate.csproj
@@ -48,13 +48,11 @@
     Set <EnableWinAppRunSupport>false</EnableWinAppRunSupport> in a
     <PropertyGroup> above to opt out.
   -->
-  <!--#if (UseLatestWindowsAppSDK)
   <ItemGroup>
-    <PackageReference Include="Microsoft.Windows.SDK.BuildTools" Version="$WindowsSdkBuildToolsVersion$" />
-    <PackageReference Include="Microsoft.WindowsAppSDK" Version="$WindowsAppSdkVersion$" />
-    <PackageReference Include="Microsoft.Windows.SDK.BuildTools.WinApp" Version="$WindowsSdkBuildToolsWinAppVersion$" />
+    <PackageReference Include="Microsoft.Windows.SDK.BuildTools" Version="*" />
+    <PackageReference Include="Microsoft.WindowsAppSDK" Version="*" />
+    <PackageReference Include="Microsoft.Windows.SDK.BuildTools.WinApp" Version="*" />
   </ItemGroup>
-  #endif -->
 
   <!--
     Defining the "HasPackageAndPublishMenuAddedByProject" property here allows the Solution

--- a/dev/Templates/Source/ProjectTemplates/Desktop/CSharp/NavigationApp/ProjectTemplate.csproj
+++ b/dev/Templates/Source/ProjectTemplates/Desktop/CSharp/NavigationApp/ProjectTemplate.csproj
@@ -49,9 +49,9 @@
     <PropertyGroup> above to opt out.
   -->
   <ItemGroup>
-    <PackageReference Include="Microsoft.Windows.SDK.BuildTools" Version="$ResolvedWindowsSdkBuildToolsVersion$" />
-    <PackageReference Include="Microsoft.WindowsAppSDK" Version="$ResolvedWindowsAppSdkVersion$" />
-    <PackageReference Include="Microsoft.Windows.SDK.BuildTools.WinApp" Version="$ResolvedWindowsSdkBuildToolsWinAppVersion$" />
+    <PackageReference Include="Microsoft.Windows.SDK.BuildTools" Version="$WindowsSdkBuildToolsVersion$" />
+    <PackageReference Include="Microsoft.WindowsAppSDK" Version="$WindowsAppSdkVersion$" />
+    <PackageReference Include="Microsoft.Windows.SDK.BuildTools.WinApp" Version="$WindowsSdkBuildToolsWinAppVersion$" />
   </ItemGroup>
 
   <!--

--- a/dev/Templates/Source/ProjectTemplates/Desktop/CSharp/NavigationApp/WinUI.Desktop.Cs.NavigationApp.vstemplate
+++ b/dev/Templates/Source/ProjectTemplates/Desktop/CSharp/NavigationApp/WinUI.Desktop.Cs.NavigationApp.vstemplate
@@ -28,9 +28,9 @@
       <CustomParameter Name="$WindowsAppSDKNupkgVersion$" Value="FIXME-Verify-Directory.Build.Targets-XmlPoke-Queries" />
       <CustomParameter Name="$WindowsSDKBuildToolsNupkgVersion$" Value="FIXME-Verify-Directory.Build.Targets-XmlPoke-Queries" />
       <CustomParameter Name="$DotNetVersion$" Value="FIXME-Verify-Directory.Build.Targets-XmlPoke-Queries"/>
-      <CustomParameter Name="$ResolvedWindowsAppSdkVersion$" Value="*" />
-      <CustomParameter Name="$ResolvedWindowsSdkBuildToolsVersion$" Value="*" />
-      <CustomParameter Name="$ResolvedWindowsSdkBuildToolsWinAppVersion$" Value="*" />
+      <CustomParameter Name="$WindowsAppSdkVersion$" Value="*" />
+      <CustomParameter Name="$WindowsSdkBuildToolsVersion$" Value="*" />
+      <CustomParameter Name="$WindowsSdkBuildToolsWinAppVersion$" Value="*" />
     </CustomParameters>
     <Project File="ProjectTemplate.csproj" ReplaceParameters="true">
       <ProjectItem ReplaceParameters="true" TargetFileName="launchSettings.json">Properties\launchSettings.json</ProjectItem>

--- a/dev/Templates/Source/ProjectTemplates/Desktop/CSharp/NavigationApp/WinUI.Desktop.Cs.NavigationApp.vstemplate
+++ b/dev/Templates/Source/ProjectTemplates/Desktop/CSharp/NavigationApp/WinUI.Desktop.Cs.NavigationApp.vstemplate
@@ -28,6 +28,9 @@
       <CustomParameter Name="$WindowsAppSDKNupkgVersion$" Value="FIXME-Verify-Directory.Build.Targets-XmlPoke-Queries" />
       <CustomParameter Name="$WindowsSDKBuildToolsNupkgVersion$" Value="FIXME-Verify-Directory.Build.Targets-XmlPoke-Queries" />
       <CustomParameter Name="$DotNetVersion$" Value="FIXME-Verify-Directory.Build.Targets-XmlPoke-Queries"/>
+      <CustomParameter Name="$ResolvedWindowsAppSdkVersion$" Value="*" />
+      <CustomParameter Name="$ResolvedWindowsSdkBuildToolsVersion$" Value="*" />
+      <CustomParameter Name="$ResolvedWindowsSdkBuildToolsWinAppVersion$" Value="*" />
     </CustomParameters>
     <Project File="ProjectTemplate.csproj" ReplaceParameters="true">
       <ProjectItem ReplaceParameters="true" TargetFileName="launchSettings.json">Properties\launchSettings.json</ProjectItem>

--- a/dev/Templates/Source/ProjectTemplates/Desktop/CSharp/PackagedApp/BlankApp/ProjectTemplate.csproj
+++ b/dev/Templates/Source/ProjectTemplates/Desktop/CSharp/PackagedApp/BlankApp/ProjectTemplate.csproj
@@ -20,6 +20,12 @@
     <Manifest Include="$(ApplicationManifest)" />
   </ItemGroup>
 
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Windows.SDK.BuildTools" Version="*" />
+    <PackageReference Include="Microsoft.WindowsAppSDK" Version="*" />
+    <PackageReference Include="Microsoft.Windows.SDK.BuildTools.WinApp" Version="*" />
+  </ItemGroup>
+
     <!-- Publish Properties -->
   <PropertyGroup>
     <PublishReadyToRun Condition="'$(Configuration)' == 'Debug'">False</PublishReadyToRun>

--- a/dev/Templates/Source/ProjectTemplates/Desktop/CSharp/SingleProjectPackagedApp/ProjectTemplate.csproj
+++ b/dev/Templates/Source/ProjectTemplates/Desktop/CSharp/SingleProjectPackagedApp/ProjectTemplate.csproj
@@ -49,9 +49,9 @@
     <PropertyGroup> above to opt out.
   -->
   <ItemGroup>
-    <PackageReference Include="Microsoft.Windows.SDK.BuildTools" Version="*" />
-    <PackageReference Include="Microsoft.WindowsAppSDK" Version="*" />
-    <PackageReference Include="Microsoft.Windows.SDK.BuildTools.WinApp" Version="*" />
+    <PackageReference Include="Microsoft.Windows.SDK.BuildTools" Version="$ResolvedWindowsSdkBuildToolsVersion$" />
+    <PackageReference Include="Microsoft.WindowsAppSDK" Version="$ResolvedWindowsAppSdkVersion$" />
+    <PackageReference Include="Microsoft.Windows.SDK.BuildTools.WinApp" Version="$ResolvedWindowsSdkBuildToolsWinAppVersion$" />
   </ItemGroup>
 
   <!--

--- a/dev/Templates/Source/ProjectTemplates/Desktop/CSharp/SingleProjectPackagedApp/ProjectTemplate.csproj
+++ b/dev/Templates/Source/ProjectTemplates/Desktop/CSharp/SingleProjectPackagedApp/ProjectTemplate.csproj
@@ -48,13 +48,11 @@
     Set <EnableWinAppRunSupport>false</EnableWinAppRunSupport> in a
     <PropertyGroup> above to opt out.
   -->
-  <!--#if (UseLatestWindowsAppSDK)
   <ItemGroup>
-    <PackageReference Include="Microsoft.Windows.SDK.BuildTools" Version="$WindowsSdkBuildToolsVersion$" />
-    <PackageReference Include="Microsoft.WindowsAppSDK" Version="$WindowsAppSdkVersion$" />
-    <PackageReference Include="Microsoft.Windows.SDK.BuildTools.WinApp" Version="$WindowsSdkBuildToolsWinAppVersion$" />
+    <PackageReference Include="Microsoft.Windows.SDK.BuildTools" Version="*" />
+    <PackageReference Include="Microsoft.WindowsAppSDK" Version="*" />
+    <PackageReference Include="Microsoft.Windows.SDK.BuildTools.WinApp" Version="*" />
   </ItemGroup>
-  #endif -->
 
   <!--
     Defining the "HasPackageAndPublishMenuAddedByProject" property here allows the Solution

--- a/dev/Templates/Source/ProjectTemplates/Desktop/CSharp/SingleProjectPackagedApp/ProjectTemplate.csproj
+++ b/dev/Templates/Source/ProjectTemplates/Desktop/CSharp/SingleProjectPackagedApp/ProjectTemplate.csproj
@@ -49,9 +49,9 @@
     <PropertyGroup> above to opt out.
   -->
   <ItemGroup>
-    <PackageReference Include="Microsoft.Windows.SDK.BuildTools" Version="$ResolvedWindowsSdkBuildToolsVersion$" />
-    <PackageReference Include="Microsoft.WindowsAppSDK" Version="$ResolvedWindowsAppSdkVersion$" />
-    <PackageReference Include="Microsoft.Windows.SDK.BuildTools.WinApp" Version="$ResolvedWindowsSdkBuildToolsWinAppVersion$" />
+    <PackageReference Include="Microsoft.Windows.SDK.BuildTools" Version="$WindowsSdkBuildToolsVersion$" />
+    <PackageReference Include="Microsoft.WindowsAppSDK" Version="$WindowsAppSdkVersion$" />
+    <PackageReference Include="Microsoft.Windows.SDK.BuildTools.WinApp" Version="$WindowsSdkBuildToolsWinAppVersion$" />
   </ItemGroup>
 
   <!--

--- a/dev/Templates/Source/ProjectTemplates/Desktop/CSharp/SingleProjectPackagedApp/WinUI.Desktop.Cs.SingleProjectPackagedApp.vstemplate
+++ b/dev/Templates/Source/ProjectTemplates/Desktop/CSharp/SingleProjectPackagedApp/WinUI.Desktop.Cs.SingleProjectPackagedApp.vstemplate
@@ -28,9 +28,9 @@
       <CustomParameter Name="$WindowsAppSDKNupkgVersion$" Value="FIXME-Verify-Directory.Build.Targets-XmlPoke-Queries" />
       <CustomParameter Name="$WindowsSDKBuildToolsNupkgVersion$" Value="FIXME-Verify-Directory.Build.Targets-XmlPoke-Queries" />
       <CustomParameter Name="$DotNetVersion$" Value="FIXME-Verify-Directory.Build.Targets-XmlPoke-Queries"/>
-      <CustomParameter Name="$ResolvedWindowsAppSdkVersion$" Value="*" />
-      <CustomParameter Name="$ResolvedWindowsSdkBuildToolsVersion$" Value="*" />
-      <CustomParameter Name="$ResolvedWindowsSdkBuildToolsWinAppVersion$" Value="*" />
+      <CustomParameter Name="$WindowsAppSdkVersion$" Value="*" />
+      <CustomParameter Name="$WindowsSdkBuildToolsVersion$" Value="*" />
+      <CustomParameter Name="$WindowsSdkBuildToolsWinAppVersion$" Value="*" />
     </CustomParameters>
     <Project File="ProjectTemplate.csproj" ReplaceParameters="true">
       <ProjectItem ReplaceParameters="true" TargetFileName="launchSettings.json">Properties\launchSettings.json</ProjectItem>

--- a/dev/Templates/Source/ProjectTemplates/Desktop/CSharp/SingleProjectPackagedApp/WinUI.Desktop.Cs.SingleProjectPackagedApp.vstemplate
+++ b/dev/Templates/Source/ProjectTemplates/Desktop/CSharp/SingleProjectPackagedApp/WinUI.Desktop.Cs.SingleProjectPackagedApp.vstemplate
@@ -28,6 +28,9 @@
       <CustomParameter Name="$WindowsAppSDKNupkgVersion$" Value="FIXME-Verify-Directory.Build.Targets-XmlPoke-Queries" />
       <CustomParameter Name="$WindowsSDKBuildToolsNupkgVersion$" Value="FIXME-Verify-Directory.Build.Targets-XmlPoke-Queries" />
       <CustomParameter Name="$DotNetVersion$" Value="FIXME-Verify-Directory.Build.Targets-XmlPoke-Queries"/>
+      <CustomParameter Name="$ResolvedWindowsAppSdkVersion$" Value="*" />
+      <CustomParameter Name="$ResolvedWindowsSdkBuildToolsVersion$" Value="*" />
+      <CustomParameter Name="$ResolvedWindowsSdkBuildToolsWinAppVersion$" Value="*" />
     </CustomParameters>
     <Project File="ProjectTemplate.csproj" ReplaceParameters="true">
       <ProjectItem ReplaceParameters="true" TargetFileName="launchSettings.json">Properties\launchSettings.json</ProjectItem>

--- a/dev/Templates/Source/ProjectTemplates/Desktop/CSharp/TabViewApp/ProjectTemplate.csproj
+++ b/dev/Templates/Source/ProjectTemplates/Desktop/CSharp/TabViewApp/ProjectTemplate.csproj
@@ -49,9 +49,9 @@
     <PropertyGroup> above to opt out.
   -->
   <ItemGroup>
-    <PackageReference Include="Microsoft.Windows.SDK.BuildTools" Version="*" />
-    <PackageReference Include="Microsoft.WindowsAppSDK" Version="*" />
-    <PackageReference Include="Microsoft.Windows.SDK.BuildTools.WinApp" Version="*" />
+    <PackageReference Include="Microsoft.Windows.SDK.BuildTools" Version="$ResolvedWindowsSdkBuildToolsVersion$" />
+    <PackageReference Include="Microsoft.WindowsAppSDK" Version="$ResolvedWindowsAppSdkVersion$" />
+    <PackageReference Include="Microsoft.Windows.SDK.BuildTools.WinApp" Version="$ResolvedWindowsSdkBuildToolsWinAppVersion$" />
   </ItemGroup>
 
   <!--

--- a/dev/Templates/Source/ProjectTemplates/Desktop/CSharp/TabViewApp/ProjectTemplate.csproj
+++ b/dev/Templates/Source/ProjectTemplates/Desktop/CSharp/TabViewApp/ProjectTemplate.csproj
@@ -48,13 +48,11 @@
     Set <EnableWinAppRunSupport>false</EnableWinAppRunSupport> in a
     <PropertyGroup> above to opt out.
   -->
-  <!--#if (UseLatestWindowsAppSDK)
   <ItemGroup>
-    <PackageReference Include="Microsoft.Windows.SDK.BuildTools" Version="$WindowsSdkBuildToolsVersion$" />
-    <PackageReference Include="Microsoft.WindowsAppSDK" Version="$WindowsAppSdkVersion$" />
-    <PackageReference Include="Microsoft.Windows.SDK.BuildTools.WinApp" Version="$WindowsSdkBuildToolsWinAppVersion$" />
+    <PackageReference Include="Microsoft.Windows.SDK.BuildTools" Version="*" />
+    <PackageReference Include="Microsoft.WindowsAppSDK" Version="*" />
+    <PackageReference Include="Microsoft.Windows.SDK.BuildTools.WinApp" Version="*" />
   </ItemGroup>
-  #endif -->
 
   <!--
     Defining the "HasPackageAndPublishMenuAddedByProject" property here allows the Solution

--- a/dev/Templates/Source/ProjectTemplates/Desktop/CSharp/TabViewApp/ProjectTemplate.csproj
+++ b/dev/Templates/Source/ProjectTemplates/Desktop/CSharp/TabViewApp/ProjectTemplate.csproj
@@ -49,9 +49,9 @@
     <PropertyGroup> above to opt out.
   -->
   <ItemGroup>
-    <PackageReference Include="Microsoft.Windows.SDK.BuildTools" Version="$ResolvedWindowsSdkBuildToolsVersion$" />
-    <PackageReference Include="Microsoft.WindowsAppSDK" Version="$ResolvedWindowsAppSdkVersion$" />
-    <PackageReference Include="Microsoft.Windows.SDK.BuildTools.WinApp" Version="$ResolvedWindowsSdkBuildToolsWinAppVersion$" />
+    <PackageReference Include="Microsoft.Windows.SDK.BuildTools" Version="$WindowsSdkBuildToolsVersion$" />
+    <PackageReference Include="Microsoft.WindowsAppSDK" Version="$WindowsAppSdkVersion$" />
+    <PackageReference Include="Microsoft.Windows.SDK.BuildTools.WinApp" Version="$WindowsSdkBuildToolsWinAppVersion$" />
   </ItemGroup>
 
   <!--

--- a/dev/Templates/Source/ProjectTemplates/Desktop/CSharp/TabViewApp/WinUI.Desktop.Cs.TabViewApp.vstemplate
+++ b/dev/Templates/Source/ProjectTemplates/Desktop/CSharp/TabViewApp/WinUI.Desktop.Cs.TabViewApp.vstemplate
@@ -28,9 +28,9 @@
       <CustomParameter Name="$WindowsAppSDKNupkgVersion$" Value="FIXME-Verify-Directory.Build.Targets-XmlPoke-Queries" />
       <CustomParameter Name="$WindowsSDKBuildToolsNupkgVersion$" Value="FIXME-Verify-Directory.Build.Targets-XmlPoke-Queries" />
       <CustomParameter Name="$DotNetVersion$" Value="FIXME-Verify-Directory.Build.Targets-XmlPoke-Queries"/>
-      <CustomParameter Name="$ResolvedWindowsAppSdkVersion$" Value="*" />
-      <CustomParameter Name="$ResolvedWindowsSdkBuildToolsVersion$" Value="*" />
-      <CustomParameter Name="$ResolvedWindowsSdkBuildToolsWinAppVersion$" Value="*" />
+      <CustomParameter Name="$WindowsAppSdkVersion$" Value="*" />
+      <CustomParameter Name="$WindowsSdkBuildToolsVersion$" Value="*" />
+      <CustomParameter Name="$WindowsSdkBuildToolsWinAppVersion$" Value="*" />
     </CustomParameters>
     <Project File="ProjectTemplate.csproj" ReplaceParameters="true">
       <ProjectItem ReplaceParameters="true" TargetFileName="launchSettings.json">Properties\launchSettings.json</ProjectItem>

--- a/dev/Templates/Source/ProjectTemplates/Desktop/CSharp/TabViewApp/WinUI.Desktop.Cs.TabViewApp.vstemplate
+++ b/dev/Templates/Source/ProjectTemplates/Desktop/CSharp/TabViewApp/WinUI.Desktop.Cs.TabViewApp.vstemplate
@@ -28,6 +28,9 @@
       <CustomParameter Name="$WindowsAppSDKNupkgVersion$" Value="FIXME-Verify-Directory.Build.Targets-XmlPoke-Queries" />
       <CustomParameter Name="$WindowsSDKBuildToolsNupkgVersion$" Value="FIXME-Verify-Directory.Build.Targets-XmlPoke-Queries" />
       <CustomParameter Name="$DotNetVersion$" Value="FIXME-Verify-Directory.Build.Targets-XmlPoke-Queries"/>
+      <CustomParameter Name="$ResolvedWindowsAppSdkVersion$" Value="*" />
+      <CustomParameter Name="$ResolvedWindowsSdkBuildToolsVersion$" Value="*" />
+      <CustomParameter Name="$ResolvedWindowsSdkBuildToolsWinAppVersion$" Value="*" />
     </CustomParameters>
     <Project File="ProjectTemplate.csproj" ReplaceParameters="true">
       <ProjectItem ReplaceParameters="true" TargetFileName="launchSettings.json">Properties\launchSettings.json</ProjectItem>

--- a/dev/Templates/Source/ProjectTemplates/Desktop/CSharp/UnitTestApp/ProjectTemplate.csproj
+++ b/dev/Templates/Source/ProjectTemplates/Desktop/CSharp/UnitTestApp/ProjectTemplate.csproj
@@ -55,13 +55,13 @@
     <PropertyGroup> above to opt out.
   -->
   <ItemGroup>
-    <PackageReference Include="Microsoft.Windows.SDK.BuildTools" Version="$ResolvedWindowsSdkBuildToolsVersion$" />
-    <PackageReference Include="Microsoft.WindowsAppSDK" Version="$ResolvedWindowsAppSdkVersion$" />
-    <PackageReference Include="Microsoft.Windows.SDK.BuildTools.WinApp" Version="$ResolvedWindowsSdkBuildToolsWinAppVersion$" />
-    <PackageReference Include="MSTest.TestAdapter" Version="$ResolvedMSTestVersion$" />
-    <PackageReference Include="MSTest.TestFramework" Version="$ResolvedMSTestVersion$" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="$ResolvedMicrosoftNetTestSdkVersion$" />
-    <PackageReference Include="Microsoft.TestPlatform.TestHost" Version="$ResolvedMicrosoftNetTestSdkVersion$" />
+    <PackageReference Include="Microsoft.Windows.SDK.BuildTools" Version="$WindowsSdkBuildToolsVersion$" />
+    <PackageReference Include="Microsoft.WindowsAppSDK" Version="$WindowsAppSdkVersion$" />
+    <PackageReference Include="Microsoft.Windows.SDK.BuildTools.WinApp" Version="$WindowsSdkBuildToolsWinAppVersion$" />
+    <PackageReference Include="MSTest.TestAdapter" Version="$MSTestVersion$" />
+    <PackageReference Include="MSTest.TestFramework" Version="$MSTestVersion$" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="$MicrosoftNetTestSdkVersion$" />
+    <PackageReference Include="Microsoft.TestPlatform.TestHost" Version="$MicrosoftNetTestSdkVersion$" />
   </ItemGroup>
 
   <!-- 

--- a/dev/Templates/Source/ProjectTemplates/Desktop/CSharp/UnitTestApp/ProjectTemplate.csproj
+++ b/dev/Templates/Source/ProjectTemplates/Desktop/CSharp/UnitTestApp/ProjectTemplate.csproj
@@ -54,17 +54,15 @@
     Set <EnableWinAppRunSupport>false</EnableWinAppRunSupport> in a
     <PropertyGroup> above to opt out.
   -->
-  <!--#if (UseLatestWindowsAppSDK)
   <ItemGroup>
-    <PackageReference Include="Microsoft.Windows.SDK.BuildTools" Version="$WindowsSdkBuildToolsVersion$" />
-    <PackageReference Include="Microsoft.WindowsAppSDK" Version="$WindowsAppSdkVersion$" />
-    <PackageReference Include="Microsoft.Windows.SDK.BuildTools.WinApp" Version="$WindowsSdkBuildToolsWinAppVersion$" />
-    <PackageReference Include="MSTest.TestAdapter" Version="$MSTestVersion$" />
-    <PackageReference Include="MSTest.TestFramework" Version="$MSTestVersion$" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="$MicrosoftNetTestSdkVersion$" />
-    <PackageReference Include="Microsoft.TestPlatform.TestHost" Version="$MicrosoftNetTestSdkVersion$" />
+    <PackageReference Include="Microsoft.Windows.SDK.BuildTools" Version="*" />
+    <PackageReference Include="Microsoft.WindowsAppSDK" Version="*" />
+    <PackageReference Include="Microsoft.Windows.SDK.BuildTools.WinApp" Version="*" />
+    <PackageReference Include="MSTest.TestAdapter" Version="*" />
+    <PackageReference Include="MSTest.TestFramework" Version="*" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="*" />
+    <PackageReference Include="Microsoft.TestPlatform.TestHost" Version="*" />
   </ItemGroup>
-  #endif -->
 
   <!-- 
     Defining the "HasPackageAndPublishMenuAddedByProject" property here allows the Solution 

--- a/dev/Templates/Source/ProjectTemplates/Desktop/CSharp/UnitTestApp/ProjectTemplate.csproj
+++ b/dev/Templates/Source/ProjectTemplates/Desktop/CSharp/UnitTestApp/ProjectTemplate.csproj
@@ -55,13 +55,13 @@
     <PropertyGroup> above to opt out.
   -->
   <ItemGroup>
-    <PackageReference Include="Microsoft.Windows.SDK.BuildTools" Version="*" />
-    <PackageReference Include="Microsoft.WindowsAppSDK" Version="*" />
-    <PackageReference Include="Microsoft.Windows.SDK.BuildTools.WinApp" Version="*" />
-    <PackageReference Include="MSTest.TestAdapter" Version="*" />
-    <PackageReference Include="MSTest.TestFramework" Version="*" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="*" />
-    <PackageReference Include="Microsoft.TestPlatform.TestHost" Version="*" />
+    <PackageReference Include="Microsoft.Windows.SDK.BuildTools" Version="$ResolvedWindowsSdkBuildToolsVersion$" />
+    <PackageReference Include="Microsoft.WindowsAppSDK" Version="$ResolvedWindowsAppSdkVersion$" />
+    <PackageReference Include="Microsoft.Windows.SDK.BuildTools.WinApp" Version="$ResolvedWindowsSdkBuildToolsWinAppVersion$" />
+    <PackageReference Include="MSTest.TestAdapter" Version="$ResolvedMSTestVersion$" />
+    <PackageReference Include="MSTest.TestFramework" Version="$ResolvedMSTestVersion$" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="$ResolvedMicrosoftNetTestSdkVersion$" />
+    <PackageReference Include="Microsoft.TestPlatform.TestHost" Version="$ResolvedMicrosoftNetTestSdkVersion$" />
   </ItemGroup>
 
   <!-- 

--- a/dev/Templates/Source/ProjectTemplates/Desktop/CSharp/UnitTestApp/WinUI.Desktop.Cs.UnitTestApp.vstemplate
+++ b/dev/Templates/Source/ProjectTemplates/Desktop/CSharp/UnitTestApp/WinUI.Desktop.Cs.UnitTestApp.vstemplate
@@ -27,11 +27,11 @@
   <TemplateContent PreferedSolutionConfiguration="Debug|x64">
     <CustomParameters>
       <CustomParameter Name="$DotNetVersion$" Value="FIXME-Verify-Directory.Build.Targets-XmlPoke-Queries"/>
-      <CustomParameter Name="$ResolvedWindowsAppSdkVersion$" Value="*" />
-      <CustomParameter Name="$ResolvedWindowsSdkBuildToolsVersion$" Value="*" />
-      <CustomParameter Name="$ResolvedWindowsSdkBuildToolsWinAppVersion$" Value="*" />
-      <CustomParameter Name="$ResolvedMSTestVersion$" Value="*" />
-      <CustomParameter Name="$ResolvedMicrosoftNetTestSdkVersion$" Value="*" />
+      <CustomParameter Name="$WindowsAppSdkVersion$" Value="*" />
+      <CustomParameter Name="$WindowsSdkBuildToolsVersion$" Value="*" />
+      <CustomParameter Name="$WindowsSdkBuildToolsWinAppVersion$" Value="*" />
+      <CustomParameter Name="$MSTestVersion$" Value="*" />
+      <CustomParameter Name="$MicrosoftNetTestSdkVersion$" Value="*" />
     </CustomParameters>
     <Project File="ProjectTemplate.csproj" ReplaceParameters="true">
       <ProjectItem ReplaceParameters="true" TargetFileName="launchSettings.json">Properties\launchSettings.json</ProjectItem>

--- a/dev/Templates/Source/ProjectTemplates/Desktop/CSharp/UnitTestApp/WinUI.Desktop.Cs.UnitTestApp.vstemplate
+++ b/dev/Templates/Source/ProjectTemplates/Desktop/CSharp/UnitTestApp/WinUI.Desktop.Cs.UnitTestApp.vstemplate
@@ -27,6 +27,11 @@
   <TemplateContent PreferedSolutionConfiguration="Debug|x64">
     <CustomParameters>
       <CustomParameter Name="$DotNetVersion$" Value="FIXME-Verify-Directory.Build.Targets-XmlPoke-Queries"/>
+      <CustomParameter Name="$ResolvedWindowsAppSdkVersion$" Value="*" />
+      <CustomParameter Name="$ResolvedWindowsSdkBuildToolsVersion$" Value="*" />
+      <CustomParameter Name="$ResolvedWindowsSdkBuildToolsWinAppVersion$" Value="*" />
+      <CustomParameter Name="$ResolvedMSTestVersion$" Value="*" />
+      <CustomParameter Name="$ResolvedMicrosoftNetTestSdkVersion$" Value="*" />
     </CustomParameters>
     <Project File="ProjectTemplate.csproj" ReplaceParameters="true">
       <ProjectItem ReplaceParameters="true" TargetFileName="launchSettings.json">Properties\launchSettings.json</ProjectItem>


### PR DESCRIPTION
Builds upon #6407 and resolves #6343

In previous PRs, the `UseLatestWindowsAppSDK` was used in the dotnet templates to update the template project dependencies to the latest version. However, if this option was unchecked or set to false, no dependencies would be installed at all. This PR fixes this error by setting the default dependency version to the latest version in the `ProjectTemplate.csproj` themselves with `PackageReference` and providing parameters to pass in specific NuGet package versions for each template's dependencies.

Before this PR, the VSIX templates installed their packages via the NuGetPackageInstaller wizard, even though C# projects have long had `PackageReference` support. The reason was to have one implementation to manage package installation for both C# and C++ templates. Now that the Windows App SDK templates extend beyond Visual Studio, it does not make sense for the C# templates to use the Wizard class when evergreen dependency versions can be written into the project files. Further work is needed to completely remove the wizard from the C# VSIX templates, however that is out of scope for this PR. Setting `PackageReference... Version="*"` simplifies the default NuGet dependency versioning for both dotnet and VSIX templates.

That only covers the default case. To accommodate custom versioning on template generation, I added `{dependency}Version` parameter for each of the template dependencies. When the parameter is empty, it is replaced with the latest version (*). Other templates have new parameters for their additional dependencies.

## Walkthrough with the single-project/blank app template
To illustrate the changes, let's walk through the blank app/single-project packaged app template:
* `dev/Templates/Source/ProjectTemplates/Desktop/CSharp/SingleProjectPackagedApp/ProjectTemplate.csproj` no longer has the dotnet conditional because we want VSIX dependencies to be resolved with `PackageReference` as well.
*`dev/Templates/Source/ProjectTemplates/Desktop/CSharp/SingleProjectPackagedApp/WinUI.Desktop.Cs.SingleProjectPackagedApp.vstemplate` sets those `CustomParameter` to `*`. This makes sense for the VSIX templates since we do not have the UI to select versions (outside of the scope of this PR)
* Then in `dev/Templates/Dotnet/templates/blank-app/.template.config/template.json`, `UseLatestWindowsAppSDK` has been removed and the default values for the other depdency versions have been replaced to the floating latest stable value (*). This will make the templates easier to maintain in the long run if we want the default value to be the highest stable available. Since the post-actions were updating to the latest version, they're no longer needed. If NuGet restore fails, there is a clear error to the user and since the dependencies have moved into the project file, we don't need to add another version on failure.
* `dev/Templates/Dotnet/templates/blank-app/.template.config/ide.host.json` and `dev/Templates/Dotnet/templates/blank-app/.template.config/dotnetcli.host.json` surface these parameters to the user in Visual Studio and donet CLI respectively

These changes have been made to each of the C# templates.

Finally, `dev/Templates/Dotnet/Test-DotnetNewTemplates.ps1` was updated to include tests for the version parameter parsing:
* If a version parameter is left blank in the dotnet CLI, it's set to *
* If a real Windows App SDK version is passed in, the instantiated project has that version
* If multiple versions are pinned, those versions are set in the instantiated templates
* If a prerelease string is included in the version (e.g. `preview`), the version is set correctly
* If an invalid NuGet version was passed in, the parameter is passed to NuGet, but NuGet restore fails
* If a valid NuGet version was passed in, but was not a WASDK version, the parameter is passed to NuGet, but NuGet restore fails

## Considered paths (and the current limitations):
* Command line/template level parameter validation would reduce the time it would take for someone to realize they made a typo. Unfortunately, parameter-level validation was not supported
* Hiding the several version input boxes in VS' New Project menu behind a checkbox so that users would not have to look at all their versioning options if they just wanted the default. Unfortunately, although the boolean isVisible can be set, the values are set at instantiation time (e.g. VS' "Create" button) and are not responsive to user input. This is a Visual Studio limitation.

## How I validated this PR:
* Ran `Test-DotnetNewTemplates.ps1` - passed
* Manually installed, opened, and built all of the dotnet tests in VS - passed
* Built and installed the vsix using `build-install-localdev-vsix.ps1`, then instantiated and built the templates in VS - passed
* Verified that the VSIX from the aggregator pipeline (`user/laurenciha/default-highest-nuget-version-csharp-templates`) also builds and runs successfully
* Manually verified the same test scenarios for the version parameters on the dotnet templates in the VS host and updated the tests to include the expected error codes

A microsoft employee must use /azp run to validate using the pipelines below.

WARNING:
Comments made by azure-pipelines bot maybe inaccurate.
Please see pipeline link to verify that the build is being ran.

For status checks on the main branch, please use TransportPackage-Foundation-PR
(https://microsoft.visualstudio.com/ProjectReunion/_build?definitionId=81063&_a=summary)
and run the build against your PR branch with the default parameters.
