### PR TITLE
 [1.8-stable] Fix CS0234 in UndockedRegFreeWinRT auto-initializer (qualify System.Globalization with global::)

### DIFF
--- a/dev/UndockedRegFreeWinRT/UndockedRegFreeWinRT-AutoInitializer.cs
+++ b/dev/UndockedRegFreeWinRT/UndockedRegFreeWinRT-AutoInitializer.cs
@@ -33,7 +33,7 @@ namespace Microsoft.Windows.Foundation.UndockedRegFreeWinRTCS
             // being steered to read files from a parent-controlled directory).
             // See https://github.com/microsoft/WindowsAppSDK/issues/5987.
             Environment.SetEnvironmentVariable("MICROSOFT_WINDOWSAPPRUNTIME_BASE_DIRECTORY_PID",
-                Environment.ProcessId.ToString(System.Globalization.CultureInfo.InvariantCulture));
+                Environment.ProcessId.ToString(global::System.Globalization.CultureInfo.InvariantCulture));
 
             // No error handling needed as the target function does nothing (just {return S_OK}).
             // It's the act of calling the function causing the DllImport to load the DLL that


### PR DESCRIPTION
## Problem
`dev/UndockedRegFreeWinRT/UndockedRegFreeWinRT-AutoInitializer.cs` on `release/1.8-stable` carries a latent CS0234 that breaks any C# app consuming the Foundation package with undocked reg-free WinRT auto-init enabled:

```
UndockedRegFreeWinRT-AutoInitializer.cs(36,48): error CS0234:
The type or namespace name 'Globalization' does not exist in the namespace 'Microsoft.Windows.System'
```

Note: the 1.8-stable `TransportPackage-Foundation-Official` pipeline has **no sample-build stage**, so this is not caught by CI here, but it is byte-identical to the 2.0-stable break (see companion PR #6669) and ships broken to consumers.

## Root cause
The file is `<Compile>`-injected into consumer apps under `namespace Microsoft.Windows.Foundation.UndockedRegFreeWinRTCS`. The unqualified leading `System` in `System.Globalization.CultureInfo` binds to the SDK's `Microsoft.Windows.System` namespace (nearest enclosing scope) instead of the BCL `System` -> CS0234. Introduced by the gated servicing port #6631 (base-directory child-process isolation, #5987), which inlined the base-directory PID stamping without `global::`.

## Fix
Qualify with `global::System.Globalization.CultureInfo.InvariantCulture`. IL is unchanged; name-resolution-only fix.

## Precedent
Direct servicing backport of **#6633** (commit 37de5653), which fixed the identical CS0234 on `main`. Companion 2.0-stable fix: #6669.
