### PR TITLE
Add WindowsServices_GetKeyboardModifiersStateRace enum (62927180)

### DIFF
--- a/dev/RuntimeCompatibilityOptions/RuntimeCompatibilityOptions.idl
+++ b/dev/RuntimeCompatibilityOptions/RuntimeCompatibilityOptions.idl
@@ -81,6 +81,7 @@ namespace Microsoft.Windows.ApplicationModel.WindowsAppRuntime
         Xaml_ReserveTrackerCollectionSpace = 62849414,
         WindowsML_ExecutionProviderEnumerationUpdate = 62865780,
         CompositionEngine_API = 62917618,
+        WindowsServices_GetKeyboardModifiersStateRace = 62927180,
         VideoSuperResolution_HardwareDetection = 62934326,
     };
 


### PR DESCRIPTION
WinUI PR [16052384](https://microsoft.visualstudio.com/WinUI/_git/microsoft-ui-xaml-lift/pullrequest/16052384) (bug [62927180](https://microsoft.visualstudio.com/OS/_workitems/edit/62927180)) merged the `CWindowsServices::GetKeyboardModifiersState` race fix into `release/2.0-stable` with containment gate `WINAPPSDK_CHANGEID_62927180`, but the corresponding `RuntimeCompatibilityChange` enum was never added to Foundation.

Without the enum, the containment gate is live and default-enabled in the WinUI 2.3.x binary, yet apps have no way to name it in `DisabledChanges` to opt out. This adds the missing enum in numeric order.

- `WindowsServices_GetKeyboardModifiersStateRace = 62927180`

Verified: after this change, every one of the 47 `WINAPPSDK_CHANGEID_*` values referenced in the microsoft-ui-xaml-lift servicing tree maps to a Foundation `RuntimeCompatibilityChange` enum.