### PR TITLE
Require Templates PR pipeline via internal dev/Templates path gate

### DIFF
--- a/build/AzurePipelinesTemplates/WindowsAppSDK-DotnetNewTemplates-Stages.yml
+++ b/build/AzurePipelinesTemplates/WindowsAppSDK-DotnetNewTemplates-Stages.yml
@@ -19,11 +19,21 @@ parameters:
 - name: IsPRBuild
   type: boolean
   default: false
+# Optional gate wiring used by the PR pipeline to short-circuit when no
+# dev/Templates files changed. Defaults preserve official-pipeline behavior.
+- name: dependsOn
+  type: object
+  default: []
+- name: condition
+  type: string
+  default: ''
 
 stages:
 - stage: DotnetNewTemplates_Build
   displayName: 'Build and pack dotnet new templates'
-  dependsOn: []
+  dependsOn: ${{ parameters.dependsOn }}
+  ${{ if ne(parameters.condition, '') }}:
+    condition: ${{ parameters.condition }}
   jobs:
   - job: PackDotnetNewTemplates
     displayName: 'Pack dotnet new template NuGet'

--- a/build/AzurePipelinesTemplates/WindowsAppSDK-DotnetNewTemplates-Test-Stage.yml
+++ b/build/AzurePipelinesTemplates/WindowsAppSDK-DotnetNewTemplates-Test-Stage.yml
@@ -26,6 +26,9 @@ parameters:
 - name: dotnetSdkVersion
   type: string
   default: '8.0.x'
+- name: WindowsAppSdkVersion
+  type: string
+  default: '*'
 # Optional gate wiring used by the PR pipeline to short-circuit when no
 # dev/Templates files changed. Defaults preserve official-pipeline behavior.
 - name: dependsOn
@@ -83,4 +86,5 @@ stages:
           & '$(Build.SourcesDirectory)\${{ parameters.sourceSubdirectory }}\dev\Templates\Dotnet\Test-DotnetNewTemplates.ps1' `
             -PackagePath $package.FullName `
             -Platforms $platforms `
+            -WindowsAppSdkVersion '${{ parameters.WindowsAppSdkVersion }}' `
             -SkipAppLaunch

--- a/build/AzurePipelinesTemplates/WindowsAppSDK-DotnetNewTemplates-Test-Stage.yml
+++ b/build/AzurePipelinesTemplates/WindowsAppSDK-DotnetNewTemplates-Test-Stage.yml
@@ -26,12 +26,24 @@ parameters:
 - name: dotnetSdkVersion
   type: string
   default: '8.0.x'
+# Optional gate wiring used by the PR pipeline to short-circuit when no
+# dev/Templates files changed. Defaults preserve official-pipeline behavior.
+- name: dependsOn
+  type: object
+  default: []
+- name: condition
+  type: string
+  default: ''
 
 stages:
 - stage: DotnetNewTemplates_Test
   displayName: 'Smoke-test dotnet new templates'
   dependsOn:
   - ${{ parameters.dependsOnStage }}
+  - ${{ each s in parameters.dependsOn }}:
+    - ${{ s }}
+  ${{ if ne(parameters.condition, '') }}:
+    condition: ${{ parameters.condition }}
   jobs:
   - job: TestDotnetNewTemplates
     displayName: 'Scaffold and build dotnet new templates'

--- a/build/AzurePipelinesTemplates/WindowsAppSDK-DotnetNewTemplates-Test-Stage.yml
+++ b/build/AzurePipelinesTemplates/WindowsAppSDK-DotnetNewTemplates-Test-Stage.yml
@@ -88,3 +88,7 @@ stages:
             -Platforms $platforms `
             -WindowsAppSdkVersion '${{ parameters.WindowsAppSdkVersion }}' `
             -SkipAppLaunch
+      env:
+        # Lets the smoke test read the latest official WindowsAppSDK version from
+        # the package source when the version is '*'.
+        SYSTEM_ACCESSTOKEN: $(System.AccessToken)

--- a/build/AzurePipelinesTemplates/WindowsAppSDK-VSIXTemplates-BuildValidation-Stage.yml
+++ b/build/AzurePipelinesTemplates/WindowsAppSDK-VSIXTemplates-BuildValidation-Stage.yml
@@ -23,11 +23,21 @@ parameters:
   type: object
   default:
     type: windows
+# Optional gate wiring used by the PR pipeline to short-circuit when no
+# dev/Templates files changed. Defaults preserve official-pipeline behavior.
+- name: dependsOn
+  type: object
+  default: []
+- name: condition
+  type: string
+  default: ''
 
 stages:
 - stage: VSIXTemplates_BuildValidation
   displayName: 'Validate VSIX templates build'
-  dependsOn: []
+  dependsOn: ${{ parameters.dependsOn }}
+  ${{ if ne(parameters.condition, '') }}:
+    condition: ${{ parameters.condition }}
   jobs:
   - job: BuildVSIX
     displayName: 'Restore + build WindowsAppSDK.Extension.sln (Standalone + Component)'

