### PR TITLE
[2.0 Servicing] Fix UniversalBGTask crash and gracefully handle CoCreateInstance failures

### DIFF
--- a/dev/RuntimeCompatibilityOptions/RuntimeCompatibilityOptions.idl
+++ b/dev/RuntimeCompatibilityOptions/RuntimeCompatibilityOptions.idl
@@ -41,6 +41,9 @@ namespace Microsoft.Windows.ApplicationModel.WindowsAppRuntime
 
         // 2.2.1
         ApplicationData_GetForUnpackaged_LocalSettings = 62698635,
+
+        // 2.2.2
+        UniversalBGTask_RunCrash = 62755661,
     };
 
     /// Represents a version of the Windows App Runtime.

--- a/dev/WindowsAppRuntime_UniversalBGTaskDLL/Task.cpp
+++ b/dev/WindowsAppRuntime_UniversalBGTaskDLL/Task.cpp
@@ -14,7 +14,7 @@ using namespace winrt::Windows::ApplicationModel::Background;
 using namespace winrt::Windows::Storage;
 
 // 62755661: [2.0 Servicing][WASDK] Fix UniversalBGTask::Task::Run crash on missing CLSID / CoCreateInstance failure
-#define WINAPPSDK_CHANGEID_62755661 62755661, WinAppSDK_2_2_2
+#define WINAPPSDK_CHANGEID_62755661 62755661
 
 namespace winrt::Microsoft::Windows::ApplicationModel::Background::UniversalBGTask::implementation
 {

--- a/dev/WindowsAppRuntime_UniversalBGTaskDLL/Task.cpp
+++ b/dev/WindowsAppRuntime_UniversalBGTaskDLL/Task.cpp
@@ -7,10 +7,14 @@
 #include "Task.g.cpp"
 #endif
 #include <wil/result_macros.h>
+#include <FrameworkUdk/Containment.h>
 
 using namespace winrt;
 using namespace winrt::Windows::ApplicationModel::Background;
 using namespace winrt::Windows::Storage;
+
+// 62755661: [2.0 Servicing][WASDK] Fix UniversalBGTask::Task::Run crash on missing CLSID / CoCreateInstance failure
+#define WINAPPSDK_CHANGEID_62755661 62755661, WinAppSDK_2_2_2
 
 namespace winrt::Microsoft::Windows::ApplicationModel::Background::UniversalBGTask::implementation
 {
@@ -21,44 +25,57 @@ namespace winrt::Microsoft::Windows::ApplicationModel::Background::UniversalBGTa
         auto values = localSettings.Values();
         auto lookupobj = values.Lookup(lookupStr);
 
-        // LocalSettings.Lookup returns S_OK with a null IInspectable when the key is missing.
-        // Treat this as an orphaned OS task registration: log and unregister so the broker
-        // stops re-firing it. Returning cleanly is preferred over throwing because thrown
-        // exceptions are treated as transient by the broker and would be retried indefinitely.
-        if (!lookupobj)
+        // 62755661: Guard the new crash-hardening behavior behind containment so apps pinned to an
+        // earlier WinAppSDK patch level keep the original (throwing) behavior.
+        if (WinAppSdk::Containment::IsChangeEnabled<WINAPPSDK_CHANGEID_62755661>())
         {
-            LOG_HR_MSG(
-                HRESULT_FROM_WIN32(ERROR_NOT_FOUND),
-                "UniversalBGTask: no CLSID stored in LocalSettings for TaskId='%ls'. Unregistering orphaned task.",
-                lookupStr.c_str());
-            try
+            // LocalSettings.Lookup returns S_OK with a null IInspectable when the key is missing.
+            // Treat this as an orphaned OS task registration: log and unregister so the broker
+            // stops re-firing it. Returning cleanly is preferred over throwing because thrown
+            // exceptions are treated as transient by the broker and would be retried indefinitely.
+            if (!lookupobj)
             {
-                taskInstance.Task().Unregister(true);
+                LOG_HR_MSG(
+                    HRESULT_FROM_WIN32(ERROR_NOT_FOUND),
+                    "UniversalBGTask: no CLSID stored in LocalSettings for TaskId='%ls'. Unregistering orphaned task.",
+                    lookupStr.c_str());
+                try
+                {
+                    taskInstance.Task().Unregister(true);
+                }
+                CATCH_LOG_MSG("UniversalBGTask: failed to unregister orphaned task TaskId='%ls'.", lookupStr.c_str());
+                return;
             }
-            CATCH_LOG_MSG("UniversalBGTask: failed to unregister orphaned task TaskId='%ls'.", lookupStr.c_str());
-            return;
+
+            winrt::guid comClsId = winrt::unbox_value<winrt::guid>(lookupobj);
+
+            // CoCreateInstance can fail when the COM class isn't registered, the stored CLSID is
+            // GUID_NULL, or the impl doesn't expose IBackgroundTask. Log the HR with the CLSID
+            // for diagnostics and return; do not unregister, since the failure may be transient.
+            wchar_t comClsIdStr[40]{};
+            ::StringFromGUID2(comClsId, comClsIdStr, ARRAYSIZE(comClsIdStr));
+            HRESULT coCreateHr = CoCreateInstance(comClsId, nullptr, CLSCTX_LOCAL_SERVER,
+                winrt::guid_of<winrt::Windows::ApplicationModel::Background::IBackgroundTask>(),
+                winrt::put_abi(m_bgTask));
+            if (FAILED(coCreateHr))
+            {
+                LOG_HR_MSG(
+                    coCreateHr,
+                    "UniversalBGTask: CoCreateInstance failed for CLSID=%ls referenced by TaskId='%ls'.",
+                    comClsIdStr,
+                    lookupStr.c_str());
+                return;
+            }
+
+            m_bgTask.Run(taskInstance);
         }
-
-        winrt::guid comClsId = winrt::unbox_value<winrt::guid>(lookupobj);
-
-        // CoCreateInstance can fail when the COM class isn't registered, the stored CLSID is
-        // GUID_NULL, or the impl doesn't expose IBackgroundTask. Log the HR with the CLSID
-        // for diagnostics and return; do not unregister, since the failure may be transient.
-        wchar_t comClsIdStr[40]{};
-        ::StringFromGUID2(comClsId, comClsIdStr, ARRAYSIZE(comClsIdStr));
-        HRESULT coCreateHr = CoCreateInstance(comClsId, nullptr, CLSCTX_LOCAL_SERVER,
-            winrt::guid_of<winrt::Windows::ApplicationModel::Background::IBackgroundTask>(),
-            winrt::put_abi(m_bgTask));
-        if (FAILED(coCreateHr))
+        else
         {
-            LOG_HR_MSG(
-                coCreateHr,
-                "UniversalBGTask: CoCreateInstance failed for CLSID=%ls referenced by TaskId='%ls'.",
-                comClsIdStr,
-                lookupStr.c_str());
-            return;
-        }
+            // Original (pre-servicing) behavior, preserved for apps pinned to an earlier patch level.
+            winrt::guid comClsId = winrt::unbox_value<winrt::guid>(lookupobj);
 
-        m_bgTask.Run(taskInstance);
+            THROW_IF_FAILED(CoCreateInstance(comClsId, nullptr, CLSCTX_LOCAL_SERVER, winrt::guid_of<winrt::Windows::ApplicationModel::Background::IBackgroundTask>(), winrt::put_abi(m_bgTask)));
+            m_bgTask.Run(taskInstance);
+        }
     }
 }

