### PR TITLE
Remove the NuGetPackageInstaller wizard from the C# templates

### DIFF
--- a/dev/Templates/Source/ProjectTemplates/Desktop/CSharp/ClassLibrary/WinUI.Desktop.Cs.ClassLibrary.vstemplate
+++ b/dev/Templates/Source/ProjectTemplates/Desktop/CSharp/ClassLibrary/WinUI.Desktop.Cs.ClassLibrary.vstemplate
@@ -34,8 +34,4 @@
       <CustomParameter Name="$WindowsSdkBuildToolsVersion$" Value="*" />
     </CustomParameters>
   </TemplateContent>
-  <WizardExtension>
-    <Assembly>WindowsAppSDK.Cs.Extension.Dev17, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null</Assembly>
-    <FullClassName>WindowsAppSDK.TemplateUtilities.NuGetPackageInstaller</FullClassName>
-  </WizardExtension>
 </VSTemplate>

--- a/dev/Templates/Source/ProjectTemplates/Desktop/CSharp/ClassLibrary/WinUI.Desktop.Cs.ClassLibrary.vstemplate
+++ b/dev/Templates/Source/ProjectTemplates/Desktop/CSharp/ClassLibrary/WinUI.Desktop.Cs.ClassLibrary.vstemplate
@@ -28,7 +28,6 @@
       <ProjectItem ReplaceParameters="true" OpenInEditor="true">Class1.cs</ProjectItem>
     </Project>
     <CustomParameters>
-      <CustomParameter Name="$NuGetPackages$" Value="Microsoft.WindowsAppSDK;Microsoft.Windows.SDK.BuildTools"/>
       <CustomParameter Name="$DotNetVersion$" Value="FIXME-Verify-Directory.Build.Targets-XmlPoke-Queries"/>        
       <CustomParameter Name="$WindowsAppSdkVersion$" Value="*" />
       <CustomParameter Name="$WindowsSdkBuildToolsVersion$" Value="*" />

--- a/dev/Templates/Source/ProjectTemplates/Desktop/CSharp/MvvmApp/WinUI.Desktop.Cs.MvvmApp.vstemplate
+++ b/dev/Templates/Source/ProjectTemplates/Desktop/CSharp/MvvmApp/WinUI.Desktop.Cs.MvvmApp.vstemplate
@@ -70,8 +70,4 @@
     <Assembly>Microsoft.VisualStudio.WinRT.TemplateWizards, Version=16.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</Assembly>
     <FullClassName>Microsoft.VisualStudio.WinRT.TemplateWizards.UpdatePublisherInManifestWizard</FullClassName>
   </WizardExtension>
-  <WizardExtension>
-    <Assembly>WindowsAppSDK.Cs.Extension.Dev17, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null</Assembly>
-    <FullClassName>WindowsAppSDK.TemplateUtilities.NuGetPackageInstaller</FullClassName>
-  </WizardExtension>
 </VSTemplate>

--- a/dev/Templates/Source/ProjectTemplates/Desktop/CSharp/MvvmApp/WinUI.Desktop.Cs.MvvmApp.vstemplate
+++ b/dev/Templates/Source/ProjectTemplates/Desktop/CSharp/MvvmApp/WinUI.Desktop.Cs.MvvmApp.vstemplate
@@ -61,9 +61,6 @@
         <ProjectItem ReplaceParameters="false" TargetFileName="Wide310x150Logo.scale-200.png">Wide310x150Logo.scale-200.png</ProjectItem>
       </Folder>
     </Project>      
-    <CustomParameters>
-      <CustomParameter Name="$NuGetPackages$" Value="Microsoft.WindowsAppSDK;Microsoft.Windows.SDK.BuildTools;Microsoft.Windows.SDK.BuildTools.WinApp;CommunityToolkit.Mvvm"/>
-    </CustomParameters>
   </TemplateContent>
   <WizardExtension>
     <!-- Generates Publisher name for appxmanifest -->

--- a/dev/Templates/Source/ProjectTemplates/Desktop/CSharp/NavigationApp/WinUI.Desktop.Cs.NavigationApp.vstemplate
+++ b/dev/Templates/Source/ProjectTemplates/Desktop/CSharp/NavigationApp/WinUI.Desktop.Cs.NavigationApp.vstemplate
@@ -72,8 +72,4 @@
     <Assembly>Microsoft.VisualStudio.WinRT.TemplateWizards, Version=16.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</Assembly>
     <FullClassName>Microsoft.VisualStudio.WinRT.TemplateWizards.UpdatePublisherInManifestWizard</FullClassName>
   </WizardExtension>
