### PR TITLE
Deployment: derive Main/Singleton short tag via canonical v2 helper (experimentalA fix)

### DIFF
--- a/dev/Deployment/DeploymentManager.cpp
+++ b/dev/Deployment/DeploymentManager.cpp
@@ -9,6 +9,7 @@
 #include <TerminalVelocityFeatures-DeploymentAPI.h>
 #include <Microsoft.Windows.ApplicationModel.WindowsAppRuntime.DeploymentManager.g.cpp>
 #include <PushNotificationsLongRunningPlatform-Startup.h>
+#include <AppModel.Identity.h>
 #include "WindowsAppRuntime-License.h"
 
 using namespace winrt;
@@ -75,19 +76,17 @@ namespace winrt::Microsoft::Windows::ApplicationModel::WindowsAppRuntime::implem
         return Initialize(GetCurrentFrameworkPackageFullName(), options, true);
     }
 
+    // Derives the short channel tag used in the Main/Singleton package family names
+    // (e.g. L"-experimentalA" -> L"-eA"). versionTag arrives with a leading '-'.
+    // Delegates to the canonical v2 derivation so the runtime, the DDLM/Bootstrap path,
+    // and the build (CreateBuildInfo.ps1) stay in agreement. See AB#63309642, AB#62727253.
     std::wstring ExtractFormattedVersionTag(const std::wstring& versionTag)
     {
-        std::wstring result{};
-        if (versionTag.size() > 1)
+        if (versionTag.size() <= 1)
         {
-            result = std::wstring(L"-") + versionTag[1];
+            return {};
         }
-        unsigned int numberBeforeUnderscore{};
-        if (swscanf_s(versionTag.c_str(), L"%*[^0-9]%u", &numberBeforeUnderscore) == 1)
-        {
-            result += std::to_wstring(numberBeforeUnderscore);
-        }
-        return result;
+        return L"-" + AppModel::Identity::GetVersionShortTagFromVersionTagV2(versionTag.c_str() + 1);
     }
 
     winrt::Microsoft::Windows::ApplicationModel::WindowsAppRuntime::DeploymentResult DeploymentManager::GetStatus(hstring const& packageFullName)

--- a/dev/Deployment/DeploymentManager.cpp
+++ b/dev/Deployment/DeploymentManager.cpp
@@ -79,7 +79,7 @@ namespace winrt::Microsoft::Windows::ApplicationModel::WindowsAppRuntime::implem
     // Derives the short channel tag used in the Main/Singleton package family names
     // (e.g. L"-experimentalA" -> L"-eA"). versionTag arrives with a leading '-'.
     // Delegates to the canonical v2 derivation so the runtime, the DDLM/Bootstrap path,
-    // and the build (CreateBuildInfo.ps1) stay in agreement. See AB#63309642, AB#62727253.
+    // and the build (CreateBuildInfo.ps1) stay in agreement.
     std::wstring ExtractFormattedVersionTag(const std::wstring& versionTag)
     {
         if (versionTag.size() <= 1)

--- a/dev/Deployment/DeploymentManager.cpp
+++ b/dev/Deployment/DeploymentManager.cpp
@@ -86,6 +86,7 @@ namespace winrt::Microsoft::Windows::ApplicationModel::WindowsAppRuntime::implem
         {
             return {};
         }
+        // +1 skips the leading '-'; the v2 helper expects the bare tag.
         return L"-" + AppModel::Identity::GetVersionShortTagFromVersionTagV2(versionTag.c_str() + 1);
     }
 

