### PR TITLE
[monobuild] Guard 'Get build revision number' against non-date build numbers (fix Foundation stage)

### DIFF
--- a/BuildAll.ps1
+++ b/BuildAll.ps1
@@ -188,9 +188,23 @@ Try {
             $env:BUILD_BUILDNUMBER = $env:TFS_BUILDNUMBER
         }
         Write-Host "BuildNumber : " $env:BUILD_BUILDNUMBER
-        $yymm = $env:BUILD_BUILDNUMBER.substring($env:BUILD_BUILDNUMBER.length - 10, 4)
-        $dd = $env:BUILD_BUILDNUMBER.substring($env:BUILD_BUILDNUMBER.length - 5, 2)
-        $revision = $env:BUILD_BUILDNUMBER.substring($env:BUILD_BUILDNUMBER.length - 3, 3)
+        # The pipeline-name scheme $(date:yyMM).$(date:dd)$(rev:rrr) yields a >=10-char build number, so
+        # the fixed end-offsets below are valid. The mono-build instead passes a short semantic build
+        # number (e.g. "2.0.0"), where Foundation is versioned from $(WindowsAppSDKFormattedVersion).
+        # Guard the offsets so a <10-char number can't throw "StartIndex cannot be less than zero".
+        if ($env:BUILD_BUILDNUMBER.length -ge 10)
+        {
+            $yymm = $env:BUILD_BUILDNUMBER.substring($env:BUILD_BUILDNUMBER.length - 10, 4)
+            $dd = $env:BUILD_BUILDNUMBER.substring($env:BUILD_BUILDNUMBER.length - 5, 2)
+            $revision = $env:BUILD_BUILDNUMBER.substring($env:BUILD_BUILDNUMBER.length - 3, 3)
+        }
+        else
+        {
+            Write-Host "BUILD_BUILDNUMBER '$env:BUILD_BUILDNUMBER' has no embedded date (mono-build); using zero build/revision."
+            $yymm = '0000'
+            $dd = '00'
+            $revision = '000'
+        }
 
         $WindowsAppSDKVersionProperty = "/p:WindowsAppSDKVersionBuild=$yymm /p:WindowsAppSDKVersionRevision=$dd$revision"
 

--- a/build/AzurePipelinesTemplates/WindowsAppSDK-SetupBuildEnvironment-Steps.yml
+++ b/build/AzurePipelinesTemplates/WindowsAppSDK-SetupBuildEnvironment-Steps.yml
@@ -15,9 +15,24 @@ steps:
     {
       $env:BUILD_BUILDNUMBER = $env:TFS_BUILDNUMBER
     }
-    $yymm = $env:BUILD_BUILDNUMBER.substring($env:BUILD_BUILDNUMBER.length - 10, 4)
-    $dd = $env:BUILD_BUILDNUMBER.substring($env:BUILD_BUILDNUMBER.length - 5, 2)
-    $revision = $env:BUILD_BUILDNUMBER.substring($env:BUILD_BUILDNUMBER.length - 3, 3)
+    # The pipeline-name scheme $(date:yyMM).$(date:dd)$(rev:rrr) yields a >=10-char build number, so
+    # the fixed end-offsets below are valid. The mono-build instead passes a short semantic build
+    # number (e.g. "2.0.0"), where Foundation is versioned from $(WindowsAppSDKFormattedVersion) and
+    # these date/revision values are unused. Guard the offsets so a <10-char number can't throw
+    # "StartIndex cannot be less than zero" (build 152839452, mono-build Official "2.0.0").
+    if ($env:BUILD_BUILDNUMBER.length -ge 10)
+    {
+      $yymm = $env:BUILD_BUILDNUMBER.substring($env:BUILD_BUILDNUMBER.length - 10, 4)
+      $dd = $env:BUILD_BUILDNUMBER.substring($env:BUILD_BUILDNUMBER.length - 5, 2)
+      $revision = $env:BUILD_BUILDNUMBER.substring($env:BUILD_BUILDNUMBER.length - 3, 3)
+    }
+    else
+    {
+      Write-Host "BUILD_BUILDNUMBER '$env:BUILD_BUILDNUMBER' has no embedded date (mono-build); using zero builddate/revision."
+      $yymm = '0000'
+      $dd = '00'
+      $revision = '000'
+    }
     Write-Host "##vso[task.setvariable variable=builddate]$yymm$dd"
     Write-Host "##vso[task.setvariable variable=builddate_yymm]$yymm"
     Write-Host "##vso[task.setvariable variable=builddate_dd]$dd"


### PR DESCRIPTION
## Summary
Fix the Foundation stage crash in the WindowsAppSDK mono-build. The build-revision extraction throws `Substring ... StartIndex cannot be less than zero` on the mono-build's short semantic build number.

## Root cause
Two copies of the same logic slice `yyMM` / `dd` / `revision` out of `BUILD_BUILDNUMBER` with fixed end-offsets (`length - 10 / -5 / -3`), which assume the standalone pipeline-name scheme `$(date:yyMM).$(date:dd)$(rev:rrr)` (>= 10 chars):

1. `build/AzurePipelinesTemplates/WindowsAppSDK-SetupBuildEnvironment-Steps.yml` (the `Get build revision number` step) -- sets `builddate` / `buildrevision` pipeline variables. These are a dead duplicate (consumed nowhere in the repo).
2. `BuildAll.ps1` -- the REAL consumer: the extracted values feed `/p:WindowsAppSDKVersionBuild` + `/p:WindowsAppSDKVersionRevision`, which stamp the Foundation binary/package version.

The mono-build passes a short semantic build number (Official = "2.0.0", 5 chars), so `length - 10` is negative and `Substring` throws. The `Get build revision number` step crashes first (observed in Official mono-build 152839452, failing every `Build Foundation` / `Build MRT` job; the `Not found SourceFolder ...\BuildOutput` errors are cascades) -- and `BuildAll.ps1` would crash the same way right after. The Nightly did not hit this because its build number (`2.0.0-dev.experimentalNNN`) is > 10 chars.

## Fix
Guard both copies behind a `length >= 10` check; otherwise fall back to zero date/revision (and log it). Exact behavior is preserved for the date-based standalone build numbers; only the previously-crashing short-number (mono-build) path changes.

## Why zeros are safe
In the mono-build Foundation is versioned from `$(WindowsAppSDKFormattedVersion)`, and the Nightly already ran green producing throwaway values from its longer build number -- so these date/revision values do not drive the shipped version. The YAML step's `builddate`/`buildrevision` variables are unused entirely.

## Validation
- Both guarded PowerShell blocks parse with 0 errors.
- Diffs are content-only apart from the intentional re-indent of the 3 extraction lines into each new `if` block; `SetupBuildEnvironment-Steps.yml` stays pure CRLF, `BuildAll.ps1` stays pure LF.
- Targets `release/dev/monobuild` (the branch the mono-build checks Foundation out at).
