### PR TITLE
Port BuildInstaller-Steps.yml from monobuild: add artifactName/SkipArtifactDownload parameters

### DIFF
--- a/build/AzurePipelinesTemplates/WindowsAppSDK-BuildInstaller-Steps.yml
+++ b/build/AzurePipelinesTemplates/WindowsAppSDK-BuildInstaller-Steps.yml
@@ -5,9 +5,6 @@ parameters:
 - name: IsOfficial
   type: boolean
   default: false 
-- name: IsOneBranch
-  type: boolean
-  default: false
 - name: runStaticAnalysis
   type: boolean
   default: false
@@ -20,29 +17,87 @@ parameters:
 - name: IsMonobuild
   type: boolean
   default: false
+# Name of the upstream NuGet+MSIX pipeline artifact to download. The monobuild's
+# Aggregate stage publishes 'WindowsAppSDK-NuGet-And-MSIX' (hyphens); the legacy
+# Aggregator pipeline used 'WindowsAppSDK_Nuget_And_MSIX' (underscores). Default
+# preserves the legacy name so non-monobuild callers don't need to opt in.
+- name: artifactName
+  type: string
+  default: 'WindowsAppSDK-NuGet-And-MSIX'
+# When true, skip the artifact download step entirely. The caller is responsible
+# for ensuring $(parameters.artifactName) content is already present at
+# $(System.ArtifactsDirectory) before this template's first MSBuild step. Used by
+# the monobuild's CreateInstaller stage so it can download the artifact with
+# rebuild-aware variables ($(_useBuildOutputFromBuildId) /
+# $(_useBuildOutputFromPipeline)) that honor useBuildOutput_BuildId /
+# useBuildOutput_RebuildStage queue-time overrides.
+- name: SkipArtifactDownload
+  type: boolean
+  default: false
+# Branch (in the Aggregator pipeline's repo) to pull the latest Windows App SDK
+# nuget from when UseCurrentBuild is false. The Aggregator nightly runs daily on
+# 'main', so default there. Override if the active publishing branch changes.
+- name: NightlyBranchName
+  type: string
+  default: 'refs/heads/release/dev/monobuild'
 
 steps:
-- ${{ if eq(parameters.UseCurrentBuild, 'true') }}:
-  - task: DownloadPipelineArtifact@2
-    displayName: 'Download WindowsAppSDK From Current Build'
-    inputs:
-      artifactName: 'WindowsAppSDK_Nuget_And_MSIX'
-      targetPath: '$(System.ArtifactsDirectory)'
-- ${{ else }}:
-  ###
-  # This step downloads the WindowsAppSDK NuGet package from a pipeline
-  # variables: OfficialPipelineID LatestOfficialBuildID
-  # for use in building the Installers
-  - task: DownloadPipelineArtifact@2
-    displayName: 'Download WindowsAppSDK From Latest Nightly'
-    inputs:
-      artifactName: 'WindowsAppSDK_Nuget_And_MSIX'
-      targetPath: '$(System.ArtifactsDirectory)'
-      source: 'specific'
-      project: 55e8140e-57ac-4e5f-8f9c-c7c15b51929d # TODO: replace with $(System.TeamProjectId) once we can have a full WinAppSDK Build on the new mono repo
-      pipeline: $(OfficialPipelineID) 
-      pipelineId: $(LatestOfficialBuildID) 
+- task: PowerShell@2
+  name: InitializeSkipInstallerBuild
+  displayName: 'Decide if we can skip this installer build job'
+  inputs:
+    targetType: 'inline'
+    # If this pipeline run is validating an arm test OS image but this job is set to build the installer for
+    # non-arm, we can skip building the installer because it won't be used for running tests. Same
+    # argument when validating a non-arm test OS image but this job is set to build the installer for arm.
+    # Setting SkipInstallerBuild to true causes all subsequent steps in this job to be skipped. When it is
+    # set to false or left uninitialized (normal / majority case), we run the remaining steps as usual.
+    script: |
+        $ValidatingArmImage = '$(TestImageToValidate)' -match '(?i)arm'
+        Write-Host "ValidatingArmImage: " $ValidatingArmImage
+        $BuildArmPlatform = '$(buildPlatform)' -match '(?i)arm'
+        Write-Host "BuildArmPlatform:" $BuildArmPlatform
+        $DisableBuildLocal = ($BuildArmPlatform -xor $ValidatingArmImage)
+        Write-Host "DisableBuildLocal: " $DisableBuildLocal
+        Write-Host "##vso[task.setvariable variable=SkipInstallerBuild;isOutput=true]$DisableBuildLocal"
+        Write-Host "##vso[task.setvariable variable=SkipInstallerBuild;]$DisableBuildLocal"  
+        Write-Host 'parameters.SignOutput: ' ${{parameters.SignOutput}}
+  # Don't bother doing this step if we are not validating a test OS image. All steps below work as usual.
+  condition: and(succeeded(), eq(variables.EnableTestImageValidation , true))
 
