### PR TITLE
Add 62927180 to 2.3.0 containment catalog group

### DIFF
--- a/dev/RuntimeCompatibilityOptions/RuntimeCompatibilityOptions.cpp
+++ b/dev/RuntimeCompatibilityOptions/RuntimeCompatibilityOptions.cpp
@@ -163,6 +163,7 @@ namespace
         62849414, // Xaml_ReserveTrackerCollectionSpace
         62865780, // WindowsML_ExecutionProviderEnumerationUpdate
         62917618, // CompositionEngine_API
+        62927180, // WindowsServices_GetKeyboardModifiersStateRace
         62934326, // VideoSuperResolution_HardwareDetection
     };
     constexpr CatalogGroup s_catalogGroupsProd[] = {


### PR DESCRIPTION
Follow-up to #6626. Containment v2 (2.0 train) requires the catalog entry in `RuntimeCompatibilityOptions.cpp` alongside the IDL enum; #6626 added only the IDL enum.

This folds `62927180` (`WindowsServices_GetKeyboardModifiersStateRace`) into `s_changes_2_3_0[]` in ascending order so `RuntimeCompatibilityOptions::Apply`'s catalog pre-prune walk covers the change. The `WinAppSDK_2_3_0` enumerator and its `MakeGroup` entry already exist.

Validated: the `s_changes_2_3_0[]` ID set now exactly matches the IDL 2.3.0 enum set (43 IDs, same order, strictly ascending, no duplicates or cross-group collisions).

A microsoft employee must use /azp run to validate using the pipelines below.

WARNING:
Comments made by azure-pipelines bot maybe inaccurate.
Please see pipeline link to verify that the build is being ran.

For status checks on the main branch, please use TransportPackage-Foundation-PR
(https://microsoft.visualstudio.com/ProjectReunion/_build?definitionId=81063&_a=summary)
and run the build against your PR branch with the default parameters.