### PR TITLE
[monobuild] Gate public symbol publish behind PublishPublicSymbols param

### DIFF
--- a/build/AzurePipelinesTemplates/WindowsAppSDK-BuildInstaller-Steps.yml
+++ b/build/AzurePipelinesTemplates/WindowsAppSDK-BuildInstaller-Steps.yml
@@ -5,6 +5,12 @@ parameters:
 - name: IsOfficial
   type: boolean
   default: false 
+# Gates the public SymWeb/MSDL symbol publish inside WindowsAppSDK-PublishSymbol-Steps.yml.
+# Default true preserves standalone per-component behavior; the monobuild passes false while
+# the public symbol-publish service connection is being sorted.
+- name: PublishPublicSymbols
+  type: boolean
+  default: true
 - name: runStaticAnalysis
   type: boolean
   default: false
@@ -333,6 +339,7 @@ steps:
     InnerParams:
       SearchPattern: '$(foundationRepoPath)BuildOutput\$(buildConfiguration)\$(buildPlatform)\WindowsAppRuntimeInstall\*.pdb'
       IsOfficial: ${{ parameters.IsOfficial }}
+      PublishPublicSymbols: ${{ parameters.PublishPublicSymbols }}
       condition: and(succeeded(), ne(variables.SkipInstallerBuild, true))
 
 - ${{ if eq(parameters.SignOutput, 'true') }}:

--- a/build/AzurePipelinesTemplates/WindowsAppSDK-BuildVSIX-Steps.yml
+++ b/build/AzurePipelinesTemplates/WindowsAppSDK-BuildVSIX-Steps.yml
@@ -5,6 +5,12 @@ parameters:
 - name: IsOfficial
   type: boolean
   default: false 
+# Gates the public SymWeb/MSDL symbol publish inside WindowsAppSDK-PublishSymbol-Steps.yml.
+# Default true preserves standalone per-component behavior; the monobuild passes false while
+# the public symbol-publish service connection is being sorted.
+- name: PublishPublicSymbols
+  type: boolean
+  default: true
 - name: runStaticAnalysis
   type: boolean
   default: true
@@ -244,6 +250,7 @@ steps:
     InnerParams:
       SearchPattern: '$(FoundationRepoPath)dev\Templates\VSIX\BuildOutput\obj\AnyCPU$(buildConfiguration)\**\WindowsAppSDK*.pdb'
       IsOfficial: ${{ parameters.IsOfficial }}
+      PublishPublicSymbols: ${{ parameters.PublishPublicSymbols }}
 
 - task: CopyFiles@2
   displayName: 'Stage VSIX component JSONs'

--- a/build/AzurePipelinesTemplates/WindowsAppSDK-PackTransportPackage-Steps.yml
+++ b/build/AzurePipelinesTemplates/WindowsAppSDK-PackTransportPackage-Steps.yml
@@ -17,6 +17,12 @@ parameters:
   - name: IsOfficial
     type: boolean
     default: false
+  # Gates the public SymWeb/MSDL symbol publish inside WindowsAppSDK-PublishSymbol-Steps.yml.
+  # Default true preserves standalone per-component behavior; the monobuild passes false while
+  # the public symbol-publish service connection is being sorted.
+  - name: PublishPublicSymbols
+    type: boolean
+    default: true
   - name: PublishPackage
     type: boolean
     default: false
@@ -117,6 +123,7 @@ steps:
       InnerParams:
         SearchPattern: '$(Build.ArtifactStagingDirectory)\symbols\**\*.pdb'
         IsOfficial: ${{ parameters.IsOfficial }}
+        PublishPublicSymbols: ${{ parameters.PublishPublicSymbols }}
 
   # ── Determine version + pack NuGet ──
   - template: WindowsAppSDK-DetermineVersion-Wrapper.yml


### PR DESCRIPTION
## What

Adds a `PublishPublicSymbols` parameter (default `true`) to the three Foundation symbol-publish step templates and threads it into the `InnerParams` object splatted to `WindowsAppSDK-PublishSymbol-Wrapper.yml`, which forwards to `WindowsAppSDK-PublishSymbol-Steps.yml`:

- `build/AzurePipelinesTemplates/WindowsAppSDK-BuildInstaller-Steps.yml`
- `build/AzurePipelinesTemplates/WindowsAppSDK-BuildVSIX-Steps.yml`
- `build/AzurePipelinesTemplates/WindowsAppSDK-PackTransportPackage-Steps.yml`

## Why

The leaf template gates the public SymWeb/MSDL symbol publish on `and(IsOfficial, PublishPublicSymbols)`. On the Official mono-build the public publish for the Installer, VSIX, and Foundation transport package currently runs unconditionally, and it needs to be turned off while the public symbol-publish service connection is being sorted. Default `true` preserves existing standalone per-component pipeline behavior; only the mono-build passes `false`.

## Merge order (cross-repo)

This change adds `PublishPublicSymbols` to the `InnerParams` that reach the leaf's `PublishPublicSymbols` parameter, which is introduced by the monorepo leaf-param PR. Merge in this order:

1. Monorepo PR: leaf param + internal chains (ADO OS/WinAppSDK PR 16235688)
2. THIS PR (Foundation step templates)
3. Monorepo PR: thread the param to the Foundation Installer/VSIX/Foundation stages

## Validation

Validated end to end via the Official mono-build (ADO OS/WinAppSDK def 196647) pipeline preview, with this branch supplied as the `WindowsAppSDKFoundation` resource and the monorepo threading branch as `self`:

- `PublishPublicSymbols=false` -> 0 "Publish symbols to SymWeb and MSDL" tasks in the compiled pipeline (down from 6)
- `PublishPublicSymbols=true` -> 6 such tasks
- Private symbol publishing (`Publish private symbols to internal server`) is unchanged: 7 instances, always on.
