### PR TITLE
Stop Updating the Minor in the Library in Exp

### DIFF
--- a/build/AzurePipelinesTemplates/WindowsAppSDK-UpdateLibrary-Job.yml
+++ b/build/AzurePipelinesTemplates/WindowsAppSDK-UpdateLibrary-Job.yml
@@ -61,18 +61,6 @@ jobs:
         }
 
   - task: PowerShell@2
-    condition: and(ne(variables.FoundationMinorVersionResolved, variables.MinorVersion), eq('${{ parameters.PrOrNightly }}', ''))
-    displayName: Update FoundationMinorVersion in Variable Group
-    env:
-      AZURE_DEVOPS_EXT_PAT: $(System.AccessToken)
-    inputs:
-      targetType: 'inline'
-      script: |
-        echo "Updating Foundation Minor Version variable in Variable Group"
-        $group_id = $(az pipelines variable-group list -p $(System.TeamProject) --group-name $(FoundationLibraryName) --query '[0].id' -o json)
-        az pipelines variable-group variable update --group-id $group_id --name FoundationMinorVersion --value $(MinorVersion)
-
-  - task: PowerShell@2
     condition: eq('${{ parameters.PrOrNightly }}', '')
     displayName: Update FoundationPatchVersion in Variable Group
     env:


### PR DESCRIPTION
A microsoft employee must use /azp run to validate using the pipelines below.

WARNING:
Comments made by azure-pipelines bot maybe inaccurate.
Please see pipeline link to verify that the build is being ran.

For status checks on the main branch, please use TransportPackage-Foundation-PR
(https://microsoft.visualstudio.com/ProjectReunion/_build?definitionId=81063&_a=summary)
and run the build against your PR branch with the default parameters.
