### PR TITLE
Fix ExtractFormattedVersionTag to preserve non-numeric channel suffixes (e.g. experimentalA)

### DIFF
--- a/dev/Deployment/DeploymentManager.cpp
+++ b/dev/Deployment/DeploymentManager.cpp
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 #include <pch.h>
+#include <regex>
 #include <DeploymentManager.h>
 #include <DeploymentResult.h>
 #include <DeploymentActivityContext.h>
@@ -75,17 +76,22 @@ namespace winrt::Microsoft::Windows::ApplicationModel::WindowsAppRuntime::implem
         return Initialize(GetCurrentFrameworkPackageFullName(), options, true);
     }
 
+    // Derives the short channel tag used in the Main/Singleton package family names
+    // (e.g. L"-experimentalA" -> L"-eA"). Must match the build-time derivation in
+    // CreateBuildInfo.ps1 (regex ^([a-z.]+)([A-Z0-9]{0,2})$). See AB#62727253.
     std::wstring ExtractFormattedVersionTag(const std::wstring& versionTag)
     {
         std::wstring result{};
         if (versionTag.size() > 1)
         {
             result = std::wstring(L"-") + versionTag[1];
-        }
-        unsigned int numberBeforeUnderscore{};
-        if (swscanf_s(versionTag.c_str(), L"%*[^0-9]%u", &numberBeforeUnderscore) == 1)
-        {
-            result += std::to_wstring(numberBeforeUnderscore);
+
+            static const std::wregex c_versionTagPattern{ L"^-[a-z.]+([A-Z0-9]{0,2})$" };
+            std::wsmatch match{};
+            if (std::regex_match(versionTag, match, c_versionTagPattern))
+            {
+                result += match[1].str();
+            }
         }
         return result;
     }


### PR DESCRIPTION
## Root cause
`DeploymentManager::GetStatus` derives the short channel tag for the Main and Singleton package family names via `ExtractFormattedVersionTag`. The old implementation only appended a **numeric** suffix (`swscanf %u`), so a trailing **letter** suffix such as the "A" in `experimentalA` was dropped, yielding `-e` instead of `-eA`.

As a result GetStatus built `...WinAppRuntime.Main.2-e_...` while the installed package is `...WinAppRuntime.Main.2-eA_...`. The runtime was reported as not installed, triggering a spurious deploy/repair that fails with access denied on Server 2019 / RS5. This surfaced as ~40s `AppLaunchWaiter` timeouts in the five `*CppWinuiPackaged` sample-launch tests on the two Windows 10 17763 (RS5) legs of the 2.0-experimental release build.

## Fix
Rework `ExtractFormattedVersionTag` to mirror the build-time short-tag derivation in `CreateBuildInfo.ps1` (regex `^([a-z.]+)([A-Z0-9]{0,2})$`), appending the trailing `[A-Z0-9]{0,2}` suffix so runtime and build agree for both numeric and letter suffixes.

## Verification
Compared old vs new vs build derivation over a tag table:

| tag | old | new | build |
|---|---|---|---|
| experimental | -e | -e | -e |
| experimental10 | -e10 | -e10 | -e10 |
| experimentalA | **-e** | **-eA** | -eA |
| experimental2 | -e2 | -e2 | -e2 |
| preview3 | -p3 | -p3 | -p3 |
| stable | -s | -s | -s |

Behavior changes only for the previously-broken letter-suffix tags; all numeric/plain tags are unchanged (backward compatible).

AB#62727253