-  <WizardExtension>
-    <Assembly>WindowsAppSDK.Cs.Extension.Dev17, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null</Assembly>
-    <FullClassName>WindowsAppSDK.TemplateUtilities.NuGetPackageInstaller</FullClassName>
-  </WizardExtension>
 </VSTemplate>

--- a/dev/Templates/Source/ProjectTemplates/Desktop/CSharp/NavigationApp/WinUI.Desktop.Cs.NavigationApp.vstemplate
+++ b/dev/Templates/Source/ProjectTemplates/Desktop/CSharp/NavigationApp/WinUI.Desktop.Cs.NavigationApp.vstemplate
@@ -63,9 +63,6 @@
         <ProjectItem ReplaceParameters="false" TargetFileName="Wide310x150Logo.scale-200.png">Wide310x150Logo.scale-200.png</ProjectItem>
       </Folder>
     </Project>      
-    <CustomParameters>
-      <CustomParameter Name="$NuGetPackages$" Value="Microsoft.WindowsAppSDK;Microsoft.Windows.SDK.BuildTools;Microsoft.Windows.SDK.BuildTools.WinApp"/>
-    </CustomParameters>
   </TemplateContent>
   <WizardExtension>
     <!-- Generates Publisher name for appxmanifest -->

--- a/dev/Templates/Source/ProjectTemplates/Desktop/CSharp/PackagedApp/BlankApp/WinUI.Desktop.Cs.BlankApp.vstemplate
+++ b/dev/Templates/Source/ProjectTemplates/Desktop/CSharp/PackagedApp/BlankApp/WinUI.Desktop.Cs.BlankApp.vstemplate
@@ -40,8 +40,4 @@
       <CustomParameter Name="$NuGetPackages$" Value="Microsoft.WindowsAppSDK;Microsoft.Windows.SDK.BuildTools"/>
     </CustomParameters>
   </TemplateContent>
-  <WizardExtension>
-    <Assembly>WindowsAppSDK.Cs.Extension.Dev17, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null</Assembly>
-    <FullClassName>WindowsAppSDK.TemplateUtilities.NuGetPackageInstaller</FullClassName>
-  </WizardExtension>
 </VSTemplate>

--- a/dev/Templates/Source/ProjectTemplates/Desktop/CSharp/PackagedApp/BlankApp/WinUI.Desktop.Cs.BlankApp.vstemplate
+++ b/dev/Templates/Source/ProjectTemplates/Desktop/CSharp/PackagedApp/BlankApp/WinUI.Desktop.Cs.BlankApp.vstemplate
@@ -36,8 +36,5 @@
       <ProjectItem ReplaceParameters="true" TargetFileName="MainWindow.xaml.cs">MainWindow.xaml.cs</ProjectItem>
       <ProjectItem ReplaceParameters="false" TargetFileName="AppIcon.ico">AppIcon.ico</ProjectItem>
     </Project>      
-    <CustomParameters>
-      <CustomParameter Name="$NuGetPackages$" Value="Microsoft.WindowsAppSDK;Microsoft.Windows.SDK.BuildTools"/>
-    </CustomParameters>
   </TemplateContent>
 </VSTemplate>

--- a/dev/Templates/Source/ProjectTemplates/Desktop/CSharp/PackagedApp/WapProj/WinUI.Desktop.Cs.WapProj.vstemplate
+++ b/dev/Templates/Source/ProjectTemplates/Desktop/CSharp/PackagedApp/WapProj/WinUI.Desktop.Cs.WapProj.vstemplate
@@ -52,10 +52,6 @@
     <Assembly>Microsoft.VisualStudio.WinRT.TemplateWizards, Version=16.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</Assembly>
     <FullClassName>Microsoft.VisualStudio.WinRT.TemplateWizards.UpdatePublisherInManifestWizard</FullClassName>
   </WizardExtension>
