### PR TITLE
Fix missing CodeQL javascript snapshot by disabling CodeQL on arm64 test legs

### DIFF
--- a/build/AzurePipelinesTemplates/WindowsAppSDK-RunTestsInPipeline-Job.yml
+++ b/build/AzurePipelinesTemplates/WindowsAppSDK-RunTestsInPipeline-Job.yml
@@ -50,6 +50,25 @@ jobs:
     # at Microsoft.Guardian.ResponseFileManager.CreateResponseFile(IList`1 arguments, String formatterName, ResponseFileOptions options, String outputPathOverride)
     # at Microsoft.Guardian.CliAnalyzerResponseFileManager.SetupResponseFile(CliAnalyzerConfig analyzeConfig, ToolConfig toolConfig)
     ob_sdl_binskim_enabled: false
+    # Disable CodeQL on the arm64 test images only (AB#63506192).
+    #
+    # The CodeQL service accepts a single upload job per (repository, commit, language), so every job that
+    # has the CodeQL 3000 tasks auto-injected races to claim each detected language. On the arm64 test
+    # images the CodeQL Windows tracer cannot inject into the parent process, and 'codeql database init'
+    # fails outright:
+    #
+    #   A fatal error occurred: Injecting Windows tracer failed [exit code: 0] with message: Could not inject into parent.
+    #   ##[warning]Database failed to initialize!
+    #
+    # Because init is invoked once for all detected languages as a single --db-cluster with --begin-tracing
+    # (required by cpp/csharp), that failure fails *every* language in the cluster - including javascript,
+    # which needs no build tracing at all. When an arm64 leg wins the race for 'javascript' the claim is
+    # released without a database, the real producers are then told the upload is "redundant", and no
+    # javascript snapshot is produced for that commit at all.
+    #
+    # The x64/x86 legs of this same template are the primary producers of the javascript, csharp and
+    # powershell snapshots, so CodeQL is deliberately left enabled for them. See https://aka.ms/codeql3000-faq
+    Codeql.Enabled: $[ iif(eq(variables['buildPlatform'], 'arm64'), 'false', 'true') ]
   steps:
     - checkout: self
       path: s


