### PR TITLE
Fix bad regkey path for ApplicationData.GetForUnpackaged().LocalSettings() (#6558)

### DIFF
--- a/dev/ApplicationData/UnpackagedApplicationData.cpp
+++ b/dev/ApplicationData/UnpackagedApplicationData.cpp
@@ -15,7 +15,7 @@
 #include <FrameworkUdk/Containment.h>
 
 // 62698635: [2.x Servicing][WASDK] Fix bad regkey path for ApplicationData.GetForUnpackaged().LocalSettings()
-#define WINAPPSDK_CHANGEID_62698635 62698635, WinAppSDK_2_2_1
+#define WINAPPSDK_CHANGEID_62698635 62698635
 
 namespace winrt::Microsoft::Windows::Storage::implementation
 {

--- a/dev/ApplicationData/UnpackagedApplicationData.cpp
+++ b/dev/ApplicationData/UnpackagedApplicationData.cpp
@@ -168,7 +168,7 @@ namespace winrt::Microsoft::Windows::Storage::implementation
 
         wil::unique_hkey currentUserKey;
         THROW_IF_WIN32_ERROR(::RegOpenCurrentUser(KEY_READ | KEY_WRITE, currentUserKey.put()));
-        auto subKey{ std::format(L"SOFTWARE\\{}\\{}", m_publisher, m_product) };
+        auto subKey{ std::format(L"SOFTWARE\\Classes\\Local Settings\\SOFTWARE\\{}\\{}", m_publisher, m_product) };
         auto key{ wil::reg::create_shared_key(currentUserKey.get(), subKey.c_str(), wil::reg::key_access::readwrite) };
         return winrt::make<UnpackagedApplicationDataContainer>(
             std::move(key), winrt::hstring{}, winrt::Microsoft::Windows::Storage::ApplicationDataLocality::Local);
@@ -223,7 +223,7 @@ namespace winrt::Microsoft::Windows::Storage::implementation
         {
             wil::unique_hkey currentUserKey;
             THROW_IF_WIN32_ERROR(::RegOpenCurrentUser(KEY_READ | KEY_WRITE, currentUserKey.put()));
-            auto subKey{ std::format(L"SOFTWARE\\{}\\{}", publisher, product) };
+            auto subKey{ std::format(L"SOFTWARE\\Classes\\Local Settings\\SOFTWARE\\{}\\{}", publisher, product) };
             const auto hr{ HRESULT_FROM_WIN32(::RegDeleteTreeW(currentUserKey.get(), subKey.c_str())) };
             if (hr != HRESULT_FROM_WIN32(ERROR_FILE_NOT_FOUND) && hr != HRESULT_FROM_WIN32(ERROR_PATH_NOT_FOUND))
             {

--- a/dev/ApplicationData/UnpackagedApplicationData.cpp
+++ b/dev/ApplicationData/UnpackagedApplicationData.cpp
@@ -12,6 +12,11 @@
 
 #include "ApplicationDataTelemetry.h"
 
+#include <FrameworkUdk/Containment.h>
+
+// 62698635: [2.x Servicing][WASDK] Fix bad regkey path for ApplicationData.GetForUnpackaged().LocalSettings()
+#define WINAPPSDK_CHANGEID_62698635 62698635, WinAppSDK_2_2_1
+
 namespace winrt::Microsoft::Windows::Storage::implementation
 {
     UnpackagedApplicationData::UnpackagedApplicationData(winrt::hstring const& publisher, winrt::hstring const& product) :
@@ -168,10 +173,20 @@ namespace winrt::Microsoft::Windows::Storage::implementation
 
         wil::unique_hkey currentUserKey;
         THROW_IF_WIN32_ERROR(::RegOpenCurrentUser(KEY_READ | KEY_WRITE, currentUserKey.put()));
-        auto subKey{ std::format(L"SOFTWARE\\Classes\\Local Settings\\SOFTWARE\\{}\\{}", m_publisher, m_product) };
-        auto key{ wil::reg::create_shared_key(currentUserKey.get(), subKey.c_str(), wil::reg::key_access::readwrite) };
-        return winrt::make<UnpackagedApplicationDataContainer>(
-            std::move(key), winrt::hstring{}, winrt::Microsoft::Windows::Storage::ApplicationDataLocality::Local);
+        if (WinAppSdk::Containment::IsChangeEnabled<WINAPPSDK_CHANGEID_62698635>())
+        {
+            auto subKey{ std::format(L"SOFTWARE\\Classes\\Local Settings\\SOFTWARE\\{}\\{}", m_publisher, m_product) };
+            auto key{ wil::reg::create_shared_key(currentUserKey.get(), subKey.c_str(), wil::reg::key_access::readwrite) };
+            return winrt::make<UnpackagedApplicationDataContainer>(
+                std::move(key), winrt::hstring{}, winrt::Microsoft::Windows::Storage::ApplicationDataLocality::Local);
+        }
+        else
+        {
+            auto subKey{ std::format(L"SOFTWARE\\{}\\{}", m_publisher, m_product) };
+            auto key{ wil::reg::create_shared_key(currentUserKey.get(), subKey.c_str(), wil::reg::key_access::readwrite) };
+            return winrt::make<UnpackagedApplicationDataContainer>(
+                std::move(key), winrt::hstring{}, winrt::Microsoft::Windows::Storage::ApplicationDataLocality::Local);
+        }
     }
     winrt::Windows::Foundation::IAsyncAction UnpackagedApplicationData::ClearAsync(winrt::Microsoft::Windows::Storage::ApplicationDataLocality locality)
     {
@@ -223,11 +238,23 @@ namespace winrt::Microsoft::Windows::Storage::implementation
         {
             wil::unique_hkey currentUserKey;
             THROW_IF_WIN32_ERROR(::RegOpenCurrentUser(KEY_READ | KEY_WRITE, currentUserKey.put()));
-            auto subKey{ std::format(L"SOFTWARE\\Classes\\Local Settings\\SOFTWARE\\{}\\{}", publisher, product) };
-            const auto hr{ HRESULT_FROM_WIN32(::RegDeleteTreeW(currentUserKey.get(), subKey.c_str())) };
-            if (hr != HRESULT_FROM_WIN32(ERROR_FILE_NOT_FOUND) && hr != HRESULT_FROM_WIN32(ERROR_PATH_NOT_FOUND))
+            if (WinAppSdk::Containment::IsChangeEnabled<WINAPPSDK_CHANGEID_62698635>())
             {
-                THROW_IF_FAILED(hr);
+                auto subKey{ std::format(L"SOFTWARE\\Classes\\Local Settings\\SOFTWARE\\{}\\{}", publisher, product) };
+                const auto hr{ HRESULT_FROM_WIN32(::RegDeleteTreeW(currentUserKey.get(), subKey.c_str())) };
+                if (hr != HRESULT_FROM_WIN32(ERROR_FILE_NOT_FOUND) && hr != HRESULT_FROM_WIN32(ERROR_PATH_NOT_FOUND))
+                {
+                    THROW_IF_FAILED(hr);
+                }
+            }
+            else
+            {
+                auto subKey{ std::format(L"SOFTWARE\\{}\\{}", publisher, product) };
+                const auto hr{ HRESULT_FROM_WIN32(::RegDeleteTreeW(currentUserKey.get(), subKey.c_str())) };
+                if (hr != HRESULT_FROM_WIN32(ERROR_FILE_NOT_FOUND) && hr != HRESULT_FROM_WIN32(ERROR_PATH_NOT_FOUND))
+                {
+                    THROW_IF_FAILED(hr);
+                }
             }
         }
 

--- a/dev/ApplicationData/UnpackagedApplicationData.cpp
+++ b/dev/ApplicationData/UnpackagedApplicationData.cpp
@@ -15,7 +15,7 @@
 #include <FrameworkUdk/Containment.h>
 
 // 62698635: [2.x Servicing][WASDK] Fix bad regkey path for ApplicationData.GetForUnpackaged().LocalSettings()
-#define WINAPPSDK_CHANGEID_62698635 62698635
+#define WINAPPSDK_CHANGEID_62698635 62698635, WinAppSDK_2_2_1
 
 namespace winrt::Microsoft::Windows::Storage::implementation
 {

--- a/dev/RuntimeCompatibilityOptions/RuntimeCompatibilityOptions.idl
+++ b/dev/RuntimeCompatibilityOptions/RuntimeCompatibilityOptions.idl
@@ -38,6 +38,9 @@ namespace Microsoft.Windows.ApplicationModel.WindowsAppRuntime
         WindowsMLFlatCCatalog_CallbackStringOwnership = 62440888,
         WindowsML_ComRundownFix = 62440888,
         WindowsML_ComInitializationFix = 62440888,
+
+        // 2.2.1
+        ApplicationData_GetForUnpackaged_LocalSettings = 62698635,
     };
 
     /// Represents a version of the Windows App Runtime.

--- a/specs/applicationdata/ApplicationData.md
+++ b/specs/applicationdata/ApplicationData.md
@@ -169,12 +169,11 @@ New properties and methods to access per-machine data:
 
 Unpackaged applications can use the ApplicationData API to access app data stores in the classic locations:
 
-|Packaged                        |Unpackaged                                                         |
-|--------------------------------|-------------------------------------------------------------------|
-|ApplicationData.LocalCachePath  |`%LOCALAPPDATA%\<publisher>\<product>`                              |
+|Packaged                        |Unpackaged                                                           |
+|--------------------------------|---------------------------------------------------------------------|
+|ApplicationData.LocalCachePath  |`%LOCALAPPDATA%\<publisher>\<product>`                               |
 |ApplicationData.LocalPath       |`%LOCALAPPDATA%\<publisher>\<product>`                               |
 |ApplicationData.MachinePath     |`%ProgramData%\<publisher>\<product>`                                |
-|ApplicationData.RoamingPath     |`%APPDATA%`                                                          |
 |ApplicationData.TemporaryPath   |`[GetTempPath2W()](https://learn.microsoft.com/windows/win32/api/fileapi/nf-fileapi-gettemppath2w)\<publisher>\<product>`<sup>1,2</sup>|
 |ApplicationData.LocalSettings   |`HKCU\SOFTWARE\Classes\Local Settings\Software\<publisher>\<product>`|
 |ApplicationData.RoamingSettings |`HKCU\SOFTWARE\<publisher>\<product>`                                |
@@ -256,9 +255,6 @@ Per https://learn.microsoft.com/uwp/api/windows.storage.applicationdata.roamingf
       is Azure App Service. Azure App Service is widely supported, well documented, reliable, and
       supports cross-platform/cross-ecosystem scenarios such as iOS, Android and web. Settings
       stored here no longer roam (as of Windows 11), but the settings store is still available.
-
-We provide `RoamingFolder` and `RoamingSettings` equivalents but they're only as functional as
-Windows provides (i.e. no data roaming on Windows after 1909 aka 19H2 aka 10.0.18363.0).
 
 We don't provide equivalents to Windows.Storage.ApplicationData's...
 

--- a/test/ApplicationData/UnpackagedApplicationDataTests.cpp
+++ b/test/ApplicationData/UnpackagedApplicationDataTests.cpp
@@ -16,8 +16,8 @@ namespace Test::ApplicationData::Tests
 {
     const auto Main_PackageFamilyName{ ::TP::DynamicDependencyDataStore::c_PackageFamilyName };
 
-    const winrt::hstring Publisher{ L"ApplicationDataTests" };
-    const winrt::hstring Product{ L"UnpackagedApplicationDataTests" };
+    const winrt::hstring Publisher{ L"TestApplicationDataUnpackaged_Contoso" };
+    const winrt::hstring Product{ L"SupermarketPointOfSale" };
 
     class UnpackagedApplicationDataTests
     {
@@ -94,14 +94,20 @@ namespace Test::ApplicationData::Tests
             }
         }
 
+        static std::filesystem::path GetResources_Registry()
+        {
+            return std::filesystem::path{ L"SOFTWARE\\Classes\\Local Settings\\Software" } / Publisher.c_str();
+        }
+
         void DeleteResources_Registry()
         {
-            const auto regkey{ std::filesystem::path{ L"SOFTWARE" } / Publisher.c_str() };
+            const auto regkey{ GetResources_Registry() };
             const auto hr{ HRESULT_FROM_WIN32(::RegDeleteTreeW(HKEY_CURRENT_USER, regkey.c_str())) };
             if (!wil::reg::is_registry_not_found(hr))
             {
-                VERIFY_SUCCEEDED(hr, WEX::Common::String().Format(L"RegDeleteTreeW HKEY_CURRENT_USER\\%s", regkey.c_str()));
+                VERIFY_SUCCEEDED(hr, WEX::Common::String().Format(L"RegDeleteTreeW HKCU\\%s", regkey.c_str()));
             }
+            VERIFY_IS_FALSE(RegistryKeyExists(regkey), WEX::Common::String().Format(L"HKCU\\%s", regkey.c_str()));
         }
 
         std::filesystem::path ToLongPath(const winrt::hstring& path)
@@ -161,6 +167,16 @@ namespace Test::ApplicationData::Tests
         {
             const std::filesystem::directory_entry directoryEntry{ path };
             return directoryEntry.is_directory();
+        }
+
+        static bool RegistryKeyExists(std::filesystem::path const& path)
+        {
+            wil::unique_hkey currentUserKey;
+            THROW_IF_WIN32_ERROR(::RegOpenCurrentUser(KEY_READ | KEY_WRITE, currentUserKey.put()));
+            wil::unique_hkey key;
+            const auto hr{ wil::reg::open_unique_key_nothrow(currentUserKey.get(), path.c_str(), key, wil::reg::key_access::readwrite) };
+            VERIFY_IS_TRUE(SUCCEEDED(hr) || ::wil::reg::is_registry_not_found(hr), WEX::Common::String().Format(L"open(%s) = 0x%08X", path.c_str(), hr));
+            return SUCCEEDED(hr);
         }
 
         std::filesystem::path UserLocalPath(winrt::hstring const& publisher)
@@ -359,6 +375,11 @@ namespace Test::ApplicationData::Tests
 
             auto container{ localSettings.CreateContainer(foodAndStuff, winrt::Microsoft::Windows::Storage::ApplicationDataCreateDisposition::Always) };
             VERIFY_ARE_EQUAL(foodAndStuff, container.Name());
+            {
+                const auto regkey{ GetResources_Registry() };
+                const auto foodAndStuffRegkey{ regkey / Product.c_str() / foodAndStuff.c_str() };
+                VERIFY_IS_TRUE(RegistryKeyExists(foodAndStuffRegkey), WEX::Common::String().Format(L"HKCU\\%s", foodAndStuffRegkey.c_str()));
+            }
             //
             VERIFY_ARE_EQUAL(0u, containers.Size());
             VERIFY_IS_FALSE(containers.HasKey(foodAndStuff));
@@ -477,7 +498,7 @@ namespace Test::ApplicationData::Tests
             const winrt::hstring invalidBackslash{ L"foo\\bar" };
             try
             {
-                [[maybe_unused]] auto container{ localSettings.CreateContainer(invalidBackslash, disposition) };
+                [[maybe_unused]] auto invalidContainer{ localSettings.CreateContainer(invalidBackslash, disposition) };
                 VERIFY_FAIL(WEX::Common::String().Format(L"Success is not expected -- Publisher:%s Product:%s", invalidBackslash.c_str(), Product.c_str()));
             }
             catch (winrt::hresult_error& e)
@@ -497,7 +518,7 @@ namespace Test::ApplicationData::Tests
             VERIFY_IS_NOT_NULL(maxLengthContainer);
             try
             {
-                [[maybe_unused]] auto container{ localSettings.CreateContainer(nameTooLong, disposition) };
+                [[maybe_unused]] auto invalidContainer{ localSettings.CreateContainer(nameTooLong, disposition) };
                 VERIFY_FAIL(WEX::Common::String().Format(L"Success is not expected -- Publisher:%s Product:%s", nameTooLong.c_str(), Product.c_str()));
             }
             catch (winrt::hresult_error& e)
@@ -508,7 +529,7 @@ namespace Test::ApplicationData::Tests
             const winrt::hstring invalidDot{ L"." };
             try
             {
-                [[maybe_unused]] auto container{ localSettings.CreateContainer(invalidDot, disposition) };
+                [[maybe_unused]] auto invalidContainer{ localSettings.CreateContainer(invalidDot, disposition) };
                 VERIFY_FAIL(WEX::Common::String().Format(L"Success is not expected -- Publisher:%s Product:%s", invalidDot.c_str(), Product.c_str()));
             }
             catch (winrt::hresult_error& e)
@@ -519,7 +540,7 @@ namespace Test::ApplicationData::Tests
             const winrt::hstring invalidDotDot{ L".." };
             try
             {
-                [[maybe_unused]] auto container{ localSettings.CreateContainer(invalidDotDot, disposition) };
+                [[maybe_unused]] auto invalidContainer{ localSettings.CreateContainer(invalidDotDot, disposition) };
                 VERIFY_FAIL(WEX::Common::String().Format(L"Success is not expected -- Publisher:%s Product:%s", invalidDotDot.c_str(), Product.c_str()));
             }
             catch (winrt::hresult_error& e)
@@ -593,7 +614,7 @@ namespace Test::ApplicationData::Tests
 
         TEST_METHOD(ContainerOperations)
         {
-            auto applicationData{ winrt::Microsoft::Windows::Storage::ApplicationData::GetForUnpackaged(L"TestApplicationData_Contoso", L"SupermarketPointOfSale") };
+            auto applicationData{ winrt::Microsoft::Windows::Storage::ApplicationData::GetForUnpackaged(Publisher, Product) };
             VERIFY_IS_NOT_NULL(applicationData);
 
             auto localSettings{ applicationData.LocalSettings() };
@@ -665,7 +686,7 @@ namespace Test::ApplicationData::Tests
 
         TEST_METHOD(Values_ScalarTypes)
         {
-            auto applicationData{ winrt::Microsoft::Windows::Storage::ApplicationData::GetForUnpackaged(L"TestApplicationData_Contoso", L"SupermarketPointOfSale") };
+            auto applicationData{ winrt::Microsoft::Windows::Storage::ApplicationData::GetForUnpackaged(Publisher, Product) };
             auto localSettings{ applicationData.LocalSettings() };
             auto values{ localSettings.Values() };
             values.Clear();
@@ -780,7 +801,7 @@ namespace Test::ApplicationData::Tests
 
         TEST_METHOD(Values_ArrayTypes)
         {
-            auto applicationData{ winrt::Microsoft::Windows::Storage::ApplicationData::GetForUnpackaged(L"TestApplicationData_Contoso", L"SupermarketPointOfSale") };
+            auto applicationData{ winrt::Microsoft::Windows::Storage::ApplicationData::GetForUnpackaged(Publisher, Product) };
             auto localSettings{ applicationData.LocalSettings() };
             auto values{ localSettings.Values() };
             values.Clear();
@@ -1049,7 +1070,7 @@ namespace Test::ApplicationData::Tests
 
         TEST_METHOD(Values_PropertySetOperations)
         {
-            auto applicationData{ winrt::Microsoft::Windows::Storage::ApplicationData::GetForUnpackaged(L"TestApplicationData_Contoso", L"SupermarketPointOfSale") };
+            auto applicationData{ winrt::Microsoft::Windows::Storage::ApplicationData::GetForUnpackaged(Publisher, Product) };
             auto localSettings{ applicationData.LocalSettings() };
             auto values{ localSettings.Values() };
             values.Clear();
@@ -1116,7 +1137,7 @@ namespace Test::ApplicationData::Tests
 
         TEST_METHOD(Values_MapChangedEvent)
         {
-            auto applicationData{ winrt::Microsoft::Windows::Storage::ApplicationData::GetForUnpackaged(L"TestApplicationData_Contoso", L"SupermarketPointOfSale") };
+            auto applicationData{ winrt::Microsoft::Windows::Storage::ApplicationData::GetForUnpackaged(Publisher, Product) };
             auto localSettings{ applicationData.LocalSettings() };
             auto values{ localSettings.Values() };
             values.Clear();
@@ -1170,7 +1191,7 @@ namespace Test::ApplicationData::Tests
 
         TEST_METHOD(Close_ThrowsAfterClose)
         {
-            auto applicationData{ winrt::Microsoft::Windows::Storage::ApplicationData::GetForUnpackaged(L"TestApplicationData_Contoso", L"SupermarketPointOfSale") };
+            auto applicationData{ winrt::Microsoft::Windows::Storage::ApplicationData::GetForUnpackaged(Publisher, Product) };
             auto localSettings{ applicationData.LocalSettings() };
 
             // Create a child container to test Close on


### PR DESCRIPTION
Fix bad regkey path for ApplicationData.GetForUnpackaged().LocalSettings() (#6558)

* Fix bad regkey path for ApplicationData.GetForUnpackaged().LocalSettings()

* Fixed Clear*()

* Removed obsolete references to Roaming*

* Fixed tests to use consistent test data

Cherry-pick of https://github.com/microsoft/WindowsAppSDK/pull/6558