### PR TITLE
Fix GITHUB_TOKEN leak in github-artifacts MCP helper

### DIFF
--- a/tools/mcp/github-artifacts/auth.js
+++ b/tools/mcp/github-artifacts/auth.js
@@ -1,0 +1,35 @@
+// Centralized control over when the GitHub bearer token may be attached to an
+// outgoing request.
+//
+// Image and ZIP URLs are extracted from untrusted issue/PR Markdown and can
+// point to any host. The GitHub bearer token (GITHUB_TOKEN) must therefore only
+// ever be sent to explicitly allowlisted GitHub API hosts, never to URLs that
+// originate from issue content. Sending it elsewhere would leak the token to an
+// attacker-controlled server.
+
+export const AUTH_ALLOWED_HOSTS = new Set([
+  "api.github.com"
+]);
+
+// Returns true only when it is safe to attach the GitHub bearer token to the
+// given URL: the request must be HTTPS and target an allowlisted GitHub API host.
+export function shouldSendGitHubToken(rawUrl) {
+  let parsed;
+  try {
+    parsed = new URL(rawUrl);
+  } catch {
+    return false;
+  }
+  return parsed.protocol === "https:" && AUTH_ALLOWED_HOSTS.has(parsed.hostname.toLowerCase());
+}
+
+// Builds request headers, attaching Authorization only when the target URL is an
+// allowlisted GitHub API host. Arbitrary image/ZIP URLs from issue content never
+// receive the token.
+export function headersForUrl(rawUrl, token, extra = {}) {
+  return {
+    ...extra,
+    ...(token && shouldSendGitHubToken(rawUrl) ? { "Authorization": `Bearer ${token}` } : {}),
+    "User-Agent": "issue-images-mcp"
+  };
+}

--- a/tools/mcp/github-artifacts/package.json
+++ b/tools/mcp/github-artifacts/package.json
@@ -4,7 +4,8 @@
   "description": "MCP server for downloading and analyzing images and ZIP attachments from GitHub issues and pull requests",
   "main": "server.js",
   "scripts": {
-    "test": "node test-github_issue_images.js && node test-github_issue_attachments.js",
+    "test": "node test-token-allowlist.js && node test-github_issue_images.js && node test-github_issue_attachments.js",
+    "test:unit": "node test-token-allowlist.js",
     "start": "node server.js"
   },
   "keywords": [],

--- a/tools/mcp/github-artifacts/server.js
+++ b/tools/mcp/github-artifacts/server.js
@@ -4,6 +4,7 @@ import { z } from "zod";
 import fs from "fs/promises";
 import path from "path";
 import { execFile } from "child_process";
