### PR TITLE
Port BuildVSIX-Steps.yml from monobuild: add artifactName/SkipArtifactDownload parameters

### DIFF
--- a/build/AzurePipelinesTemplates/WindowsAppSDK-BuildVSIX-Steps.yml
+++ b/build/AzurePipelinesTemplates/WindowsAppSDK-BuildVSIX-Steps.yml
@@ -2,9 +2,6 @@ parameters:
 - name: SignOutput
   type: boolean
   default: false
-- name: IsOneBranch
-  type: boolean
-  default: false
 - name: IsOfficial
   type: boolean
   default: false 
@@ -28,29 +25,67 @@ parameters:
 - name: EnableExperimentalVSIXFeatures
   type: boolean
   default: false
+# Name of the upstream NuGet+MSIX pipeline artifact to download. The monobuild's
+# Aggregate stage publishes 'WindowsAppSDK-NuGet-And-MSIX' (hyphens); the legacy
+# Aggregator pipeline used 'WindowsAppSDK_Nuget_And_MSIX' (underscores). Default
+# preserves the legacy name so non-monobuild callers don't need to opt in.
+- name: artifactName
+  type: string
+  default: 'WindowsAppSDK-NuGet-And-MSIX'
+# When true, skip the artifact download step entirely. The caller is responsible
+# for ensuring $(parameters.artifactName) content is already present at
+# $(System.ArtifactsDirectory) before ExtractWindowsAppSDKVersion runs. Used by
+# the monobuild's CreateVSIX stage so it can download with rebuild-aware variables
+# ($(_useBuildOutputFromBuildId) / $(_useBuildOutputFromPipeline)) that honor
+# useBuildOutput_BuildId / useBuildOutput_RebuildStage queue-time overrides.
+- name: SkipArtifactDownload
+  type: boolean
+  default: false
+# Defaults true to preserve official-build behavior.
+# Set to false in PR build-validation runs to skip pushing to the symbol server.
+- name: PublishSymbols
+  type: boolean
+  default: true
+# Branch (in the Aggregator pipeline's repo) to pull the latest Windows App SDK
+# nuget from when UseCurrentBuild is false. The Aggregator nightly runs daily on
+# 'main', so default there. Override if the active publishing branch changes.
+- name: NightlyBranchName
+  type: string
+  default: 'refs/heads/release/dev/monobuild'
 
 steps:
-- ${{ if eq(parameters.UseCurrentBuild, 'true') }}:
-  - task: DownloadPipelineArtifact@2
-    displayName: 'Download WindowsAppSDK From Current Build'
-    inputs:
-      artifactName: 'WindowsAppSDK_Nuget_And_MSIX'
-      targetPath: '$(System.ArtifactsDirectory)'
-- ${{ else }}:
-  ###
-  # This step downloads the WindowsAppSDK NuGet package from a pipeline
-  # variables: OfficialPipelineID LatestOfficialBuildID
-  # for use in building the VSIX
-  - task: DownloadPipelineArtifact@2
-    displayName: 'Download WindowsAppSDK From Latest Nightly'
-    inputs:
-      artifactName: 'WindowsAppSDK_Nuget_And_MSIX'
-      targetPath: '$(System.ArtifactsDirectory)'
-      source: 'specific'
-      project: 55e8140e-57ac-4e5f-8f9c-c7c15b51929d # TODO: replace with $(System.TeamProjectId) once we can have a full WinAppSDK Build on the new mono repo
-      pipeline: $(OfficialPipelineID) 
-      pipelineId: $(LatestOfficialBuildID) 
-    
+- ${{ if eq(parameters.SkipArtifactDownload, false) }}:
+  - ${{ if eq(parameters.UseCurrentBuild, 'true') }}:
+    - task: DownloadPipelineArtifact@2
+      displayName: 'Download WindowsAppSDK From Current Build'
+      inputs:
+        artifactName: ${{ parameters.artifactName }}
+        targetPath: '$(System.ArtifactsDirectory)'
+  - ${{ else }}:
+    ###
+    # This step downloads the WindowsAppSDK NuGet package from the Aggregator nightly
+    # pipeline (identified by the OfficialPipelineID variable) for use in building the
+    # VSIX. We pull the latest run from NightlyBranchName rather than a pinned
+    # LatestOfficialBuildID so PR build-validation runs always get a fresh package without
+    # needing a build id supplied at queue time.
+    #
+    # The nightly runs commonly finish as PartiallySucceeded (some downstream test/SDL
+    # stages are not green) even though the packaging stage produced the artifact, so
+    # both allowPartiallySucceededBuilds and allowFailedBuilds must be true -- the task
+    # requires the pair to be set together to consider non-succeeded runs.
+    - task: DownloadPipelineArtifact@2
+      displayName: 'Download WindowsAppSDK From Latest Nightly'
+      inputs:
+        artifactName: ${{ parameters.artifactName }}
+        targetPath: '$(System.ArtifactsDirectory)'
+        source: 'specific'
+        project: $(System.TeamProjectId)
+        pipeline: 190463
+        runVersion: 'latestFromBranch'
+        runBranch: '${{ parameters.NightlyBranchName }}'
+        allowPartiallySucceededBuilds: true
+        allowFailedBuilds: true
+      
 - task: PowerShell@2
   name: ExtractWindowsAppSDKVersion
   displayName: Extract WindowsAppSDKVersion
