### PR TITLE
Test: retry MddBootstrapInitialize on transient State Repository error (AB#62489699)

### DIFF
--- a/test/inc/WindowsAppRuntime.Test.Bootstrap.h
+++ b/test/inc/WindowsAppRuntime.Test.Bootstrap.h
@@ -130,7 +130,29 @@ namespace Test::Bootstrap
                 TP::WindowsAppRuntimeMain::c_PackageNamePrefix));
         }
 
-        VERIFY_SUCCEEDED(MddBootstrapInitialize(version_MajorMinor, nullptr, minVersion));
+        // AB#62489699: On slow/loaded test agents (observed on the x86 Win10 22H2 stage) the State
+        // Repository can still be indexing the DDLM package we just installed when the bootstrapper
+        // enumerates it, so MddBootstrapInitialize fails with STATEREPOSITORY_E_DEPENDENCY_NOT_RESOLVED
+        // (0x80670016). This is transient and clears once indexing completes, so retry with a bounded
+        // backoff. Only this specific HRESULT is retried; any other failure is verified immediately and
+        // is not masked.
+        constexpr HRESULT c_stateRepositoryDependencyNotResolved{ static_cast<HRESULT>(0x80670016) }; // STATEREPOSITORY_E_DEPENDENCY_NOT_RESOLVED
+        constexpr UINT32 c_maxInitRetries{ 10 };
+        constexpr DWORD c_initRetryDelayMs{ 300 };
+        HRESULT initHR{ E_FAIL };
+        for (UINT32 retry = 0; ; ++retry)
+        {
+            initHR = MddBootstrapInitialize(version_MajorMinor, nullptr, minVersion);
+            if (SUCCEEDED(initHR) || (initHR != c_stateRepositoryDependencyNotResolved) || (retry >= c_maxInitRetries))
+            {
+                break;
+            }
+            WEX::Logging::Log::Comment(WEX::Common::String().Format(
+                L"MddBootstrapInitialize returned STATEREPOSITORY_E_DEPENDENCY_NOT_RESOLVED (0x%X); State Repository likely still indexing the just-installed package. Retry %u/%u after %ums.",
+                initHR, retry + 1, c_maxInitRetries, c_initRetryDelayMs));
+            Sleep(c_initRetryDelayMs);
+        }
+        VERIFY_SUCCEEDED(initHR);
         s_bootstrapDll = std::move(bootstrapDll);
     }
 

--- a/test/inc/WindowsAppRuntime.Test.Bootstrap.h
+++ b/test/inc/WindowsAppRuntime.Test.Bootstrap.h
@@ -137,19 +137,19 @@ namespace Test::Bootstrap
         // backoff. Only this specific HRESULT is retried; any other failure is verified immediately and
         // is not masked.
         constexpr HRESULT c_stateRepositoryDependencyNotResolved{ static_cast<HRESULT>(0x80670016) }; // STATEREPOSITORY_E_DEPENDENCY_NOT_RESOLVED
-        constexpr UINT32 c_maxInitRetries{ 10 };
+        constexpr UINT32 c_maxInitAttempts{ 10 };
         constexpr DWORD c_initRetryDelayMs{ 300 };
         HRESULT initHR{ E_FAIL };
-        for (UINT32 retry = 0; ; ++retry)
+        for (UINT32 attempt = 1; attempt <= c_maxInitAttempts; ++attempt)
         {
             initHR = MddBootstrapInitialize(version_MajorMinor, nullptr, minVersion);
-            if (SUCCEEDED(initHR) || (initHR != c_stateRepositoryDependencyNotResolved) || (retry >= c_maxInitRetries))
+            if (SUCCEEDED(initHR) || (initHR != c_stateRepositoryDependencyNotResolved) || (attempt == c_maxInitAttempts))
             {
                 break;
             }
             WEX::Logging::Log::Comment(WEX::Common::String().Format(
-                L"MddBootstrapInitialize returned STATEREPOSITORY_E_DEPENDENCY_NOT_RESOLVED (0x%X); State Repository likely still indexing the just-installed package. Retry %u/%u after %ums.",
-                initHR, retry + 1, c_maxInitRetries, c_initRetryDelayMs));
+                L"MddBootstrapInitialize returned STATEREPOSITORY_E_DEPENDENCY_NOT_RESOLVED (0x%X); State Repository likely still indexing the just-installed package. Attempt %u/%u. Retrying after %ums.",
+                initHR, attempt, c_maxInitAttempts, c_initRetryDelayMs));
             Sleep(c_initRetryDelayMs);
         }
         VERIFY_SUCCEEDED(initHR);


### PR DESCRIPTION
## Problem
The Test_x86_Windows.10.Professional.22H2_releasex86 stage in the Foundation PR pipeline intermittently fails in TAEF ClassSetup with MddBootstrapInitialize returning STATEREPOSITORY_E_DEPENDENCY_NOT_RESOLVED (0x80670016). The same SHA passes on retry, and only this one x86 Win10 22H2 stage is affected, pointing to a transient timing race rather than a product regression.

## Root cause
SetupPackages installs the DDLM package via AddPackageAsync().get() (which completes), then immediately calls MddBootstrapInitialize. On a slow/loaded agent the State Repository can still be indexing the just-registered DDLM package when the bootstrapper enumerates it, so no fitting DDLM is found and it throws STATEREPOSITORY_E_DEPENDENCY_NOT_RESOLVED. This clears on its own once indexing catches up.

## Fix
SetupBootstrapWithVersion now retries MddBootstrapInitialize with a bounded backoff (up to 10 total attempts, 300ms apart) only when it returns 0x80670016. Any other HRESULT is verified immediately via VERIFY_SUCCEEDED and is not masked. Test-harness-only change; no product bootstrap code is touched.