--- a/build/WindowsAppSDK-Templates-PR.yml
+++ b/build/WindowsAppSDK-Templates-PR.yml
@@ -105,16 +105,32 @@ extends:
                 displayName: 'Detect dev/Templates changes'
                 inputs:
                   targetType: inline
+                  workingDirectory: '$(Build.SourcesDirectory)'
                   script: |
+                    # The repo is checked out under a WindowsAppSDK subfolder
+                    # (1ES convention, matching the other Templates stages which
+                    # all reference $(Build.SourcesDirectory)\WindowsAppSDK). The
+                    # task cwd is not the repo root, so point git at it with -C.
+                    # Fail fast: if git can't determine the diff, throw so the gate
+                    # goes red instead of silently running full validation.
+                    $ErrorActionPreference = 'Stop'
+                    $repo = Join-Path $env:BUILD_SOURCESDIRECTORY 'WindowsAppSDK'
+                    Write-Host "Using repo: $repo"
+
+                    # Non-PR runs (manual queue) build everything.
                     $changed = 'True'
                     if ($env:BUILD_REASON -eq 'PullRequest') {
-                      git fetch origin $env:SYSTEM_PULLREQUEST_TARGETBRANCH | Out-Null
-                      $files = git diff "origin/$env:SYSTEM_PULLREQUEST_TARGETBRANCH" --name-only
+                      $target = $env:SYSTEM_PULLREQUEST_TARGETBRANCH
+                      git -C $repo fetch --no-tags origin $target 2>&1 | Out-Null
+                      if ($LASTEXITCODE -ne 0) { throw "git fetch failed (exit $LASTEXITCODE) for target '$target'" }
+                      $files = git -C $repo diff --name-only FETCH_HEAD HEAD 2>&1
+                      if ($LASTEXITCODE -ne 0) { throw "git diff failed (exit $LASTEXITCODE): $files" }
                       $hit = $files | Where-Object { $_ -like 'dev/Templates/*' }
                       $changed = if ($hit) { 'True' } else { 'False' }
                     }
                     Write-Host "templatesChanged=$changed"
                     Write-Host "##vso[task.setvariable variable=templatesChanged;isOutput=true]$changed"
+                    exit 0
 
       # Build + pack the templates NuGet. IsPRBuild=true makes the stage stamp
       # every pack as <csproj-Version>-<yyyy>-<MMdd>-<HHmm>-pr<PR# or 0> so the

--- a/build/WindowsAppSDK-Templates-PR.yml
+++ b/build/WindowsAppSDK-Templates-PR.yml
@@ -111,9 +111,13 @@ extends:
                     # (1ES convention, matching the other Templates stages which
                     # all reference $(Build.SourcesDirectory)\WindowsAppSDK). The
                     # task cwd is not the repo root, so point git at it with -C.
-                    # Fail fast: if git can't determine the diff, throw so the gate
-                    # goes red instead of silently running full validation.
-                    $ErrorActionPreference = 'Stop'
+                    #
+                    # git writes normal progress (e.g. "From https://github.com/...")
+                    # to stderr even on success, so keep ErrorActionPreference at
+                    # Continue -- otherwise that stderr becomes a terminating
+                    # NativeCommandError. Fail-fast is enforced via $LASTEXITCODE +
+                    # throw, so a real git failure still turns the gate red.
+                    $ErrorActionPreference = 'Continue'
                     $repo = Join-Path $env:BUILD_SOURCESDIRECTORY 'WindowsAppSDK'
                     Write-Host "Using repo: $repo"
 