--- a/specs/Deployment/MSIXPackages.md
+++ b/specs/Deployment/MSIXPackages.md
@@ -175,7 +175,7 @@ where
 * ReleaseMajor = project release major version number. See the [MSIX Package Versioning](https://github.com/microsoft/WindowsAppSDK/blob/main/specs/deployment/MSIXPackageVersioning.md) for more details.
 * ShortVersionTag = short form of the VersionTag
 
-ShortVersionTag is derived from a VersionTag by combining the 1st letter and up to the last 2 digit (depending on build number) for non-Stable channels (ShortVeresionTag is blank for the Stable channel, just like VersionTag).
+ShortVersionTag is derived from a VersionTag by combining the 1st letter and up to 2 trailing base-36 characters (0-9, A-Z) of the channel build string for non-Stable channels (ShortVeresionTag is blank for the Stable channel, just like VersionTag).
 
 ## 3.3. Package Naming - Singleton
 


### PR DESCRIPTION
## Summary
Follow-up to #6656 (which fixed the `experimentalA` -> `-eA` short-tag bug on `release/2.0-experimental` with a self-contained regex). This applies the cleaner fix on `main` per @JesseCol's review: instead of adding a third private copy of the short-tag rule, delegate to the canonical v2 helper that the DDLM/Bootstrap path already uses.

## Background
`DeploymentManager::ExtractFormattedVersionTag` re-derived the Main/Singleton short channel tag with its own rule that appended only a **numeric** suffix (`swscanf %u`). A **letter** suffix (the "A" in `experimentalA`) was dropped, so `GetStatus` built `...WinAppRuntime.Main.2-e_...` while the installed package is `...WinAppRuntime.Main.2-eA_...`, mis-detected the runtime as not installed, and forced a spurious repair that fails with access denied on Server 2019 / RS5 (~40s `AppLaunchWaiter` timeouts in the CppWinuiPackaged sample tests). Same root cause as [bug 63309642](https://microsoft.visualstudio.com/OS/_workitems/edit/63309642) / [bug 62727253](https://microsoft.visualstudio.com/OS/_workitems/edit/62727253).

## Change
- `ExtractFormattedVersionTag` now delegates to `AppModel::Identity::GetVersionShortTagFromVersionTagV2` (`dev/Common/AppModel.Identity.h`), the v2.x rule already used by `MddBootstrap.cpp`. It derives first-char + trailing base-36 `[0-9A-Z]{0,2}` suffix, which matches the build (`CreateBuildInfo.ps1`).
- Spec `specs/Deployment/MSIXPackages.md`: the short tag was described as "digits"; corrected to base-36 (0-9, A-Z).

## Why this over the regex in #6656
- **Removes duplication** rather than adding a fourth copy of the rule (build PS1, spec C#, v1 helper, v2 helper). One source of truth means the runtime can't drift from Bootstrap again.
- **Off the hot startup path**: `GetStatus` runs from the packaged-app auto-initializer before `wWinMain`; this drops `std::regex`/`swscanf` construction cost there.
- **Fails loud**: `GetVersionShortTagFromVersionTagV2` validates via `IsValidVersionShortTag` and throws `E_INVALIDARG` on a malformed tag instead of silently emitting a wrong short tag (the exact failure mode that was so hard to diagnose).

## Verification
`GetVersionShortTagFromVersionTagV2` produces identical output to #6656 and to the build across the tag table (`experimental`->`-e`, `experimental10`->`-e10`, `experimentalA`->`-eA`, `experimentalZ`->`-eZ`, `experimental1M`->`-e1M`, `preview3`->`-p3`, `stable`->`-s`). Caller passes the dash-prefixed tag (`substr(versionTagPos)`); the helper is called on the tag without the dash and the dash is re-prepended.

## Notes / follow-ups
- No repo test currently exercises `ExtractFormattedVersionTag` or the short-tag helpers. A parity unit test (runtime short-tag == build short-tag over a tag table) is worth adding but needs a TAEF home; deferring rather than bloating this PR.
- Branch coverage: `release/2.0-stable` still carries the old `swscanf` (no symptom today since it has no version tag, but a snap stable->experimental could reintroduce it). Recommend a defensive port there as well.

Bugs: [63309642](https://microsoft.visualstudio.com/OS/_workitems/edit/63309642), [62727253](https://microsoft.visualstudio.com/OS/_workitems/edit/62727253)

*Investigation and change drafted by an AI assistant on behalf of @agniuks; review feedback incorporated from @JesseCol.*