-  <WizardExtension>
-    <Assembly>WindowsAppSDK.Cs.Extension.Dev17, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null</Assembly>
-    <FullClassName>WindowsAppSDK.TemplateUtilities.NuGetPackageInstaller</FullClassName>
-  </WizardExtension>
   <WizardData>
     <MinSupportedVersion>10.0.17763.0</MinSupportedVersion>
     <SkipXamlCompilerCheck>true</SkipXamlCompilerCheck>

--- a/dev/Templates/Source/ProjectTemplates/Desktop/CSharp/PackagedApp/WapProj/WinUI.Desktop.Cs.WapProj.vstemplate
+++ b/dev/Templates/Source/ProjectTemplates/Desktop/CSharp/PackagedApp/WapProj/WinUI.Desktop.Cs.WapProj.vstemplate
@@ -39,9 +39,6 @@
       <ProjectItem ReplaceParameters="false" TargetFileName="Images\StoreLogo.png">StoreLogo.png</ProjectItem>
       <ProjectItem ReplaceParameters="false" TargetFileName="Images\Wide310x150Logo.scale-200.png">Wide310x150Logo.scale-200.png</ProjectItem>
     </Project>      
-    <CustomParameters>
-      <CustomParameter Name="$NuGetPackages$" Value="Microsoft.WindowsAppSDK;Microsoft.Windows.SDK.BuildTools"/>
-    </CustomParameters>
   </TemplateContent>
   <WizardExtension>
     <Assembly>Microsoft.VisualStudio.Universal.TemplateWizards, Version=16.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</Assembly>

--- a/dev/Templates/Source/ProjectTemplates/Desktop/CSharp/PackagedApp/WinUI.Desktop.Cs.PackagedApp.vstemplate
+++ b/dev/Templates/Source/ProjectTemplates/Desktop/CSharp/PackagedApp/WinUI.Desktop.Cs.PackagedApp.vstemplate
@@ -35,8 +35,4 @@
       <CustomParameter Name="$NuGetPackages$" Value="Microsoft.WindowsAppSDK;Microsoft.Windows.SDK.BuildTools"/>
     </CustomParameters>
   </TemplateContent>
-  <WizardExtension>
-    <Assembly>WindowsAppSDK.Cs.Extension.Dev17, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null</Assembly>
-    <FullClassName>WindowsAppSDK.TemplateUtilities.NuGetPackageInstaller</FullClassName>
-  </WizardExtension>
 </VSTemplate>

--- a/dev/Templates/Source/ProjectTemplates/Desktop/CSharp/PackagedApp/WinUI.Desktop.Cs.PackagedApp.vstemplate
+++ b/dev/Templates/Source/ProjectTemplates/Desktop/CSharp/PackagedApp/WinUI.Desktop.Cs.PackagedApp.vstemplate
@@ -31,8 +31,5 @@
       <ProjectTemplateLink ProjectName="$projectname$ (Package)" CopyParameters="true">WapProj\WinUI.Desktop.Cs.WapProj.vstemplate</ProjectTemplateLink>
       <ProjectTemplateLink ProjectName="$projectname$" CopyParameters="true">BlankApp\WinUI.Desktop.Cs.BlankApp.vstemplate</ProjectTemplateLink>
     </ProjectCollection>
-    <CustomParameters>
-      <CustomParameter Name="$NuGetPackages$" Value="Microsoft.WindowsAppSDK;Microsoft.Windows.SDK.BuildTools"/>
-    </CustomParameters>
   </TemplateContent>
 </VSTemplate>

--- a/dev/Templates/Source/ProjectTemplates/Desktop/CSharp/SingleProjectPackagedApp/WinUI.Desktop.Cs.SingleProjectPackagedApp.vstemplate
+++ b/dev/Templates/Source/ProjectTemplates/Desktop/CSharp/SingleProjectPackagedApp/WinUI.Desktop.Cs.SingleProjectPackagedApp.vstemplate
@@ -57,9 +57,6 @@
         <ProjectItem ReplaceParameters="false" TargetFileName="Wide310x150Logo.scale-200.png">Wide310x150Logo.scale-200.png</ProjectItem>
       </Folder>
     </Project>      
-    <CustomParameters>
-      <CustomParameter Name="$NuGetPackages$" Value="Microsoft.WindowsAppSDK;Microsoft.Windows.SDK.BuildTools;Microsoft.Windows.SDK.BuildTools.WinApp"/>
-    </CustomParameters>
   </TemplateContent>
   <WizardExtension>
     <!-- Generates Publisher name for appxmanifest -->

