### PR TITLE
[release/2.0-stable] Revert DCPP dependency updates to restore Version.Details.xml to #6513 state

### DIFF
--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -27,25 +27,25 @@
     -->
 <Dependencies>
   <ProductDependencies>
-    <Dependency Name="Microsoft.FrameworkUdk" Version="2.0.0-stable-27200.1026.260601-1300.3">
+    <Dependency Name="Microsoft.FrameworkUdk" Version="2.0.0-stable-27200.1024.260527-1035.1">
       <Uri>https://dev.azure.com/microsoft/LiftedIXP/_git/DCPP</Uri>
-      <Sha>16ffc9acf96bc285a28d6e08e7f5449b02c27908</Sha>
+      <Sha>bcefb53ef31cde2d4d7e97760db1970335047aed</Sha>
     </Dependency>
     <Dependency Name="Microsoft.WindowsAppSDK.AppLicensingInternal.TransportPackage" Version="2.0.0-stable.20260423.1">
       <Uri>https://dev.azure.com/microsoft/ProjectReunion/_git/WindowsAppSDKClosed</Uri>
       <Sha>45057b562d6175c4a9db3b8c4b80f363b2dc3d1d</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.ProjectReunion.InteractiveExperiences.TransportPackage" Version="2.0.0-stable-27200.1026.260601-1300.3">
+    <Dependency Name="Microsoft.ProjectReunion.InteractiveExperiences.TransportPackage" Version="2.0.0-stable-27200.1024.260527-1035.1">
       <Uri>https://dev.azure.com/microsoft/LiftedIXP/_git/DCPP</Uri>
-      <Sha>16ffc9acf96bc285a28d6e08e7f5449b02c27908</Sha>
+      <Sha>bcefb53ef31cde2d4d7e97760db1970335047aed</Sha>
     </Dependency>
     <Dependency Name="Microsoft.WindowsAppSDK.Base" Version="2.0.4">
       <Uri>https://dev.azure.com/microsoft/ProjectReunion/_git/WindowsAppSDKAggregator</Uri>
       <Sha>2e5d355241392cf5331ebaa2c6e5c554c7852ceb</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.WindowsAppSDK.InteractiveExperiences" Version="2.0.16-stable-Rolling.20260602.3">
+    <Dependency Name="Microsoft.WindowsAppSDK.InteractiveExperiences" Version="2.0.15">
       <Uri>https://dev.azure.com/microsoft/LiftedIXP/_git/DCPP</Uri>
-      <Sha>16ffc9acf96bc285a28d6e08e7f5449b02c27908</Sha>
+      <Sha>bcefb53ef31cde2d4d7e97760db1970335047aed</Sha>
     </Dependency>
   </ProductDependencies>
   <ToolsetDependencies>

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -27,7 +27,7 @@
     -->
 <Dependencies>
   <ProductDependencies>
-    <Dependency Name="Microsoft.FrameworkUdk" Version="2.0.0-stable-27200.1027.260605-1010.0">
+    <Dependency Name="Microsoft.FrameworkUdk" Version="2.0.0-stable-27200.1026.260601-1300.3">
       <Uri>https://dev.azure.com/microsoft/LiftedIXP/_git/DCPP</Uri>
       <Sha>16ffc9acf96bc285a28d6e08e7f5449b02c27908</Sha>
     </Dependency>
@@ -35,7 +35,7 @@
       <Uri>https://dev.azure.com/microsoft/ProjectReunion/_git/WindowsAppSDKClosed</Uri>
       <Sha>45057b562d6175c4a9db3b8c4b80f363b2dc3d1d</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.ProjectReunion.InteractiveExperiences.TransportPackage" Version="2.0.0-stable-27200.1027.260605-1010.0">
+    <Dependency Name="Microsoft.ProjectReunion.InteractiveExperiences.TransportPackage" Version="2.0.0-stable-27200.1026.260601-1300.3">
       <Uri>https://dev.azure.com/microsoft/LiftedIXP/_git/DCPP</Uri>
       <Sha>16ffc9acf96bc285a28d6e08e7f5449b02c27908</Sha>
     </Dependency>
@@ -43,7 +43,7 @@
       <Uri>https://dev.azure.com/microsoft/ProjectReunion/_git/WindowsAppSDKAggregator</Uri>
       <Sha>2e5d355241392cf5331ebaa2c6e5c554c7852ceb</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.WindowsAppSDK.InteractiveExperiences" Version="2.0.16-stable-Rolling.20260605.2">
+    <Dependency Name="Microsoft.WindowsAppSDK.InteractiveExperiences" Version="2.0.16-stable-Rolling.20260602.3">
       <Uri>https://dev.azure.com/microsoft/LiftedIXP/_git/DCPP</Uri>
       <Sha>16ffc9acf96bc285a28d6e08e7f5449b02c27908</Sha>
     </Dependency>

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -27,9 +27,9 @@
     -->
 <Dependencies>
   <ProductDependencies>
-    <Dependency Name="Microsoft.FrameworkUdk" Version="2.0.0-stable-27200.1024.260527-1035.1">
+    <Dependency Name="Microsoft.FrameworkUdk" Version="2.0.0-stable-27200.1029.260616-0840.3">
       <Uri>https://dev.azure.com/microsoft/LiftedIXP/_git/DCPP</Uri>