--- a/dev/WindowsAppRuntime_UniversalBGTaskDLL/Task.cpp
+++ b/dev/WindowsAppRuntime_UniversalBGTaskDLL/Task.cpp
@@ -20,9 +20,45 @@ namespace winrt::Microsoft::Windows::ApplicationModel::Background::UniversalBGTa
         ApplicationDataContainer localSettings = ApplicationData::Current().LocalSettings();
         auto values = localSettings.Values();
         auto lookupobj = values.Lookup(lookupStr);
+
+        // LocalSettings.Lookup returns S_OK with a null IInspectable when the key is missing.
+        // Treat this as an orphaned OS task registration: log and unregister so the broker
+        // stops re-firing it. Returning cleanly is preferred over throwing because thrown
+        // exceptions are treated as transient by the broker and would be retried indefinitely.
+        if (!lookupobj)
+        {
+            LOG_HR_MSG(
+                HRESULT_FROM_WIN32(ERROR_NOT_FOUND),
+                "UniversalBGTask: no CLSID stored in LocalSettings for TaskId='%ls'. Unregistering orphaned task.",
+                lookupStr.c_str());
+            try
+            {
+                taskInstance.Task().Unregister(true);
+            }
+            CATCH_LOG_MSG("UniversalBGTask: failed to unregister orphaned task TaskId='%ls'.", lookupStr.c_str());
+            return;
+        }
+
         winrt::guid comClsId = winrt::unbox_value<winrt::guid>(lookupobj);
 