@@ -121,8 +125,8 @@ extends:
                     $changed = 'True'
                     if ($env:BUILD_REASON -eq 'PullRequest') {
                       $target = $env:SYSTEM_PULLREQUEST_TARGETBRANCH
-                      git -C $repo fetch --no-tags origin $target 2>&1 | Out-Null
-                      if ($LASTEXITCODE -ne 0) { throw "git fetch failed (exit $LASTEXITCODE) for target '$target'" }
+                      $fetchOut = git -C $repo fetch --no-tags origin $target 2>&1
+                      if ($LASTEXITCODE -ne 0) { throw "git fetch failed (exit $LASTEXITCODE) for target '$target': $fetchOut" }
                       $files = git -C $repo diff --name-only FETCH_HEAD HEAD 2>&1
                       if ($LASTEXITCODE -ne 0) { throw "git diff failed (exit $LASTEXITCODE): $files" }
                       $hit = $files | Where-Object { $_ -like 'dev/Templates/*' }

--- a/build/WindowsAppSDK-Templates-PR.yml
+++ b/build/WindowsAppSDK-Templates-PR.yml
@@ -16,6 +16,12 @@
 
 trigger: none
 
+parameters:
+- name: WindowsAppSDKVersion
+  displayName: 'WindowsAppSDK version for template validation (* = latest stable)'
+  type: string
+  default: '*'
+
 # Shared variable templates:
 #   - Foundation-TestConfig: test matrices reused from the main pipeline.
 #   - Versions: MajorVersion / MinorVersion / PatchVersion (consumed by CommonVariables).
@@ -158,6 +164,7 @@ extends:
           dependsOnStage: 'DotnetNewTemplates_Build'
           dependsOn: [EvaluateTemplatesPaths]
           condition: eq(dependencies.EvaluateTemplatesPaths.outputs['Evaluate.detect.templatesChanged'], 'True')
+          WindowsAppSdkVersion: ${{ parameters.WindowsAppSDKVersion }}
 
       # Build-validate the VSIX. Runs the production VSIX pack steps so
       # VSIX-pack regressions (e.g. VSSDK1300 path overflow) surface at PR

--- a/build/WindowsAppSDK-Templates-PR.yml
+++ b/build/WindowsAppSDK-Templates-PR.yml
@@ -6,14 +6,13 @@
 # published. PR-stamped versions keep PR artifacts from colliding with
 # canonical packages -- see each stage for the exact format.
 #
-# Triggers are configured in the Azure DevOps UI (Edit pipeline -> Triggers),
-# NOT in this YAML -- matches the WindowsAppSDK-Foundation-PR.yml convention.
-# In the UI, under Pull request validation:
-#   - Override the YAML pull request trigger from here: ON
-#   - Enable pull request validation:                   ON
-#   - Branch filters:  Include refs/heads/main
-#                      Include refs/heads/release/*
-#   - Path filters:    Include dev/Templates/**
+# Triggered via the existing "/azp run" comment, same as TransportPackage-Foundation-PR.
+# Stays its own independent pipeline; "/azp run" just fans out to every PR-enabled
+# pipeline. To be a required GitHub check, it must report on EVERY PR -- so there is
+# NO path filter. Instead the EvaluateTemplatesPaths gate below diffs against the PR
+# target branch and, when nothing under dev/Templates/** changed, skips the heavy
+# build/test/VSIX stages and reports a fast success. Configure only branch filters
+# (refs/heads/main, refs/heads/release/*) in the ADO UI; do NOT add a path filter.
 
 trigger: none
 
@@ -85,6 +84,38 @@ extends:
         enabled: false
 
     stages:
+      # Gate: only do real work when this PR touched dev/Templates/**. Diffs against
+      # the PR target branch; manual/non-PR runs default to true so they still build.
+      # The downstream stages condition on this output, so non-Templates PRs get a
+      # fast success and the required check is always reported.
+      - stage: EvaluateTemplatesPaths
+        displayName: 'Detect dev/Templates changes'
+        dependsOn: []
+        jobs:
+          - job: Evaluate
+            pool:
+              type: windows
+            variables:
+              ob_outputDirectory: '$(Build.ArtifactStagingDirectory)\evaluate'
+            steps:
+              - checkout: self
+                fetchDepth: 0
+              - task: PowerShell@2
+                name: detect
+                displayName: 'Detect dev/Templates changes'
+                inputs:
+                  targetType: inline
+                  script: |
+                    $changed = 'True'
+                    if ($env:BUILD_REASON -eq 'PullRequest') {
+                      git fetch origin $env:SYSTEM_PULLREQUEST_TARGETBRANCH | Out-Null
+                      $files = git diff "origin/$env:SYSTEM_PULLREQUEST_TARGETBRANCH" --name-only
+                      $hit = $files | Where-Object { $_ -like 'dev/Templates/*' }
+                      $changed = if ($hit) { 'True' } else { 'False' }
+                    }
+                    Write-Host "templatesChanged=$changed"
+                    Write-Host "##vso[task.setvariable variable=templatesChanged;isOutput=true]$changed"
+
       # Build + pack the templates NuGet. IsPRBuild=true makes the stage stamp
       # every pack as <csproj-Version>-<yyyy>-<MMdd>-<HHmm>-pr<PR# or 0> so the
       # .nupkg filename uniquely identifies the run (manual replays without a
@@ -96,6 +127,8 @@ extends:
           publishToInternalFeed: false
           SignOutput: false
           IsPRBuild: true
+          dependsOn: [EvaluateTemplatesPaths]
+          condition: eq(dependencies.EvaluateTemplatesPaths.outputs['Evaluate.detect.templatesChanged'], 'True')
 
       # Smoke-test: scaffold every template from the pack and dotnet build each.
       - template: AzurePipelinesTemplates\WindowsAppSDK-DotnetNewTemplates-Test-Stage.yml@self
@@ -103,6 +136,8 @@ extends:
           pool:
             type: windows
           dependsOnStage: 'DotnetNewTemplates_Build'
+          dependsOn: [EvaluateTemplatesPaths]
+          condition: eq(dependencies.EvaluateTemplatesPaths.outputs['Evaluate.detect.templatesChanged'], 'True')
 
       # Build-validate the VSIX. Runs the production VSIX pack steps so
       # VSIX-pack regressions (e.g. VSSDK1300 path overflow) surface at PR
@@ -111,3 +146,5 @@ extends:
         parameters:
           pool:
             type: windows
+          dependsOn: [EvaluateTemplatesPaths]
+          condition: eq(dependencies.EvaluateTemplatesPaths.outputs['Evaluate.detect.templatesChanged'], 'True')

--- a/dev/Templates/Dotnet/Test-DotnetNewTemplates.ps1
+++ b/dev/Templates/Dotnet/Test-DotnetNewTemplates.ps1
@@ -308,12 +308,21 @@ function Write-ResolvedPackageVersions {
         [string]$ProjectPath
     )
 
-    # Log the actual resolved Microsoft.WindowsAppSDK / SDK.BuildTools versions.
-    # The templates float these as Version="*", so a green build is only as good
-    # as whatever the feed serves that day. Logging the resolved versions makes a
-    # smoke-test failure point at a specific package build, and turns this test
-    # into an early-warning for regressions in already-published WindowsAppSDK
-    # packages. Logging must never fail the run, hence EAP=Continue + try/finally.
+    # Why we log this:
+    #   The templates reference Microsoft.WindowsAppSDK and the SDK build tools
+    #   with Version="*", so every build quietly picks up whatever the feed
+    #   serves that day. When a build breaks, the first thing we need to know is
+    #   which package versions it actually used.
+    #
+    # What this does:
+    #   Prints the resolved versions (via 'dotnet list package') BEFORE the build
+    #   runs, so they appear in the log even when the build later fails. As a
+    #   bonus, this lets the smoke test act as an early warning when a freshly
+    #   published WindowsAppSDK package regresses.
+    #
+    # Safety:
+    #   Logging must never fail the run, so we keep going on errors
+    #   (ErrorActionPreference = Continue) and always restore state (try/finally).
     Write-Step "Resolving package versions for $(Split-Path -Path $ProjectFile -Leaf)"
     $savedEAP = $ErrorActionPreference
     $ErrorActionPreference = 'Continue'

--- a/dev/Templates/Dotnet/Test-DotnetNewTemplates.ps1
+++ b/dev/Templates/Dotnet/Test-DotnetNewTemplates.ps1
@@ -85,6 +85,9 @@ param(
     [string]$DotnetSdkVersion,
 
     [Parameter()]
+    [string]$WindowsAppSdkVersion = '*',
+
+    [Parameter()]
     [switch]$KeepWorkingDirectory
 )
 
@@ -92,6 +95,10 @@ Set-StrictMode -Version 2.0
 $ErrorActionPreference = 'Stop'
 
 $script:exitCode = 0
+# WindowsAppSDK NuGet version passed to `dotnet new --wasdk-version` when
+# scaffolding. Defaults to '*' (latest stable); a caller or the pipeline can pin
+# a known-good version to work around a bad latest package.
+$script:windowsAppSdkVersion = $WindowsAppSdkVersion
 $results = New-Object System.Collections.Generic.List[object]
 $appExecutables = New-Object System.Collections.Generic.List[object]
 $dotnetPath = (Get-Command dotnet -ErrorAction Stop).Source
@@ -292,14 +299,19 @@ function New-ProjectFromTemplate {
         [string]$TemplateShortName,
         [string]$ProjectName,
         [string]$OutputPath,
-        [string]$WorkingDirectory
+        [string]$WorkingDirectory,
+        [string]$WindowsAppSdkVersion
     )
 
     if (-not (Test-Path -Path $OutputPath)) {
         New-Item -ItemType Directory -Path $OutputPath -Force | Out-Null
     }
 
-    Invoke-DotnetCommand -Arguments @('new', $TemplateShortName, '-n', $ProjectName, '-o', $OutputPath, '--force', '--no-update-check') -WorkingDirectory $WorkingDirectory -Description "create $TemplateShortName template"
+    $createArgs = @('new', $TemplateShortName, '-n', $ProjectName, '-o', $OutputPath, '--force', '--no-update-check')
+    if (-not [string]::IsNullOrWhiteSpace($WindowsAppSdkVersion)) {
+        $createArgs += @('--wasdk-version', $WindowsAppSdkVersion)
+    }
+    Invoke-DotnetCommand -Arguments $createArgs -WorkingDirectory $WorkingDirectory -Description "create $TemplateShortName template"
 }
 
 function Write-ResolvedPackageVersions {
@@ -346,7 +358,7 @@ function Test-WinUiProjectTemplate {
 
     $projectName = '{0}_{1}_{2}' -f $TemplateShortName, $Platform, ([Guid]::NewGuid().ToString('N').Substring(0, 8))
     $projectPath = Join-Path -Path $WorkingRoot -ChildPath $projectName
-    New-ProjectFromTemplate -TemplateShortName $TemplateShortName -ProjectName $projectName -OutputPath $projectPath -WorkingDirectory $WorkingRoot
+    New-ProjectFromTemplate -TemplateShortName $TemplateShortName -ProjectName $projectName -OutputPath $projectPath -WorkingDirectory $WorkingRoot -WindowsAppSdkVersion $script:windowsAppSdkVersion
     Add-Result -Template $TemplateShortName -Platform $Platform -Step 'create' -Status 'Succeeded' -Path $projectPath
 
     $projectFile = Join-Path -Path $projectPath -ChildPath "$projectName.csproj"
@@ -389,7 +401,7 @@ function Test-ItemTemplates {
 
     $hostName = 'ItemHost_{0}' -f ([Guid]::NewGuid().ToString('N').Substring(0, 8))
     $hostPath = Join-Path -Path $WorkingRoot -ChildPath $hostName
-    New-ProjectFromTemplate -TemplateShortName 'winui' -ProjectName $hostName -OutputPath $hostPath -WorkingDirectory $WorkingRoot
+    New-ProjectFromTemplate -TemplateShortName 'winui' -ProjectName $hostName -OutputPath $hostPath -WorkingDirectory $WorkingRoot -WindowsAppSdkVersion $script:windowsAppSdkVersion
     Add-Result -Template 'winui (item host)' -Platform $Platform -Step 'create' -Status 'Succeeded' -Path $hostPath
 
     $projectFile = Join-Path -Path $hostPath -ChildPath "$hostName.csproj"
@@ -517,6 +529,7 @@ try {
     $packageToInstall = Get-TemplatePackagePath -PackagePathOverride $PackagePath -ProjectPath $templateProject -Configuration $Configuration -PackOutputDirectory $PackOutputDirectory -RepoRoot $repoRoot
     Write-Step "Using template package '$packageToInstall'"
     Write-Step "Active .NET SDK: $(& $dotnetPath --version)"
+    Write-Step "WindowsAppSDK version for scaffolding: $script:windowsAppSdkVersion"
 
     Remove-TemplatePackIfPresent -RepoRoot $repoRoot
     Install-TemplatePack -RepoRoot $repoRoot -PackageToInstall $packageToInstall

--- a/dev/Templates/Dotnet/Test-DotnetNewTemplates.ps1
+++ b/dev/Templates/Dotnet/Test-DotnetNewTemplates.ps1
@@ -302,6 +302,41 @@ function New-ProjectFromTemplate {
     Invoke-DotnetCommand -Arguments @('new', $TemplateShortName, '-n', $ProjectName, '-o', $OutputPath, '--force', '--no-update-check') -WorkingDirectory $WorkingDirectory -Description "create $TemplateShortName template"
 }
 
+function Write-ResolvedPackageVersions {
+    param(
+        [string]$ProjectFile,
+        [string]$ProjectPath
+    )
+
+    # Log the actual resolved Microsoft.WindowsAppSDK / SDK.BuildTools versions.
+    # The templates float these as Version="*", so a green build is only as good
+    # as whatever the feed serves that day. Logging the resolved versions makes a
+    # smoke-test failure point at a specific package build, and turns this test
+    # into an early-warning for regressions in already-published WindowsAppSDK
+    # packages. Logging must never fail the run, hence EAP=Continue + try/finally.
+    Write-Step "Resolving package versions for $(Split-Path -Path $ProjectFile -Leaf)"
+    $savedEAP = $ErrorActionPreference
+    $ErrorActionPreference = 'Continue'
+    try {
+        Push-Location -Path $ProjectPath
+        & $dotnetPath restore $ProjectFile 2>&1 | ForEach-Object { Write-Host $_ }
+        $packages = & $dotnetPath list $ProjectFile package --include-transitive 2>&1
+        $packages | ForEach-Object { Write-Host $_ }
+        $key = $packages | Select-String -Pattern 'Microsoft\.WindowsAppSDK|Microsoft\.Windows\.SDK\.BuildTools'
+        if ($key) {
+            Write-Host '>> Resolved key package versions:'
+            $key | ForEach-Object { Write-Host "     $($_.Line.Trim())" }
+        }
+    }
+    catch {
+        Write-Warning "Could not list resolved package versions: $_"
+    }
+    finally {
+        Pop-Location
+        $ErrorActionPreference = $savedEAP
+    }
+}
+
 function Test-WinUiProjectTemplate {
     param(
         [string]$TemplateShortName,
@@ -317,6 +352,8 @@ function Test-WinUiProjectTemplate {
     Add-Result -Template $TemplateShortName -Platform $Platform -Step 'create' -Status 'Succeeded' -Path $projectPath
 
     $projectFile = Join-Path -Path $projectPath -ChildPath "$projectName.csproj"
+
+    Write-ResolvedPackageVersions -ProjectFile $projectFile -ProjectPath $projectPath
 
     switch ($Kind) {
         'App' {
@@ -481,6 +518,7 @@ try {
 
     $packageToInstall = Get-TemplatePackagePath -PackagePathOverride $PackagePath -ProjectPath $templateProject -Configuration $Configuration -PackOutputDirectory $PackOutputDirectory -RepoRoot $repoRoot
     Write-Step "Using template package '$packageToInstall'"
+    Write-Step "Active .NET SDK: $(& $dotnetPath --version)"
 
     Remove-TemplatePackIfPresent -RepoRoot $repoRoot
     Install-TemplatePack -RepoRoot $repoRoot -PackageToInstall $packageToInstall

--- a/dev/Templates/Dotnet/Test-DotnetNewTemplates.ps1
+++ b/dev/Templates/Dotnet/Test-DotnetNewTemplates.ps1
@@ -308,21 +308,10 @@ function Write-ResolvedPackageVersions {
         [string]$ProjectPath
     )
 
-    # Why we log this:
-    #   The templates reference Microsoft.WindowsAppSDK and the SDK build tools
-    #   with Version="*", so every build quietly picks up whatever the feed
-    #   serves that day. When a build breaks, the first thing we need to know is
-    #   which package versions it actually used.
-    #
-    # What this does:
-    #   Prints the resolved versions (via 'dotnet list package') BEFORE the build
-    #   runs, so they appear in the log even when the build later fails. As a
-    #   bonus, this lets the smoke test act as an early warning when a freshly
-    #   published WindowsAppSDK package regresses.
-    #
-    # Safety:
-    #   Logging must never fail the run, so we keep going on errors
-    #   (ErrorActionPreference = Continue) and always restore state (try/finally).
+    # Templates reference WindowsAppSDK and the SDK build tools with Version="*",
+    # so each build silently picks whatever the feed serves. Log the resolved
+    # versions before building, so a failed build shows which ones it used.
+    # Logging must never fail the run, hence Continue + try/finally.
     Write-Step "Resolving package versions for $(Split-Path -Path $ProjectFile -Leaf)"
     $savedEAP = $ErrorActionPreference
     $ErrorActionPreference = 'Continue'

--- a/dev/Templates/Dotnet/Test-DotnetNewTemplates.ps1
+++ b/dev/Templates/Dotnet/Test-DotnetNewTemplates.ps1
@@ -800,9 +800,19 @@ try {
     Write-Step "Resolved: $resolvedWasdk"
     Add-Result -Template 'winui' -Platform 'N/A' -Step 'working source: restore resolves packages' -Status 'Succeeded' -Path $workingSourcePath
 
-    # Build the project
-    Invoke-DotnetCommand -Arguments @('build', $workingSourceCsproj, '-p:Configuration=Debug', "-p:Platform=$($Platforms[0])", '-p:WindowsPackageType=None', '--no-restore') -WorkingDirectory $workingSourcePath -Description 'build with working NuGet source'
-    Add-Result -Template 'winui' -Platform $Platforms[0] -Step 'working source: build succeeds' -Status 'Succeeded' -Path $workingSourceCsproj
+    # This is the only scenario that builds the default Version="*" wildcard, so
+    # it is what proves the latest published packages build cleanly (an early
+    # warning for a bad WindowsAppSDK release). When the pipeline pins a specific
+    # version to work around a broken latest, skip this build so the pinned run
+    # can go green -- the real templates above already built against the pin.
+    if ($script:windowsAppSdkVersion -eq '*') {
+        Invoke-DotnetCommand -Arguments @('build', $workingSourceCsproj, '-p:Configuration=Debug', "-p:Platform=$($Platforms[0])", '-p:WindowsPackageType=None', '--no-restore') -WorkingDirectory $workingSourcePath -Description 'build with working NuGet source'
+        Add-Result -Template 'winui' -Platform $Platforms[0] -Step 'working source: build succeeds' -Status 'Succeeded' -Path $workingSourceCsproj
+    }
+    else {
+        Write-Step "WindowsAppSDK pinned to '$script:windowsAppSdkVersion'; skipping the default-wildcard 'latest builds' check."
+        Add-Result -Template 'winui' -Platform 'N/A' -Step "working source: build skipped (pinned to $script:windowsAppSdkVersion)" -Status 'Skipped' -Path $workingSourceCsproj
+    }
 
     Write-Step 'Version parameter test scenarios completed.'
 

--- a/dev/Templates/Dotnet/Test-DotnetNewTemplates.ps1
+++ b/dev/Templates/Dotnet/Test-DotnetNewTemplates.ps1
@@ -443,6 +443,41 @@ function Assert-CsprojPackageVersion {
     }
 }
 
+function Get-LatestOfficialWasdkVersion {
+    # Reads ONLY the version list from nuget.org (an official-only feed) to learn
+    # the latest official Microsoft.WindowsAppSDK version number. It does NOT
+    # restore any package from nuget.org -- the caller restores that exact version
+    # from the internal feed, which mirrors the official package. This is how we
+    # get "latest official": the internal feed also carries dev builds published
+    # without a prerelease tag (e.g. 2.63.x), so a plain Version="*" there would
+    # pick a dev build. Returns the version string, or $null if nuget.org can't be
+    # reached (caller then falls back to '*').
+    $url = 'https://api.nuget.org/v3-flatcontainer/microsoft.windowsappsdk/index.json'
+    try {
+        [Net.ServicePointManager]::SecurityProtocol = [Net.ServicePointManager]::SecurityProtocol -bor [Net.SecurityProtocolType]::Tls12
+        $response = Invoke-RestMethod -Uri $url -TimeoutSec 30 -ErrorAction Stop
+        $latest = $null
+        foreach ($v in $response.versions) {
+            if ($v -match '-') { continue }   # skip prerelease / experimental
+            $parsed = $null
+            if (-not [version]::TryParse($v, [ref]$parsed)) { continue }
+            if (($null -eq $latest) -or ($parsed -gt $latest.Ver)) {
+                $latest = [pscustomobject]@{ Raw = $v; Ver = $parsed }
+            }
+        }
+        if ($latest) {
+            Write-Host "nuget.org: latest official stable Microsoft.WindowsAppSDK = $($latest.Raw) (version number only; packages still come from the internal feed)"
+            return $latest.Raw
+        }
+        Write-Warning "nuget.org returned no stable Microsoft.WindowsAppSDK versions."
+        return $null
+    }
+    catch {
+        Write-Warning "Failed to query nuget.org for the latest official version: $($_.Exception.Message)"
+        return $null
+    }
+}
+
 try {
     $repoRoot = (Resolve-Path -Path (Join-Path -Path $PSScriptRoot -ChildPath '..\..\..')).Path
     $templateProject = Join-Path -Path $repoRoot -ChildPath 'dev\Templates\Dotnet\WinAppSdk.CSharp.DotnetNewTemplates.csproj'
@@ -529,6 +564,20 @@ try {
     $packageToInstall = Get-TemplatePackagePath -PackagePathOverride $PackagePath -ProjectPath $templateProject -Configuration $Configuration -PackOutputDirectory $PackOutputDirectory -RepoRoot $repoRoot
     Write-Step "Using template package '$packageToInstall'"
     Write-Step "Active .NET SDK: $(& $dotnetPath --version)"
+
+    # '*' means "latest OFFICIAL": resolve the number from nuget.org (official-only),
+    # then scaffold with that exact version so it restores from the internal feed.
+    # If nuget.org can't give us the number, fail fast (throw) so it's obvious the
+    # lookup didn't work, rather than silently building an internal dev build.
+    if ($script:windowsAppSdkVersion -eq '*') {
+        $latestOfficial = Get-LatestOfficialWasdkVersion
+        if (-not $latestOfficial) {
+            throw "Could not get the latest official Microsoft.WindowsAppSDK version from nuget.org; cannot resolve '*'. See the warning above for the reason."
+        }
+        $script:windowsAppSdkVersion = $latestOfficial
+        Write-Step "Using latest official WindowsAppSDK $latestOfficial (number from nuget.org; package from the internal feed)."
+    }
+
     Write-Step "WindowsAppSDK version for scaffolding: $script:windowsAppSdkVersion"
 
     Remove-TemplatePackIfPresent -RepoRoot $repoRoot

--- a/dev/Templates/Dotnet/Test-DotnetNewTemplates.ps1
+++ b/dev/Templates/Dotnet/Test-DotnetNewTemplates.ps1
@@ -444,21 +444,28 @@ function Assert-CsprojPackageVersion {
 }
 
 function Get-LatestOfficialWasdkVersion {
-    # Reads ONLY the version list from nuget.org (an official-only feed) to learn
-    # the latest official Microsoft.WindowsAppSDK version number. It does NOT
-    # restore any package from nuget.org -- the caller restores that exact version
-    # from the internal feed, which mirrors the official package. This is how we
-    # get "latest official": the internal feed also carries dev builds published
-    # without a prerelease tag (e.g. 2.63.x), so a plain Version="*" there would
-    # pick a dev build. Returns the version string, or $null if nuget.org can't be
-    # reached (caller then falls back to '*').
-    $url = 'https://api.nuget.org/v3-flatcontainer/microsoft.windowsappsdk/index.json'
+    # Returns the latest official Microsoft.WindowsAppSDK version number from the
+    # package source. NuGet only distinguishes stable vs prerelease, but some
+    # stable-tagged builds (2.63.x) aren't shipping releases, so we skip those and
+    # take the highest remaining. Reads the version list only (auth via the build
+    # token); packages are still restored normally. Returns $null on failure.
+    # If those excluded builds ever move off 2.63.x, update $excludedVersionPrefixes.
+    $sourceFeed = 'https://microsoft.pkgs.visualstudio.com/ProjectReunion/_packaging/Project.Reunion.nuget.internal/nuget/v3/flat2/microsoft.windowsappsdk/index.json'
+    $excludedVersionPrefixes = @('2.63.')
+    $token = $env:SYSTEM_ACCESSTOKEN
+    if ([string]::IsNullOrWhiteSpace($token)) {
+        Write-Warning "SYSTEM_ACCESSTOKEN is not set; cannot query the package source for versions."
+        return $null
+    }
     try {
         [Net.ServicePointManager]::SecurityProtocol = [Net.ServicePointManager]::SecurityProtocol -bor [Net.SecurityProtocolType]::Tls12
-        $response = Invoke-RestMethod -Uri $url -TimeoutSec 30 -ErrorAction Stop
+        $response = Invoke-RestMethod -Uri $sourceFeed -Headers @{ Authorization = "Bearer $token" } -TimeoutSec 30 -ErrorAction Stop
         $latest = $null
         foreach ($v in $response.versions) {
-            if ($v -match '-') { continue }   # skip prerelease / experimental
+            if ($v -match '-') { continue }   # skip prerelease
+            $excluded = $false
+            foreach ($p in $excludedVersionPrefixes) { if ($v.StartsWith($p)) { $excluded = $true; break } }
+            if ($excluded) { continue }
             $parsed = $null
             if (-not [version]::TryParse($v, [ref]$parsed)) { continue }
             if (($null -eq $latest) -or ($parsed -gt $latest.Ver)) {
@@ -466,14 +473,14 @@ function Get-LatestOfficialWasdkVersion {
             }
         }
         if ($latest) {
-            Write-Host "nuget.org: latest official stable Microsoft.WindowsAppSDK = $($latest.Raw) (version number only; packages still come from the internal feed)"
+            Write-Host "Latest official Microsoft.WindowsAppSDK = $($latest.Raw) (excluded prerelease and $($excludedVersionPrefixes -join ', ')*)"
             return $latest.Raw
         }
-        Write-Warning "nuget.org returned no stable Microsoft.WindowsAppSDK versions."
+        Write-Warning "No official Microsoft.WindowsAppSDK version found on the package source."
         return $null
     }
     catch {
-        Write-Warning "Failed to query nuget.org for the latest official version: $($_.Exception.Message)"
+        Write-Warning "Failed to query the package source for versions: $($_.Exception.Message)"
         return $null
     }
 }
@@ -565,17 +572,15 @@ try {
     Write-Step "Using template package '$packageToInstall'"
     Write-Step "Active .NET SDK: $(& $dotnetPath --version)"
 
-    # '*' means "latest OFFICIAL": resolve the number from nuget.org (official-only),
-    # then scaffold with that exact version so it restores from the internal feed.
-    # If nuget.org can't give us the number, fail fast (throw) so it's obvious the
-    # lookup didn't work, rather than silently building an internal dev build.
+    # '*' means "latest official": resolve the number from the package source, then
+    # scaffold with that exact version. Fail fast if we can't get it.
     if ($script:windowsAppSdkVersion -eq '*') {
         $latestOfficial = Get-LatestOfficialWasdkVersion
         if (-not $latestOfficial) {
-            throw "Could not get the latest official Microsoft.WindowsAppSDK version from nuget.org; cannot resolve '*'. See the warning above for the reason."
+            throw "Could not determine the latest official Microsoft.WindowsAppSDK version from the package source; cannot resolve '*'. See the warning above."
         }
         $script:windowsAppSdkVersion = $latestOfficial
-        Write-Step "Using latest official WindowsAppSDK $latestOfficial (number from nuget.org; package from the internal feed)."
+        Write-Step "Using latest official WindowsAppSDK $latestOfficial."
     }
 
     Write-Step "WindowsAppSDK version for scaffolding: $script:windowsAppSdkVersion"

--- a/dev/Templates/Source/ProjectTemplates/Desktop/CSharp/PackagedApp/BlankApp/ProjectTemplate.csproj
+++ b/dev/Templates/Source/ProjectTemplates/Desktop/CSharp/PackagedApp/BlankApp/ProjectTemplate.csproj
@@ -21,9 +21,9 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Windows.SDK.BuildTools" Version="*" />
-    <PackageReference Include="Microsoft.WindowsAppSDK" Version="*" />
-    <PackageReference Include="Microsoft.Windows.SDK.BuildTools.WinApp" Version="*" />
+    <PackageReference Include="Microsoft.Windows.SDK.BuildTools" Version="$WindowsSdkBuildToolsVersion$" />
+    <PackageReference Include="Microsoft.WindowsAppSDK" Version="$WindowsAppSdkVersion$" />
+    <PackageReference Include="Microsoft.Windows.SDK.BuildTools.WinApp" Version="$WindowsSdkBuildToolsWinAppVersion$" />
   </ItemGroup>
 
     <!-- Publish Properties -->

--- a/dev/Templates/how-to-create-a-new-csharp-template.md
+++ b/dev/Templates/how-to-create-a-new-csharp-template.md
@@ -322,3 +322,6 @@ For C++ templates, add the template content under
 and a corresponding `<Asset>` to the C++ vsixmanifest. 
 
 There is no dotnet-new pack for C++/WinRT templates yet.
+
+<!-- ci: trigger Templates PR pipeline (remove after validation) -->
+


### PR DESCRIPTION
Adds **WindowsAppSDK-Templates-PR** pipeline to "/azp run" with path gate so it can verify GitHub PRs that touch `dev/Templates/**` without blocking unrelated PRs.

Details:

- Make the WindowsAppSDK-Templates-PR pipeline to be triggered by "/azp run" comments, for github PRs targeting main branch (set in policy, not in this code)
- when the `WindowsAppSDK-Templates-PR` pipeline launched, it checks with git diff to see if the current PR changes anything under folder `dev/Templates`. 
    - If not, `WindowsAppSDK-Templates-PR` will be passed, and silently skip templates check.
    - if the templates folder is touched, run build verifications and smoke tests for all the templates.
- By default `WindowsAppSDK-Templates-PR` runs with the latest stable version of WindowsAppSDK. Adding a variable (by default = "*") to customize the WindowsAppSDK version on pipeline's launching page, so users can run tests for their target packages (if they want to).