### PR TITLE
Foundation-PR: pick the nightly by artifact presence, not build result

### DIFF
--- a/build/AzurePipelinesTemplates/WindowsAppSDK-BuildInstaller-Steps.yml
+++ b/build/AzurePipelinesTemplates/WindowsAppSDK-BuildInstaller-Steps.yml
@@ -40,6 +40,12 @@ parameters:
 - name: NightlyBranchName
   type: string
   default: 'refs/heads/release/dev/monobuild'
+# How far back the nightly search may reach. See
+# WindowsAppSDK-DownloadNightlyPackage-Steps.yml for why we search rather than take the
+# latest run from the branch.
+- name: MaxNightlyAgeInDays
+  type: number
+  default: 7
 
 steps:
 - task: PowerShell@2
@@ -75,29 +81,17 @@ steps:
       condition: and(succeeded(), ne(variables.SkipInstallerBuild, true))
   - ${{ else }}:
     ###
-    # This step downloads the WindowsAppSDK NuGet package from the Aggregator nightly
-    # pipeline (identified by the OfficialPipelineID variable) for use in building the
-    # VSIX. We pull the latest run from NightlyBranchName rather than a pinned
+    # Download the WindowsAppSDK NuGet package from the monobuild nightly for use in
+    # building the installer. We pull from NightlyBranchName rather than a pinned
     # LatestOfficialBuildID so PR build-validation runs always get a fresh package without
     # needing a build id supplied at queue time.
-    #
-    # Accept PartiallySucceeded nightlies (downstream test/SDL stages red but the
-    # Aggregate/packaging stage still produced the artifact). Do NOT accept fully-failed
-    # runs: when Aggregate itself fails, 1ES names the artifact '<name>_failed_N', so a
-    # download of the plain '<name>' 404s -- fall back to the last packaging-green run.
-    - task: DownloadPipelineArtifact@2
-      displayName: 'Download WindowsAppSDK From Latest Nightly'
-      inputs:
+    - template: WindowsAppSDK-DownloadNightlyPackage-Steps.yml
+      parameters:
         artifactName: ${{ parameters.artifactName }}
         targetPath: '$(System.ArtifactsDirectory)'
-        source: 'specific'
-        project: $(System.TeamProjectId)
-        pipeline: 190463
-        runVersion: 'latestFromBranch'
-        runBranch: '${{ parameters.NightlyBranchName }}'
-        allowPartiallySucceededBuilds: true
-        allowFailedBuilds: false
-    
+        nightlyBranchName: ${{ parameters.NightlyBranchName }}
+        maxNightlyAgeInDays: ${{ parameters.MaxNightlyAgeInDays }}
+
 ###
 # Install the internal licensing support for release-signed packages. This can always be present in
 # pipeline builds. The installer code will automatically degrade / skip licenses in non-release builds

--- a/build/AzurePipelinesTemplates/WindowsAppSDK-BuildInstaller-Steps.yml
+++ b/build/AzurePipelinesTemplates/WindowsAppSDK-BuildInstaller-Steps.yml
@@ -45,7 +45,7 @@ parameters:
 # latest run from the branch.
 - name: MaxNightlyAgeInDays
   type: number
-  default: 7
+  default: 30
 
 steps:
 - task: PowerShell@2

--- a/build/AzurePipelinesTemplates/WindowsAppSDK-BuildVSIX-Steps.yml
+++ b/build/AzurePipelinesTemplates/WindowsAppSDK-BuildVSIX-Steps.yml
@@ -55,6 +55,12 @@ parameters:
 - name: NightlyBranchName
   type: string
   default: 'refs/heads/release/dev/monobuild'
+# How far back the nightly search may reach. See
+# WindowsAppSDK-DownloadNightlyPackage-Steps.yml for why we search rather than take the
+# latest run from the branch.
+- name: MaxNightlyAgeInDays
+  type: number
+  default: 7
 
 steps:
 - ${{ if eq(parameters.SkipArtifactDownload, false) }}:
@@ -66,29 +72,17 @@ steps:
         targetPath: '$(System.ArtifactsDirectory)'
   - ${{ else }}:
     ###
-    # This step downloads the WindowsAppSDK NuGet package from the Aggregator nightly
-    # pipeline (identified by the OfficialPipelineID variable) for use in building the
-    # VSIX. We pull the latest run from NightlyBranchName rather than a pinned
+    # Download the WindowsAppSDK NuGet package from the monobuild nightly for use in
+    # building the VSIX. We pull from NightlyBranchName rather than a pinned
     # LatestOfficialBuildID so PR build-validation runs always get a fresh package without
     # needing a build id supplied at queue time.