+- ${{ if eq(parameters.SkipArtifactDownload, false) }}:
+  - ${{ if eq(parameters.UseCurrentBuild, 'true') }}:
+    - task: DownloadPipelineArtifact@2
+      displayName: 'Download WindowsAppSDK From Current Build'
+      inputs:
+        artifactName: ${{ parameters.artifactName }}
+        targetPath: '$(System.ArtifactsDirectory)'
+      condition: and(succeeded(), ne(variables.SkipInstallerBuild, true))
+  - ${{ else }}:
+    ###
+    # This step downloads the WindowsAppSDK NuGet package from the Aggregator nightly
+    # pipeline (identified by the OfficialPipelineID variable) for use in building the
+    # VSIX. We pull the latest run from NightlyBranchName rather than a pinned
+    # LatestOfficialBuildID so PR build-validation runs always get a fresh package without
+    # needing a build id supplied at queue time.
+    #
+    # The nightly runs commonly finish as PartiallySucceeded (some downstream test/SDL
+    # stages are not green) even though the packaging stage produced the artifact, so
+    # both allowPartiallySucceededBuilds and allowFailedBuilds must be true -- the task
+    # requires the pair to be set together to consider non-succeeded runs.
+    - task: DownloadPipelineArtifact@2
+      displayName: 'Download WindowsAppSDK From Latest Nightly'
+      inputs:
+        artifactName: ${{ parameters.artifactName }}
+        targetPath: '$(System.ArtifactsDirectory)'
+        source: 'specific'
+        project: $(System.TeamProjectId)
+        pipeline: 190463
+        runVersion: 'latestFromBranch'
+        runBranch: '${{ parameters.NightlyBranchName }}'
+        allowPartiallySucceededBuilds: true
+        allowFailedBuilds: true
+    
 ###
 # Install the internal licensing support for release-signed packages. This can always be present in
 # pipeline builds. The installer code will automatically degrade / skip licenses in non-release builds
@@ -57,13 +112,14 @@ steps:
     msbuildArguments: '/t:GeneratePackagesConfig'
   condition: and(succeeded(), ne(variables.SkipInstallerBuild, true))
 
-- task: 333b11bd-d341-40d9-afcf-b32d5ce6f23b@2
+- task: NuGetCommand@2
   displayName: RestoreNuGetPackages
   inputs:
     restoreSolution: $(foundationRepoPath)build/packages.config
     feedsToUse: config
     nugetConfigPath: $(foundationRepoPath)nuget.config
     restoreDirectory: packages
+  condition: and(succeeded(), ne(variables.SkipInstallerBuild, true))
 
 - task: powershell@2
   displayName: 'Create test pfx to sign MSIX test packages (DevCheck)'
@@ -72,6 +128,7 @@ steps:
     filePath: $(foundationRepoPath)tools\DevCheck\DevCheck.ps1
     arguments: -NoInteractive -Offline -Verbose -CheckTestPfx -Clean
     workingDirectory: '$(Build.SourcesDirectory)'
+  condition: and(succeeded(), ne(variables.SkipInstallerBuild, true))
 
 - task: powershell@2
   displayName: 'Install test certificate for MSIX test packages (DevCheck)'
@@ -80,6 +137,7 @@ steps:
     filePath: $(foundationRepoPath)tools\DevCheck\DevCheck.ps1
     arguments: -NoInteractive -Offline -Verbose -CheckTestCert
     workingDirectory: '$(Build.SourcesDirectory)'
+  condition: and(succeeded(), ne(variables.SkipInstallerBuild, true))
 
 # Copy license files into the InstallerInput directory. License files should be named consistently with the
 # package naming used in the installer. See build\Scripts\ExtractMSIXFromNuget.ps1 for specifics.
