### PR TITLE
Fix CS0234 in BaseDirectory auto-initializer: qualify System.Globaliz…

### DIFF
--- a/dev/Common/WindowsAppRuntimeBaseDirectoryAutoInitializer.cs
+++ b/dev/Common/WindowsAppRuntimeBaseDirectoryAutoInitializer.cs
@@ -29,7 +29,7 @@ namespace Microsoft.Windows.ApplicationModel.WindowsAppRuntime.BaseDirectoryCS
             // being steered to read files from a parent-controlled directory).
             // See https://github.com/microsoft/WindowsAppSDK/issues/5987.
             Environment.SetEnvironmentVariable("MICROSOFT_WINDOWSAPPRUNTIME_BASE_DIRECTORY_PID",
-                Environment.ProcessId.ToString(System.Globalization.CultureInfo.InvariantCulture));
+                Environment.ProcessId.ToString(global::System.Globalization.CultureInfo.InvariantCulture));
         }
     }
 }


### PR DESCRIPTION
Problem
TransportPackage-Foundation-Nightly (OneBranch) on main (commit https://github.com/microsoft/WindowsAppSDK/commit/aa197a52f3066e317978995b904c50f990e93861) fails with:

WindowsAppRuntimeBaseDirectoryAutoInitializer.cs(32,48): error CS0234:
The type or namespace name 'Globalization' does not exist in the namespace 'Microsoft.Windows.System'

Root cause
dev/Common/WindowsAppRuntimeBaseDirectoryAutoInitializer.cs (added in https://github.com/microsoft/WindowsAppSDK/pull/6619) lives in
namespace Microsoft.Windows.ApplicationModel.WindowsAppRuntime.BaseDirectoryCS. When the
file is compiled into a consumer that references the Microsoft.Windows.System WinMD, the
leading System in System.Globalization.CultureInfo binds to Microsoft.Windows.System
(reachable via the enclosing Microsoft.Windows namespace) instead of the root System
namespace → CS0234. A standalone compile doesn't hit this, which is why https://github.com/microsoft/WindowsAppSDK/pull/6619 passed but
the nightly transport build (with Microsoft.Windows.System in scope) broke.

Fix
Qualify with global::System.Globalization.CultureInfo.InvariantCulture to force the root
namespace. Matches the existing convention in the repo (e.g. VSPackage.Designer.cs).