-        THROW_IF_FAILED(CoCreateInstance(comClsId, nullptr, CLSCTX_LOCAL_SERVER, winrt::guid_of<winrt::Windows::ApplicationModel::Background::IBackgroundTask>(), winrt::put_abi(m_bgTask)));
+        // CoCreateInstance can fail when the COM class isn't registered, the stored CLSID is
+        // GUID_NULL, or the impl doesn't expose IBackgroundTask. Log the HR with the CLSID
+        // for diagnostics and return; do not unregister, since the failure may be transient.
+        wchar_t comClsIdStr[40]{};
+        ::StringFromGUID2(comClsId, comClsIdStr, ARRAYSIZE(comClsIdStr));
+        HRESULT coCreateHr = CoCreateInstance(comClsId, nullptr, CLSCTX_LOCAL_SERVER,
+            winrt::guid_of<winrt::Windows::ApplicationModel::Background::IBackgroundTask>(),
+            winrt::put_abi(m_bgTask));
+        if (FAILED(coCreateHr))
+        {
+            LOG_HR_MSG(
+                coCreateHr,
+                "UniversalBGTask: CoCreateInstance failed for CLSID=%ls referenced by TaskId='%ls'.",
+                comClsIdStr,
+                lookupStr.c_str());
+            return;
+        }
+
         m_bgTask.Run(taskInstance);
     }
 }

--- a/dev/WindowsAppRuntime_UniversalBGTaskDLL/WindowsAppRuntime_UniversalBGTaskDLL.vcxproj
+++ b/dev/WindowsAppRuntime_UniversalBGTaskDLL/WindowsAppRuntime_UniversalBGTaskDLL.vcxproj
@@ -149,6 +149,7 @@
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">
+    <Import Project="$(NugetPackageDirectory)\Microsoft.FrameworkUdk\$(MicrosoftFrameworkUdkPackageVersion)\build\native\Microsoft.FrameworkUdk.targets" Condition="Exists('$(NugetPackageDirectory)\Microsoft.FrameworkUdk\$(MicrosoftFrameworkUdkPackageVersion)\build\native\Microsoft.FrameworkUdk.targets')" />
     <Import Project="$(NugetPackageDirectory)\Microsoft.Windows.CppWinRT.$(MicrosoftWindowsCppWinRTVersion)\build\native\Microsoft.Windows.CppWinRT.targets" Condition="Exists('$(NugetPackageDirectory)\Microsoft.Windows.CppWinRT.$(MicrosoftWindowsCppWinRTVersion)\build\native\Microsoft.Windows.CppWinRT.targets')" />
     <Import Project="$(NugetPackageDirectory)\Microsoft.Windows.SDK.BuildTools.10.0.26100.4654\build\Microsoft.Windows.SDK.BuildTools.targets" Condition="Exists('$(NugetPackageDirectory)\Microsoft.Windows.SDK.BuildTools.10.0.26100.4654\build\Microsoft.Windows.SDK.BuildTools.targets')" />
     <Import Project="$(NugetPackageDirectory)\Microsoft.Windows.ImplementationLibrary.$(MicrosoftWindowsImplementationLibraryVersion)\build\native\Microsoft.Windows.ImplementationLibrary.targets" Condition="Exists('$(NugetPackageDirectory)\Microsoft.Windows.ImplementationLibrary.$(MicrosoftWindowsImplementationLibraryVersion)\build\native\Microsoft.Windows.ImplementationLibrary.targets')" />