@@ -93,6 +151,7 @@ steps:
       *.xml
     TargetFolder: '$(Build.SourcesDirectory)\InstallerInput'
     flattenFolders: false
+  condition: and(succeeded(), ne(variables.SkipInstallerBuild, true))
 
 # Copy license installation header into the correct installer source location.
 - task: CopyFiles@2
@@ -104,6 +163,7 @@ steps:
     TargetFolder: '$(Build.SourcesDirectory)\$(foundationRepoPath)installer\dev'
     flattenFolders: false
     overWrite: true
+  condition: and(succeeded(), ne(variables.SkipInstallerBuild, true))
 
 ###
 # Copy MSIX packages from build artifacts into the installer content location and create
@@ -116,6 +176,7 @@ steps:
     arguments: >
       -Source '$(System.ArtifactsDirectory)'
       -Dest '$(Build.SourcesDirectory)\InstallerInput'
+  condition: and(succeeded(), ne(variables.SkipInstallerBuild, true))
 
 - task: PowerShell@2
   displayName: CreateInstallerOverrideHeader
@@ -124,15 +185,17 @@ steps:
     arguments: >
       -SourceFolder '$(Build.SourcesDirectory)\InstallerInput'
       -DestinationFolder '$(Build.SourcesDirectory)\InstallerInput'
+  condition: and(succeeded(), ne(variables.SkipInstallerBuild, true))
 
 # NuGetCommand@2
-- task: 333b11bd-d341-40d9-afcf-b32d5ce6f23b@2
+- task: NuGetCommand@2
   displayName: 'Restore Windows App Runtime Install Nuget'
   inputs:
     command: 'restore'
     restoreSolution: $(foundationRepoPath)installer\WindowsAppRuntimeInstall.sln
     feedsToUse: config
     nugetConfigPath: $(Build.SourcesDirectory)\$(foundationRepoPath)nuget.config
+  condition: and(succeeded(), ne(variables.SkipInstallerBuild, true))
 
 - task: CopyFiles@2
   displayName: 'Copy installer override header'
@@ -142,19 +205,22 @@ steps:
       windowsappruntime_definitions_override.h
     TargetFolder: $(foundationRepoPath)installer\dev
     flattenFolders: false
+  condition: and(succeeded(), ne(variables.SkipInstallerBuild, true))
 
 - task: NuGetAuthenticate@1
   displayName: "NuGet authenticate to restore Microsoft.Telemetry.Inbox.Native"
   inputs:
     nuGetServiceConnections: "TelemetryInternal"
+  condition: and(succeeded(), ne(variables.SkipInstallerBuild, true))
 
 # NuGetCommand@2
-- task: 333b11bd-d341-40d9-afcf-b32d5ce6f23b@2
+- task: NuGetCommand@2
   displayName: "NuGet restore Microsoft.Telemetry.Inbox.Native package"
   inputs:
     command: "custom"
     arguments:
         'restore $(Build.SourcesDirectory)\$(foundationRepoPath)installer\dev\telemetry\packages.config -ConfigFile $(Build.SourcesDirectory)\$(foundationRepoPath)nuget.config -PackagesDirectory $(Build.SourcesDirectory)\$(foundationRepoPath)packages'
+  condition: and(succeeded(), ne(variables.SkipInstallerBuild, true))
 
 # Overwrite wil\Traceloggingconfig.h content in public nuget with that of MicrosoftTelemetry.h from internal nuget
 # This step enables telemetry in the Installer
@@ -185,6 +251,7 @@ steps:
           Write-Host Did not find the source MicrosoftTelemetry.h under $(Build.SourcesDirectory)\$(foundationRepoPath)packages\
           Get-Childitem -Path '$(Build.SourcesDirectory)\$(foundationRepoPath)packages\' -Recurse
         }
+  condition: and(succeeded(), ne(variables.SkipInstallerBuild, true))
 
 # Extract Microsoft.WindowsAppSDK Nuget package artifact published by BuildWindowsAppSDKPackages job of Aggregate stage,
 # that runs before the current CreateInstaller stage in the same build pipeline, to the installer's packages folder.
