### PR TITLE
[CP to 1.8] Fix focus not restored after Storage Pickers dialog closes

### DIFF
--- a/dev/Interop/StoragePickers/FileOpenPicker.cpp
+++ b/dev/Interop/StoragePickers/FileOpenPicker.cpp
@@ -16,7 +16,7 @@
 #include <FrameworkUdk/Containment.h>
 
 // Bug 63006043: [1.8 servicing] Fix focus not restored after Storage Pickers dialog closes
-#define WINAPPSDK_CHANGEID_63006043 63006043, WinAppSDK_1_8_10
+#define WINAPPSDK_CHANGEID_63006043 63006043, WinAppSDK_1_8_11
 
 namespace winrt::Microsoft::Windows::Storage::Pickers::implementation
 {

--- a/dev/Interop/StoragePickers/FileOpenPicker.cpp
+++ b/dev/Interop/StoragePickers/FileOpenPicker.cpp
@@ -74,6 +74,9 @@ namespace winrt::Microsoft::Windows::Storage::Pickers::implementation
 
         CaptureParameters(parameters);
 
+        // Capture focus on the UI thread so it can be restored after the dialog closes (issue #6505).
+        PickerCommon::DialogFocusRestorer focusRestorer{};
+
         auto cancellationToken = co_await winrt::get_cancellation_token();
         cancellationToken.enable_propagation(true);
         co_await winrt::resume_background();
@@ -126,6 +129,9 @@ namespace winrt::Microsoft::Windows::Storage::Pickers::implementation
         parameters.AllFilesText = PickerLocalization::GetStoragePickersLocalizationText(PickerCommon::AllFilesLocalizationKey);
 
         CaptureParameters(parameters);
+
+        // Capture focus on the UI thread so it can be restored after the dialog closes (issue #6505).
+        PickerCommon::DialogFocusRestorer focusRestorer{};
 
         auto cancellationToken = co_await winrt::get_cancellation_token();
         cancellationToken.enable_propagation(true);

--- a/dev/Interop/StoragePickers/FileOpenPicker.cpp
+++ b/dev/Interop/StoragePickers/FileOpenPicker.cpp
@@ -78,10 +78,11 @@ namespace winrt::Microsoft::Windows::Storage::Pickers::implementation
 
         CaptureParameters(parameters);
 
+        std::optional<PickerCommon::DialogFocusRestorer> focusRestorer;
         if (WinAppSdk::Containment::IsChangeEnabled<WINAPPSDK_CHANGEID_63006043>())
         {
             // Capture focus on the UI thread so it can be restored after the dialog closes (issue #6505).
-            PickerCommon::DialogFocusRestorer focusRestorer{};
+            focusRestorer.emplace();
         }
         
         auto cancellationToken = co_await winrt::get_cancellation_token();
@@ -137,10 +138,11 @@ namespace winrt::Microsoft::Windows::Storage::Pickers::implementation
 
         CaptureParameters(parameters);
 
+        std::optional<PickerCommon::DialogFocusRestorer> focusRestorer;
         if (WinAppSdk::Containment::IsChangeEnabled<WINAPPSDK_CHANGEID_63006043>())
         {
             // Capture focus on the UI thread so it can be restored after the dialog closes (issue #6505).
-            PickerCommon::DialogFocusRestorer focusRestorer{};
+            focusRestorer.emplace();
         }
 
         auto cancellationToken = co_await winrt::get_cancellation_token();

--- a/dev/Interop/StoragePickers/FileOpenPicker.cpp
+++ b/dev/Interop/StoragePickers/FileOpenPicker.cpp
@@ -13,6 +13,10 @@
 #include "PickerCommon.h"
 #include "PickFileResult.h"
 #include "PickerLocalization.h"
+#include <FrameworkUdk/Containment.h>
+
+// Bug 63006043: [1.8 servicing] Fix focus not restored after Storage Pickers dialog closes
+#define WINAPPSDK_CHANGEID_63006043 63006043, WinAppSDK_1_8_10
 
 namespace winrt::Microsoft::Windows::Storage::Pickers::implementation
 {
@@ -74,9 +78,12 @@ namespace winrt::Microsoft::Windows::Storage::Pickers::implementation
 
         CaptureParameters(parameters);
 
-        // Capture focus on the UI thread so it can be restored after the dialog closes (issue #6505).
-        PickerCommon::DialogFocusRestorer focusRestorer{};
-
+        if (WinAppSdk::Containment::IsChangeEnabled<WINAPPSDK_CHANGEID_63006043>())
+        {
+            // Capture focus on the UI thread so it can be restored after the dialog closes (issue #6505).
+            PickerCommon::DialogFocusRestorer focusRestorer{};
+        }
+        
         auto cancellationToken = co_await winrt::get_cancellation_token();
         cancellationToken.enable_propagation(true);
         co_await winrt::resume_background();
@@ -130,8 +137,11 @@ namespace winrt::Microsoft::Windows::Storage::Pickers::implementation
 
         CaptureParameters(parameters);
 
-        // Capture focus on the UI thread so it can be restored after the dialog closes (issue #6505).
-        PickerCommon::DialogFocusRestorer focusRestorer{};
+        if (WinAppSdk::Containment::IsChangeEnabled<WINAPPSDK_CHANGEID_63006043>())
+        {
+            // Capture focus on the UI thread so it can be restored after the dialog closes (issue #6505).
+            PickerCommon::DialogFocusRestorer focusRestorer{};
+        }
 
         auto cancellationToken = co_await winrt::get_cancellation_token();
         cancellationToken.enable_propagation(true);

--- a/dev/Interop/StoragePickers/FileSavePicker.cpp
+++ b/dev/Interop/StoragePickers/FileSavePicker.cpp
@@ -107,10 +107,11 @@ namespace winrt::Microsoft::Windows::Storage::Pickers::implementation
 
         CaptureParameters(parameters);
 
+        std::optional<PickerCommon::DialogFocusRestorer> focusRestorer;
         if (WinAppSdk::Containment::IsChangeEnabled<WINAPPSDK_CHANGEID_63006043>())
         {
             // Capture focus on the UI thread so it can be restored after the dialog closes (issue #6505).
-            PickerCommon::DialogFocusRestorer focusRestorer{};
+            focusRestorer.emplace();
         }
 
         auto defaultFileExtension = m_defaultFileExtension;

--- a/dev/Interop/StoragePickers/FileSavePicker.cpp
+++ b/dev/Interop/StoragePickers/FileSavePicker.cpp
@@ -104,6 +104,9 @@ namespace winrt::Microsoft::Windows::Storage::Pickers::implementation
 
         CaptureParameters(parameters);
 
+        // Capture focus on the UI thread so it can be restored after the dialog closes (issue #6505).
+        PickerCommon::DialogFocusRestorer focusRestorer{};
+
         auto defaultFileExtension = m_defaultFileExtension;
         auto suggestedFolder = m_suggestedFolder;
         auto suggestedFileName = m_suggestedFileName;

--- a/dev/Interop/StoragePickers/FileSavePicker.cpp
+++ b/dev/Interop/StoragePickers/FileSavePicker.cpp
@@ -24,7 +24,7 @@
 #define WINAPPSDK_CHANGEID_60257559 60257559, WinAppSDK_1_8_4
 
 // Bug 63006043: [1.8 servicing] Fix focus not restored after Storage Pickers dialog closes
-#define WINAPPSDK_CHANGEID_63006043 63006043, WinAppSDK_1_8_10
+#define WINAPPSDK_CHANGEID_63006043 63006043, WinAppSDK_1_8_11
 
 namespace winrt::Microsoft::Windows::Storage::Pickers::implementation
 {

--- a/dev/Interop/StoragePickers/FileSavePicker.cpp
+++ b/dev/Interop/StoragePickers/FileSavePicker.cpp
@@ -23,6 +23,9 @@
 // Bug 60257559: [1.8 servicing] Bugfix: FileSavePicker.PickSaveFileAsync() should not truncate file when the picked file exists.
 #define WINAPPSDK_CHANGEID_60257559 60257559, WinAppSDK_1_8_4
 
+// Bug 63006043: [1.8 servicing] Fix focus not restored after Storage Pickers dialog closes
+#define WINAPPSDK_CHANGEID_63006043 63006043, WinAppSDK_1_8_10
+
 namespace winrt::Microsoft::Windows::Storage::Pickers::implementation
 {
 
@@ -104,8 +107,11 @@ namespace winrt::Microsoft::Windows::Storage::Pickers::implementation
 
         CaptureParameters(parameters);
 
-        // Capture focus on the UI thread so it can be restored after the dialog closes (issue #6505).
-        PickerCommon::DialogFocusRestorer focusRestorer{};
+        if (WinAppSdk::Containment::IsChangeEnabled<WINAPPSDK_CHANGEID_63006043>())
+        {
+            // Capture focus on the UI thread so it can be restored after the dialog closes (issue #6505).
+            PickerCommon::DialogFocusRestorer focusRestorer{};
+        }
 
         auto defaultFileExtension = m_defaultFileExtension;
         auto suggestedFolder = m_suggestedFolder;

--- a/dev/Interop/StoragePickers/FolderPicker.cpp
+++ b/dev/Interop/StoragePickers/FolderPicker.cpp
@@ -72,10 +72,11 @@ namespace winrt::Microsoft::Windows::Storage::Pickers::implementation
 
         CaptureParameters(parameters);
 
+        std::optional<PickerCommon::DialogFocusRestorer> focusRestorer;
         if (WinAppSdk::Containment::IsChangeEnabled<WINAPPSDK_CHANGEID_63006043>())
         {
             // Capture focus on the UI thread so it can be restored after the dialog closes (issue #6505).
-            PickerCommon::DialogFocusRestorer focusRestorer{};
+            focusRestorer.emplace();
         }
 
         auto cancellationToken = co_await winrt::get_cancellation_token();

--- a/dev/Interop/StoragePickers/FolderPicker.cpp
+++ b/dev/Interop/StoragePickers/FolderPicker.cpp
@@ -67,7 +67,10 @@ namespace winrt::Microsoft::Windows::Storage::Pickers::implementation
         parameters.AllFilesText = PickerLocalization::GetStoragePickersLocalizationText(PickerCommon::AllFilesLocalizationKey);
 
         CaptureParameters(parameters);
-        
+
+        // Capture focus on the UI thread so it can be restored after the dialog closes (issue #6505).
+        PickerCommon::DialogFocusRestorer focusRestorer{};
+
         auto cancellationToken = co_await winrt::get_cancellation_token();
         cancellationToken.enable_propagation(true);
         co_await winrt::resume_background();

--- a/dev/Interop/StoragePickers/FolderPicker.cpp
+++ b/dev/Interop/StoragePickers/FolderPicker.cpp
@@ -15,7 +15,7 @@
 #include <FrameworkUdk/Containment.h>
 
 // Bug 63006043: [1.8 servicing] Fix focus not restored after Storage Pickers dialog closes
-#define WINAPPSDK_CHANGEID_63006043 63006043, WinAppSDK_1_8_10
+#define WINAPPSDK_CHANGEID_63006043 63006043, WinAppSDK_1_8_11
 
 namespace winrt::Microsoft::Windows::Storage::Pickers::implementation
 {

--- a/dev/Interop/StoragePickers/FolderPicker.cpp
+++ b/dev/Interop/StoragePickers/FolderPicker.cpp
@@ -11,7 +11,11 @@
 #include "TerminalVelocityFeatures-StoragePickers.h"
 #include "PickerCommon.h"
 #include "PickFolderResult.h"
-#include "PickerLocalization.h" 
+#include "PickerLocalization.h"
+#include <FrameworkUdk/Containment.h>
+
+// Bug 63006043: [1.8 servicing] Fix focus not restored after Storage Pickers dialog closes
+#define WINAPPSDK_CHANGEID_63006043 63006043, WinAppSDK_1_8_10
 
 namespace winrt::Microsoft::Windows::Storage::Pickers::implementation
 {
@@ -68,8 +72,11 @@ namespace winrt::Microsoft::Windows::Storage::Pickers::implementation
 
         CaptureParameters(parameters);
 
-        // Capture focus on the UI thread so it can be restored after the dialog closes (issue #6505).
-        PickerCommon::DialogFocusRestorer focusRestorer{};
+        if (WinAppSdk::Containment::IsChangeEnabled<WINAPPSDK_CHANGEID_63006043>())
+        {
+            // Capture focus on the UI thread so it can be restored after the dialog closes (issue #6505).
+            PickerCommon::DialogFocusRestorer focusRestorer{};
+        }
 
         auto cancellationToken = co_await winrt::get_cancellation_token();
         cancellationToken.enable_propagation(true);

--- a/dev/Interop/StoragePickers/ManualTests/README.md
+++ b/dev/Interop/StoragePickers/ManualTests/README.md
@@ -56,5 +56,21 @@ auto& file = co_await picker.PickSaveFileAsync();
     **Example of unexpected behavior - without the fix:**
     ![alter-extension-with-choices-beforefix](./media/alter-extension-with-choices-beforefix.gif)
 
+### Keyboard focus is restored after the dialog closes
+Run from a WinUI 3 app with a button whose Click handler opens a picker. This applies to every pick
+method: `FileOpenPicker.PickSingleFileAsync` / `PickMultipleFilesAsync`, `FileSavePicker.PickSaveFileAsync`,
+and `FolderPicker.PickSingleFolderAsync` / `PickMultipleFoldersAsync`.
 
+Test code (C++), in the button's Click handler:
+```C++
+winrt::Microsoft::Windows::Storage::Pickers::FileOpenPicker picker{ AppWindow().Id() };
+co_await picker.PickSingleFileAsync();
+```
 
+1. Click the button. The file dialog opens.
+2. Pick a file and confirm. The dialog closes.
+3. Without touching the mouse, press Enter.
+
+    **Expected behavior - with the fix:** Enter re-invokes the button and the dialog reopens.
+
+    **Example of unexpected behavior - without the fix:** Enter does nothing.

--- a/dev/Interop/StoragePickers/ManualTests/README.md
+++ b/dev/Interop/StoragePickers/ManualTests/README.md
@@ -59,7 +59,7 @@ auto& file = co_await picker.PickSaveFileAsync();
 ### Keyboard focus is restored after the dialog closes
 Run from a WinUI 3 app with a button whose Click handler opens a picker. This applies to every pick
 method: `FileOpenPicker.PickSingleFileAsync` / `PickMultipleFilesAsync`, `FileSavePicker.PickSaveFileAsync`,
-and `FolderPicker.PickSingleFolderAsync` / `PickMultipleFoldersAsync`.
+and `FolderPicker.PickSingleFolderAsync`.
 
 Test code (C++), in the button's Click handler:
 ```C++

--- a/dev/Interop/StoragePickers/PickerCommon.cpp
+++ b/dev/Interop/StoragePickers/PickerCommon.cpp
@@ -105,6 +105,28 @@ namespace {
 namespace PickerCommon {
     using namespace winrt;
 
+
+    DialogFocusRestorer::DialogFocusRestorer()
+    {
+        // Capture on the UI thread: GetFocus returns the focused window of the calling
+        // thread's message queue, which is the WinUI content island hosting the focused element.
+        m_focusedWindow = ::GetFocus();
+        m_dispatcherQueue = winrt::Microsoft::UI::Dispatching::DispatcherQueue::GetForCurrentThread();
+    }
+
+    DialogFocusRestorer::~DialogFocusRestorer()
+    {
+        if (m_focusedWindow && m_dispatcherQueue)
+        {
+            HWND focusedWindow = m_focusedWindow;
+            // Marshal back to the UI thread so SetFocus runs on the thread that owns the window.
+            m_dispatcherQueue.TryEnqueue([focusedWindow]()
+            {
+                ::SetFocus(focusedWindow);
+            });
+        }
+    }
+
     bool IsHStringNullOrEmpty(winrt::hstring value)
     {
         return value.empty();

--- a/dev/Interop/StoragePickers/PickerCommon.h
+++ b/dev/Interop/StoragePickers/PickerCommon.h
@@ -9,6 +9,7 @@
 #include <winrt/Windows.Security.Cryptography.Core.h>
 #include <winrt/Microsoft.UI.Windowing.h>
 #include <winrt/Microsoft.UI.Dispatching.h>
+#include <optional>
 
 namespace PickerCommon {
     winrt::hstring GetPathFromShellItem(winrt::com_ptr<IShellItem> shellItem);

--- a/dev/Interop/StoragePickers/PickerCommon.h
+++ b/dev/Interop/StoragePickers/PickerCommon.h
@@ -8,6 +8,7 @@
 #include <winrt/Windows.Security.Cryptography.h>
 #include <winrt/Windows.Security.Cryptography.Core.h>
 #include <winrt/Microsoft.UI.Windowing.h>
+#include <winrt/Microsoft.UI.Dispatching.h>
 
 namespace PickerCommon {
     winrt::hstring GetPathFromShellItem(winrt::com_ptr<IShellItem> shellItem);
@@ -27,6 +28,27 @@ namespace PickerCommon {
     void ValidateSingleFileTypeFilterElement(winrt::hstring const& filter);
     void ValidateSuggestedFileName(winrt::hstring const& suggestedFileName);
     void ValidateSuggestedFolder(winrt::hstring const& path);
+
+    // Restores keyboard focus to the WinUI window after a COM file dialog closes.
+    //
+    // These dialogs run on a background thread (winrt::resume_background), so the SetFocus they
+    // perform on close comes from a thread that does not own the window and is ignored, leaving the
+    // window unable to receive key presses until the user clicks it again (issue #6505).
+    //
+    // Construct this RAII helper on the UI thread before switching to the background thread: it
+    // captures the focused window at construction and, on destruction, marshals SetFocus back to
+    // the UI thread via its DispatcherQueue, restoring focus once the dialog has closed.
+    struct DialogFocusRestorer
+    {
+        DialogFocusRestorer();
+        ~DialogFocusRestorer();
+        DialogFocusRestorer(DialogFocusRestorer const&) = delete;
+        DialogFocusRestorer& operator=(DialogFocusRestorer const&) = delete;
+
+    private:
+        HWND m_focusedWindow{ nullptr };
+        winrt::Microsoft::UI::Dispatching::DispatcherQueue m_dispatcherQueue{ nullptr };
+    };
 
     struct PickerParameters {
         HWND HWnd{};

--- a/dev/RuntimeCompatibilityOptions/RuntimeCompatibilityOptions.idl
+++ b/dev/RuntimeCompatibilityOptions/RuntimeCompatibilityOptions.idl
@@ -60,6 +60,7 @@ namespace Microsoft.Windows.ApplicationModel.WindowsAppRuntime
 
         // 1.8.10
         ThemeSettings_OffThreadDestructorFix = 62451730,
+        StoragePickers_RestoreFocusAfterDialogCloses = 63006043,
     };
 
     /// Represents a version of the Windows App Runtime.

--- a/dev/RuntimeCompatibilityOptions/RuntimeCompatibilityOptions.idl
+++ b/dev/RuntimeCompatibilityOptions/RuntimeCompatibilityOptions.idl
@@ -60,6 +60,8 @@ namespace Microsoft.Windows.ApplicationModel.WindowsAppRuntime
 
         // 1.8.10
         ThemeSettings_OffThreadDestructorFix = 62451730,
+        
+        // 1.8.11
         StoragePickers_RestoreFocusAfterDialogCloses = 63006043,
     };
 


### PR DESCRIPTION
This is a cherry-pick of #6544

**Summary:** 
Issue reported in #6505. Storage Pickers leave the WinUI window without keyboard focus after their dialog closes, so the keyboard stops working until the user clicks the window again. 

**Repro:** 
1. in code map a button's Click handler with a picker behavior. 
2. Click the button (dialog opens), pick a file and confirm (dialog closes), 
3. then press Enter. 
4. Before the fix Enter does nothing; 
    After the fix Enter re-invokes the button and the dialog reopens.

**Fix:** 
An RAII helper `DialogFocusRestorer` captures the focused window before the dialog opens and restores focus to it once the dialog closes. Applied to all five pick methods.
