### PR TITLE
Add ContentDialog item template to the C# VSIX

### DIFF
--- a/dev/Templates/Dotnet/templates/item-content-dialog/.template.config/template.json
+++ b/dev/Templates/Dotnet/templates/item-content-dialog/.template.config/template.json
@@ -10,7 +10,6 @@
   "groupIdentity": "Microsoft.WindowsAppSDK.WinUI.CSharp.Item.ContentDialog",
   "name": "WinUI Content Dialog (Item)",
   "shortName": ["winui-dialog", "winui3-dialog"],
-  "sourceName": "ContentDialog",
   "defaultName": "ContentDialog",
   "description": "Adds a WinUI 3 ContentDialog with markup and code-behind.",
   "preferNameDirectory": false,
@@ -26,7 +25,8 @@
       "type": "derived",
       "valueSource": "name",
       "valueTransform": "safe_name",
-      "replaces": "$safeitemname$"
+      "replaces": "$safeitemname$",
+      "fileRename": "ContentDialog"
     },
     "itemName": {
       "type": "derived",
@@ -39,30 +39,6 @@
       "valueSource": "name",
       "valueTransform": "identity",
       "replaces": "$fileinputname$"
-    },
-    "contentDialogType": {
-      "type": "generated",
-      "generator": "constant",
-      "parameters": {
-        "value": "ContentDialog"
-      },
-      "replaces": "__WINUI_CONTENT_DIALOG__"
-    },
-    "contentDialogButtonClickEventArgsType": {
-      "type": "generated",
-      "generator": "constant",
-      "parameters": {
-        "value": "ContentDialogButtonClickEventArgs"
-      },
-      "replaces": "__WINUI_CONTENT_DIALOG_BUTTON_CLICK_EVENT_ARGS__"
-    },
-    "defaultContentDialogStyleResourceKey": {
-      "type": "generated",
-      "generator": "constant",
-      "parameters": {
-        "value": "DefaultContentDialogStyle"
-      },
-      "replaces": "__WINUI_DEFAULT_CONTENT_DIALOG_STYLE__"
     }
   },
   "constraints": {

--- a/dev/Templates/Source/ItemTemplates/Neutral/CSharp/ContentDialog/ContentDialog.xaml
+++ b/dev/Templates/Source/ItemTemplates/Neutral/CSharp/ContentDialog/ContentDialog.xaml
@@ -1,19 +1,21 @@
 <?xml version="1.0" encoding="utf-8" ?>
-<__WINUI_CONTENT_DIALOG__
+<ContentDialog
     x:Class="$rootnamespace$.$safeitemname$"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:local="using:$rootnamespace$"
+    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-    Style="{StaticResource __WINUI_DEFAULT_CONTENT_DIALOG_STYLE__}"
     Title="Title"
-    PrimaryButtonClick="ContentDialog_PrimaryButtonClick"
     PrimaryButtonText="Button1"
-    SecondaryButtonClick="ContentDialog_SecondaryButtonClick"
     SecondaryButtonText="Button2"
+    CloseButtonText="Close"
+    DefaultButton="Primary"
+    PrimaryButtonClick="ContentDialog_PrimaryButtonClick"
+    SecondaryButtonClick="ContentDialog_SecondaryButtonClick"
     mc:Ignorable="d">
+
     <Grid>
 
     </Grid>
-</__WINUI_CONTENT_DIALOG__>
+</ContentDialog>

--- a/dev/Templates/Source/ItemTemplates/Neutral/CSharp/ContentDialog/ContentDialog.xaml.cs
+++ b/dev/Templates/Source/ItemTemplates/Neutral/CSharp/ContentDialog/ContentDialog.xaml.cs
@@ -7,18 +7,18 @@ using Microsoft.UI.Xaml.Controls;
 
 namespace $rootnamespace$;
 
-public sealed partial class $safeitemname$ : __WINUI_CONTENT_DIALOG__
+public sealed partial class $safeitemname$ : ContentDialog
 {
     public $safeitemname$()
     {
         InitializeComponent();
     }
 
-    private void ContentDialog_PrimaryButtonClick(__WINUI_CONTENT_DIALOG__ sender, __WINUI_CONTENT_DIALOG_BUTTON_CLICK_EVENT_ARGS__ args)
+    private void ContentDialog_PrimaryButtonClick(ContentDialog sender, ContentDialogButtonClickEventArgs args)
     {
     }
 
-    private void ContentDialog_SecondaryButtonClick(__WINUI_CONTENT_DIALOG__ sender, __WINUI_CONTENT_DIALOG_BUTTON_CLICK_EVENT_ARGS__ args)
+    private void ContentDialog_SecondaryButtonClick(ContentDialog sender, ContentDialogButtonClickEventArgs args)
     {
     }
 }

--- a/dev/Templates/Source/ItemTemplates/Neutral/CSharp/ContentDialog/WinUI.Neutral.Cs.ContentDialog.vstemplate
+++ b/dev/Templates/Source/ItemTemplates/Neutral/CSharp/ContentDialog/WinUI.Neutral.Cs.ContentDialog.vstemplate
@@ -2,8 +2,8 @@
 <VSTemplate Version="3.0.0" Type="Item" xmlns="http://schemas.microsoft.com/developer/vstemplate/2005" xmlns:sdk="http://schemas.microsoft.com/developer/vstemplate-sdkextension/2010">
   <TemplateData>
     <DefaultName>ContentDialog.xaml</DefaultName>
-    <Name ID="1021" Package="FIXME-PACKAGEGUID" />
-    <Description ID="1023" Package="FIXME-PACKAGEGUID" />
+    <Name ID="1065" Package="FIXME-PACKAGEGUID" />
+    <Description ID="1067" Package="FIXME-PACKAGEGUID" />
     <Icon>WinUI.Neutral.Cs.ContentDialog.ico</Icon>
     <ProjectType>CSharp</ProjectType>
     <TemplateID>WinUI.Cs.Neutral.ContentDialog</TemplateID>

--- a/dev/Templates/VSIX/Extension/Cs/Common/VSPackage.resx
+++ b/dev/Templates/VSIX/Extension/Cs/Common/VSPackage.resx
@@ -279,4 +279,13 @@
   <data name="1064" xml:space="preserve">
     <value>A project template for creating a WinUI app structured with the MVVM pattern using the CommunityToolkit.Mvvm package.</value>
   </data>
+  <data name="1065" xml:space="preserve">
+    <value>Content Dialog</value>
+  </data>
+  <data name="1066" xml:space="preserve">
+    <value>[Experimental] Content Dialog</value>
+  </data>
+  <data name="1067" xml:space="preserve">
+    <value>A dialog box that displays content over the app UI to show information or gather input (WinUI).</value>
+  </data>
 </root>

--- a/dev/Templates/VSIX/Extension/Directory.Build.targets
+++ b/dev/Templates/VSIX/Extension/Directory.Build.targets
@@ -130,7 +130,14 @@
     <PropertyGroup>
       <VsixIdentity>$(_OriginalVsixId)</VsixIdentity>
       <ExperimentalVsixIdentity>$(_OriginalVsixId).Experimental</ExperimentalVsixIdentity>
-      <ExperimentalVsixDisplayName>Experimental $(_OriginalVsixName)</ExperimentalVsixDisplayName>
+      <!--
+        The VSIX manifest DisplayName has a 50-character maximum. Prepending
+        "Experimental " (13 chars) to a full name like
+        "Windows App SDK C# VS Templates (LocalDev)" (42) overflows it, so strip
+        the trailing deployment parenthetical (e.g. " (LocalDev)") - the
+        deployment is already encoded in the .Experimental Identity/suffix.
+      -->
+      <ExperimentalVsixDisplayName>Experimental $([System.Text.RegularExpressions.Regex]::Replace('$(_OriginalVsixName)', ' \(.*\)', ''))</ExperimentalVsixDisplayName>
       <ExperimentalVsixTags>$(_OriginalVsixTags)</ExperimentalVsixTags>
 
       <_OriginalVsixId></_OriginalVsixId>


### PR DESCRIPTION
Resolves #3723 and #5941

The ContentDialog item template was present since #6407 for the dotnet templates. To add them to the VSIX templates, they needed unique strings and `$parameter$` syntax instead of `__WINUI_CONTENT_DIALOG__`, the latter of which only works with the dotnet template engine. The `$parameter$` syntax works in both.

Validation:
* Fetch and build the branch with .\dev\Templates\VSIX\build-local-VSIX-packagebuild-install-localdev-vsix.ps1.
* For each C# templates in Visual Studio:
   * Created a project with the template
   * Opened the New Item menu (Ctrl+Shift+A)
   * Selected the ContentDialog
   * Added a button to the main page
   * Built and deployed with F5
   * Confirmed that the ContentDialog appeared on the button click
* For the Class library template, I confirmed that the solution built with the content dialog included
* Confirmed there were no regressions on the dotnet templates with `.\dev\Templates\Dotnet\Test-DotnetNewTemplates.ps1 -WindowsAppSDkVersion "2.2.0" -dotnetsdkversion "*"`
  
---

A microsoft employee must use /azp run to validate using the pipelines below.

WARNING:
Comments made by azure-pipelines bot maybe inaccurate.
Please see pipeline link to verify that the build is being ran.

For status checks on the main branch, please use TransportPackage-Foundation-PR
(https://microsoft.visualstudio.com/ProjectReunion/_build?definitionId=81063&_a=summary)
and run the build against your PR branch with the default parameters.