@@ -209,6 +276,7 @@ steps:
       Rename-Item -Path $destWinAppSDKNupkgPath.FullName -NewName $winAppSDKZip
       Expand-Archive $winAppSDKZip -DestinationPath ($destWinAppSDKNupkgPath.Directory.FullName + '\' + $destWinAppSDKNupkgPath.BaseName)
       Copy-Item -Force ($destWinAppSDKNupkgPath.Directory.FullName + '\' + $destWinAppSDKNupkgPath.BaseName + "\include\WindowsAppSDK-VersionInfo.h") '$(Build.SourcesDirectory)\$(foundationRepoPath)installer\dev\'
+  condition: and(succeeded(), ne(variables.SkipInstallerBuild, true))
 
 - task: WinUndockNativeCompiler@1
   displayName: 'Setup native compiler version override'
@@ -220,6 +288,7 @@ steps:
     includeUCRT: true
     ucrtFeedPat: $(System.AccessToken)
     platform: $(buildPlatform)
+  condition: and(succeeded(), ne(variables.SkipInstallerBuild, true))
 
 - task: VSBuild@1
   displayName: 'Build Windows App Runtime Install'
@@ -228,6 +297,7 @@ steps:
     platform: '$(buildPlatform)'
     configuration: '$(buildConfiguration)'
     msbuildArgs: /binaryLogger:$(ob_outputDirectory)\binlogs\WindowsAppRuntimeInstall.$(buildPlatform).$(buildConfiguration).binlog
+  condition: and(succeeded(), ne(variables.SkipInstallerBuild, true))
 
 # The VSBuild@1 task above seems to be able to do inline PREfast scanning with the EO-compliant ruleset now. So, we don't seem to
 # need the following any more. Commenting it out for now and observe a bit more. Remove it when we feel comfortable.
@@ -248,12 +318,14 @@ steps:
 #    continueOnError: true
 #    env:
 #      SYSTEM_ACCESSTOKEN: $(System.AccessToken)
+#    condition: and(succeeded(), ne(variables.SkipInstallerBuild, true))
 
 - task: ms.vss-governance-buildtask.governance-build-task-component-detection.ComponentGovernanceComponentDetection@0
   displayName: 'Component Governance Detection'
   inputs:
     scanType: 'Register'
     failOnAlert: false
+  condition: and(succeeded(), ne(variables.SkipInstallerBuild, true))
 
 - template: WindowsAppSDK-PublishSymbol-Wrapper.yml
   parameters:
@@ -278,6 +350,7 @@ steps:
   inputs:
     SourceFolder: '$(foundationRepoPath)BuildOutput'
     TargetFolder: '$(ob_outputDirectory)\Installer'
+  condition: and(succeeded(), ne(variables.SkipInstallerBuild, true))
 
 - task: powershell@2
   displayName: 'Remove test certificate for MSIX test packages (DevCheck)'
@@ -286,10 +359,5 @@ steps:
     filePath: $(foundationRepoPath)tools\DevCheck\DevCheck.ps1
     arguments: -NoInteractive -Offline -Verbose -RemoveTestCert -RemoveTestPfx
     workingDirectory: '$(Build.SourcesDirectory)'
+  condition: and(succeeded(), ne(variables.SkipInstallerBuild, true))
 
-- ${{ if ne(parameters.IsOneBranch, 'true') }}:
-  - task: PublishBuildArtifacts@1
-    condition: always()
-    inputs:
-      PathtoPublish: '$(ob_outputDirectory)'
-      artifactName: '$(ob_artifactBaseName)'


### PR DESCRIPTION
Ports the monobuild-ready version of `WindowsAppSDK-BuildInstaller-Steps.yml` from `release/dev/monobuild` to `release/dev/monobuild-2.0-stable`.

## Problem

The monorepo's `WinAppSDK-CreateInstaller-Stage.yml` passes `artifactName` and `SkipArtifactDownload` parameters to this template, but the 2.0-stable branch doesn't declare them — causing pipeline compile errors ("Unexpected parameter").

## Changes

- Add `artifactName`, `SkipArtifactDownload`, `NightlyBranchName` parameters
- Add `InitializeSkipInstallerBuild` step (arm/non-arm test image validation skip logic)
- Add `SkipInstallerBuild` conditions on all steps
- Replace GUID-based NuGet task refs with `NuGetCommand@2`
- Remove `IsOneBranch` parameter and `PublishBuildArtifacts` step (`ob_outputDirectory` handles publishing)

## Note

This is a follow-up gap fix not covered by Task 62490593 (which only listed specific cherry-picks, all already merged via PR #16072918).