### PR TITLE
VSIX and Installer Template adapation for monobuild

### DIFF
--- a/build/AzurePipelinesTemplates/WindowsAppSDK-BuildInstaller-Steps.yml
+++ b/build/AzurePipelinesTemplates/WindowsAppSDK-BuildInstaller-Steps.yml
@@ -17,6 +17,23 @@ parameters:
 - name: IsMonobuild
   type: boolean
   default: false
+# Name of the upstream NuGet+MSIX pipeline artifact to download. The monobuild's
+# Aggregate stage publishes 'WindowsAppSDK-NuGet-And-MSIX' (hyphens); the legacy
+# Aggregator pipeline used 'WindowsAppSDK_Nuget_And_MSIX' (underscores). Default
+# preserves the legacy name so non-monobuild callers don't need to opt in.
+- name: artifactName
+  type: string
+  default: 'WindowsAppSDK_Nuget_And_MSIX'
+# When true, skip the artifact download step entirely. The caller is responsible
+# for ensuring $(parameters.artifactName) content is already present at
+# $(System.ArtifactsDirectory) before this template's first MSBuild step. Used by
+# the monobuild's CreateInstaller stage so it can download the artifact with
+# rebuild-aware variables ($(_useBuildOutputFromBuildId) /
+# $(_useBuildOutputFromPipeline)) that honor useBuildOutput_BuildId /
+# useBuildOutput_RebuildStage queue-time overrides.
+- name: SkipArtifactDownload
+  type: boolean
+  default: false
 
 steps:
 - task: PowerShell@2
@@ -42,28 +59,29 @@ steps:
   # Don't bother doing this step if we are not validating a test OS image. All steps below work as usual.
   condition: and(succeeded(), eq(variables.EnableTestImageValidation , true))
 
-- ${{ if eq(parameters.UseCurrentBuild, 'true') }}:
-  - task: DownloadPipelineArtifact@2
-    displayName: 'Download WindowsAppSDK From Current Build'
-    inputs:
-      artifactName: 'WindowsAppSDK_Nuget_And_MSIX'
-      targetPath: '$(System.ArtifactsDirectory)'
-    condition: and(succeeded(), ne(variables.SkipInstallerBuild, true))
-- ${{ else }}:
-  ###
-  # This step downloads the WindowsAppSDK NuGet package from a pipeline
-  # variables: OfficialPipelineID LatestOfficialBuildID
-  # for use in building the Installers
-  - task: DownloadPipelineArtifact@2
-    displayName: 'Download WindowsAppSDK From Latest Nightly'
-    inputs:
-      artifactName: 'WindowsAppSDK_Nuget_And_MSIX'
-      targetPath: '$(System.ArtifactsDirectory)'
-      source: 'specific'
-      project: 55e8140e-57ac-4e5f-8f9c-c7c15b51929d # TODO: replace with $(System.TeamProjectId) once we can have a full WinAppSDK Build on the new mono repo
-      pipeline: $(OfficialPipelineID) 
-      pipelineId: $(LatestOfficialBuildID) 
-    condition: and(succeeded(), ne(variables.SkipInstallerBuild, true))
+- ${{ if eq(parameters.SkipArtifactDownload, false) }}:
+  - ${{ if eq(parameters.UseCurrentBuild, 'true') }}:
+    - task: DownloadPipelineArtifact@2
+      displayName: 'Download WindowsAppSDK From Current Build'
+      inputs:
+        artifactName: ${{ parameters.artifactName }}
+        targetPath: '$(System.ArtifactsDirectory)'
+      condition: and(succeeded(), ne(variables.SkipInstallerBuild, true))
+  - ${{ else }}:
+    ###
+    # This step downloads the WindowsAppSDK NuGet package from a pipeline
+    # variables: OfficialPipelineID LatestOfficialBuildID
+    # for use in building the Installers
+    - task: DownloadPipelineArtifact@2
+      displayName: 'Download WindowsAppSDK From Latest Nightly'
+      inputs:
+        artifactName: ${{ parameters.artifactName }}
+        targetPath: '$(System.ArtifactsDirectory)'
+        source: 'specific'
+        project: 55e8140e-57ac-4e5f-8f9c-c7c15b51929d # TODO: replace with $(System.TeamProjectId) once we can have a full WinAppSDK Build on the new mono repo
+        pipeline: $(OfficialPipelineID) 
+        pipelineId: $(LatestOfficialBuildID) 
+      condition: and(succeeded(), ne(variables.SkipInstallerBuild, true))
     
 ###
 # Install the internal licensing support for release-signed packages. This can always be present in

