### PR TITLE
Bring in the Removal of the MinorUpdateLibrary task and the Revision numbers to stable

### DIFF
--- a/build/AzurePipelinesTemplates/WindowsAppSDK-UpdateLibrary-Job.yml
+++ b/build/AzurePipelinesTemplates/WindowsAppSDK-UpdateLibrary-Job.yml
@@ -61,18 +61,6 @@ jobs:
         }
 
   - task: PowerShell@2
-    condition: and(ne(variables.FoundationMinorVersionResolved, variables.MinorVersion), eq('${{ parameters.PrOrNightly }}', ''))
-    displayName: Update FoundationMinorVersion in Variable Group
-    env:
-      AZURE_DEVOPS_EXT_PAT: $(System.AccessToken)
-    inputs:
-      targetType: 'inline'
-      script: |
-        echo "Updating Foundation Minor Version variable in Variable Group"
-        $group_id = $(az pipelines variable-group list -p $(System.TeamProject) --group-name $(FoundationLibraryName) --query '[0].id' -o json)
-        az pipelines variable-group variable update --group-id $group_id --name FoundationMinorVersion --value $(MinorVersion)
-
-  - task: PowerShell@2
     condition: eq('${{ parameters.PrOrNightly }}', '')
     displayName: Update PreviewRevision in Variable Group
     env:

--- a/build/AzurePipelinesTemplates/WindowsAppSDK-UpdateLibrary-Job.yml
+++ b/build/AzurePipelinesTemplates/WindowsAppSDK-UpdateLibrary-Job.yml
@@ -53,63 +53,11 @@ jobs:
         if ($groupExists.Count -eq 0)
         {
           echo "Creating Variable Group $NextLibraryName"
-          az pipelines variable-group create --name "$NextLibraryName" --description "Variable group for Windows App SDK Foundation Major Version $NextMajorVersion" --authorize --variables FoundationMinorVersion=0 FoundationPatchVersion=0 FoundationPreviewRevision=0 FoundationExperimentalRevision=0
+          az pipelines variable-group create --name "$NextLibraryName" --description "Variable group for Windows App SDK Foundation Major Version $NextMajorVersion" --authorize --variables FoundationMinorVersion=0 FoundationPatchVersion=0
         }
         else
         {
           echo "Variable Group $NextLibraryName already exists"
-        }
-
-  - task: PowerShell@2
-    condition: eq('${{ parameters.PrOrNightly }}', '')
-    displayName: Update PreviewRevision in Variable Group
-    env:
-      AZURE_DEVOPS_EXT_PAT: $(System.AccessToken)
-    inputs:
-      targetType: 'inline'
-      script: |
-        echo "Determining if we need to update FoundationPreviewRevision variable in Variable Group"
-        $NextPreviewRevision = [int]$(FoundationPreviewRevisionResolved)
-        if ("${{ parameters.BuildType }}" -eq 'preview')
-        {
-          $NextPreviewRevision = $NextPreviewRevision + 1
-        }
-
-        if ($NextPreviewRevision -ne '$(FoundationPreviewRevision)')
-        {
-          echo "Updating FoundationPreviewRevision variable in Variable Group to $NextPreviewRevision"
-          $group_id = $(az pipelines variable-group list -p $(System.TeamProject) --group-name $(FoundationLibraryName) --query '[0].id' -o json)
-          az pipelines variable-group variable update --group-id $group_id --name FoundationPreviewRevision --value $NextPreviewRevision
-        }
-        else
-        {
-          echo "No update needed for FoundationPreviewRevision variable in Variable Group"
-        }
-
-  - task: PowerShell@2
-    condition: eq('${{ parameters.PrOrNightly }}', '')
-    displayName: Update ExperimentalRevision in Variable Group
-    env:
-      AZURE_DEVOPS_EXT_PAT: $(System.AccessToken)
-    inputs:
-      targetType: 'inline'
-      script: |
-        echo "Determining if we need to update FoundationExperimentalRevision variable in Variable Group"
-        $NextExperimentalRevision = [int]$(FoundationExperimentalRevisionResolved)
-        if ("${{ parameters.BuildType }}" -eq "experimental")
-        {
-          $NextExperimentalRevision = $NextExperimentalRevision + 1
-        }
-
-        if ($NextExperimentalRevision -ne '$(FoundationExperimentalRevision)')
-        {
-          echo "Updating FoundationExperimentalRevision variable in Variable Group to $NextExperimentalRevision"
-          $group_id = $(az pipelines variable-group list -p $(System.TeamProject) --group-name $(FoundationLibraryName) --query '[0].id' -o json)
-          az pipelines variable-group variable update --group-id $group_id --name FoundationExperimentalRevision --value $NextExperimentalRevision
-        }
-        else
-        {
-          echo "No update needed for FoundationExperimentalRevision variable in Variable Group"
         }
 
   - task: PowerShell@2

--- a/build/AzurePipelinesTemplates/WindowsAppSDK-VersionVariables.yml
+++ b/build/AzurePipelinesTemplates/WindowsAppSDK-VersionVariables.yml
@@ -32,21 +32,9 @@ variables:
     value: $[coalesce(variables['FoundationPatchVersion'], 0)]
   - name: PRNightlyRevision
     value: $[counter(format('{0}-{1}-{2}-{3}', variables.MajorVersion, variables.FoundationMinorVersionResolved, variables.FoundationPatchVersionResolved, variables.NugetBuildTypePrefix), 1)]
-  - name: FoundationPreviewRevisionResolved
-    value: $[coalesce(variables['FoundationPreviewRevision'], 0)]
-  - name: FoundationExperimentalRevisionResolved
-    value: $[coalesce(variables['FoundationExperimentalRevision'], 0)]
   - ${{ if ne(parameters.PrOrNightly, '') }}:
     - name: Revision
       value: $[variables['PRNightlyRevision']]
   - ${{ else }}:
-    - ${{ if eq(parameters.BuildType, 'experimental') }}:
-      - name: Revision
-        value: $[variables['FoundationExperimentalRevisionResolved']]
-    - ${{ else }}:
-      - ${{ if eq(parameters.BuildType, 'preview') }}:
-        - name: Revision
-          value: $[variables['FoundationPreviewRevisionResolved']]
-      - ${{ else }}:
-        - name: Revision
-          value: ""
+    - name: Revision
+      value: ""


### PR DESCRIPTION
A microsoft employee must use /azp run to validate using the pipelines below.

WARNING:
Comments made by azure-pipelines bot maybe inaccurate.
Please see pipeline link to verify that the build is being ran.

For status checks on the main branch, please use TransportPackage-Foundation-PR
(https://microsoft.visualstudio.com/ProjectReunion/_build?definitionId=81063&_a=summary)
and run the build against your PR branch with the default parameters.
