### PR TITLE
Propagate the PackageReference version into the C# wapproj template's BlankApp project file

### DIFF
--- a/dev/Templates/Source/ProjectTemplates/Desktop/CSharp/PackagedApp/BlankApp/WinUI.Desktop.Cs.BlankApp.vstemplate
+++ b/dev/Templates/Source/ProjectTemplates/Desktop/CSharp/PackagedApp/BlankApp/WinUI.Desktop.Cs.BlankApp.vstemplate
@@ -24,6 +24,11 @@
     <ProjectTypeTag>desktop</ProjectTypeTag>
     <ProjectTypeTag>WinUI</ProjectTypeTag>
   </TemplateData>
+  <CustomParameters>
+    <CustomParameter Name="$WindowsAppSdkVersion$" Value="*" />
+    <CustomParameter Name="$DotNetVersion$" Value="*"/>
+    <CustomParameter Name="$WindowsSdkBuildToolsVersion$" Value="*" />
+  </CustomParameters>
   <TemplateContent PreferedSolutionConfiguration="Debug|x64">
     <Project File="ProjectTemplate.csproj" ReplaceParameters="true">
       <ProjectItem ReplaceParameters="true" TargetFileName="win-arm64.pubxml">Properties\PublishProfiles\win-arm64.pubxml</ProjectItem>

--- a/dev/Templates/Source/ProjectTemplates/Desktop/CSharp/PackagedApp/WinUI.Desktop.Cs.PackagedApp.vstemplate
+++ b/dev/Templates/Source/ProjectTemplates/Desktop/CSharp/PackagedApp/WinUI.Desktop.Cs.PackagedApp.vstemplate
@@ -25,6 +25,8 @@
   </TemplateData>
   <TemplateContent PreferedSolutionConfiguration="Debug|x64">
     <CustomParameters>
+      <CustomParameter Name="$WindowsAppSDKNupkgVersion$" Value="FIXME-Verify-Directory.Build.Targets-XmlPoke-Queries" />
+      <CustomParameter Name="$WindowsSDKBuildToolsNupkgVersion$" Value="FIXME-Verify-Directory.Build.Targets-XmlPoke-Queries" />
       <CustomParameter Name="$DotNetVersion$" Value="FIXME-Verify-Directory.Build.Targets-XmlPoke-Queries"/>
       <CustomParameter Name="$WindowsAppSdkVersion$" Value="*" />
       <CustomParameter Name="$WindowsSdkBuildToolsVersion$" Value="*" />


### PR DESCRIPTION
This PR corrects a bug where the wapproj's BlankApp project failed to resolve the floating package reference for its NuGet dependencies. The problem was that the `$WindowsAppSdkVersion$`, `$WindowsSdkBuildToolsVersion$`, and `$WindowsSdkBuildToolsWinAppVersion$` were passed into the BlankApp.csproj file directly when the variable comes from the parent project. The fix was to prepend `ext_` to the variable name so the VS template engine could substitute the variables as expected.

I verified this fix locally using `dev\Templates\VSIX\build-local-VSIX-package\build-install-localdev-vsix.ps1` with MSBuild 17 (from Visual Studio 2022) and manually verifying that the template built and deployed on Visual Studio 2026. I chose to use MSBuild 17 because [there is a bug in MSBuild 18 where template projects are built, but not included in the VSIX file](https://developercommunity.visualstudio.com/t/VSIX-build-omits-project-and-item-templa/11127128?q=TemplateProjectOutputGroup). To work around this bug in the future, I added a check in `build-vsix-local.ps1` to verify that the correct number of templates were included in the VSIX and an `MSBuildVersion` parameter to select the MSBuild version to test.

---

A microsoft employee must use /azp run to validate using the pipelines below.

WARNING:
Comments made by azure-pipelines bot maybe inaccurate.
Please see pipeline link to verify that the build is being ran.

For status checks on the main branch, please use TransportPackage-Foundation-PR
(https://microsoft.visualstudio.com/ProjectReunion/_build?definitionId=81063&_a=summary)
and run the build against your PR branch with the default parameters.