### PR DESCRIPTION
Fixes the S360 `[SFI-PS2.1] Continuous SDL` -> `CodeQL.Uploading` action item [AB#63506192](https://dev.azure.com/microsoft/OS/_workitems/edit/63506192):

> "A CodeQL snapshot for repository `ado:microsoft/projectreunion/windowsappsdk` and language **`javascript`** must be produced by the Due Date." (due 2026-08-18)

## Why javascript is in scope

#6158 added `tools/mcp/github-artifacts` (6 `.js` files) - the only JavaScript in the repo. CodeQL correctly detects it:

```
javascript: Supported. Artifacts: code: 6, ignored: 0
Detected languages: cpp,csharp,powershell,javascript,actions
```

## Root cause

The CodeQL service accepts **one upload job per (repository, commit, language)**, so every job that has the CodeQL 3000 tasks auto-injected **races** to claim each detected language. A single nightly has **64** CodeQL task records across ~30 jobs.

On the **arm64** test images the CodeQL Windows tracer cannot inject into the parent process, so `codeql database init` fails outright:

```
A fatal error occurred: Injecting Windows tracer failed [exit code: 0] with message: Could not inject into parent.
##[warning]Database failed to initialize!
|javascript | failed | Database failed to initialize! |
```

Init is invoked **once for all detected languages** as a single `--db-cluster` with `--begin-tracing` (required by cpp/csharp), so that tracer failure fails **every** language in the cluster - including `javascript`, which needs no build tracing at all. The claim is then released without a database, the real producers are told the upload is "redundant", and no snapshot lands for that commit. The Finalize task confirms it:

```
CodeQL Init task ended without creating database, exiting...
```

Because it is a race it is intermittent, which is why it went unnoticed. Nightly on `main`:

| Build | Date | Languages uploaded |
|---|---|---|
| 152534661 | 7/19 | javascript |
| 152731647 | 7/22 | actions, csharp, javascript, powershell |
| 153077460 | 7/26 | **none** - all 8 javascript claimants were arm64 legs |
| 153493099 | 7/30 | actions, csharp, javascript, powershell |
| 153706287 | 8/2 | **none** |
| 154333949 | 8/10 | **actions only** - all 8 javascript claimants were arm64 legs |

Compounding this, a scan is not re-accepted for the **same commit for 24 days**, and `main` has been pinned at `ee3c5078` since 7/30 - so the misses cannot self-heal and the gap keeps widening toward the due date.

## The fix

One additive variable in the shared test job template, keyed off the matrix `buildPlatform`:

```yaml
Codeql.Enabled: $[ iif(eq(variables['buildPlatform'], 'arm64'), 'false', 'true') ]
```

This mirrors the `ob_sdl_binskim_enabled: false` precedent already in this file ("we currently don't build any code here, but only run tests") - CodeQL was simply never given the same treatment.

### Scoped to arm64 only, deliberately

I first drafted this as a blanket disable for the whole template, then checked which jobs actually produce successful uploads before committing. The **x64/x86 legs of this same template are the primary producers** of the javascript, csharp and powershell snapshots:

```
CheckApiChanges                             -> javascript,powershell
PipelineTests   Server25_DC_x64fre          -> csharp,javascript,powershell
TestSamplesX64  Win11_25H2_Ent_x64fre       -> csharp,javascript,powershell
PipelineTests   Win10_Ent_LTSC_2021_x64chk  -> csharp,javascript,powershell
StaticValidationTest                        -> csharp,javascript,powershell
... (~20 more x64 legs)
```

The compiled-language build jobs (`BuildFoundation`, `BuildMRT`) claim `cpp` during their MSBuild trace; the non-compiled languages get picked up by these lighter x64 jobs. **Disabling the template wholesale would have removed the main javascript producer and made compliance worse, not better.** Only the arm64 legs - which can never succeed - are skipped.

Verified in `WindowsAppSDK-Foundation-TestConfig.yml` that every arm64 matrix leg carries `buildPlatform: 'arm64'` (and `poolName: 'WinAppSDK-Test-Pool-Arm64'`), so the key is reliable.

## Validation

- YAML parses cleanly.
- Azure Pipelines **Preview API** against `TransportPackage-Foundation-Nightly (OneBranch)` (117346) on this branch compiles the full graph (990,245 char `finalYaml`) - **no build queued**.
- The expanded YAML confirms the variable lands on exactly the intended jobs and nothing else: `PipelineTests` (x3 stages), `TestSamplesX64`, `TestSamplesArm64` and their OneBranch `post*` jobs.
- Uses `iif(...)` returning literal lowercase `'true'`/`'false'` rather than a bare `ne()` (which renders `True`/`False`) so it matches exactly what the CodeQL 3000 task parses.

## Expected result

With the arm64 legs no longer claiming and dropping languages, the x64 legs reliably win `javascript` again (as they did on 7/19, 7/22 and 7/30). The next nightly Finalize CodeQL log should show `|javascript | database uploaded |`. S360 clears after analysis plus the documented ~48h ingestion latency. Merging this also moves `main` off `ee3c5078`, which conveniently resets the 24-day same-commit block.

## Notes for reviewers

- **Optional follow-up, deliberately not included:** full determinism would mean pinning `Codeql.Language` per job (plus `Codeql.BuildIdentifier` for the multi-job pattern in the CodeQL FAQ) so nothing races at all. I left that out because `cpp`/`csharp` are currently compliant and I did not want to risk destabilising them in a fix targeted at `javascript`. `Codeql.BuildIdentifier` in particular changes the tracking identity on the CodeQL service side, which deserves its own change and validation.
- The 6 `.js` files are dev-only MCP tooling, so removing them from the repo would also retire the requirement. Given #6578 was a real `GITHUB_TOKEN` leak fix in that exact code, scanning it seems the better call. Note it cannot simply be excluded via `Codeql.ExcludePathPatterns` - the language inventory is driven by repo content, so that yields an empty database rather than compliance.

Refs: AB#63506192