### PR TITLE
Change Test-DotnetNewTemplates' nugetCacheRoot to C:\

### DIFF
--- a/dev/Templates/Dotnet/Test-DotnetNewTemplates.ps1
+++ b/dev/Templates/Dotnet/Test-DotnetNewTemplates.ps1
@@ -418,7 +418,7 @@ try {
     # fails to resolve the type universe and never emits App.g.i.cs, causing a
     # downstream CS2001 when the test templates build. A short cache root keeps
     # every package path comfortably under 260, so any version builds.
-    $nugetCacheRoot = $env:TEMP
+    $nugetCacheRoot = 'C:'
     if ([string]::IsNullOrEmpty($nugetCacheRoot)) {
         $nugetCacheRoot = 'C:'
     }

--- a/dev/Templates/Dotnet/Test-DotnetNewTemplates.ps1
+++ b/dev/Templates/Dotnet/Test-DotnetNewTemplates.ps1
@@ -407,7 +407,22 @@ try {
     }
     New-Item -ItemType Directory -Path $workingRoot -Force | Out-Null
 
-    $nugetFallback = Join-Path -Path $workingRoot -ChildPath '.nuget'
+    # Use a SHORT, dedicated NuGet package cache instead of a path nested
+    # under the deep working directory. The WinUI XAML compiler (and other
+    # build tooling) resolves transitive assemblies such as
+    # Microsoft.InteractiveExperiences.Projection.dll directly out of this cache
+    # using APIs that are NOT long-path aware. Any WindowsAppSDK build that carries
+    # long pre-release version segments (e.g. "2.0.15-experimental-...")
+    # that, when combined with a deep cache root, pushes those assembly paths past
+    # Windows MAX_PATH (260). When that happens, the XAML compiler silently
+    # fails to resolve the type universe and never emits App.g.i.cs, causing a
+    # downstream CS2001 when the test templates build. A short cache root keeps
+    # every package path comfortably under 260, so any version builds.
+    $nugetCacheRoot = $env:TEMP
+    if ([string]::IsNullOrEmpty($nugetCacheRoot)) {
+        $nugetCacheRoot = 'C:'
+    }
+    $nugetFallback = Join-Path -Path "$nugetCacheRoot\" -ChildPath ('wn' + [Guid]::NewGuid().ToString('N').Substring(0, 6))
     New-Item -ItemType Directory -Path $nugetFallback -Force | Out-Null
     $env:NUGET_PACKAGES = $nugetFallback
 
@@ -781,6 +796,11 @@ finally {
     }
 
     Remove-Item Env:DOTNET_CLI_DO_NOT_USE_MSBUILD_SERVER -ErrorAction SilentlyContinue
+
+    if (-not $KeepWorkingDirectory.IsPresent -and $nugetFallback -and (Test-Path -Path $nugetFallback)) {
+        Write-Step "Cleaning up NuGet cache '$nugetFallback'"
+        Remove-Item -Path $nugetFallback -Recurse -Force -ErrorAction SilentlyContinue
+    }
 
     if (-not $KeepWorkingDirectory.IsPresent -and (Test-Path -Path $workingRoot)) {
         Write-Step "Cleaning up '$workingRoot'"

--- a/dev/Templates/Dotnet/Test-DotnetNewTemplates.ps1
+++ b/dev/Templates/Dotnet/Test-DotnetNewTemplates.ps1
@@ -419,9 +419,6 @@ try {
     # downstream CS2001 when the test templates build. A short cache root keeps
     # every package path comfortably under 260, so any version builds.
     $nugetCacheRoot = 'C:'
-    if ([string]::IsNullOrEmpty($nugetCacheRoot)) {
-        $nugetCacheRoot = 'C:'
-    }
     $nugetFallback = Join-Path -Path "$nugetCacheRoot\" -ChildPath ('wn' + [Guid]::NewGuid().ToString('N').Substring(0, 6))
     New-Item -ItemType Directory -Path $nugetFallback -Force | Out-Null
     $env:NUGET_PACKAGES = $nugetFallback


### PR DESCRIPTION
Resolves the recent pipeline errors in #6583.

In `Test-DotnetNewTemplates.ps1`, a temporary NuGet cache is created to keep test template dependencies separate from the user's NuGet configuration. Originally, this path was set within the repo's path. When files were added to this path, it exceeded the  Windows MAX_PATH of 260 characters. The WinUI Xaml compiler resolves transitive dependencies using APIs that are not long-path aware. Therefore, when the dependency versions were longer and the nuget cache path was deep, the total path length was longer than the maximum path length, causing the XAML compiler to not emit App.g.i.cs. When the templates were built, the missing App.g.i.cs caused a CS2001 build error. We can prevent this build error by setting the test NuGet cache path to a shorter string. Currently, this is set to `$env:TEMP`, but this is not the only path option. `$env:TEMP` was chosen because it's a short path name that is already a location for temporary files like the test cache.

A microsoft employee must use /azp run to validate using the pipelines below.

WARNING:
Comments made by azure-pipelines bot maybe inaccurate.
Please see pipeline link to verify that the build is being ran.

For status checks on the main branch, please use TransportPackage-Foundation-PR
(https://microsoft.visualstudio.com/ProjectReunion/_build?definitionId=81063&_a=summary)
and run the build against your PR branch with the default parameters.