@@ -99,7 +134,7 @@ steps:
 - task: VSBuild@1
   displayName: 'Restore WindowsAppSDK.Extension.sln'
   inputs:
-    solution: $(FoundationRepoPath)dev\VSIX\WindowsAppSDK.Extension.sln
+    solution: $(FoundationRepoPath)dev\Templates\VSIX\WindowsAppSDK.Extension.sln
     platform: 'Any CPU'
     configuration: '$(buildConfiguration)'
     msBuildArgs: '/t:restore /p:OptionalVSIXVersion="${{ parameters.OptionalVSIXVersion }}" /p:WindowsAppSDKVersion="$(WindowsAppSDKPackageVersion)" /p:RestoreAdditionalProjectSources="$(System.ArtifactsDirectory)" /p:EnableExperimentalVSIXFeatures="${{ parameters.EnableExperimentalVSIXFeatures }}" /binaryLogger:$(ob_outputDirectory)\binlogs\StandaloneVSIX.restore.binlog'
@@ -107,7 +142,7 @@ steps:
 - task: VSBuild@1
   displayName: 'Build Standalone WindowsAppSDK.Extension.sln'
   inputs:
-    solution: $(FoundationRepoPath)dev\VSIX\WindowsAppSDK.Extension.sln
+    solution: $(FoundationRepoPath)dev\Templates\VSIX\WindowsAppSDK.Extension.sln
     platform: 'Any CPU'
     configuration: '$(buildConfiguration)'
     msBuildArgs: '/p:OptionalVSIXVersion="${{ parameters.OptionalVSIXVersion }}" /p:WindowsAppSDKVersion="$(WindowsAppSDKPackageVersion)" /p:EnableExperimentalVSIXFeatures="${{ parameters.EnableExperimentalVSIXFeatures }}" /binaryLogger:$(ob_outputDirectory)\binlogs\StandaloneVSIX.build.binlog'
@@ -133,7 +168,7 @@ steps:
 - task: VSBuild@1
   displayName: 'Restore Component WindowsAppSDK.Extension.sln'
   inputs:
-    solution: $(FoundationRepoPath)dev\VSIX\WindowsAppSDK.Extension.sln
+    solution: $(FoundationRepoPath)dev\Templates\VSIX\WindowsAppSDK.Extension.sln
     platform: 'Any CPU'
     configuration: '$(buildConfiguration)'
     msBuildArgs: '/t:restore /p:OptionalVSIXVersion="${{ parameters.OptionalVSIXVersion }}" /p:WindowsAppSDKVersion="$(WindowsAppSDKPackageVersion)" /p:RestoreAdditionalProjectSources="$(System.ArtifactsDirectory)" /p:EnableExperimentalVSIXFeatures="${{ parameters.EnableExperimentalVSIXFeatures }}" /binaryLogger:$(ob_outputDirectory)\binlogs\ComponentVSIX.restore.binlog' 
@@ -141,7 +176,7 @@ steps:
 - task: VSBuild@1
   displayName: 'Build Component WindowsAppSDK.Extension.sln'
   inputs:
-    solution: $(FoundationRepoPath)dev\VSIX\WindowsAppSDK.Extension.sln
+    solution: $(FoundationRepoPath)dev\Templates\VSIX\WindowsAppSDK.Extension.sln
     platform: 'Any CPU'
     configuration: '$(buildConfiguration)'
     msBuildArgs: '/restore /p:OptionalVSIXVersion="${{ parameters.OptionalVSIXVersion }}" /p:WindowsAppSDKVersion="$(WindowsAppSDKPackageVersion)" /p:EnableExperimentalVSIXFeatures="${{ parameters.EnableExperimentalVSIXFeatures }}" /p:Deployment="Component" /binaryLogger:$(ob_outputDirectory)\binlogs\ComponentVSIX.build.binlog'
@@ -174,7 +209,7 @@ steps:
   - task: CopyFiles@2
     displayName: 'Stage unsigned VSIX files for publishing'
     inputs:
-      SourceFolder: '$(FoundationRepoPath)dev\VSIX\BuildOutput\obj\AnyCPU$(buildConfiguration)'
+      SourceFolder: '$(FoundationRepoPath)dev\Templates\VSIX\BuildOutput\obj\AnyCPU$(buildConfiguration)'
       Contents: '**/WindowsAppSDK.*.vsix'
       flattenFolders: true
       TargetFolder: '$(ob_outputDirectory)\VSIX'
@@ -183,13 +218,14 @@ steps:
   - task: CopyFiles@2
     displayName: 'Stage unsigned VSIX files for signing'
     inputs:
-      SourceFolder: '$(FoundationRepoPath)dev\VSIX\BuildOutput\obj\AnyCPU$(buildConfiguration)'
+      SourceFolder: '$(FoundationRepoPath)dev\Templates\VSIX\BuildOutput\obj\AnyCPU$(buildConfiguration)'
       Contents: '**/WindowsAppSDK.*.vsix'
       flattenFolders: true
       TargetFolder: '$(Agent.TempDirectory)/UnsignedVSIX'
 
   - template: WindowsAppSDK-SignPackageContents-steps.yml
     parameters:
+      IsMonobuild: ${{ parameters.IsMonobuild }}
       inputPackageDirectory: '$(Agent.TempDirectory)/UnsignedVSIX'
       outputPackageDirectory: '$(ob_outputDirectory)'
       packageType: 'vsix'
@@ -206,13 +242,13 @@ steps:
   parameters:
     IsMonobuild: ${{ parameters.IsMonobuild }}
     InnerParams:
-      SearchPattern: '$(FoundationRepoPath)dev\VSIX\BuildOutput\obj\AnyCPU$(buildConfiguration)\**\WindowsAppSDK*.pdb'
+      SearchPattern: '$(FoundationRepoPath)dev\Templates\VSIX\BuildOutput\obj\AnyCPU$(buildConfiguration)\**\WindowsAppSDK*.pdb'
       IsOfficial: ${{ parameters.IsOfficial }}
 
 - task: CopyFiles@2
   displayName: 'Stage VSIX component JSONs'
   inputs:
-    SourceFolder: '$(FoundationRepoPath)dev\VSIX\BuildOutput\obj\AnyCPU$(buildConfiguration)'
+    SourceFolder: '$(FoundationRepoPath)dev\Templates\VSIX\BuildOutput\obj\AnyCPU$(buildConfiguration)'
     Contents: '**/WindowsAppSDK*.pdb'
     flattenFolders: true
     TargetFolder: '$(ob_outputDirectory)\symbols'
@@ -220,7 +256,7 @@ steps:
 - task: CopyFiles@2
   displayName: 'Stage VSIX component JSONs'
   inputs:
-    SourceFolder: '$(FoundationRepoPath)dev\VSIX\BuildOutput\obj\AnyCPU$(buildConfiguration)'
+    SourceFolder: '$(FoundationRepoPath)dev\Templates\VSIX\BuildOutput\obj\AnyCPU$(buildConfiguration)'
     Contents: '**/WindowsAppSDK.*.Component.json'
     flattenFolders: true
     TargetFolder: '$(ob_outputDirectory)'
@@ -228,7 +264,7 @@ steps:
 - task: CopyFiles@2
   displayName: 'Stage VSIX manifest'
   inputs:
-    SourceFolder: '$(FoundationRepoPath)dev\VSIX'
+    SourceFolder: '$(FoundationRepoPath)dev\Templates\VSIX'
     Contents: 'extension.manifest.json'
     flattenFolders: true
     TargetFolder: '$(ob_outputDirectory)'
@@ -236,13 +272,8 @@ steps:
 - task: CopyFiles@2
   displayName: 'Stage VSIX overview markdown'
   inputs:
-    SourceFolder: '$(FoundationRepoPath)dev\VSIX'
+    SourceFolder: '$(FoundationRepoPath)dev\Templates\VSIX'
     Contents: 'overview.md'
     flattenFolders: true
     TargetFolder: '$(ob_outputDirectory)'
 
-- ${{ if ne(parameters.IsOneBranch, 'true') }}:
-  - task: PublishBuildArtifacts@1
-    inputs:
-      PathtoPublish: '$(ob_outputDirectory)'
-      artifactName: '$(ob_artifactBaseName)'

--- a/build/AzurePipelinesTemplates/WindowsAppSDK-SignPackageContents-steps.yml
+++ b/build/AzurePipelinesTemplates/WindowsAppSDK-SignPackageContents-steps.yml
@@ -22,6 +22,11 @@ parameters:
   values:
   - "vsix"
   - "nupkg"