--- a/build/AzurePipelinesTemplates/WindowsAppSDK-BuildVSIX-Steps.yml
+++ b/build/AzurePipelinesTemplates/WindowsAppSDK-BuildVSIX-Steps.yml
@@ -25,28 +25,45 @@ parameters:
 - name: EnableExperimentalVSIXFeatures
   type: boolean
   default: false
+# Name of the upstream NuGet+MSIX pipeline artifact to download. The monobuild's
+# Aggregate stage publishes 'WindowsAppSDK-NuGet-And-MSIX' (hyphens); the legacy
+# Aggregator pipeline used 'WindowsAppSDK_Nuget_And_MSIX' (underscores). Default
+# preserves the legacy name so non-monobuild callers don't need to opt in.
+- name: artifactName
+  type: string
+  default: 'WindowsAppSDK_Nuget_And_MSIX'
+# When true, skip the artifact download step entirely. The caller is responsible
+# for ensuring $(parameters.artifactName) content is already present at
+# $(System.ArtifactsDirectory) before ExtractWindowsAppSDKVersion runs. Used by
+# the monobuild's CreateVSIX stage so it can download with rebuild-aware variables
+# ($(_useBuildOutputFromBuildId) / $(_useBuildOutputFromPipeline)) that honor
+# useBuildOutput_BuildId / useBuildOutput_RebuildStage queue-time overrides.
+- name: SkipArtifactDownload
+  type: boolean
+  default: false
 
 steps:
-- ${{ if eq(parameters.UseCurrentBuild, 'true') }}:
-  - task: DownloadPipelineArtifact@2
-    displayName: 'Download WindowsAppSDK From Current Build'
-    inputs:
-      artifactName: 'WindowsAppSDK_Nuget_And_MSIX'
-      targetPath: '$(System.ArtifactsDirectory)'
-- ${{ else }}:
-  ###
-  # This step downloads the WindowsAppSDK NuGet package from a pipeline
-  # variables: OfficialPipelineID LatestOfficialBuildID
-  # for use in building the VSIX
-  - task: DownloadPipelineArtifact@2
-    displayName: 'Download WindowsAppSDK From Latest Nightly'
-    inputs:
-      artifactName: 'WindowsAppSDK_Nuget_And_MSIX'
-      targetPath: '$(System.ArtifactsDirectory)'
-      source: 'specific'
-      project: 55e8140e-57ac-4e5f-8f9c-c7c15b51929d # TODO: replace with $(System.TeamProjectId) once we can have a full WinAppSDK Build on the new mono repo
-      pipeline: $(OfficialPipelineID) 
-      pipelineId: $(LatestOfficialBuildID) 
+- ${{ if eq(parameters.SkipArtifactDownload, false) }}:
+  - ${{ if eq(parameters.UseCurrentBuild, 'true') }}:
+    - task: DownloadPipelineArtifact@2
+      displayName: 'Download WindowsAppSDK From Current Build'
+      inputs:
+        artifactName: ${{ parameters.artifactName }}
+        targetPath: '$(System.ArtifactsDirectory)'
+  - ${{ else }}:
+    ###
+    # This step downloads the WindowsAppSDK NuGet package from a pipeline
+    # variables: OfficialPipelineID LatestOfficialBuildID
+    # for use in building the VSIX
+    - task: DownloadPipelineArtifact@2
+      displayName: 'Download WindowsAppSDK From Latest Nightly'
+      inputs:
+        artifactName: ${{ parameters.artifactName }}
+        targetPath: '$(System.ArtifactsDirectory)'
+        source: 'specific'
+        project: 55e8140e-57ac-4e5f-8f9c-c7c15b51929d # TODO: replace with $(System.TeamProjectId) once we can have a full WinAppSDK Build on the new mono repo
+        pipeline: $(OfficialPipelineID) 
+        pipelineId: $(LatestOfficialBuildID) 
     
 - task: PowerShell@2
   name: ExtractWindowsAppSDKVersion

--- a/build/AzurePipelinesTemplates/WindowsAppSDK-BuildVSIX-Steps.yml
+++ b/build/AzurePipelinesTemplates/WindowsAppSDK-BuildVSIX-Steps.yml
@@ -204,6 +204,7 @@ steps:
 
   - template: WindowsAppSDK-SignPackageContents-steps.yml
     parameters:
+      IsMonobuild: ${{ parameters.IsMonobuild }}
       inputPackageDirectory: '$(Agent.TempDirectory)/UnsignedVSIX'
       outputPackageDirectory: '$(ob_outputDirectory)'
       packageType: 'vsix'

--- a/build/AzurePipelinesTemplates/WindowsAppSDK-SignPackageContents-steps.yml
+++ b/build/AzurePipelinesTemplates/WindowsAppSDK-SignPackageContents-steps.yml
@@ -22,6 +22,11 @@ parameters:
   values:
   - "vsix"
   - "nupkg"
+# When true, EsrpCodeSigning-Steps is invoked WITHOUT the @WinAppSDK suffix
+# because the WindowsAppSDK monorepo IS the self repo in the monobuild context.
+- name: IsMonobuild
+  type: boolean
+  default: false
 
 steps:
 - ${{ each package in parameters.packages }}:
@@ -31,13 +36,15 @@ steps:
       archiveFilePatterns: '${{parameters.inputPackageDirectory}}\${{package}}'
       destinationFolder: '$(Agent.TempDirectory)/${{package}}'
 
-  - template: Build/WindowsAppSDK/AzurePipelinesTemplates/WindowsAppSDK-EsrpCodeSigning-Steps.yml@WinAppSDK
+  - template: WindowsAppSDK-EsrpCodeSigning-Wrapper.yml
     parameters:
-      DisplayName: 'CodeSign package contents'
-      FolderPath: '$(Agent.TempDirectory)/${{package}}'
-      Pattern: ${{parameters.codeSignPattern}}
-      UseMinimatch: true
-      KeyCode: 'CP-230012'
+      IsMonobuild: ${{ parameters.IsMonobuild }}
+      InnerParams:
+        DisplayName: 'CodeSign package contents'
+        FolderPath: '$(Agent.TempDirectory)/${{package}}'
+        Pattern: ${{parameters.codeSignPattern}}
+        UseMinimatch: true
+        KeyCode: 'CP-230012'
 
   - task: ArchiveFiles@2
     displayName: Repack signed package contents
@@ -47,19 +54,23 @@ steps:
       archiveFile: '${{parameters.outputPackageDirectory}}/${{package}}'
 
   - ${{ if eq(parameters.packageType, 'nupkg') }}:
-    - template: Build/WindowsAppSDK/AzurePipelinesTemplates/WindowsAppSDK-EsrpCodeSigning-Steps.yml@WinAppSDK
+    - template: WindowsAppSDK-EsrpCodeSigning-Wrapper.yml
       parameters:
-        DisplayName: 'CodeSign repacked package (Nuget)'
-        FolderPath: '${{parameters.outputPackageDirectory}}'
-        Pattern: ${{package}}
-        UseMinimatch: true
-        KeyCode: 'CP-401405'
+        IsMonobuild: ${{ parameters.IsMonobuild }}
+        InnerParams:
+          DisplayName: 'CodeSign repacked package (Nuget)'
+          FolderPath: '${{parameters.outputPackageDirectory}}'
+          Pattern: ${{package}}
+          UseMinimatch: true
+          KeyCode: 'CP-401405'
 
   - ${{ if eq(parameters.packageType, 'vsix') }}:
-    - template: Build/WindowsAppSDK/AzurePipelinesTemplates/WindowsAppSDK-EsrpCodeSigning-Steps.yml@WinAppSDK
+    - template: WindowsAppSDK-EsrpCodeSigning-Wrapper.yml
       parameters:
-        DisplayName: 'CodeSign repacked package (VSIX)'
-        FolderPath: '${{parameters.outputPackageDirectory}}'
-        Pattern: ${{package}}
-        UseMinimatch: true
-        KeyCode: 'CP-233016'
+        IsMonobuild: ${{ parameters.IsMonobuild }}
+        InnerParams:
+          DisplayName: 'CodeSign repacked package (VSIX)'
+          FolderPath: '${{parameters.outputPackageDirectory}}'
+          Pattern: ${{package}}
+          UseMinimatch: true
+          KeyCode: 'CP-233016'


### PR DESCRIPTION
A microsoft employee must use /azp run to validate using the pipelines below.

WARNING:
Comments made by azure-pipelines bot maybe inaccurate.
Please see pipeline link to verify that the build is being ran.

For status checks on the main branch, please use TransportPackage-Foundation-PR
(https://microsoft.visualstudio.com/ProjectReunion/_build?definitionId=81063&_a=summary)
and run the build against your PR branch with the default parameters.
