### PR TITLE
Pin BuildVSIX to .NET SDK 10.0.110

### DIFF
--- a/build/AzurePipelinesTemplates/WindowsAppSDK-BuildVSIX-Steps.yml
+++ b/build/AzurePipelinesTemplates/WindowsAppSDK-BuildVSIX-Steps.yml
@@ -122,6 +122,12 @@ steps:
       }
       Exit 1
 
+- task: UseDotNet@2
+  displayName: 'Use .NET SDK 10.0.110'
+  inputs:
+    packageType: 'sdk'
+    version: '10.0.110'
+
 - task: NuGetAuthenticate@1
 
 - task: VSBuild@1


### PR DESCRIPTION
## Summary
- Install .NET SDK 10.0.110 before the BuildVSIX restore/build steps.

## Motivation
Component Governance reports `DOTNET-Security-10.0` for .NET SDK 10.0.101 in the BuildVSIX snapshot. SDK 10.0.110 is the July 14, 2026 security servicing release in the same 1xx SDK feature band.

## Validation
- Awaiting pipeline run for validation