### PR TITLE
Enable item templates for metapackage and WinUI projects

### DIFF
--- a/dev/Templates/Source/ItemTemplates/Desktop/CSharp/BlankWindow/WinUI.Desktop.Cs.BlankWindow.vstemplate
+++ b/dev/Templates/Source/ItemTemplates/Desktop/CSharp/BlankWindow/WinUI.Desktop.Cs.BlankWindow.vstemplate
@@ -8,7 +8,7 @@
     <ProjectType>CSharp</ProjectType>
     <TemplateID>WinUI.Desktop.Cs.BlankWindow</TemplateID>
     <TemplateGroupID>WinRT-Managed-UAP</TemplateGroupID>
-    <AppliesTo>CSharp + WindowsAppSDK</AppliesTo>
+    <AppliesTo>CSharp + (WindowsAppSDK | WinUI)</AppliesTo>
     <NumberOfParentCategoriesToRollUp>2</NumberOfParentCategoriesToRollUp>
     <ShowByDefault>false</ShowByDefault>
     <TargetPlatformName>Windows</TargetPlatformName>

--- a/dev/Templates/Source/ItemTemplates/Desktop/CppWinRT/BlankWindow/WinUI.Desktop.CppWinRT.BlankWindow.vstemplate
+++ b/dev/Templates/Source/ItemTemplates/Desktop/CppWinRT/BlankWindow/WinUI.Desktop.CppWinRT.BlankWindow.vstemplate
@@ -8,7 +8,7 @@
     <ProjectType>VC</ProjectType>
     <TemplateID>WinUI.Desktop.CppWinRT.BlankWindow</TemplateID>
     <TemplateGroupID>WinRT-Native-UAP</TemplateGroupID>
-    <AppliesTo>VisualC + WindowsAppSDK</AppliesTo>
+    <AppliesTo>VisualC + (WindowsAppSDK | WinUI)</AppliesTo>
     <NumberOfParentCategoriesToRollUp>2</NumberOfParentCategoriesToRollUp>
     <ShowByDefault>false</ShowByDefault>
     <TargetPlatformName>Windows</TargetPlatformName>

--- a/dev/Templates/Source/ItemTemplates/Neutral/CSharp/BlankPage/WinUI.Neutral.Cs.BlankPage.vstemplate
+++ b/dev/Templates/Source/ItemTemplates/Neutral/CSharp/BlankPage/WinUI.Neutral.Cs.BlankPage.vstemplate
@@ -8,7 +8,7 @@
     <ProjectType>CSharp</ProjectType>
     <TemplateID>WinUI.Neutral.Cs.BlankPage</TemplateID>
     <TemplateGroupID>WinRT-Managed-UAP</TemplateGroupID>
-    <AppliesTo>CSharp + WindowsAppSDK</AppliesTo>
+    <AppliesTo>CSharp + (WindowsAppSDK | WinUI)</AppliesTo>
     <NumberOfParentCategoriesToRollUp>2</NumberOfParentCategoriesToRollUp>
     <ShowByDefault>false</ShowByDefault>
     <TargetPlatformName>Windows</TargetPlatformName>

--- a/dev/Templates/Source/ItemTemplates/Neutral/CSharp/ContentDialog/WinUI.Neutral.Cs.ContentDialog.vstemplate
+++ b/dev/Templates/Source/ItemTemplates/Neutral/CSharp/ContentDialog/WinUI.Neutral.Cs.ContentDialog.vstemplate
@@ -8,7 +8,7 @@
     <ProjectType>CSharp</ProjectType>
     <TemplateID>WinUI.Cs.Neutral.ContentDialog</TemplateID>
     <TemplateGroupID>WinRT-Managed-UAP</TemplateGroupID>
-    <AppliesTo>CSharp + WindowsAppSDK</AppliesTo>
+    <AppliesTo>CSharp + (WindowsAppSDK | WinUI)</AppliesTo>
     <NumberOfParentCategoriesToRollUp>2</NumberOfParentCategoriesToRollUp>
     <ShowByDefault>false</ShowByDefault>
     <TargetPlatformName>Windows</TargetPlatformName>

--- a/dev/Templates/Source/ItemTemplates/Neutral/CSharp/ResourceDictionary/WinUI.Neutral.Cs.ResourceDictionary.vstemplate
+++ b/dev/Templates/Source/ItemTemplates/Neutral/CSharp/ResourceDictionary/WinUI.Neutral.Cs.ResourceDictionary.vstemplate
@@ -8,7 +8,7 @@
     <ProjectType>CSharp</ProjectType>
     <TemplateID>WinUI.Cs.Neutral.ResourceDictionary</TemplateID>
     <TemplateGroupID>WinRT-Managed-UAP</TemplateGroupID>
-    <AppliesTo>CSharp + WindowsAppSDK</AppliesTo>
+    <AppliesTo>CSharp + (WindowsAppSDK | WinUI)</AppliesTo>
     <NumberOfParentCategoriesToRollUp>1</NumberOfParentCategoriesToRollUp>
     <ShowByDefault>false</ShowByDefault>
     <TargetPlatformName>Windows</TargetPlatformName>

