### PR TITLE
Update review prompts for GitHub MCP migration

### DIFF
--- a/.github/prompts/review-issue.prompt.md
+++ b/.github/prompts/review-issue.prompt.md
@@ -37,13 +37,6 @@ If the user chooses to proceed without MCP:
 ## Inputs
 Figure out required inputs {{issue_number}} from the invocation context; if anything is missing, ask for the value or note it as a gap.
 
-## When to call MCP tools (github-artifacts)
-If the MCP "github-artifacts" tools are available in the environment, use them:
-- `github_issue_images`: use when the issue likely contains screenshots or other visual evidence (UI bugs, layout glitches, design problems).
-- `github_issue_attachments`: use when the issue mentions attached ZIPs or diagnostic bundles (for example, `*.zip`, `logs.zip`, `debug.zip`). Always provide `extractFolder` as `Generated Files/issueReview/{{issue_number}}/logs`.
-
-If these tools are not available, ensure the `github-artifacts` MCP server is started and available, then retry.
-
 ## Fetch Issue Data with GitHub MCP
 
 ### Core issue information
@@ -66,7 +59,7 @@ Use `github-pull-request_renderIssues`:
 - Pass array of issues to render as markdown table for display
 
 # CONTEXT (brief)
-Use the MCP tools above to gather issue data. Download images via MCP `github_issue_images` to better understand the issue context. Finally, use MCP `github_issue_attachments` to download logs with parameter `extractFolder` as `Generated Files/issueReview/{{issue_number}}/logs`, and analyze the downloaded logs if available to identify relevant issues. Locate source code in the current workspace; feel free to use `rg`/`git grep`. Link related issues and PRs.
+Use the GitHub MCP tools or `gh` CLI fallback above to gather issue data. Use Copilot's standard web, file, and execution tools to review images or attached logs when needed. Store extracted diagnostic files under `Generated Files/issueReview/{{issue_number}}/logs`. Locate source code in the current workspace; feel free to use `rg`/`git grep`. Link related issues and PRs.
 
 # OVERVIEW.MD
 ## Summary

--- a/.github/prompts/review-pr.prompt.md
+++ b/.github/prompts/review-pr.prompt.md
@@ -16,12 +16,8 @@ Use whatever GitHub MCP/API tools are available to fetch PR details. Common tool
 
 **Just try calling one of these tools** to get PR info for PR #6130 (or the PR from context). The call will either succeed or fail - that tells you which tools work.
 
-## Issue/PR artifacts (github-artifacts MCP)
-If the MCP "github-artifacts" tools are available in the environment, use them to pull supporting evidence linked from the PR or linked issues:
-- `github_issue_images`: use when linked issues or PR discussion include screenshots (UI bugs, layout, design).
-- `github_issue_attachments`: use when linked issues mention attached ZIPs or diagnostic bundles. Always provide `extractFolder` as `Generated Files/prReview/{{pr_number}}/issue-artifacts/<issue_number>`.
-
-If these tools are not available, ensure the `github-artifacts` MCP server is started and available, then retry.
+## Issue/PR artifacts
+Use Copilot's standard web, file, and execution tools to review screenshots or ZIP attachments linked from the PR or related issues when relevant. Store extracted issue artifacts under `Generated Files/prReview/{{pr_number}}/issue-artifacts/<issue_number>`.
 
 ## PR selection
 Resolve the target PR using these fallbacks in order:


### PR DESCRIPTION
## Summary

Complete the GitHub MCP migration in #6684 by updating the issue and pull request review prompts that still referenced the removed `github-artifacts` helper.

- Use the existing GitHub MCP or `gh` fallback for issue metadata.
- Use Copilot's standard web, file, and execution tools for linked images and ZIP attachments.
- Preserve the existing artifact output locations under `Generated Files`.

## Validation

- Ran `git diff --check`.
- Confirmed no references to `github-artifacts`, `github_issue_images`, or `github_issue_attachments` remain.
- Prompt-only change; build and automated tests are not applicable.

This PR intentionally targets the branch for #6684 so the prompt migration ships with the MCP removal.