-      <Sha>bcefb53ef31cde2d4d7e97760db1970335047aed</Sha>
+      <Sha>352b642cc65a014a13951f0bd1994d7e0ba108be</Sha>
     </Dependency>
     <Dependency Name="Microsoft.WindowsAppSDK.AppLicensingInternal.TransportPackage" Version="2.0.0-stable.20260423.1">
       <Uri>https://dev.azure.com/microsoft/ProjectReunion/_git/WindowsAppSDKClosed</Uri>

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -27,25 +27,25 @@
     -->
 <Dependencies>
   <ProductDependencies>
-    <Dependency Name="Microsoft.FrameworkUdk" Version="2.0.0-stable-27200.1028.260608-1010.2">
+    <Dependency Name="Microsoft.FrameworkUdk" Version="2.0.0-stable-27200.1027.260605-1010.0">
       <Uri>https://dev.azure.com/microsoft/LiftedIXP/_git/DCPP</Uri>
-      <Sha>352b642cc65a014a13951f0bd1994d7e0ba108be</Sha>
+      <Sha>16ffc9acf96bc285a28d6e08e7f5449b02c27908</Sha>
     </Dependency>
     <Dependency Name="Microsoft.WindowsAppSDK.AppLicensingInternal.TransportPackage" Version="2.0.0-stable.20260423.1">
       <Uri>https://dev.azure.com/microsoft/ProjectReunion/_git/WindowsAppSDKClosed</Uri>
       <Sha>45057b562d6175c4a9db3b8c4b80f363b2dc3d1d</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.ProjectReunion.InteractiveExperiences.TransportPackage" Version="2.0.0-stable-27200.1028.260608-1010.2">
+    <Dependency Name="Microsoft.ProjectReunion.InteractiveExperiences.TransportPackage" Version="2.0.0-stable-27200.1027.260605-1010.0">
       <Uri>https://dev.azure.com/microsoft/LiftedIXP/_git/DCPP</Uri>
-      <Sha>352b642cc65a014a13951f0bd1994d7e0ba108be</Sha>
+      <Sha>16ffc9acf96bc285a28d6e08e7f5449b02c27908</Sha>
     </Dependency>
     <Dependency Name="Microsoft.WindowsAppSDK.Base" Version="2.0.4">
       <Uri>https://dev.azure.com/microsoft/ProjectReunion/_git/WindowsAppSDKAggregator</Uri>
       <Sha>2e5d355241392cf5331ebaa2c6e5c554c7852ceb</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.WindowsAppSDK.InteractiveExperiences" Version="2.0.16-stable-Rolling.20260609.1">
+    <Dependency Name="Microsoft.WindowsAppSDK.InteractiveExperiences" Version="2.0.16-stable-Rolling.20260605.2">
       <Uri>https://dev.azure.com/microsoft/LiftedIXP/_git/DCPP</Uri>
-      <Sha>352b642cc65a014a13951f0bd1994d7e0ba108be</Sha>
+      <Sha>16ffc9acf96bc285a28d6e08e7f5449b02c27908</Sha>
     </Dependency>
   </ProductDependencies>
   <ToolsetDependencies>

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -27,7 +27,7 @@
     -->
 <Dependencies>
   <ProductDependencies>
-    <Dependency Name="Microsoft.FrameworkUdk" Version="2.0.0-stable-27200.1029.260616-0840.3">
+    <Dependency Name="Microsoft.FrameworkUdk" Version="2.0.0-stable-27200.1028.260608-1010.2">
       <Uri>https://dev.azure.com/microsoft/LiftedIXP/_git/DCPP</Uri>
       <Sha>352b642cc65a014a13951f0bd1994d7e0ba108be</Sha>
     </Dependency>
@@ -35,7 +35,7 @@
       <Uri>https://dev.azure.com/microsoft/ProjectReunion/_git/WindowsAppSDKClosed</Uri>
       <Sha>45057b562d6175c4a9db3b8c4b80f363b2dc3d1d</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.ProjectReunion.InteractiveExperiences.TransportPackage" Version="2.0.0-stable-27200.1029.260616-0840.3">
+    <Dependency Name="Microsoft.ProjectReunion.InteractiveExperiences.TransportPackage" Version="2.0.0-stable-27200.1028.260608-1010.2">
       <Uri>https://dev.azure.com/microsoft/LiftedIXP/_git/DCPP</Uri>
       <Sha>352b642cc65a014a13951f0bd1994d7e0ba108be</Sha>
     </Dependency>
@@ -43,7 +43,7 @@
       <Uri>https://dev.azure.com/microsoft/ProjectReunion/_git/WindowsAppSDKAggregator</Uri>
       <Sha>2e5d355241392cf5331ebaa2c6e5c554c7852ceb</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.WindowsAppSDK.InteractiveExperiences" Version="2.0.16-stable-Rolling.20260617.1">
+    <Dependency Name="Microsoft.WindowsAppSDK.InteractiveExperiences" Version="2.0.16-stable-Rolling.20260609.1">
       <Uri>https://dev.azure.com/microsoft/LiftedIXP/_git/DCPP</Uri>
       <Sha>352b642cc65a014a13951f0bd1994d7e0ba108be</Sha>
     </Dependency>


### PR DESCRIPTION
Reverts the top 4 Maestro `Update dependencies from .../DCPP` commits so that `eng/Version.Details.xml` is restored to the state at commit 71205cf5ddc60cb7ea7342e7e40e7ed38ded6d73 (#6513).

Reverted commits (newest to oldest):
- 78720cd - build 20260617.1
- 7a2bed8 - build 20260609.1
- 85f0069 - build 20260605.2
- b9c6dc6 - build 20260602.3

Verification: `git diff 71205cf HEAD -- eng/Version.Details.xml` is empty, confirming the file matches the target commit exactly. No other files are modified.