@@ -157,6 +158,7 @@
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
+    <Error Condition="!Exists('$(NugetPackageDirectory)\Microsoft.FrameworkUdk\$(MicrosoftFrameworkUdkPackageVersion)\build\native\Microsoft.FrameworkUdk.targets')" Text="$([System.String]::Format('$(ErrorText)', '$(NugetPackageDirectory)\Microsoft.FrameworkUdk\$(MicrosoftFrameworkUdkPackageVersion)\build\native\Microsoft.FrameworkUdk.targets'))" />
     <Error Condition="!Exists('$(NugetPackageDirectory)\Microsoft.Windows.CppWinRT.$(MicrosoftWindowsCppWinRTVersion)\build\native\Microsoft.Windows.CppWinRT.props')" Text="$([System.String]::Format('$(ErrorText)', '$(NugetPackageDirectory)\Microsoft.Windows.CppWinRT.$(MicrosoftWindowsCppWinRTVersion)\build\native\Microsoft.Windows.CppWinRT.props'))" />
     <Error Condition="!Exists('$(NugetPackageDirectory)\Microsoft.Windows.CppWinRT.$(MicrosoftWindowsCppWinRTVersion)\build\native\Microsoft.Windows.CppWinRT.targets')" Text="$([System.String]::Format('$(ErrorText)', '$(NugetPackageDirectory)\Microsoft.Windows.CppWinRT.$(MicrosoftWindowsCppWinRTVersion)\build\native\Microsoft.Windows.CppWinRT.targets'))" />
     <Error Condition="!Exists('$(NugetPackageDirectory)\Microsoft.Windows.SDK.BuildTools.10.0.26100.4654\build\Microsoft.Windows.SDK.BuildTools.props')" Text="$([System.String]::Format('$(ErrorText)', '$(NugetPackageDirectory)\Microsoft.Windows.SDK.BuildTools.10.0.26100.4654\build\Microsoft.Windows.SDK.BuildTools.props'))" />


### PR DESCRIPTION
UniversalBGTask::Task::Run could crash backgroundTaskHost.exe in two scenarios:

1. When LocalSettings has no entry for the task's TaskId, ApplicationDataContainerSettings::Lookup returns S_OK with a null IInspectable. The subsequent unbox_value<winrt::guid> then throws hresult_no_interface, and because the broker treats the failure as transient it re-fires the trigger forever.

2. When CoCreateInstance fails (e.g. the COM class isn't registered against the package), the wrapped THROW_IF_FAILED produced no diagnostic context.

## Fix

- If LocalSettings.Lookup returns null, log via wil and Unregister the orphaned OS task so the broker stops re-firing it.
- If CoCreateInstance fails, log the HR with the CLSID and TaskId and return cleanly. The registration is left in place so the broker can retry on the next trigger in case the failure is transient.

## Servicing

- Contained behind `WINAPPSDK_CHANGEID_62755661` (`WinAppSDK_2_2_2`); the original (throwing) behavior is preserved in the `else` branch for apps pinned to an earlier patch level.
- RuntimeCompatibilityChange: `UniversalBGTask_RunCrash = 62755661`.
- ADO servicing bug: 62755661.

Cherry picked from #6507