+import { headersForUrl } from "./auth.js";
 
 const server = new McpServer({
   name: "github-artifacts",
@@ -52,23 +53,20 @@ function extractZipUrls(markdownOrHtml) {
 
 async function fetchJson(url, token) {
   const res = await fetch(url, {
-    headers: {
+    headers: headersForUrl(url, token, {
       "Accept": "application/vnd.github+json",
-      ...(token ? { "Authorization": `Bearer ${token}` } : {}),
-      "X-GitHub-Api-Version": "2022-11-28",
-      "User-Agent": "issue-images-mcp"
-    }
+      "X-GitHub-Api-Version": "2022-11-28"
+    })
   });
   if (!res.ok) throw new Error(`GitHub API failed: ${res.status} ${res.statusText}`);
   return await res.json();
 }
 
 async function downloadBytes(url, token) {
+  // URL comes from untrusted issue content: headersForUrl withholds the token
+  // unless the host is an allowlisted GitHub API host.
   const res = await fetch(url, {
-    headers: {
-      ...(token ? { "Authorization": `Bearer ${token}` } : {}),
-      "User-Agent": "issue-images-mcp"
-    }
+    headers: headersForUrl(url, token)
   });
   if (!res.ok) throw new Error(`Image download failed: ${res.status} ${res.statusText}`);
   const buf = new Uint8Array(await res.arrayBuffer());
@@ -79,34 +77,21 @@ async function downloadBytes(url, token) {
 async function downloadZipBytes(url, token) {
   const zipUrl = url.includes("?") ? url : `${url}?download=1`;
 
-  const tryFetch = async (useAuth) => {
-    const res = await fetch(zipUrl, {
-      headers: {
-        "Accept": "application/octet-stream",
-        ...(useAuth && token ? { "Authorization": `Bearer ${token}` } : {}),
-        "User-Agent": "issue-images-mcp"
-      },
-      redirect: "follow"
-    });
+  // URL comes from untrusted issue content: headersForUrl withholds the token
+  // unless the host is an allowlisted GitHub API host.
+  const res = await fetch(zipUrl, {
+    headers: headersForUrl(zipUrl, token, { "Accept": "application/octet-stream" }),
+    redirect: "follow"
+  });
 
-    if (!res.ok) throw new Error(`ZIP download failed: ${res.status} ${res.statusText}`);
+  if (!res.ok) throw new Error(`ZIP download failed: ${res.status} ${res.statusText}`);
 
-    const contentType = (res.headers.get("content-type") || "").toLowerCase();
-    const buf = new Uint8Array(await res.arrayBuffer());
+  const contentType = (res.headers.get("content-type") || "").toLowerCase();
+  const buf = new Uint8Array(await res.arrayBuffer());
 
-    return { buf, contentType };
-  };
-
-  let { buf, contentType } = await tryFetch(true);
   const isZip = buf.length >= 4 && buf[0] === 0x50 && buf[1] === 0x4b;
 
-  if (!isZip) {
-    ({ buf, contentType } = await tryFetch(false));
-  }
-
-  const isZipRetry = buf.length >= 4 && buf[0] === 0x50 && buf[1] === 0x4b;
-
-  if (!isZipRetry || contentType.includes("text/html") || buf.length < 100) {
+  if (!isZip || contentType.includes("text/html") || buf.length < 100) {
     throw new Error("ZIP download returned HTML or invalid data. Check permissions or rate limits.");
   }
 

--- a/tools/mcp/github-artifacts/test-token-allowlist.js
+++ b/tools/mcp/github-artifacts/test-token-allowlist.js
@@ -1,0 +1,77 @@
+// Regression test for the GITHUB_TOKEN allowlist (security fix).
+// Run with: node test-token-allowlist.js
+//
+// Proves that the bearer token is attached ONLY to allowlisted GitHub API hosts
+// and is NEVER sent to arbitrary URLs extracted from untrusted issue content.
+
+import assert from "node:assert/strict";
+import { shouldSendGitHubToken, headersForUrl } from "./auth.js";
+
+const TOKEN = "PT_MCP_TEST_FAKE_TOKEN";
+
+let failures = 0;
+function check(name, fn) {
+  try {
+    fn();
+    console.log(`  ok  - ${name}`);
+  } catch (err) {
+    failures++;
+    console.error(`  FAIL - ${name}: ${err.message}`);
+  }
+}
+
+// Hosts that MUST receive the token.
+const allowed = [
+  "https://api.github.com/repos/microsoft/PowerToys/issues/1",
+  "https://api.github.com/repos/microsoft/PowerToys/issues/1/comments?per_page=100&page=1"
+];
+
+// Hosts that MUST NOT receive the token (attacker-controlled or non-API hosts,
+// including GitHub's own user-content hosts which never need the API token).
+const denied = [
+  "http://127.0.0.1:8000/capture.png",
+  "http://127.0.0.1:8000/PowerToysReport.zip?download=1",
+  "https://evil.example.com/capture.png",
+  "https://evil.example.com/PowerToysReport.zip",
+  "http://api.github.com/repos/microsoft/PowerToys/issues/1", // not HTTPS
+  "https://api.github.com.attacker.com/x", // look-alike host
+  "https://objects.githubusercontent.com/some/asset.zip",
+  "https://user-images.githubusercontent.com/1/screenshot.png",
+  "not a url"
+];
+
+for (const url of allowed) {
+  check(`token sent to allowlisted host: ${url}`, () => {
+    assert.equal(shouldSendGitHubToken(url), true);
+    const h = headersForUrl(url, TOKEN);
+    assert.equal(h["Authorization"], `Bearer ${TOKEN}`);
+    assert.equal(h["User-Agent"], "issue-images-mcp");
+  });
+}
+
+for (const url of denied) {
+  check(`token withheld from untrusted host: ${url}`, () => {
+    assert.equal(shouldSendGitHubToken(url), false);
+    const h = headersForUrl(url, TOKEN);
+    assert.equal("Authorization" in h, false, "Authorization header must not be present");
+    assert.equal(h["User-Agent"], "issue-images-mcp");
+  });
+}
+
+check("no token configured => no Authorization even for allowlisted host", () => {
+  const h = headersForUrl("https://api.github.com/x", undefined);
+  assert.equal("Authorization" in h, false);
+});
+
+check("extra headers are preserved", () => {
+  const h = headersForUrl("https://api.github.com/x", TOKEN, { "Accept": "application/vnd.github+json" });
+  assert.equal(h["Accept"], "application/vnd.github+json");
+  assert.equal(h["Authorization"], `Bearer ${TOKEN}`);
+});
+
+console.log("");
+if (failures > 0) {
+  console.error(`${failures} test(s) failed.`);
+  process.exit(1);
+}
+console.log("All token-allowlist regression tests passed.");


### PR DESCRIPTION
## Summary

Hardens the local `github-artifacts` MCP helper (`tools/mcp/github-artifacts/server.js`) so the `GITHUB_TOKEN` bearer token is only ever sent to allowlisted GitHub API hosts. Previously the same token was attached when downloading image and ZIP URLs extracted from issue/PR Markdown, which could forward the token to any host referenced in untrusted issue content.

This is repository MCP dev-tooling, not shipped Windows App SDK runtime. The same helper exists in microsoft/PowerToys and is fixed in microsoft/PowerToys#48782.

## What changed

- **New `auth.js`** centralizes token handling:
  - `AUTH_ALLOWED_HOSTS = { api.github.com }`
  - `shouldSendGitHubToken(url)` - true only for HTTPS + allowlisted host
  - `headersForUrl(url, token, extra)` - attaches `Authorization` only when the host is allowlisted
- **`server.js`** routes all three request sites (`fetchJson`, `downloadBytes`, `downloadZipBytes`) through `headersForUrl`. Image/ZIP URLs from issue content are now fetched **without** `Authorization`. Removed the ZIP dual-attempt auth retry that previously sent the token to untrusted hosts.
- **New `test-token-allowlist.js`** regression test (wired into `npm test` / `npm run test:unit`).

## Verification

- Unit test: 13/13 pass - token attached for `api.github.com`, withheld from arbitrary hosts, loopback, look-alike hostnames (`api.github.com.attacker.com`), non-HTTPS, and `*.githubusercontent.com`.
- Cross-origin redirects: Node's `fetch` (undici) strips `Authorization` when a redirect leaves the origin.
- Normal operation preserved: the patched server (identical to the PowerToys fix) downloads real public issue images and ZIP attachments without the token, since GitHub serves that content via public/signed URLs.

## Note

For private-repo attachments that would require an `Authorization` header on a non-API host, the token is intentionally not sent (the recommended tradeoff).