--- a/dev/Templates/Source/ItemTemplates/Neutral/CSharp/Resw/WinUI.Neutral.Cs.Resw.vstemplate
+++ b/dev/Templates/Source/ItemTemplates/Neutral/CSharp/Resw/WinUI.Neutral.Cs.Resw.vstemplate
@@ -8,7 +8,7 @@
     <ProjectType>CSharp</ProjectType>
     <TemplateID>WinUI.Cs.Neutral.Resw</TemplateID>
     <TemplateGroupID>WinRT-Managed-UAP</TemplateGroupID>
-    <AppliesTo>CSharp + WindowsAppSDK</AppliesTo>
+    <AppliesTo>CSharp + (WindowsAppSDK | WinUI)</AppliesTo>
     <NumberOfParentCategoriesToRollUp>1</NumberOfParentCategoriesToRollUp>
     <ShowByDefault>false</ShowByDefault>
     <TargetPlatformName>Windows</TargetPlatformName>

--- a/dev/Templates/Source/ItemTemplates/Neutral/CSharp/TemplatedControl/WinUI.Neutral.Cs.TemplatedControl.vstemplate
+++ b/dev/Templates/Source/ItemTemplates/Neutral/CSharp/TemplatedControl/WinUI.Neutral.Cs.TemplatedControl.vstemplate
@@ -8,7 +8,7 @@
     <ProjectType>CSharp</ProjectType>
     <TemplateID>WinUI.Neutral.Cs.TemplatedControl</TemplateID>
     <TemplateGroupID>WinRT-Managed-UAP</TemplateGroupID>
-    <AppliesTo>CSharp + WindowsAppSDK</AppliesTo>
+    <AppliesTo>CSharp + (WindowsAppSDK | WinUI)</AppliesTo>
     <NumberOfParentCategoriesToRollUp>2</NumberOfParentCategoriesToRollUp>
     <ShowByDefault>false</ShowByDefault>
     <TargetPlatformName>Windows</TargetPlatformName>

--- a/dev/Templates/Source/ItemTemplates/Neutral/CSharp/UserControl/WinUI.Neutral.Cs.UserControl.vstemplate
+++ b/dev/Templates/Source/ItemTemplates/Neutral/CSharp/UserControl/WinUI.Neutral.Cs.UserControl.vstemplate
@@ -8,7 +8,7 @@
     <ProjectType>CSharp</ProjectType>
     <TemplateID>WinUI.Cs.Neutral.UserControl</TemplateID>
     <TemplateGroupID>WinRT-Managed-UAP</TemplateGroupID>
-    <AppliesTo>CSharp + WindowsAppSDK</AppliesTo>
+    <AppliesTo>CSharp + (WindowsAppSDK | WinUI)</AppliesTo>
     <NumberOfParentCategoriesToRollUp>2</NumberOfParentCategoriesToRollUp>
     <ShowByDefault>false</ShowByDefault>
     <TargetPlatformName>Windows</TargetPlatformName>

--- a/dev/Templates/Source/ItemTemplates/Neutral/CppWinRT/BlankPage/WinUI.Neutral.CppWinRT.BlankPage.vstemplate
+++ b/dev/Templates/Source/ItemTemplates/Neutral/CppWinRT/BlankPage/WinUI.Neutral.CppWinRT.BlankPage.vstemplate
@@ -8,7 +8,7 @@
     <ProjectType>VC</ProjectType>
     <TemplateID>WinUI.Neutral.CppWinRT.BlankPage</TemplateID>
     <TemplateGroupID>WinRT-Native-UAP</TemplateGroupID>
-    <AppliesTo>VisualC + WindowsAppSDK</AppliesTo>
+    <AppliesTo>VisualC + (WindowsAppSDK | WinUI)</AppliesTo>
     <NumberOfParentCategoriesToRollUp>2</NumberOfParentCategoriesToRollUp>
     <ShowByDefault>false</ShowByDefault>
     <TargetPlatformName>Windows</TargetPlatformName>

--- a/dev/Templates/Source/ItemTemplates/Neutral/CppWinRT/ResourceDictionary/WinUI.Neutral.CppWinRT.ResourceDictionary.vstemplate
+++ b/dev/Templates/Source/ItemTemplates/Neutral/CppWinRT/ResourceDictionary/WinUI.Neutral.CppWinRT.ResourceDictionary.vstemplate
@@ -8,7 +8,7 @@
     <ProjectType>VC</ProjectType>
     <TemplateID>WinUI.Neutral.CppWinRT.ResourceDictionary</TemplateID>
     <TemplateGroupID>WinRT-Native-UAP</TemplateGroupID>
-    <AppliesTo>VisualC + WindowsAppSDK</AppliesTo>
+    <AppliesTo>VisualC + (WindowsAppSDK | WinUI)</AppliesTo>
     <NumberOfParentCategoriesToRollUp>1</NumberOfParentCategoriesToRollUp>
     <ShowByDefault>false</ShowByDefault>
     <TargetPlatformName>Windows</TargetPlatformName>

