### PR TITLE
Add WinUI_WindowWidthHeight experimental runtime compatibility enum

### DIFF
--- a/dev/RuntimeCompatibilityOptions/RuntimeCompatibilityOptions.cpp
+++ b/dev/RuntimeCompatibilityOptions/RuntimeCompatibilityOptions.cpp
@@ -54,6 +54,7 @@ namespace
         WinAppSDK_2_1_0 = WinAppSDKReleaseVersionFromValues(2, 1, 0),
         WinAppSDK_2_1_5 = WinAppSDKReleaseVersionFromValues(2, 1, 5),
         WinAppSDK_2_3_0 = WinAppSDKReleaseVersionFromValues(2, 3, 0),
+        WinAppSDK_2_3_3 = WinAppSDKReleaseVersionFromValues(2, 3, 3),
         WinAppSDK_Latest = 999999999,
         WinAppSDK_Security = 0,
     };
@@ -166,10 +167,14 @@ namespace
         62927180, // WindowsServices_GetKeyboardModifiersStateRace
         62934326, // VideoSuperResolution_HardwareDetection
     };
+    constexpr UINT32 s_changes_2_3_3[] = {
+        63077767, // WinUI_WindowWidthHeight
+    };
     constexpr CatalogGroup s_catalogGroupsProd[] = {
         MakeGroup(s_changes_2_1_0, WinAppSDKReleaseVersion::WinAppSDK_2_1_0),
         MakeGroup(s_changes_2_1_5, WinAppSDKReleaseVersion::WinAppSDK_2_1_5),
         MakeGroup(s_changes_2_3_0, WinAppSDKReleaseVersion::WinAppSDK_2_3_0),
+        MakeGroup(s_changes_2_3_3, WinAppSDKReleaseVersion::WinAppSDK_2_3_3),
     };
     constexpr size_t s_catalogGroupsProdCount{ std::size(s_catalogGroupsProd) };
 

--- a/dev/RuntimeCompatibilityOptions/RuntimeCompatibilityOptions.idl
+++ b/dev/RuntimeCompatibilityOptions/RuntimeCompatibilityOptions.idl
@@ -84,7 +84,7 @@ namespace Microsoft.Windows.ApplicationModel.WindowsAppRuntime
         WindowsServices_GetKeyboardModifiersStateRace = 62927180,
         VideoSuperResolution_HardwareDetection = 62934326,
 
-        // Experimental-only, flighting in 2.0-experimental; fold into the stable release group when it graduates.
+        // 2.3.3
         WinUI_WindowWidthHeight = 63077767,
     };
 

--- a/dev/RuntimeCompatibilityOptions/RuntimeCompatibilityOptions.idl
+++ b/dev/RuntimeCompatibilityOptions/RuntimeCompatibilityOptions.idl
@@ -83,6 +83,9 @@ namespace Microsoft.Windows.ApplicationModel.WindowsAppRuntime
         CompositionEngine_API = 62917618,
         WindowsServices_GetKeyboardModifiersStateRace = 62927180,
         VideoSuperResolution_HardwareDetection = 62934326,
+
+        // Experimental-only, flighting in 2.0-experimental; fold into the stable release group when it graduates.
+        WinUI_WindowWidthHeight = 63077767,
     };
 
     /// Represents a version of the Windows App Runtime.


### PR DESCRIPTION
Adds the `WinUI_WindowWidthHeight` (63077767) runtime compatibility change for the experimental Window.Width/Height feature, which is already merged into the WinUI `release/2.0-experimental` branch (guarded by `IsChangeEnabled<WINAPPSDK_CHANGEID_63077767>()`).

Two coordinated edits, per the Containment v2 model:
- **IDL** (`RuntimeCompatibilityOptions.idl`): adds the `WinUI_WindowWidthHeight` value to the `RuntimeCompatibilityChange` enum so apps can name it in `DisabledChanges`.
- **Catalog** (`RuntimeCompatibilityOptions.cpp`): associates the change with release `2.3.3` via a new `WinAppSDK_2_3_3` release-version enumerator, an `s_changes_2_3_3[]` group, and a `MakeGroup(...)` entry. This is what makes per-release patch-level containment target the change (an app pinning a patch level below 2.3.3 gets the new API disabled).

A microsoft employee must use /azp run to validate using the pipelines below.

WARNING:
Comments made by azure-pipelines bot maybe inaccurate.
Please see pipeline link to verify that the build is being ran.

For status checks on the main branch, please use TransportPackage-Foundation-PR
(https://microsoft.visualstudio.com/ProjectReunion/_build?definitionId=81063&_a=summary)
and run the build against your PR branch with the default parameters.