### PR TITLE
[MonoBuild 2.0-stable] Fix VSIX build: repoint dev/Templates/VSIX -> dev/VSIX

### DIFF
--- a/build/AzurePipelinesTemplates/WindowsAppSDK-BuildVSIX-Steps.yml
+++ b/build/AzurePipelinesTemplates/WindowsAppSDK-BuildVSIX-Steps.yml
@@ -134,7 +134,7 @@ steps:
 - task: VSBuild@1
   displayName: 'Restore WindowsAppSDK.Extension.sln'
   inputs:
-    solution: $(FoundationRepoPath)dev\Templates\VSIX\WindowsAppSDK.Extension.sln
+    solution: $(FoundationRepoPath)dev\VSIX\WindowsAppSDK.Extension.sln
     platform: 'Any CPU'
     configuration: '$(buildConfiguration)'
     msBuildArgs: '/t:restore /p:OptionalVSIXVersion="${{ parameters.OptionalVSIXVersion }}" /p:WindowsAppSDKVersion="$(WindowsAppSDKPackageVersion)" /p:RestoreAdditionalProjectSources="$(System.ArtifactsDirectory)" /p:EnableExperimentalVSIXFeatures="${{ parameters.EnableExperimentalVSIXFeatures }}" /binaryLogger:$(ob_outputDirectory)\binlogs\StandaloneVSIX.restore.binlog'
@@ -142,7 +142,7 @@ steps:
 - task: VSBuild@1
   displayName: 'Build Standalone WindowsAppSDK.Extension.sln'
   inputs:
-    solution: $(FoundationRepoPath)dev\Templates\VSIX\WindowsAppSDK.Extension.sln
+    solution: $(FoundationRepoPath)dev\VSIX\WindowsAppSDK.Extension.sln
     platform: 'Any CPU'
     configuration: '$(buildConfiguration)'
     msBuildArgs: '/p:OptionalVSIXVersion="${{ parameters.OptionalVSIXVersion }}" /p:WindowsAppSDKVersion="$(WindowsAppSDKPackageVersion)" /p:EnableExperimentalVSIXFeatures="${{ parameters.EnableExperimentalVSIXFeatures }}" /binaryLogger:$(ob_outputDirectory)\binlogs\StandaloneVSIX.build.binlog'
@@ -168,7 +168,7 @@ steps:
 - task: VSBuild@1
   displayName: 'Restore Component WindowsAppSDK.Extension.sln'
   inputs:
-    solution: $(FoundationRepoPath)dev\Templates\VSIX\WindowsAppSDK.Extension.sln
+    solution: $(FoundationRepoPath)dev\VSIX\WindowsAppSDK.Extension.sln
     platform: 'Any CPU'
     configuration: '$(buildConfiguration)'
     msBuildArgs: '/t:restore /p:OptionalVSIXVersion="${{ parameters.OptionalVSIXVersion }}" /p:WindowsAppSDKVersion="$(WindowsAppSDKPackageVersion)" /p:RestoreAdditionalProjectSources="$(System.ArtifactsDirectory)" /p:EnableExperimentalVSIXFeatures="${{ parameters.EnableExperimentalVSIXFeatures }}" /binaryLogger:$(ob_outputDirectory)\binlogs\ComponentVSIX.restore.binlog' 
@@ -176,7 +176,7 @@ steps:
 - task: VSBuild@1
   displayName: 'Build Component WindowsAppSDK.Extension.sln'
   inputs:
-    solution: $(FoundationRepoPath)dev\Templates\VSIX\WindowsAppSDK.Extension.sln
+    solution: $(FoundationRepoPath)dev\VSIX\WindowsAppSDK.Extension.sln
     platform: 'Any CPU'
     configuration: '$(buildConfiguration)'
     msBuildArgs: '/restore /p:OptionalVSIXVersion="${{ parameters.OptionalVSIXVersion }}" /p:WindowsAppSDKVersion="$(WindowsAppSDKPackageVersion)" /p:EnableExperimentalVSIXFeatures="${{ parameters.EnableExperimentalVSIXFeatures }}" /p:Deployment="Component" /binaryLogger:$(ob_outputDirectory)\binlogs\ComponentVSIX.build.binlog'
@@ -209,7 +209,7 @@ steps:
   - task: CopyFiles@2
     displayName: 'Stage unsigned VSIX files for publishing'
     inputs:
-      SourceFolder: '$(FoundationRepoPath)dev\Templates\VSIX\BuildOutput\obj\AnyCPU$(buildConfiguration)'
+      SourceFolder: '$(FoundationRepoPath)dev\VSIX\BuildOutput\obj\AnyCPU$(buildConfiguration)'
       Contents: '**/WindowsAppSDK.*.vsix'
       flattenFolders: true
       TargetFolder: '$(ob_outputDirectory)\VSIX'