--- a/dev/Templates/Source/ItemTemplates/Neutral/CppWinRT/Resw/WinUI.Neutral.CppWinRT.Resw.vstemplate
+++ b/dev/Templates/Source/ItemTemplates/Neutral/CppWinRT/Resw/WinUI.Neutral.CppWinRT.Resw.vstemplate
@@ -8,7 +8,7 @@
     <ProjectType>VC</ProjectType>
     <TemplateID>WinUI.CppWinRT.Neutral.Resw</TemplateID>
     <TemplateGroupID>WinRT-Native-UAP</TemplateGroupID>
-    <AppliesTo>VisualC + WindowsAppSDK</AppliesTo>
+    <AppliesTo>VisualC + (WindowsAppSDK | WinUI)</AppliesTo>
     <NumberOfParentCategoriesToRollUp>1</NumberOfParentCategoriesToRollUp>
     <ShowByDefault>false</ShowByDefault>
     <TargetPlatformName>Windows</TargetPlatformName>

--- a/dev/Templates/Source/ItemTemplates/Neutral/CppWinRT/TemplatedControl/WinUI.Neutral.CppWinRT.TemplatedControl.vstemplate
+++ b/dev/Templates/Source/ItemTemplates/Neutral/CppWinRT/TemplatedControl/WinUI.Neutral.CppWinRT.TemplatedControl.vstemplate
@@ -8,7 +8,7 @@
     <ProjectType>VC</ProjectType>
     <TemplateID>WinUI.Neutral.CppWinRT.TemplatedControl</TemplateID>
     <TemplateGroupID>WinRT-Native-UAP</TemplateGroupID>
-    <AppliesTo>VisualC + WindowsAppSDK</AppliesTo>
+    <AppliesTo>VisualC + (WindowsAppSDK | WinUI)</AppliesTo>
     <NumberOfParentCategoriesToRollUp>2</NumberOfParentCategoriesToRollUp>
     <ShowByDefault>false</ShowByDefault>
     <TargetPlatformName>Windows</TargetPlatformName>

--- a/dev/Templates/Source/ItemTemplates/Neutral/CppWinRT/UserControl/WinUI.Neutral.CppWinRT.UserControl.vstemplate
+++ b/dev/Templates/Source/ItemTemplates/Neutral/CppWinRT/UserControl/WinUI.Neutral.CppWinRT.UserControl.vstemplate
@@ -8,7 +8,7 @@
     <ProjectType>VC</ProjectType>
     <TemplateID>WinUI.Neutral.CppWinRT.UserControl</TemplateID>
     <TemplateGroupID>WinRT-Native-UAP</TemplateGroupID>
-    <AppliesTo>VisualC + WindowsAppSDK</AppliesTo>
+    <AppliesTo>VisualC + (WindowsAppSDK | WinUI)</AppliesTo>
     <NumberOfParentCategoriesToRollUp>2</NumberOfParentCategoriesToRollUp>
     <ShowByDefault>false</ShowByDefault>
     <TargetPlatformName>Windows</TargetPlatformName>

--- a/dev/Templates/VSIX/Shared/WizardImplementation.cs
+++ b/dev/Templates/VSIX/Shared/WizardImplementation.cs
@@ -75,6 +75,8 @@ namespace WindowsAppSDK.TemplateUtilities
             }
         }
 
+        // This event is called when a project has finished generating. We use it to 
+        // trigger NuGet package installation for VC++ projects (C++ templates)
         public void ProjectFinishedGenerating(Project project)
         {
             ThreadHelper.ThrowIfNotOnUIThread();


### PR DESCRIPTION
Resolves #5923, which reported that the `Add New Item` menu omitted the WinUI templates when the WinUI `PackageReference ` was included without the Windows App SDK metapackage.

Before, the item templates' `.vstemplate` `AppliesTo` property only had `WindowsAppSDK`, which is only emitted by the metapackage. Adding `WinUI` allows the item templates to appear when either the metapackage `Microsoft.WindowsAppSDK` or WinUI package `Microsoft.WindowsAppSDK.WinUI` is included in the project.

Notes:
* The `build` assets for either package need to be included in order to see the item templates. Setting `IncludeAssets=None` in the `PackageReference` will omit the item templates.
* If adding Windows App SDK or WinUI to an existing project, close and reopen VS to see the WinUI templates in the New Item menu

Validation:
* Fetch and build the branch with `.\dev\Templates\VSIX\build-local-VSIX-packagebuild-install-localdev-vsix.ps1`.
* Create a new C# template with the local dev templates
* In the {AppName}.csproj, switch `<PackageReference Include="Microsoft.WindowsAppSDK" Version="*" />` to `Microsoft.WindowsAppSDK.WinUI`.
* Close VS
* Reopen the same project in VS
* Click "Add New Item" (Ctrl+Shift+A)

I ran the same validation on a standalone VSIX.

---

A microsoft employee must use /azp run to validate using the pipelines below.

WARNING:
Comments made by azure-pipelines bot maybe inaccurate.
Please see pipeline link to verify that the build is being ran.

For status checks on the main branch, please use TransportPackage-Foundation-PR
(https://microsoft.visualstudio.com/ProjectReunion/_build?definitionId=81063&_a=summary)
and run the build against your PR branch with the default parameters.
