### PR TITLE
Bump VSIX build .NET SDK to 10.0.111 (security release)

### DIFF
--- a/build/AzurePipelinesTemplates/WindowsAppSDK-BuildVSIX-Steps.yml
+++ b/build/AzurePipelinesTemplates/WindowsAppSDK-BuildVSIX-Steps.yml
@@ -123,10 +123,10 @@ steps:
       Exit 1
 
 - task: UseDotNet@2
-  displayName: 'Use .NET SDK 10.0.110'
+  displayName: 'Use .NET SDK 10.0.111'
   inputs:
     packageType: 'sdk'
-    version: '10.0.110'
+    version: '10.0.111'
 
 - task: NuGetAuthenticate@1
 

--- a/global.json
+++ b/global.json
@@ -1,8 +1,4 @@
 {
-  "sdk": {
-    "version": "10.0.111",
-    "rollForward": "latestMinor"
-  },
   "tools": {
     "dotnet": "6.0.425"
   },

--- a/global.json
+++ b/global.json
@@ -1,4 +1,8 @@
 {
+  "sdk": {
+    "version": "10.0.111",
+    "rollForward": "latestMinor"
+  },
   "tools": {
     "dotnet": "6.0.425"
   },


### PR DESCRIPTION
## What this does

Bumps the VSIX build's .NET SDK **10.0.110 -> 10.0.111**, picking up the August 2026 security release.

| SDK (`1xx` band) | Runtime | Released | Security | |
|---|---|---|---|---|
| `10.0.110` | 10.0.10 | 2026-07-14 | :white_check_mark: | current |
| **`10.0.111`** | **10.0.11** | **2026-08-11** | :white_check_mark: | **this PR** |

`10.0.111` ships in release `10.0.11`, which fixes 10 CVEs: CVE-2026-62871, -62886, -62897, -62898, -62899, -62900, -62901, -62902, -62909, -70354.

It stays in the `1xx` feature band already used here, avoiding unrelated MSBuild/SDK/analyzer behavior changes from a feature-band jump (`latest-sdk` is currently `10.0.400`). Confirmed against the [official .NET release metadata](https://dotnetcli.blob.core.windows.net/dotnet/release-metadata/10.0/releases.json). Follows up #6624.

## CG alert 9903532

The `UseDotNet@2` task in this template is the **only** place the repo installs a .NET 10 SDK -- `10.0.110` is the sole .NET 10 version string in the tree. Per the [CG .NET detector docs](https://github.com/microsoft/component-detection/blob/main/docs/detectors/dotnet.md) the detector reports the SDK *actually selected* by `dotnet --version`, which in the `BuildVSIX` job is exactly what this task installed. So this bump is expected to clear the S360 `DOTNET-Security-10.0` alert (ADO 63646026, due 2026-08-26).

## Scope change

This PR originally also added an `sdk` pin to the root `global.json`. **That change has been removed** -- it broke 10 CI jobs and is not needed to address the alert.

<details>
<summary>Why the root pin failed</summary>

A root `global.json` `sdk` block is a repo-wide **floor** for every `dotnet`/MSBuild invocation beneath it. Only BuildVSIX installs .NET 10; Foundation/MRT/PREfast use `WindowsAppSDK-SetupBuildEnvironment-Steps.yml`, which installs only **6.0.414** -- matched to the shipping `net6.0` / `net6.0-windows10.0.19041.0` TFMs (`Microsoft.WindowsAppRuntime.Bootstrap.Net`). `rollForward` rolls forward only, never backward across majors:

```
Requested SDK version: 10.0.111
Installed SDKs: 6.0.414 [C:\__t\dotnet\sdk]
error MSB4236: The SDK 'Microsoft.NET.Sdk' specified could not be found.
```

10 jobs failed in build 155211960 (BuildFoundation x4, BuildMRT x4, PREfast x2). This is the scenario already documented in `WindowsAppSDK-BuildSamplesCompat-Job.yml`:

> *"In Aggregator, we use global.json to specify the .NET SDK version to use. However, in Foundation it encounters error when using global.json, so we specify the version and call `UseDotNet@2` multiple times instead."*

</details>