### PR TITLE
Refactor DefPointerList with compliant C++

### DIFF
--- a/dev/MRTCore/mrt/mrm/include/mrm/build/DefList.h
+++ b/dev/MRTCore/mrt/mrm/include/mrm/build/DefList.h
@@ -560,6 +560,8 @@ private:
 template<typename VALUE, typename CallBackCompareFunc = VoidComparerFunc, typename CallbackHashFunc = VoidHashFunc>
 class DefPointerList : public DefList<VALUE*, CallBackCompareFunc, CallbackHashFunc>
 {
+private:
+    using Base = DefList<VALUE*, CallBackCompareFunc, CallbackHashFunc>;
 public:
     static HRESULT CreateInstance(_Outptr_ DefPointerList<VALUE, CallBackCompareFunc, CallbackHashFunc>** result)
     {
@@ -607,10 +609,10 @@ public:
 
     virtual ~DefPointerList()
     {
-        for (int i = 0; i < DefList::Count(); i++)
+        for (int i = 0; i < Base::Count(); i++)
         {
             const VALUE* pMember = nullptr;
-            if (TryGetValue(i, &pMember))
+            if (Base::TryGetValue(i, &pMember))
             {
                 delete (pMember);
             }


### PR DESCRIPTION
Use qualified names when accessing template parent class members.

This allows MRTCore to be compiled with Clang on MinGW.

A microsoft employee must use /azp run to validate using the pipelines below.

WARNING:
Comments made by azure-pipelines bot maybe inaccurate.
Please see pipeline link to verify that the build is being ran.

For status checks on the main branch, please use TransportPackage-Foundation-PR
(https://microsoft.visualstudio.com/ProjectReunion/_build?definitionId=81063&_a=summary)
and run the build against your PR branch with the default parameters.