-    #
-    # Accept PartiallySucceeded nightlies (downstream test/SDL stages red but the
-    # Aggregate/packaging stage still produced the artifact). Do NOT accept fully-failed
-    # runs: when Aggregate itself fails, 1ES names the artifact '<name>_failed_N', so a
-    # download of the plain '<name>' 404s -- fall back to the last packaging-green run.
-    - task: DownloadPipelineArtifact@2
-      displayName: 'Download WindowsAppSDK From Latest Nightly'
-      inputs:
+    - template: WindowsAppSDK-DownloadNightlyPackage-Steps.yml
+      parameters:
         artifactName: ${{ parameters.artifactName }}
         targetPath: '$(System.ArtifactsDirectory)'
-        source: 'specific'
-        project: $(System.TeamProjectId)
-        pipeline: 190463
-        runVersion: 'latestFromBranch'
-        runBranch: '${{ parameters.NightlyBranchName }}'
-        allowPartiallySucceededBuilds: true
-        allowFailedBuilds: false
-      
+        nightlyBranchName: ${{ parameters.NightlyBranchName }}
+        maxNightlyAgeInDays: ${{ parameters.MaxNightlyAgeInDays }}
+
 - task: PowerShell@2
   name: ExtractWindowsAppSDKVersion
   displayName: Extract WindowsAppSDKVersion

