### PR TITLE
Add 2.3.3 runtime compatibility enums

### DIFF
--- a/dev/RuntimeCompatibilityOptions/RuntimeCompatibilityOptions.cpp
+++ b/dev/RuntimeCompatibilityOptions/RuntimeCompatibilityOptions.cpp
@@ -174,7 +174,7 @@ namespace
         63096865, // InputPointerSource_OSHaptics
         63098302, // WindowsAppRuntime_BaseDirectoryIsolation
         63264582, // AppContentSearchNewAPI_LafCheck
-        63293066, // LanguageModelLanguageDetectionStatus
+        63293066, // LanguageModel_LanguageDetectionStatus
     };
     constexpr CatalogGroup s_catalogGroupsProd[] = {
         MakeGroup(s_changes_2_1_0, WinAppSDKReleaseVersion::WinAppSDK_2_1_0),

--- a/dev/RuntimeCompatibilityOptions/RuntimeCompatibilityOptions.cpp
+++ b/dev/RuntimeCompatibilityOptions/RuntimeCompatibilityOptions.cpp
@@ -54,6 +54,7 @@ namespace
         WinAppSDK_2_1_0 = WinAppSDKReleaseVersionFromValues(2, 1, 0),
         WinAppSDK_2_1_5 = WinAppSDKReleaseVersionFromValues(2, 1, 5),
         WinAppSDK_2_3_0 = WinAppSDKReleaseVersionFromValues(2, 3, 0),
+        WinAppSDK_2_3_3 = WinAppSDKReleaseVersionFromValues(2, 3, 3),
         WinAppSDK_Latest = 999999999,
         WinAppSDK_Security = 0,
     };
@@ -166,10 +167,20 @@ namespace
         62927180, // WindowsServices_GetKeyboardModifiersStateRace
         62934326, // VideoSuperResolution_HardwareDetection
     };
+    constexpr UINT32 s_changes_2_3_3[] = {
+        62785439, // InputPointerSource_DepartingScrollInputCrashFix
+        63006068, // StoragePickers_RestoreFocusAfterDialogCloses
+        63048673, // ResourceManager_RestoreDefaultFallbackPath
+        63096865, // InputPointerSource_OSHaptics
+        63098302, // WindowsAppRuntime_BaseDirectoryIsolation
+        63264582, // AppContentSearchNewAPI_LafCheck
+        63293066, // LanguageModelLanguageDetectionStatus
+    };
     constexpr CatalogGroup s_catalogGroupsProd[] = {
         MakeGroup(s_changes_2_1_0, WinAppSDKReleaseVersion::WinAppSDK_2_1_0),
         MakeGroup(s_changes_2_1_5, WinAppSDKReleaseVersion::WinAppSDK_2_1_5),
         MakeGroup(s_changes_2_3_0, WinAppSDKReleaseVersion::WinAppSDK_2_3_0),
+        MakeGroup(s_changes_2_3_3, WinAppSDKReleaseVersion::WinAppSDK_2_3_3),
     };
     constexpr size_t s_catalogGroupsProdCount{ std::size(s_catalogGroupsProd) };
 

--- a/dev/RuntimeCompatibilityOptions/RuntimeCompatibilityOptions.idl
+++ b/dev/RuntimeCompatibilityOptions/RuntimeCompatibilityOptions.idl
@@ -91,7 +91,7 @@ namespace Microsoft.Windows.ApplicationModel.WindowsAppRuntime
         InputPointerSource_OSHaptics = 63096865,
         WindowsAppRuntime_BaseDirectoryIsolation = 63098302,
         AppContentSearchNewAPI_LafCheck = 63264582,
-        LanguageModelLanguageDetectionStatus = 63293066,
+        LanguageModel_LanguageDetectionStatus = 63293066,
     };
 
     /// Represents a version of the Windows App Runtime.

--- a/dev/RuntimeCompatibilityOptions/RuntimeCompatibilityOptions.idl
+++ b/dev/RuntimeCompatibilityOptions/RuntimeCompatibilityOptions.idl
@@ -83,6 +83,15 @@ namespace Microsoft.Windows.ApplicationModel.WindowsAppRuntime
         CompositionEngine_API = 62917618,
         WindowsServices_GetKeyboardModifiersStateRace = 62927180,
         VideoSuperResolution_HardwareDetection = 62934326,
+
+        // 2.3.3
+        InputPointerSource_DepartingScrollInputCrashFix = 62785439,
+        StoragePickers_RestoreFocusAfterDialogCloses = 63006068,
+        ResourceManager_RestoreDefaultFallbackPath = 63048673,
+        InputPointerSource_OSHaptics = 63096865,
+        WindowsAppRuntime_BaseDirectoryIsolation = 63098302,
+        AppContentSearchNewAPI_LafCheck = 63264582,
+        LanguageModelLanguageDetectionStatus = 63293066,
     };
 
     /// Represents a version of the Windows App Runtime.


### PR DESCRIPTION
A microsoft employee must use /azp run to validate using the pipelines below.

WARNING:
Comments made by azure-pipelines bot maybe inaccurate.
Please see pipeline link to verify that the build is being ran.

For status checks on the main branch, please use TransportPackage-Foundation-PR
(https://microsoft.visualstudio.com/ProjectReunion/_build?definitionId=81063&_a=summary)
and run the build against your PR branch with the default parameters.