@@ -218,7 +218,7 @@ steps:
   - task: CopyFiles@2
     displayName: 'Stage unsigned VSIX files for signing'
     inputs:
-      SourceFolder: '$(FoundationRepoPath)dev\Templates\VSIX\BuildOutput\obj\AnyCPU$(buildConfiguration)'
+      SourceFolder: '$(FoundationRepoPath)dev\VSIX\BuildOutput\obj\AnyCPU$(buildConfiguration)'
       Contents: '**/WindowsAppSDK.*.vsix'
       flattenFolders: true
       TargetFolder: '$(Agent.TempDirectory)/UnsignedVSIX'
@@ -242,13 +242,13 @@ steps:
   parameters:
     IsMonobuild: ${{ parameters.IsMonobuild }}
     InnerParams:
-      SearchPattern: '$(FoundationRepoPath)dev\Templates\VSIX\BuildOutput\obj\AnyCPU$(buildConfiguration)\**\WindowsAppSDK*.pdb'
+      SearchPattern: '$(FoundationRepoPath)dev\VSIX\BuildOutput\obj\AnyCPU$(buildConfiguration)\**\WindowsAppSDK*.pdb'
       IsOfficial: ${{ parameters.IsOfficial }}
 
 - task: CopyFiles@2
   displayName: 'Stage VSIX component JSONs'
   inputs:
-    SourceFolder: '$(FoundationRepoPath)dev\Templates\VSIX\BuildOutput\obj\AnyCPU$(buildConfiguration)'
+    SourceFolder: '$(FoundationRepoPath)dev\VSIX\BuildOutput\obj\AnyCPU$(buildConfiguration)'
     Contents: '**/WindowsAppSDK*.pdb'
     flattenFolders: true
     TargetFolder: '$(ob_outputDirectory)\symbols'
@@ -256,7 +256,7 @@ steps:
 - task: CopyFiles@2
   displayName: 'Stage VSIX component JSONs'
   inputs:
-    SourceFolder: '$(FoundationRepoPath)dev\Templates\VSIX\BuildOutput\obj\AnyCPU$(buildConfiguration)'
+    SourceFolder: '$(FoundationRepoPath)dev\VSIX\BuildOutput\obj\AnyCPU$(buildConfiguration)'
     Contents: '**/WindowsAppSDK.*.Component.json'
     flattenFolders: true
     TargetFolder: '$(ob_outputDirectory)'
@@ -264,7 +264,7 @@ steps:
 - task: CopyFiles@2
   displayName: 'Stage VSIX manifest'
   inputs:
-    SourceFolder: '$(FoundationRepoPath)dev\Templates\VSIX'
+    SourceFolder: '$(FoundationRepoPath)dev\VSIX'
     Contents: 'extension.manifest.json'
     flattenFolders: true
     TargetFolder: '$(ob_outputDirectory)'
@@ -272,7 +272,7 @@ steps:
 - task: CopyFiles@2
   displayName: 'Stage VSIX overview markdown'
   inputs:
-    SourceFolder: '$(FoundationRepoPath)dev\Templates\VSIX'
+    SourceFolder: '$(FoundationRepoPath)dev\VSIX'
     Contents: 'overview.md'
     flattenFolders: true
     TargetFolder: '$(ob_outputDirectory)'


### PR DESCRIPTION
## Summary
Fixes the `CreateVSIX` stage failure on the 2.0-stable mono-build:
`MSBUILD : error MSB1009: Project file does not exist. Switch: ...\dev\Templates\VSIX\WindowsAppSDK.Extension.sln`.

## Root cause
`build/AzurePipelinesTemplates/WindowsAppSDK-BuildVSIX-Steps.yml` was ported verbatim from `release/dev/monobuild` (#6645), which uses main''s reorganized **`dev/Templates/VSIX/`** layout. On **`release/dev/monobuild-2.0-stable`** the VSIX source still lives at **`dev/VSIX/`** (the `release/2.0-stable` layout), so the ported Restore/Build/Stage steps looked in `dev\Templates\VSIX\` where the `.sln` does not exist on this branch -> `MSB1009`.

- main: `dev/Templates/VSIX/` present, `dev/VSIX/` absent
- 2.0-stable: `dev/VSIX/` present (`WindowsAppSDK.Extension.sln`, `Extension/`, `ItemTemplates/`, `ProjectTemplates/`, `Shared/`, `extension.manifest.json`, ...), `dev/Templates/VSIX/` absent

## Change
Repoint all **11** `solution:` / `SourceFolder:` / `SearchPattern:` references from `dev\Templates\VSIX\` -> `dev\VSIX\`. No source is moved; the change is confined to this pipeline template and scoped to this branch. `release/dev/monobuild` is unaffected.

## Validation
To be validated by a full 2.0-stable mono-build (def 190463) reaching the `CreateVSIX` stage.
