### PR TITLE
Remove unnecessary explicit override

### DIFF
--- a/dev/MRTCore/mrt/mrm/include/mrm/build/MrmBuilders.h
+++ b/dev/MRTCore/mrt/mrm/include/mrm/build/MrmBuilders.h
@@ -1432,7 +1432,7 @@ public:
         _In_ const HierarchicalSchemaSectionBuilder* linkToSchema,
         _In_ PCWSTR linkToResourceName);
 
-    virtual HierarchicalSchemaSectionBuilder* IResourceLinkBuilder::GetSchema() const { return m_pPrimarySchema; }
+    virtual HierarchicalSchemaSectionBuilder* GetSchema() const { return m_pPrimarySchema; }
 
     ~PriSectionBuilder();
 


### PR DESCRIPTION
Since `IResourceLinkBuilder` is the only base of `PriSectionBuilder` that defines `GetSchema()`, the explicit qualifier is redundant.

Removing this MSVC-specific feature also allows MRTCore to be built with Clang and MinGW.

A microsoft employee must use /azp run to validate using the pipelines below.

WARNING:
Comments made by azure-pipelines bot maybe inaccurate.
Please see pipeline link to verify that the build is being ran.

For status checks on the main branch, please use TransportPackage-Foundation-PR
(https://microsoft.visualstudio.com/ProjectReunion/_build?definitionId=81063&_a=summary)
and run the build against your PR branch with the default parameters.