--- a/build/AzurePipelinesTemplates/WindowsAppSDK-DownloadNightlyPackage-Steps.yml
+++ b/build/AzurePipelinesTemplates/WindowsAppSDK-DownloadNightlyPackage-Steps.yml
@@ -1,0 +1,159 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+#
+# Downloads the Windows App SDK NuGet + MSIX artifact from the most recent monobuild
+# nightly that actually published it.
+#
+# Why this exists instead of `runVersion: 'latestFromBranch'`:
+#   That selector picks candidates by WHOLE-BUILD result, which is not the property this
+#   download depends on. The monobuild nightly is routinely `failed` purely because of its
+#   Test Gate stage while its Aggregate stage still published a correctly named artifact.
+#   So neither setting of allowFailedBuilds is correct:
+#     * false -> rejects every Test-Gate-red nightly and walks back to the newest non-failed
+#       run, which can be weeks old and have had its artifacts purged by retention. The
+#       download then fails with "Artifact <name> was not found for build <id>" naming a
+#       build id far enough in the past to make the failure look unrelated to the PR.
+#     * true  -> takes the newest run even when its Aggregate stage never produced the
+#       artifact, or produced it under the 1ES `<name>_failed_N` rename, which 404s too.
+#   Artifact presence is what we actually need, so probe for it directly via the Build REST
+#   API and download from that specific run.
+#
+# To pin a known-good nightly, queue the build with a `NightlyBuildIdOverride` variable set
+# to its build id. When that variable is not set the resolver ignores it and auto-selects.
+
+parameters:
+# Exact pipeline artifact name to download. Must match, not prefix-match: the nightly also
+# publishes '<name>_sdl_analysis', which is not the payload.
+- name: artifactName
+  type: string
+- name: targetPath
+  type: string
+  default: '$(System.ArtifactsDirectory)'
+# Definition id of WinAppSDK-MonoBuild-Nightly.
+- name: nightlyPipelineId
+  type: string
+  default: '190463'
+- name: nightlyBranchName
+  type: string
+# Recency guard. The search stops once it reaches runs older than this, so a regression that
+# stops the nightly publishing the artifact fails fast and says so, instead of silently
+# reaching back to a build whose artifacts no longer exist.
+- name: maxNightlyAgeInDays
+  type: number
+  default: 7
+# Upper bound on REST calls. The nightly currently runs ~8 times a day, so this covers more
+# than maxNightlyAgeInDays' worth of runs and the age guard is what terminates the search.
+# Only the matching run is probed in the healthy case; the full walk happens only when the
+# nightly has genuinely stopped publishing.
+- name: maxRunsToProbe
+  type: number
+  default: 100
+
+steps:
+- task: PowerShell@2
+  displayName: 'Resolve latest nightly publishing ${{ parameters.artifactName }}'
+  env:
+    SYSTEM_ACCESSTOKEN: $(System.AccessToken)
+    WASDK_COLLECTION_URI: $(System.CollectionUri)
+    WASDK_PROJECT_ID: $(System.TeamProjectId)
+    WASDK_PIPELINE_ID: ${{ parameters.nightlyPipelineId }}
+    WASDK_BRANCH_NAME: ${{ parameters.nightlyBranchName }}
+    WASDK_ARTIFACT_NAME: ${{ parameters.artifactName }}
+    WASDK_MAX_AGE_DAYS: ${{ parameters.maxNightlyAgeInDays }}
+    WASDK_MAX_RUNS: ${{ parameters.maxRunsToProbe }}
+    # Renders as the literal '$(NightlyBuildIdOverride)' when the variable is undefined;
+    # the resolver only honours it when it is all digits.
+    WASDK_PINNED_BUILD_ID: $(NightlyBuildIdOverride)
+  inputs:
+    targetType: 'inline'
+    script: |
+      $ErrorActionPreference = 'Stop'
+      [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
+
+      $collectionUri = $env:WASDK_COLLECTION_URI.TrimEnd('/')
+      $projectId     = $env:WASDK_PROJECT_ID
+      $pipelineId    = $env:WASDK_PIPELINE_ID
+      $branchName    = $env:WASDK_BRANCH_NAME
+      $artifactName  = $env:WASDK_ARTIFACT_NAME
+      $maxAgeDays    = [int]$env:WASDK_MAX_AGE_DAYS
+      $maxRuns       = [int]$env:WASDK_MAX_RUNS
+      $pinnedBuildId = $env:WASDK_PINNED_BUILD_ID
+
+      if ([string]::IsNullOrWhiteSpace($env:SYSTEM_ACCESSTOKEN)) {
+        Write-Host '##vso[task.logissue type=error]System.AccessToken is empty, so the nightly that publishes the artifact cannot be resolved. Map it into the step env or grant the build identity access to the OAuth token.'
+        exit 1
+      }
+      $headers = @{ Authorization = 'Bearer ' + $env:SYSTEM_ACCESSTOKEN }
+
+      function Get-ArtifactNames([string] $BuildId) {
+        $uri = $collectionUri + '/' + $projectId + '/_apis/build/builds/' + $BuildId + '/artifacts?api-version=7.1'
+        $response = Invoke-RestMethod -Uri $uri -Headers $headers -Method Get
+        if ($null -eq $response -or $null -eq $response.value) { return @() }
+        return @($response.value | ForEach-Object { $_.name })
+      }
+
+      $resolvedBuildId = ''
+
+      if ($pinnedBuildId -match '^\d+$') {
+        Write-Host ('NightlyBuildIdOverride is set; using pinned nightly build ' + $pinnedBuildId)
+        $names = @(Get-ArtifactNames $pinnedBuildId)
+        if ($names -notcontains $artifactName) {
+          Write-Host ('##vso[task.logissue type=error]Pinned build ' + $pinnedBuildId + ' does not publish an artifact named ''' + $artifactName + '''. It reports ' + $names.Count + ' artifacts; its artifacts may already have been purged by retention. Pick a newer build id or clear NightlyBuildIdOverride.')
+          exit 1
+        }
+        $resolvedBuildId = $pinnedBuildId
+      }
+      else {
+        $listUri = $collectionUri + '/' + $projectId + '/_apis/build/builds' +
+                   '?definitions=' + $pipelineId +
+                   '&branchName=' + [uri]::EscapeDataString($branchName) +
+                   '&statusFilter=completed' +
+                   '&queryOrder=finishTimeDescending' +
+                   '&$top=' + $maxRuns +
+                   '&api-version=7.1'
+        $runs = @((Invoke-RestMethod -Uri $listUri -Headers $headers -Method Get).value)
+        Write-Host ('Looking for the newest run of pipeline ' + $pipelineId + ' on ' + $branchName +
+                    ' that publishes ''' + $artifactName + ''' (' + $runs.Count + ' completed runs returned, ' +
+                    $maxAgeDays + '-day limit).')
+
+        $cutoff = (Get-Date).ToUniversalTime().AddDays(-$maxAgeDays)
+        foreach ($run in $runs) {
+          $finishTime = $null
+          if ($run.finishTime) { $finishTime = ([datetime]$run.finishTime).ToUniversalTime() }
+          if ($null -ne $finishTime -and $finishTime -lt $cutoff) {
+            Write-Host ('  build ' + $run.id + ' finished ' + $finishTime.ToString('u') + ', past the ' + $maxAgeDays + '-day limit. Stopping.')
+            break
+          }
+
+          $names = @(Get-ArtifactNames $run.id)
+          $hasArtifact = ($names -contains $artifactName)
+          Write-Host ('  build ' + $run.id + ' (' + $run.buildNumber + ') result=' + $run.result +
+                      ' artifacts=' + $names.Count + ' hasArtifact=' + $hasArtifact)
+          if ($hasArtifact) {
+            $resolvedBuildId = [string]$run.id
+            break
+          }
+        }
+      }
+
+      if ([string]::IsNullOrWhiteSpace($resolvedBuildId)) {
+        Write-Host ('##vso[task.logissue type=error]No run of pipeline ' + $pipelineId + ' on ' + $branchName +
+                    ' in the last ' + $maxAgeDays + ' days publishes an artifact named ''' + $artifactName +
+                    '''. The nightly is not producing it (check its Aggregate stage), or the artifact was renamed. ' +
+                    'Queue with NightlyBuildIdOverride=<build id> to unblock with a known-good run.')
+        exit 1
+      }
+
+      Write-Host ('Resolved nightly build id: ' + $resolvedBuildId)
+      Write-Host ('##vso[task.setvariable variable=ResolvedNightlyBuildId]' + $resolvedBuildId)
+
+- task: DownloadPipelineArtifact@2
+  displayName: 'Download WindowsAppSDK From Latest Nightly'
+  inputs:
+    artifactName: ${{ parameters.artifactName }}
+    targetPath: '${{ parameters.targetPath }}'
+    source: 'specific'
+    project: $(System.TeamProjectId)
+    pipeline: ${{ parameters.nightlyPipelineId }}
+    runVersion: 'specific'
+    runId: $(ResolvedNightlyBuildId)


### PR DESCRIPTION
Installer and VSIX are permanently red on every Foundation PR targeting release/dev/monobuild:

    Artifact WindowsAppSDK-NuGet-And-MSIX was not found for build 150121328.

150121328 is a 2026-06-18 nightly whose artifacts retention has purged (the artifacts API returns 0), so the download can never succeed. Everything else in the run is green, which makes the failure look unrelated to the PR.

Root cause: both step templates selected the nightly with `runVersion: 'latestFromBranch'`, which filters candidates on the WHOLE-BUILD result. That is not the property the download depends on. The monobuild nightly is routinely `failed` purely because of its Test Gate stage while its Aggregate stage still publishes a correctly named WindowsAppSDK-NuGet-And-MSIX, so neither setting of allowFailedBuilds is right:

  * false (today, from d46b72ae) rejects roughly two months of perfectly usable artifact producers and falls back to the newest non-failed run, which is old enough to have been purged. The 10 most recent non-failed nightlies all report 0 artifacts, so there is no self-healing fallback on the branch.
  * true (what d46b72ae replaced) takes the newest run even when its Aggregate stage never produced the artifact - about a quarter of recent nightlies - or produced it under the 1ES `<name>_failed_N` rename, which 404s the same way.

Fix: resolve the build id from artifact presence instead. A new shared steps template probes the Build REST API for the newest completed run on the branch that publishes the exact artifact name, then downloads with `runVersion: 'specific'` / `runId`.

  * Recency guard (maxNightlyAgeInDays, default 7): the search stops once it reaches older runs and fails with "No run of pipeline ... in the last N days publishes an artifact named ...", instead of a confusing 404 against a build id weeks in the past.
  * Escape hatch: queue with a NightlyBuildIdOverride variable to pin a known-good nightly. The pinned build is validated the same way, so a stale pin also fails with a clear message.
  * Exact-name matching, because the nightly also publishes `<name>_sdl_analysis`, which is not the payload.

The new template is referenced by a bare relative path, matching the existing same-repo includes in these files (PublishSymbol-Wrapper, SignPackageContents, EsrpCodeSigning-Wrapper), so it keeps resolving against this repo when the monobuild consumes these templates as @WindowsAppSDKFoundation. The monobuild passes SkipArtifactDownload: true and so compiles this block out entirely; only the standalone Foundation pipelines change behaviour.

Validated without queueing a build: all three files yaml-parse; the resolver script was extracted from the template and run against the live Build API, correctly picking 155530767 (the newest nightly that has the artifact) and correctly failing on the age guard, on an unknown artifact name, and on the expired 150121328 when pinned; and a template-parameter gate over build/** reports the same result on this tree as on the pristine branch, so no new "Unexpected parameter" surface was introduced.

A microsoft employee must use /azp run to validate using the pipelines below.

WARNING:
Comments made by azure-pipelines bot maybe inaccurate.
Please see pipeline link to verify that the build is being ran.

For status checks on the main branch, please use TransportPackage-Foundation-PR
(https://microsoft.visualstudio.com/ProjectReunion/_build?definitionId=81063&_a=summary)
and run the build against your PR branch with the default parameters.