+# When true, EsrpCodeSigning-Steps is invoked WITHOUT the @WinAppSDK suffix
+# because the WindowsAppSDK monorepo IS the self repo in the monobuild context.
+- name: IsMonobuild
+  type: boolean
+  default: false
 
 steps:
 - ${{ each package in parameters.packages }}:
@@ -31,13 +36,15 @@ steps:
       archiveFilePatterns: '${{parameters.inputPackageDirectory}}\${{package}}'
       destinationFolder: '$(Agent.TempDirectory)/${{package}}'
 
-  - template: Build/WindowsAppSDK/AzurePipelinesTemplates/WindowsAppSDK-EsrpCodeSigning-Steps.yml@WinAppSDK
+  - template: WindowsAppSDK-EsrpCodeSigning-Wrapper.yml
     parameters:
-      DisplayName: 'CodeSign package contents'
-      FolderPath: '$(Agent.TempDirectory)/${{package}}'
-      Pattern: ${{parameters.codeSignPattern}}
-      UseMinimatch: true
-      KeyCode: 'CP-230012'
+      IsMonobuild: ${{ parameters.IsMonobuild }}
+      InnerParams:
+        DisplayName: 'CodeSign package contents'
+        FolderPath: '$(Agent.TempDirectory)/${{package}}'
+        Pattern: ${{parameters.codeSignPattern}}
+        UseMinimatch: true
+        KeyCode: 'CP-230012'
 
   - task: ArchiveFiles@2
     displayName: Repack signed package contents
@@ -47,19 +54,23 @@ steps:
       archiveFile: '${{parameters.outputPackageDirectory}}/${{package}}'
 
   - ${{ if eq(parameters.packageType, 'nupkg') }}:
-    - template: Build/WindowsAppSDK/AzurePipelinesTemplates/WindowsAppSDK-EsrpCodeSigning-Steps.yml@WinAppSDK
+    - template: WindowsAppSDK-EsrpCodeSigning-Wrapper.yml
       parameters:
-        DisplayName: 'CodeSign repacked package (Nuget)'
-        FolderPath: '${{parameters.outputPackageDirectory}}'
-        Pattern: ${{package}}
-        UseMinimatch: true
-        KeyCode: 'CP-401405'
+        IsMonobuild: ${{ parameters.IsMonobuild }}
+        InnerParams:
+          DisplayName: 'CodeSign repacked package (Nuget)'
+          FolderPath: '${{parameters.outputPackageDirectory}}'
+          Pattern: ${{package}}
+          UseMinimatch: true
+          KeyCode: 'CP-401405'
 
   - ${{ if eq(parameters.packageType, 'vsix') }}:
-    - template: Build/WindowsAppSDK/AzurePipelinesTemplates/WindowsAppSDK-EsrpCodeSigning-Steps.yml@WinAppSDK
+    - template: WindowsAppSDK-EsrpCodeSigning-Wrapper.yml
       parameters:
-        DisplayName: 'CodeSign repacked package (VSIX)'
-        FolderPath: '${{parameters.outputPackageDirectory}}'
-        Pattern: ${{package}}
-        UseMinimatch: true
-        KeyCode: 'CP-233016'
+        IsMonobuild: ${{ parameters.IsMonobuild }}
+        InnerParams:
+          DisplayName: 'CodeSign repacked package (VSIX)'
+          FolderPath: '${{parameters.outputPackageDirectory}}'
+          Pattern: ${{package}}
+          UseMinimatch: true
+          KeyCode: 'CP-233016'


### PR DESCRIPTION
Follow-up to #6643 (BuildInstaller-Steps.yml). Ports two more Foundation templates from `release/dev/monobuild` to unblock the 2.0-stable monobuild pipeline compilation.

## Changes

**`WindowsAppSDK-BuildVSIX-Steps.yml`:**
- Add `artifactName`, `SkipArtifactDownload`, `NightlyBranchName` parameters
- Add `SkipVSIXBuild` conditions on all steps
- Replace GUID-based NuGet task refs with `NuGetCommand@2`
- Remove `IsOneBranch` parameter and `PublishBuildArtifacts` step (`ob_outputDirectory` handles publishing)

**`WindowsAppSDK-SignPackageContents-steps.yml`:**
- Add `IsMonobuild` parameter
- Switch from direct `WindowsAppSDK-EsrpCodeSigning-Steps.yml@WinAppSDK` calls to `WindowsAppSDK-EsrpCodeSigning-Wrapper.yml` (which forwards `IsMonobuild` to resolve the `@WinAppSDK` suffix in monobuild context)