--- a/dev/Templates/Source/ProjectTemplates/Desktop/CSharp/SingleProjectPackagedApp/WinUI.Desktop.Cs.SingleProjectPackagedApp.vstemplate
+++ b/dev/Templates/Source/ProjectTemplates/Desktop/CSharp/SingleProjectPackagedApp/WinUI.Desktop.Cs.SingleProjectPackagedApp.vstemplate
@@ -66,8 +66,4 @@
     <Assembly>Microsoft.VisualStudio.WinRT.TemplateWizards, Version=16.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</Assembly>
     <FullClassName>Microsoft.VisualStudio.WinRT.TemplateWizards.UpdatePublisherInManifestWizard</FullClassName>
   </WizardExtension>
-  <WizardExtension>
-    <Assembly>WindowsAppSDK.Cs.Extension.Dev17, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null</Assembly>
-    <FullClassName>WindowsAppSDK.TemplateUtilities.NuGetPackageInstaller</FullClassName>
-  </WizardExtension>
 </VSTemplate>

--- a/dev/Templates/Source/ProjectTemplates/Desktop/CSharp/TabViewApp/WinUI.Desktop.Cs.TabViewApp.vstemplate
+++ b/dev/Templates/Source/ProjectTemplates/Desktop/CSharp/TabViewApp/WinUI.Desktop.Cs.TabViewApp.vstemplate
@@ -70,8 +70,4 @@
     <Assembly>Microsoft.VisualStudio.WinRT.TemplateWizards, Version=16.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</Assembly>
     <FullClassName>Microsoft.VisualStudio.WinRT.TemplateWizards.UpdatePublisherInManifestWizard</FullClassName>
   </WizardExtension>
-  <WizardExtension>
-    <Assembly>WindowsAppSDK.Cs.Extension.Dev17, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null</Assembly>
-    <FullClassName>WindowsAppSDK.TemplateUtilities.NuGetPackageInstaller</FullClassName>
-  </WizardExtension>
 </VSTemplate>

--- a/dev/Templates/Source/ProjectTemplates/Desktop/CSharp/TabViewApp/WinUI.Desktop.Cs.TabViewApp.vstemplate
+++ b/dev/Templates/Source/ProjectTemplates/Desktop/CSharp/TabViewApp/WinUI.Desktop.Cs.TabViewApp.vstemplate
@@ -61,9 +61,6 @@
         <ProjectItem ReplaceParameters="false" TargetFileName="Wide310x150Logo.scale-200.png">Wide310x150Logo.scale-200.png</ProjectItem>
       </Folder>
     </Project>      
-    <CustomParameters>
-      <CustomParameter Name="$NuGetPackages$" Value="Microsoft.WindowsAppSDK;Microsoft.Windows.SDK.BuildTools;Microsoft.Windows.SDK.BuildTools.WinApp"/>
-    </CustomParameters>
   </TemplateContent>
   <WizardExtension>
     <!-- Generates Publisher name for appxmanifest -->

--- a/dev/Templates/Source/ProjectTemplates/Desktop/CSharp/UnitTestApp/WinUI.Desktop.Cs.UnitTestApp.vstemplate
+++ b/dev/Templates/Source/ProjectTemplates/Desktop/CSharp/UnitTestApp/WinUI.Desktop.Cs.UnitTestApp.vstemplate
@@ -65,8 +65,4 @@
     <Assembly>Microsoft.VisualStudio.WinRT.TemplateWizards, Version=16.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</Assembly>
     <FullClassName>Microsoft.VisualStudio.WinRT.TemplateWizards.UpdatePublisherInManifestWizard</FullClassName>
   </WizardExtension>
-  <WizardExtension>
-    <Assembly>WindowsAppSDK.Cs.Extension.Dev17, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null</Assembly>
-    <FullClassName>WindowsAppSDK.TemplateUtilities.NuGetPackageInstaller</FullClassName>
-  </WizardExtension>
 </VSTemplate>

