### PR TITLE
[2.0-stable] Fix CS0234 in UndockedRegFreeWinRT auto-initializer (qualify System.Globalization with global::) 

### DIFF
--- a/dev/UndockedRegFreeWinRT/UndockedRegFreeWinRT-AutoInitializer.cs
+++ b/dev/UndockedRegFreeWinRT/UndockedRegFreeWinRT-AutoInitializer.cs
@@ -33,7 +33,7 @@ namespace Microsoft.Windows.Foundation.UndockedRegFreeWinRTCS
             // being steered to read files from a parent-controlled directory).
             // See https://github.com/microsoft/WindowsAppSDK/issues/5987.
             Environment.SetEnvironmentVariable("MICROSOFT_WINDOWSAPPRUNTIME_BASE_DIRECTORY_PID",
-                Environment.ProcessId.ToString(System.Globalization.CultureInfo.InvariantCulture));
+                Environment.ProcessId.ToString(global::System.Globalization.CultureInfo.InvariantCulture));
 
             // No error handling needed as the target function does nothing (just {return S_OK}).
             // It's the act of calling the function causing the DllImport to load the DLL that


### PR DESCRIPTION
## Problem
Build `TransportPackage-Foundation-Official` on `release/2.0-stable` (2.3.8-stable, [buildId 153733386](https://microsoft.visualstudio.com/ProjectReunion/_build/results?buildId=153733386&view=results)) fails: **every C# sample** in the `Build all Sample solutions` stage errors with:

```
UndockedRegFreeWinRT-AutoInitializer.cs(36,48): error CS0234:
The type or namespace name 'Globalization' does not exist in the namespace 'Microsoft.Windows.System'
```

## Root cause
`dev/UndockedRegFreeWinRT/UndockedRegFreeWinRT-AutoInitializer.cs` ships in the Foundation nuget and is `<Compile>`-injected into consumer apps under `namespace Microsoft.Windows.Foundation.UndockedRegFreeWinRTCS`. Those apps also reference the `Microsoft.Windows.System` namespace (EnvironmentManager / PowerManager). C# resolves the leading `System` of `System.Globalization.CultureInfo` against the nearest enclosing namespace, finds `Microsoft.Windows.System`, and fails to locate `Globalization` there -> CS0234. (`using System;` does not help; it only affects simple-name lookup, not the leading token of a qualified name.)

The offending line was introduced by the gated servicing port #6632 (base-directory child-process isolation, #5987), which inlined the base-directory PID stamping into this file **without** the `global::` qualifier.

## Fix
Qualify with `global::System.Globalization.CultureInfo.InvariantCulture` so it always binds to the BCL `System`. IL is unchanged; this is a name-resolution-only fix.

## Precedent
This is the direct servicing backport of **#6633** (commit 37de5653), which fixed the **identical** CS0234 on `main` (`WindowsAppRuntimeBaseDirectoryAutoInitializer.cs(32,48)`). The `main` nightly went red Jul 16 and green from Jul 18 onward once #6633 merged; it has stayed green through Aug 2.
