### PR TITLE
Fix "Cancel" button in the C# and C++ wapproj templates so that it returns to the "Configure your new project" menu instead of creating a broken project

### DIFF
--- a/dev/Templates/Dotnet/Test-DotnetNewTemplates.ps1
+++ b/dev/Templates/Dotnet/Test-DotnetNewTemplates.ps1
@@ -453,31 +453,101 @@ function Get-LatestOfficialWasdkVersion {
     $sourceFeed = 'https://microsoft.pkgs.visualstudio.com/ProjectReunion/_packaging/Project.Reunion.nuget.internal/nuget/v3/flat2/microsoft.windowsappsdk/index.json'
     $excludedVersionPrefixes = @('2.63.')
     $token = $env:SYSTEM_ACCESSTOKEN
-    if ([string]::IsNullOrWhiteSpace($token)) {
-        Write-Warning "SYSTEM_ACCESSTOKEN is not set; cannot query the package source for versions."
-        return $null
-    }
     try {
-        [Net.ServicePointManager]::SecurityProtocol = [Net.ServicePointManager]::SecurityProtocol -bor [Net.SecurityProtocolType]::Tls12
-        $response = Invoke-RestMethod -Uri $sourceFeed -Headers @{ Authorization = "Bearer $token" } -TimeoutSec 30 -ErrorAction Stop
-        $latest = $null
-        foreach ($v in $response.versions) {
-            if ($v -match '-') { continue }   # skip prerelease
-            $excluded = $false
-            foreach ($p in $excludedVersionPrefixes) { if ($v.StartsWith($p)) { $excluded = $true; break } }
-            if ($excluded) { continue }
-            $parsed = $null
-            if (-not [version]::TryParse($v, [ref]$parsed)) { continue }
-            if (($null -eq $latest) -or ($parsed -gt $latest.Ver)) {
-                $latest = [pscustomobject]@{ Raw = $v; Ver = $parsed }
+        # SYSTEM_ACCESSTOKEN is a pipeline variable. Use nuget CLI when running outside of pipeline runs
+        if ([string]::IsNullOrWhiteSpace($token)) {
+            Write-Warning "SYSTEM_ACCESSTOKEN is not set; cannot query package source for latest official Microsoft.WindowsAppSDK version."
+            Write-Host "Using NuGet CLI instead"
+            $packageId = 'Microsoft.WindowsAppSDK'
+            $sourceFeed = 'https://microsoft.pkgs.visualstudio.com/ProjectReunion/_packaging/Project.Reunion.nuget.internal/nuget/v3/index.json'
+            $excludedVersionPrefixes = @('1.0.', '1.1.')
+            $json = & dotnet package search $packageId `
+                --source $sourceFeed `
+                --exact-match `
+                --format json `
+                --verbosity quiet
+
+            if ($LASTEXITCODE -ne 0) {
+                throw "dotnet package search failed with exit code $LASTEXITCODE."
             }
-        }
-        if ($latest) {
-            Write-Host "Latest official Microsoft.WindowsAppSDK = $($latest.Raw) (excluded prerelease and $($excludedVersionPrefixes -join ', ')*)"
+
+            $response = $json | ConvertFrom-Json
+
+            $problems = @()
+
+            if ($response.PSObject.Properties['problems']) {
+                $problems += @($response.problems)
+            }
+
+            foreach ($result in @($response.searchResult)) {
+                if ($result.PSObject.Properties['problems']) {
+                    $problems += @($result.problems)
+                }
+            }
+
+            if ($problems.Count -gt 0) {
+                throw ($problems | ForEach-Object { $_.text } | Join-String -Separator "`n")
+            }
+
+            if ($problems.Count -gt 0) {
+                throw ($problems.text -join [Environment]::NewLine)
+            }
+
+            $versions = foreach ($result in @($response.searchResult)) {
+                foreach ($package in @($result.packages)) {
+                    if ($package.id -ine $packageId) {
+                        continue
+                    }
+
+                    if ($package.PSObject.Properties['version']) {
+                        $package.version
+                    }
+                    elseif ($package.PSObject.Properties['latestVersion']) {
+                        $package.latestVersion
+                    }
+                }
+            }
+            $latest = $versions |
+                Where-Object {
+                    $version = $_
+                    -not ($excludedVersionPrefixes | Where-Object {
+                        $version.StartsWith($_)
+                    })
+                } |
+                ForEach-Object {
+                    [pscustomobject]@{
+                        Raw = $_
+                        Ver = [version]$_
+                    }
+                } |
+                Sort-Object Ver -Descending |
+                Select-Object -First 1
+
             return $latest.Raw
         }
-        Write-Warning "No official Microsoft.WindowsAppSDK version found on the package source."
-        return $null
+        else
+        {
+            [Net.ServicePointManager]::SecurityProtocol = [Net.ServicePointManager]::SecurityProtocol -bor [Net.SecurityProtocolType]::Tls12
+            $response = Invoke-RestMethod -Uri $sourceFeed -Headers @{ Authorization = "Bearer $token" } -TimeoutSec 30 -ErrorAction Stop
+            $latest = $null
+            foreach ($v in $response.versions) {
+                if ($v -match '-') { continue }   # skip prerelease
+                $excluded = $false
+                foreach ($p in $excludedVersionPrefixes) { if ($v.StartsWith($p)) { $excluded = $true; break } }
+                if ($excluded) { continue }
+                $parsed = $null
+                if (-not [version]::TryParse($v, [ref]$parsed)) { continue }
+                if (($null -eq $latest) -or ($parsed -gt $latest.Ver)) {
+                    $latest = [pscustomobject]@{ Raw = $v; Ver = $parsed }
+                }
+            }
+            if ($latest) {
+                Write-Host "Latest official Microsoft.WindowsAppSDK = $($latest.Raw) (excluded prerelease and $($excludedVersionPrefixes -join ', ')*)"
+                return $latest.Raw
+            }
+            Write-Warning "No official Microsoft.WindowsAppSDK version found on the package source."
+            return $null
+        }
     }
     catch {
         Write-Warning "Failed to query the package source for versions: $($_.Exception.Message)"

--- a/dev/Templates/Dotnet/Test-DotnetNewTemplates.ps1
+++ b/dev/Templates/Dotnet/Test-DotnetNewTemplates.ps1
@@ -489,10 +489,6 @@ function Get-LatestOfficialWasdkVersion {
                 throw ($problems | ForEach-Object { $_.text } | Join-String -Separator "`n")
             }
 
-            if ($problems.Count -gt 0) {
-                throw ($problems.text -join [Environment]::NewLine)
-            }
-
             $versions = foreach ($result in @($response.searchResult)) {
                 foreach ($package in @($result.packages)) {
                     if ($package.id -ine $packageId) {

--- a/dev/Templates/Dotnet/Test-DotnetNewTemplates.ps1
+++ b/dev/Templates/Dotnet/Test-DotnetNewTemplates.ps1
@@ -456,11 +456,9 @@ function Get-LatestOfficialWasdkVersion {
     try {
         # SYSTEM_ACCESSTOKEN is a pipeline variable. Use nuget CLI when running outside of pipeline runs
         if ([string]::IsNullOrWhiteSpace($token)) {
-            Write-Warning "SYSTEM_ACCESSTOKEN is not set; cannot query package source for latest official Microsoft.WindowsAppSDK version."
-            Write-Host "Using NuGet CLI instead"
+            Write-Warning "SYSTEM_ACCESSTOKEN is not set; cannot query package source for latest official Microsoft.WindowsAppSDK version. Using NuGet CLI instead"
             $packageId = 'Microsoft.WindowsAppSDK'
             $sourceFeed = 'https://microsoft.pkgs.visualstudio.com/ProjectReunion/_packaging/Project.Reunion.nuget.internal/nuget/v3/index.json'
-            $excludedVersionPrefixes = @('1.0.', '1.1.')
             $json = & dotnet package search $packageId `
                 --source $sourceFeed `
                 --exact-match `

--- a/dev/Templates/Source/ProjectTemplates/Desktop/CSharp/PackagedApp/BlankApp/ProjectTemplate.csproj
+++ b/dev/Templates/Source/ProjectTemplates/Desktop/CSharp/PackagedApp/BlankApp/ProjectTemplate.csproj
@@ -21,9 +21,9 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Windows.SDK.BuildTools" Version="$WindowsSdkBuildToolsVersion$" />
-    <PackageReference Include="Microsoft.WindowsAppSDK" Version="$WindowsAppSdkVersion$" />
-    <PackageReference Include="Microsoft.Windows.SDK.BuildTools.WinApp" Version="$WindowsSdkBuildToolsWinAppVersion$" />
+    <PackageReference Include="Microsoft.Windows.SDK.BuildTools" Version="$ext_WindowsSdkBuildToolsVersion$" />
+    <PackageReference Include="Microsoft.WindowsAppSDK" Version="$ext_WindowsAppSdkVersion$" />
+    <PackageReference Include="Microsoft.Windows.SDK.BuildTools.WinApp" Version="$ext_WindowsSdkBuildToolsWinAppVersion$" />
   </ItemGroup>
 
     <!-- Publish Properties -->

--- a/dev/Templates/Source/ProjectTemplates/Desktop/CSharp/PackagedApp/WapProj/WapProjTemplate.wapproj
+++ b/dev/Templates/Source/ProjectTemplates/Desktop/CSharp/PackagedApp/WapProj/WapProjTemplate.wapproj
@@ -42,11 +42,11 @@
 
   <PropertyGroup>
     <ProjectGuid>$guid1$</ProjectGuid>
-    <TargetPlatformVersion>$targetplatformversion$</TargetPlatformVersion>
-    <TargetPlatformMinVersion>$targetplatformminversion$</TargetPlatformMinVersion>
+    <TargetPlatformVersion>$ext_targetplatformversion$</TargetPlatformVersion>
+    <TargetPlatformMinVersion>$ext_targetplatformminversion$</TargetPlatformMinVersion>
     <AssetTargetFallback>$ext_DotNetVersion$-windows$(TargetPlatformVersion);$(AssetTargetFallback)</AssetTargetFallback>
     <DefaultLanguage>$currentuiculturename$</DefaultLanguage>
-    $if$($includeKeyFile$==true)
+    $if$($ext_includeKeyFile$==true)
     <PackageCertificateKeyFile>$projectname$_TemporaryKey.pfx</PackageCertificateKeyFile>
     $endif$
     <AppxPackageSigningEnabled>false</AppxPackageSigningEnabled>
@@ -56,7 +56,7 @@
     <AppxManifest Include="Package.appxmanifest">
       <SubType>Designer</SubType>
     </AppxManifest>
-    $if$($includeKeyFile$==true)
+    $if$($ext_includeKeyFile$==true)
     <None Include="$projectname$_TemporaryKey.pfx" />
     $endif$
   </ItemGroup>

--- a/dev/Templates/Source/ProjectTemplates/Desktop/CSharp/PackagedApp/WapProj/WinUI.Desktop.Cs.WapProj.vstemplate
+++ b/dev/Templates/Source/ProjectTemplates/Desktop/CSharp/PackagedApp/WapProj/WinUI.Desktop.Cs.WapProj.vstemplate
@@ -41,18 +41,8 @@
     </Project>      
   </TemplateContent>
   <WizardExtension>
-    <Assembly>Microsoft.VisualStudio.Universal.TemplateWizards, Version=16.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</Assembly>
-    <FullClassName>Microsoft.VisualStudio.Universal.TemplateWizards.PlatformVersion.Wizard</FullClassName>
-  </WizardExtension>
-  <WizardExtension>
     <!-- Generates Publisher name for appxmanifest -->
     <Assembly>Microsoft.VisualStudio.WinRT.TemplateWizards, Version=16.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</Assembly>
     <FullClassName>Microsoft.VisualStudio.WinRT.TemplateWizards.UpdatePublisherInManifestWizard</FullClassName>
   </WizardExtension>
-  <WizardData>
-    <MinSupportedVersion>10.0.17763.0</MinSupportedVersion>
-    <SkipXamlCompilerCheck>true</SkipXamlCompilerCheck>
-    <UseWindowsSdkBuildToolsPackage>true</UseWindowsSdkBuildToolsPackage>
-    <UseSdkFallbackFile>true</UseSdkFallbackFile>
-  </WizardData>
 </VSTemplate>

--- a/dev/Templates/Source/ProjectTemplates/Desktop/CSharp/PackagedApp/WinUI.Desktop.Cs.PackagedApp.vstemplate
+++ b/dev/Templates/Source/ProjectTemplates/Desktop/CSharp/PackagedApp/WinUI.Desktop.Cs.PackagedApp.vstemplate
@@ -35,4 +35,14 @@
       <ProjectTemplateLink ProjectName="$projectname$" CopyParameters="true">BlankApp\WinUI.Desktop.Cs.BlankApp.vstemplate</ProjectTemplateLink>
     </ProjectCollection>
   </TemplateContent>
+  <WizardExtension>
+    <Assembly>Microsoft.VisualStudio.Universal.TemplateWizards, Version=16.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</Assembly>
+    <FullClassName>Microsoft.VisualStudio.Universal.TemplateWizards.PlatformVersion.Wizard</FullClassName>
+  </WizardExtension>
+  <WizardData>
+    <MinSupportedVersion>10.0.17763.0</MinSupportedVersion>
+    <SkipXamlCompilerCheck>true</SkipXamlCompilerCheck>
+    <UseWindowsSdkBuildToolsPackage>true</UseWindowsSdkBuildToolsPackage>
+    <UseSdkFallbackFile>true</UseSdkFallbackFile>
+  </WizardData>
 </VSTemplate>

--- a/dev/Templates/Source/ProjectTemplates/Desktop/CSharp/PackagedApp/WinUI.Desktop.Cs.PackagedApp.vstemplate
+++ b/dev/Templates/Source/ProjectTemplates/Desktop/CSharp/PackagedApp/WinUI.Desktop.Cs.PackagedApp.vstemplate
@@ -26,6 +26,9 @@
   <TemplateContent PreferedSolutionConfiguration="Debug|x64">
     <CustomParameters>
       <CustomParameter Name="$DotNetVersion$" Value="FIXME-Verify-Directory.Build.Targets-XmlPoke-Queries"/>
+      <CustomParameter Name="$WindowsAppSdkVersion$" Value="*" />
+      <CustomParameter Name="$WindowsSdkBuildToolsVersion$" Value="*" />
+      <CustomParameter Name="$WindowsSdkBuildToolsWinAppVersion$" Value="*" />
     </CustomParameters>
     <ProjectCollection>
       <ProjectTemplateLink ProjectName="$projectname$ (Package)" CopyParameters="true">WapProj\WinUI.Desktop.Cs.WapProj.vstemplate</ProjectTemplateLink>

--- a/dev/Templates/Source/ProjectTemplates/Desktop/CppWinRT/PackagedApp/WapProj/Package-managed.appxmanifest
+++ b/dev/Templates/Source/ProjectTemplates/Desktop/CppWinRT/PackagedApp/WapProj/Package-managed.appxmanifest
@@ -11,7 +11,7 @@
 
   <Identity
     Name="$guid9$"
-    Publisher="$XmlEscapedPublisherDistinguishedName$"
+    Publisher="$ext_XmlEscapedPublisherDistinguishedName$"
     Version="1.0.0.0" />
 
   <mp:PhoneIdentity PhoneProductId="$guid9$" PhonePublisherId="00000000-0000-0000-0000-000000000000"/>

--- a/dev/Templates/Source/ProjectTemplates/Desktop/CppWinRT/PackagedApp/WapProj/WapProjTemplate.wapproj
+++ b/dev/Templates/Source/ProjectTemplates/Desktop/CppWinRT/PackagedApp/WapProj/WapProjTemplate.wapproj
@@ -43,10 +43,10 @@
 
   <PropertyGroup>
     <ProjectGuid>$guid1$</ProjectGuid>
-    <TargetPlatformVersion>$targetplatformversion$</TargetPlatformVersion>
-    <TargetPlatformMinVersion>$targetplatformminversion$</TargetPlatformMinVersion>
+    <TargetPlatformVersion>$ext_targetplatformversion$</TargetPlatformVersion>
+    <TargetPlatformMinVersion>$ext_targetplatformminversion$</TargetPlatformMinVersion>
     <DefaultLanguage>$currentuiculturename$</DefaultLanguage>
-    $if$($includeKeyFile$==true)
+    $if$($ext_includeKeyFile$==true)
     <PackageCertificateKeyFile>$projectname$_TemporaryKey.pfx</PackageCertificateKeyFile>
     $endif$
     <AppxPackageSigningEnabled>false</AppxPackageSigningEnabled>
@@ -56,7 +56,7 @@
     <AppxManifest Include="Package.appxmanifest">
       <SubType>Designer</SubType>
     </AppxManifest>
-    $if$($includeKeyFile$==true)
+    $if$($ext_includeKeyFile$==true)
     <None Include="$projectname$_TemporaryKey.pfx" />
     $endif$
   </ItemGroup>

--- a/dev/Templates/Source/ProjectTemplates/Desktop/CppWinRT/PackagedApp/WapProj/WinUI.Desktop.CppWinRT.WapProj.vstemplate
+++ b/dev/Templates/Source/ProjectTemplates/Desktop/CppWinRT/PackagedApp/WapProj/WinUI.Desktop.CppWinRT.WapProj.vstemplate
@@ -40,20 +40,7 @@
     </CustomParameters>
   </TemplateContent>
   <WizardExtension>
-    <Assembly>Microsoft.VisualStudio.Universal.TemplateWizards, Version=16.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</Assembly>
-    <FullClassName>Microsoft.VisualStudio.Universal.TemplateWizards.PlatformVersion.Wizard</FullClassName>
-  </WizardExtension>
-  <WizardExtension>
-    <!-- Generates Publisher name for appxmanifest -->
-    <Assembly>Microsoft.VisualStudio.WinRT.TemplateWizards, Version=16.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</Assembly>
-    <FullClassName>Microsoft.VisualStudio.WinRT.TemplateWizards.UpdatePublisherInManifestWizard</FullClassName>
-  </WizardExtension>
-  <WizardExtension>
     <Assembly>WindowsAppSDK.Cpp.Extension.Dev17, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null</Assembly>
     <FullClassName>WindowsAppSDK.TemplateUtilities.NuGetPackageInstaller</FullClassName>
   </WizardExtension>
-  <WizardData>
-    <MinSupportedVersion>10.0.17763.0</MinSupportedVersion>
-    <SkipXamlCompilerCheck>true</SkipXamlCompilerCheck>
-  </WizardData>
 </VSTemplate>

--- a/dev/Templates/Source/ProjectTemplates/Desktop/CppWinRT/PackagedApp/WinUI.Desktop.CppWinRT.PackagedApp.vstemplate
+++ b/dev/Templates/Source/ProjectTemplates/Desktop/CppWinRT/PackagedApp/WinUI.Desktop.CppWinRT.PackagedApp.vstemplate
@@ -27,5 +27,18 @@
       <ProjectTemplateLink ProjectName="$projectname$ (Package)" CopyParameters="true">WapProj\WinUI.Desktop.CppWinRT.WapProj.vstemplate</ProjectTemplateLink>
       <ProjectTemplateLink ProjectName="$projectname$" CopyParameters="true">BlankApp\WinUI.Desktop.CppWinRT.BlankApp.vstemplate</ProjectTemplateLink>
     </ProjectCollection> 
-  </TemplateContent>   
+  </TemplateContent>
+  <WizardExtension>
+    <!-- Generates Publisher name for appxmanifest -->
+    <Assembly>Microsoft.VisualStudio.WinRT.TemplateWizards, Version=16.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</Assembly>
+    <FullClassName>Microsoft.VisualStudio.WinRT.TemplateWizards.UpdatePublisherInManifestWizard</FullClassName>
+  </WizardExtension>
+  <WizardExtension>
+    <Assembly>Microsoft.VisualStudio.Universal.TemplateWizards, Version=16.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</Assembly>
+    <FullClassName>Microsoft.VisualStudio.Universal.TemplateWizards.PlatformVersion.Wizard</FullClassName>
+  </WizardExtension>
+  <WizardData>
+    <MinSupportedVersion>10.0.17763.0</MinSupportedVersion>
+    <SkipXamlCompilerCheck>true</SkipXamlCompilerCheck>
+  </WizardData>
 </VSTemplate>

--- a/dev/Templates/VSIX/build-local-VSIX-package/Build-VSIX-Local.ps1
+++ b/dev/Templates/VSIX/build-local-VSIX-package/Build-VSIX-Local.ps1
@@ -49,7 +49,7 @@
 .PARAMETER SkipRestore
     Skip NuGet restore (useful if you've already restored).
 
-.PARAMETER VsVersion
+.PARAMETER MsBuildVersion
     Visual Studio version to target for MSBuild. Default: 17 (Visual Studio 2022).
     Set to 18 for Visual Studio 2026.
 

--- a/dev/Templates/VSIX/build-local-VSIX-package/Build-VSIX-Local.ps1
+++ b/dev/Templates/VSIX/build-local-VSIX-package/Build-VSIX-Local.ps1
@@ -132,7 +132,7 @@ function Find-MSBuild {
     $range = '[{0},{1})' -f $MsBuildVersion, ($MsBuildVersion + 1)
     $msbuildPath = & $vswherePath -version $range -requires Microsoft.Component.MSBuild -find "MSBuild\**\Bin\MSBuild.exe" 2>$null | Select-Object -First 1
     if (-not $msbuildPath -or -not (Test-Path $msbuildPath)) {
-        Write-Err "MSBuild.exe not found. Please install Visual Studio 2022+ with the '.NET desktop development' workload."
+        Write-Err "MSBuild.exe not found. Please install Visual Studio $MsBuildVersion with the '.NET desktop development' workload."
         exit 1
     }
 

--- a/dev/Templates/VSIX/build-local-VSIX-package/Build-VSIX-Local.ps1
+++ b/dev/Templates/VSIX/build-local-VSIX-package/Build-VSIX-Local.ps1
@@ -420,6 +420,44 @@ function Invoke-MSBuildBuild {
     }
 }
 
+function Test-VsixContainsTemplates {
+    param(
+        [string]$Path
+    )
+
+    Add-Type -AssemblyName System.IO.Compression.FileSystem
+
+    $archive = [System.IO.Compression.ZipFile]::OpenRead($Path)
+    try {
+        $projectTemplates = @(
+            $archive.Entries | Where-Object {
+                $_.FullName.StartsWith("ProjectTemplates/", [System.StringComparison]::OrdinalIgnoreCase) -and
+                $_.FullName.EndsWith(".vstemplate", [System.StringComparison]::OrdinalIgnoreCase)
+            }
+        )
+        $itemTemplates = @(
+            $archive.Entries | Where-Object {
+                $_.FullName.StartsWith("ItemTemplates/", [System.StringComparison]::OrdinalIgnoreCase) -and
+                $_.FullName.EndsWith(".vstemplate", [System.StringComparison]::OrdinalIgnoreCase)
+            }
+        )
+
+        if ($projectTemplates.Count -eq 0 -or $itemTemplates.Count -eq 0) {
+            Write-Err "VSIX template validation failed: $Path"
+            Write-Err "  Project templates: $($projectTemplates.Count)"
+            Write-Err "  Item templates   : $($itemTemplates.Count)"
+            Write-Err "The selected Visual Studio/MSBuild toolset may not support packaging these templates."
+            return $false
+        }
+
+        Write-Step "Verified templates in $($archive.Entries.Count)-entry VSIX: $($projectTemplates.Count) project, $($itemTemplates.Count) item"
+        return $true
+    }
+    finally {
+        $archive.Dispose()
+    }
+}
+
 function Copy-VsixOutput {
     param(
         [string]$DeploymentType
@@ -446,6 +484,10 @@ function Copy-VsixOutput {
     foreach ($vsix in $vsixFiles) {
         if (-not $seen.ContainsKey($vsix.Name)) {
             $seen[$vsix.Name] = $vsix
+            if (-not (Test-VsixContainsTemplates -Path $vsix.FullName)) {
+                exit 1
+            }
+
             # Rename to include version: WindowsAppSDK.Cs.Extension.Dev17.Component.vsix
             #   -> WindowsAppSDK.Cs.Extension.Dev17.Component.99.2026.0416.1640.vsix
             $newName = $vsix.BaseName + ".$OptionalVSIXVersion.vsix"

--- a/dev/Templates/VSIX/build-local-VSIX-package/Build-VSIX-Local.ps1
+++ b/dev/Templates/VSIX/build-local-VSIX-package/Build-VSIX-Local.ps1
@@ -49,6 +49,10 @@
 .PARAMETER SkipRestore
     Skip NuGet restore (useful if you've already restored).
 
+.PARAMETER VsVersion
+    Visual Studio version to target for MSBuild. Default: 17 (Visual Studio 2022).
+    Set to 18 for Visual Studio 2026.
+
 .EXAMPLE
     .\Build-VSIX-Local.ps1
     # Build the LocalDev VSIX (default). Then install with .\Install-LocalDev-VSIX.ps1
@@ -82,7 +86,10 @@ param(
 
     [string]$OptionalVSIXVersion = "",
 
-    [switch]$SkipRestore
+    [switch]$SkipRestore,
+
+    [ValidateSet(17, 18)]
+    [double]$MsBuildVersion = 17
 )
 
 Set-StrictMode -Version 2.0
@@ -122,7 +129,8 @@ function Find-MSBuild {
         exit 1
     }
 
-    $msbuildPath = & $vswherePath -latest -requires Microsoft.Component.MSBuild -find "MSBuild\**\Bin\MSBuild.exe" 2>$null | Select-Object -First 1
+    $range = '[{0},{1})' -f $MsBuildVersion, ($MsBuildVersion + 1)
+    $msbuildPath = & $vswherePath -version $range -requires Microsoft.Component.MSBuild -find "MSBuild\**\Bin\MSBuild.exe" 2>$null | Select-Object -First 1
     if (-not $msbuildPath -or -not (Test-Path $msbuildPath)) {
         Write-Err "MSBuild.exe not found. Please install Visual Studio 2022+ with the '.NET desktop development' workload."
         exit 1

--- a/dev/Templates/VSIX/build-local-VSIX-package/build-install-localdev-vsix.ps1
+++ b/dev/Templates/VSIX/build-local-VSIX-package/build-install-localdev-vsix.ps1
@@ -26,6 +26,10 @@
 .PARAMETER UninstallFirst
     Run VSIXInstaller /uninstall before installing for a clean reinstall.
 
+.PARAMETER MsBuildVersion
+    Visual Studio version to target for MSBuild. Default: 17 (Visual Studio 2022).
+    Set to 18 for Visual Studio 2026.
+
 .EXAMPLE
     .\build-install-localdev-vsix.ps1
     # Build + install LocalDev C# + C++ to all VS 17+.
@@ -44,7 +48,10 @@ param(
 
     [string]$VsVersionRange = '[17.0,)',
 
-    [switch]$UninstallFirst
+    [switch]$UninstallFirst,
+
+    [ValidateSet(17, 18)]
+    [double]$MsBuildVersion = 17
 )
 
 Set-StrictMode -Version 2.0
@@ -86,7 +93,7 @@ if ($SkipBuild) {
     }
     Push-Location $scriptDir
     try {
-        & $buildScript -Deployment LocalDev
+        & $buildScript -Deployment LocalDev -MsBuildVersion $MsBuildVersion
         if ($LASTEXITCODE -ne 0) {
             Write-Err "Build-VSIX-Local.ps1 exited with code $LASTEXITCODE"
             exit $LASTEXITCODE


### PR DESCRIPTION
In the WinUI Blank App (Packaged with Windows Application Packaging Project) templates for C# and C++, a dialog appears asking users to confirm target and minimum platform versions they want their app to support:
<img width="603" height="218" alt="image" src="https://github.com/user-attachments/assets/94774b64-79a4-4d46-a157-65164914b960" />

Before this change, when a user clicked "Cancel", the template would generate the BlankApp project, but not the packaging (wapproj) project. This was because the wizard that launched this dialog only existed in the packaging project and not the parent project (an invisible project that configures the entire template). By moving the dialog into the parent project, both projects exit when "Cancel" is clicked, returning users to the "Configure your new project menu" to edit their app settings further.

Locally validated the fix and confirmed there were no regression by manually testing with the local builds (`dev\Templates\VSIX\build-local-VSIX-package\build-install-localdev-vsix.ps1`).

---

A microsoft employee must use /azp run to validate using the pipelines below.

WARNING:
Comments made by azure-pipelines bot maybe inaccurate.
Please see pipeline link to verify that the build is being ran.

For status checks on the main branch, please use TransportPackage-Foundation-PR
(https://microsoft.visualstudio.com/ProjectReunion/_build?definitionId=81063&_a=summary)
and run the build against your PR branch with the default parameters.