--- a/dev/Templates/Source/ProjectTemplates/Desktop/CSharp/UnitTestApp/WinUI.Desktop.Cs.UnitTestApp.vstemplate
+++ b/dev/Templates/Source/ProjectTemplates/Desktop/CSharp/UnitTestApp/WinUI.Desktop.Cs.UnitTestApp.vstemplate
@@ -56,9 +56,6 @@
         <ProjectItem ReplaceParameters="false" TargetFileName="Wide310x150Logo.scale-200.png">Wide310x150Logo.scale-200.png</ProjectItem>
       </Folder>
     </Project>
-    <CustomParameters>
-      <CustomParameter Name="$NuGetPackages$" Value="Microsoft.Windows.SDK.BuildTools;MSTest.TestAdapter;MSTest.TestFramework;Microsoft.TestPlatform.TestHost;Microsoft.WindowsAppSDK"/>
-    </CustomParameters>    
   </TemplateContent>
   <WizardExtension>
     <!-- Generates Publisher name for appxmanifest -->

--- a/dev/Templates/VSIX/Extension/Cs/Dev17/Component/source.extension.vsixmanifest
+++ b/dev/Templates/VSIX/Extension/Cs/Dev17/Component/source.extension.vsixmanifest
@@ -39,10 +39,6 @@
   <Prerequisites>
     <Prerequisite Id="Microsoft.Component.MSBuild" Version="[17.0,19.0)" DisplayName="MSBuild" />
   </Prerequisites>
-  <Reference Id="NuPackToolsVsix.Microsoft.67e54e40-0ae3-42c5-a949-fddf5739e7a5" MinVersion="1.7.30402.9028">
-    <Name>NuGet Package Manager</Name>
-    <MoreInfoUrl>http://docs.microsoft.com/nuget/</MoreInfoUrl>
-  </Reference>
   <Assets>
     <Asset Type="Microsoft.VisualStudio.VsPackage" d:Source="Project" d:ProjectName="%CurrentProject%" Path="|%CurrentProject%;PkgdefProjectOutputGroup|" />
     <Asset Type="Microsoft.VisualStudio.Assembly" d:Source="Project" d:ProjectName="%CurrentProject%" Path="|%CurrentProject%|" AssemblyName="|%CurrentProject%;AssemblyName|" />

--- a/dev/Templates/VSIX/Extension/Cs/Dev17/LocalDev/source.extension.vsixmanifest
+++ b/dev/Templates/VSIX/Extension/Cs/Dev17/LocalDev/source.extension.vsixmanifest
@@ -83,10 +83,6 @@
         <Prerequisite Id="Microsoft.VisualStudio.Component.CoreEditor" Version="[16.0,19.0)" DisplayName="Visual Studio core editor" />
         <Prerequisite Id="Microsoft.VisualStudio.ComponentGroup.UWP.Support" Version="[16.2.29003.222,19.0)" DisplayName="Universal Windows Platform tools" />
     </Prerequisites>
-    <Reference Id="NuPackToolsVsix.Microsoft.67e54e40-0ae3-42c5-a949-fddf5739e7a5" MinVersion="1.7.30402.9028">
-        <Name>NuGet Package Manager</Name>
-        <MoreInfoUrl>http://docs.microsoft.com/nuget/</MoreInfoUrl>
-    </Reference>
     <Assets>
         <Asset Type="Microsoft.VisualStudio.VsPackage" d:Source="Project" d:ProjectName="%CurrentProject%" Path="|%CurrentProject%;PkgdefProjectOutputGroup|" />
         <Asset Type="Microsoft.VisualStudio.Assembly" d:Source="Project" d:ProjectName="%CurrentProject%" Path="|%CurrentProject%|" AssemblyName="|%CurrentProject%;AssemblyName|" />

--- a/dev/Templates/VSIX/Extension/Cs/Dev17/Standalone/source.extension.vsixmanifest
+++ b/dev/Templates/VSIX/Extension/Cs/Dev17/Standalone/source.extension.vsixmanifest
@@ -39,10 +39,6 @@
         <Prerequisite Id="Microsoft.VisualStudio.Component.CoreEditor" Version="[16.0,19.0)" DisplayName="Visual Studio core editor" />
         <Prerequisite Id="Microsoft.VisualStudio.ComponentGroup.UWP.Support" Version="[16.2.29003.222,19.0)" DisplayName="Universal Windows Platform tools" />
     </Prerequisites>
-    <Reference Id="NuPackToolsVsix.Microsoft.67e54e40-0ae3-42c5-a949-fddf5739e7a5" MinVersion="1.7.30402.9028">
-        <Name>NuGet Package Manager</Name>
-        <MoreInfoUrl>http://docs.microsoft.com/nuget/</MoreInfoUrl>
-    </Reference>
     <Assets>
         <Asset Type="Microsoft.VisualStudio.VsPackage" d:Source="Project" d:ProjectName="%CurrentProject%" Path="|%CurrentProject%;PkgdefProjectOutputGroup|" />
         <Asset Type="Microsoft.VisualStudio.Assembly" d:Source="Project" d:ProjectName="%CurrentProject%" Path="|%CurrentProject%|" AssemblyName="|%CurrentProject%;AssemblyName|" />

--- a/dev/Templates/VSIX/Extension/Cs/Dev17/WindowsAppSDK.Cs.Extension.Dev17.csproj
+++ b/dev/Templates/VSIX/Extension/Cs/Dev17/WindowsAppSDK.Cs.Extension.Dev17.csproj
@@ -46,9 +46,7 @@
     <PackageReference Include="Microsoft.VisualStudio.SDK" ExcludeAssets="runtime">
       <IncludeAssets>compile; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.VisualStudio.TemplateWizardInterface" />
     <PackageReference Include="Newtonsoft.Json" />
-    <PackageReference Include="NuGet.VisualStudio" GeneratePathProperty="true" />
     <PackageReference Include="System.Net.Http" />
     <PackageReference Include="System.Text.Json" />
     <PackageReference Include="Microsoft.VSSDK.BuildTools">
@@ -60,19 +58,11 @@
     </PackageReference>
   </ItemGroup>
   <ItemGroup>
-    <ExtensionDependencies Condition=" '$(ExcludeRestorePackageImports)' != 'true' " Include="$(PkgNuget_VisualStudio)\**\NuGet.VisualStudio.dll" />
-    <Compile Include="..\..\..\Shared\WizardImplementation.cs" Link="WizardImplementation.cs" />
-    <Compile Include="..\..\..\Shared\WizardInfoBarEvents.cs" Link="WizardInfoBarEvents.cs" />
-    <Compile Include="..\..\..\Shared\OutputWindowHelper.cs" Link="OutputWindowHelper.cs" />
     <Compile Include="..\Common\VSPackage.Designer.cs">
       <DesignTime>True</DesignTime>
       <AutoGen>True</AutoGen>
       <DependentUpon>VSPackage.resx</DependentUpon>
     </Compile>
-    <Content Include="@(ExtensionDependencies)">
-      <VSIXSubPath>.</VSIXSubPath>
-      <IncludeInVSIX>true</IncludeInVSIX>
-    </Content>
     <Content Include="$(ExtensionDir)WindowsAppSDK.png">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
       <IncludeInVSIX>true</IncludeInVSIX>
@@ -86,7 +76,6 @@
   </ItemGroup>
   <ItemGroup>
     <Reference Include="System" />
-    <Reference Include="System.Windows.Forms" />
   </ItemGroup>
   <!--
       ProjectReferences for the WinUI templates, derived from ..\..\..\..\templates.props:


### PR DESCRIPTION
The `NuGetPackageInstaller` wizard was created to unify the package installation process for the C# and C++ Windows App SDK templates. With the addition of C# dotnet templates in #6407, it made sense to instead unify the package installation process between the C# templates with the built-in `PackageReference` behavior #6523. Now that both the .NET and VS templates use `PackageReference`, the `NuGetPackageInstaller` wizard is no longer needed for the C# templates. This PR removes that wizard, eliminating the main difference between the .NET and VS templates.

Validation (manual):
- Tested locally via (script)
- Ran the pipeline to generate the Standalone VSIX
- For each of the C# templates, I verified that the Standalone VSIX installed successfully and the `NuGetPackageInstaller` wizard was no longer present when creating C# template projects

A microsoft employee must use /azp run to validate using the pipelines below.

WARNING:
Comments made by azure-pipelines bot maybe inaccurate.
Please see pipeline link to verify that the build is being ran.

For status checks on the main branch, please use TransportPackage-Foundation-PR
(https://microsoft.visualstudio.com/ProjectReunion/_build?definitionId=81063&_a=summary)
and run the build against your PR branch with the default parameters.
