### PR TITLE
Foundation-PR: pick the nightly by artifact presence, not build result

### DIFF
--- a/build/AzurePipelinesTemplates/WindowsAppSDK-BuildInstaller-Steps.yml
+++ b/build/AzurePipelinesTemplates/WindowsAppSDK-BuildInstaller-Steps.yml
@@ -40,6 +40,12 @@ parameters:
 - name: NightlyBranchName
   type: string
   default: 'refs/heads/release/dev/monobuild'
+# How far back the nightly search may reach. See
+# WindowsAppSDK-DownloadNightlyPackage-Steps.yml for why we search rather than take the
+# latest run from the branch.
+- name: MaxNightlyAgeInDays
+  type: number
+  default: 7
 
 steps:
 - task: PowerShell@2
@@ -75,29 +81,17 @@ steps:
       condition: and(succeeded(), ne(variables.SkipInstallerBuild, true))
   - ${{ else }}:
     ###
-    # This step downloads the WindowsAppSDK NuGet package from the Aggregator nightly
-    # pipeline (identified by the OfficialPipelineID variable) for use in building the
-    # VSIX. We pull the latest run from NightlyBranchName rather than a pinned
+    # Download the WindowsAppSDK NuGet package from the monobuild nightly for use in
+    # building the installer. We pull from NightlyBranchName rather than a pinned
     # LatestOfficialBuildID so PR build-validation runs always get a fresh package without
     # needing a build id supplied at queue time.
-    #
-    # The nightly runs commonly finish as PartiallySucceeded (some downstream test/SDL
-    # stages are not green) even though the packaging stage produced the artifact, so
-    # both allowPartiallySucceededBuilds and allowFailedBuilds must be true -- the task
-    # requires the pair to be set together to consider non-succeeded runs.
-    - task: DownloadPipelineArtifact@2
-      displayName: 'Download WindowsAppSDK From Latest Nightly'
-      inputs:
+    - template: WindowsAppSDK-DownloadNightlyPackage-Steps.yml
+      parameters:
         artifactName: ${{ parameters.artifactName }}
         targetPath: '$(System.ArtifactsDirectory)'
-        source: 'specific'
-        project: $(System.TeamProjectId)
-        pipeline: 190463
-        runVersion: 'latestFromBranch'
-        runBranch: '${{ parameters.NightlyBranchName }}'
-        allowPartiallySucceededBuilds: true
-        allowFailedBuilds: true
-    
+        nightlyBranchName: ${{ parameters.NightlyBranchName }}
+        maxNightlyAgeInDays: ${{ parameters.MaxNightlyAgeInDays }}
+
 ###
 # Install the internal licensing support for release-signed packages. This can always be present in
 # pipeline builds. The installer code will automatically degrade / skip licenses in non-release builds

--- a/build/AzurePipelinesTemplates/WindowsAppSDK-BuildInstaller-Steps.yml
+++ b/build/AzurePipelinesTemplates/WindowsAppSDK-BuildInstaller-Steps.yml
@@ -45,7 +45,7 @@ parameters:
 # latest run from the branch.
 - name: MaxNightlyAgeInDays
   type: number
-  default: 7
+  default: 30
 
 steps:
 - task: PowerShell@2

--- a/build/AzurePipelinesTemplates/WindowsAppSDK-BuildVSIX-Steps.yml
+++ b/build/AzurePipelinesTemplates/WindowsAppSDK-BuildVSIX-Steps.yml
@@ -52,6 +52,12 @@ parameters:
 - name: NightlyBranchName
   type: string
   default: 'refs/heads/release/dev/monobuild'
+# How far back the nightly search may reach. See
+# WindowsAppSDK-DownloadNightlyPackage-Steps.yml for why we search rather than take the
+# latest run from the branch.
+- name: MaxNightlyAgeInDays
+  type: number
+  default: 7
 
 steps:
 - ${{ if eq(parameters.SkipArtifactDownload, false) }}:
@@ -63,29 +69,17 @@ steps:
         targetPath: '$(System.ArtifactsDirectory)'
   - ${{ else }}:
     ###
-    # This step downloads the WindowsAppSDK NuGet package from the Aggregator nightly
-    # pipeline (identified by the OfficialPipelineID variable) for use in building the
-    # VSIX. We pull the latest run from NightlyBranchName rather than a pinned
+    # Download the WindowsAppSDK NuGet package from the monobuild nightly for use in
+    # building the VSIX. We pull from NightlyBranchName rather than a pinned
     # LatestOfficialBuildID so PR build-validation runs always get a fresh package without
     # needing a build id supplied at queue time.
-    #
-    # The nightly runs commonly finish as PartiallySucceeded (some downstream test/SDL
-    # stages are not green) even though the packaging stage produced the artifact, so
-    # both allowPartiallySucceededBuilds and allowFailedBuilds must be true -- the task
-    # requires the pair to be set together to consider non-succeeded runs.
-    - task: DownloadPipelineArtifact@2
-      displayName: 'Download WindowsAppSDK From Latest Nightly'
-      inputs:
+    - template: WindowsAppSDK-DownloadNightlyPackage-Steps.yml
+      parameters:
         artifactName: ${{ parameters.artifactName }}
         targetPath: '$(System.ArtifactsDirectory)'
-        source: 'specific'
-        project: $(System.TeamProjectId)
-        pipeline: 190463
-        runVersion: 'latestFromBranch'
-        runBranch: '${{ parameters.NightlyBranchName }}'
-        allowPartiallySucceededBuilds: true
-        allowFailedBuilds: true
-      
+        nightlyBranchName: ${{ parameters.NightlyBranchName }}
+        maxNightlyAgeInDays: ${{ parameters.MaxNightlyAgeInDays }}
+
 - task: PowerShell@2
   name: ExtractWindowsAppSDKVersion
   displayName: Extract WindowsAppSDKVersion

--- a/build/AzurePipelinesTemplates/WindowsAppSDK-DownloadNightlyPackage-Steps.yml
+++ b/build/AzurePipelinesTemplates/WindowsAppSDK-DownloadNightlyPackage-Steps.yml
@@ -1,0 +1,159 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+#
+# Downloads the Windows App SDK NuGet + MSIX artifact from the most recent monobuild
+# nightly that actually published it.
+#
+# Why this exists instead of `runVersion: 'latestFromBranch'`:
+#   That selector picks candidates by WHOLE-BUILD result, which is not the property this
+#   download depends on. The monobuild nightly is routinely `failed` purely because of its
+#   Test Gate stage while its Aggregate stage still published a correctly named artifact.
+#   So neither setting of allowFailedBuilds is correct:
+#     * false -> rejects every Test-Gate-red nightly and walks back to the newest non-failed
+#       run, which can be weeks old and have had its artifacts purged by retention. The
+#       download then fails with "Artifact <name> was not found for build <id>" naming a
+#       build id far enough in the past to make the failure look unrelated to the PR.
+#     * true  -> takes the newest run even when its Aggregate stage never produced the
+#       artifact, or produced it under the 1ES `<name>_failed_N` rename, which 404s too.
+#   Artifact presence is what we actually need, so probe for it directly via the Build REST
+#   API and download from that specific run.
+#
+# To pin a known-good nightly, queue the build with a `NightlyBuildIdOverride` variable set
+# to its build id. When that variable is not set the resolver ignores it and auto-selects.
+
+parameters:
+# Exact pipeline artifact name to download. Must match, not prefix-match: the nightly also
+# publishes '<name>_sdl_analysis', which is not the payload.
+- name: artifactName
+  type: string
+- name: targetPath
+  type: string
+  default: '$(System.ArtifactsDirectory)'
+# Definition id of WinAppSDK-MonoBuild-Nightly.
+- name: nightlyPipelineId
+  type: string
+  default: '190463'
+- name: nightlyBranchName
+  type: string
+# Recency guard. The search stops once it reaches runs older than this, so a regression that
+# stops the nightly publishing the artifact fails fast and says so, instead of silently
+# reaching back to a build whose artifacts no longer exist.
+- name: maxNightlyAgeInDays
+  type: number
+  default: 7
+# Upper bound on REST calls. The nightly currently runs ~8 times a day, so this covers more
+# than maxNightlyAgeInDays' worth of runs and the age guard is what terminates the search.
+# Only the matching run is probed in the healthy case; the full walk happens only when the
+# nightly has genuinely stopped publishing.
+- name: maxRunsToProbe
+  type: number
+  default: 100
+
+steps:
+- task: PowerShell@2
+  displayName: 'Resolve latest nightly publishing ${{ parameters.artifactName }}'
+  env:
+    SYSTEM_ACCESSTOKEN: $(System.AccessToken)
+    WASDK_COLLECTION_URI: $(System.CollectionUri)
+    WASDK_PROJECT_ID: $(System.TeamProjectId)
+    WASDK_PIPELINE_ID: ${{ parameters.nightlyPipelineId }}
+    WASDK_BRANCH_NAME: ${{ parameters.nightlyBranchName }}
+    WASDK_ARTIFACT_NAME: ${{ parameters.artifactName }}
+    WASDK_MAX_AGE_DAYS: ${{ parameters.maxNightlyAgeInDays }}
+    WASDK_MAX_RUNS: ${{ parameters.maxRunsToProbe }}
+    # Renders as the literal '$(NightlyBuildIdOverride)' when the variable is undefined;
+    # the resolver only honours it when it is all digits.
+    WASDK_PINNED_BUILD_ID: $(NightlyBuildIdOverride)
+  inputs:
+    targetType: 'inline'
+    script: |
+      $ErrorActionPreference = 'Stop'
+      [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
+
+      $collectionUri = $env:WASDK_COLLECTION_URI.TrimEnd('/')
+      $projectId     = $env:WASDK_PROJECT_ID
+      $pipelineId    = $env:WASDK_PIPELINE_ID
+      $branchName    = $env:WASDK_BRANCH_NAME
+      $artifactName  = $env:WASDK_ARTIFACT_NAME
+      $maxAgeDays    = [int]$env:WASDK_MAX_AGE_DAYS
+      $maxRuns       = [int]$env:WASDK_MAX_RUNS
+      $pinnedBuildId = $env:WASDK_PINNED_BUILD_ID
+
+      if ([string]::IsNullOrWhiteSpace($env:SYSTEM_ACCESSTOKEN)) {
+        Write-Host '##vso[task.logissue type=error]System.AccessToken is empty, so the nightly that publishes the artifact cannot be resolved. Map it into the step env or grant the build identity access to the OAuth token.'
+        exit 1
+      }
+      $headers = @{ Authorization = 'Bearer ' + $env:SYSTEM_ACCESSTOKEN }
+
+      function Get-ArtifactNames([string] $BuildId) {
+        $uri = $collectionUri + '/' + $projectId + '/_apis/build/builds/' + $BuildId + '/artifacts?api-version=7.1'
+        $response = Invoke-RestMethod -Uri $uri -Headers $headers -Method Get
+        if ($null -eq $response -or $null -eq $response.value) { return @() }
+        return @($response.value | ForEach-Object { $_.name })
+      }
+
+      $resolvedBuildId = ''
+
+      if ($pinnedBuildId -match '^\d+$') {
+        Write-Host ('NightlyBuildIdOverride is set; using pinned nightly build ' + $pinnedBuildId)
+        $names = @(Get-ArtifactNames $pinnedBuildId)
+        if ($names -notcontains $artifactName) {
+          Write-Host ('##vso[task.logissue type=error]Pinned build ' + $pinnedBuildId + ' does not publish an artifact named ''' + $artifactName + '''. It reports ' + $names.Count + ' artifacts; its artifacts may already have been purged by retention. Pick a newer build id or clear NightlyBuildIdOverride.')
+          exit 1
+        }
+        $resolvedBuildId = $pinnedBuildId
+      }
+      else {
+        $listUri = $collectionUri + '/' + $projectId + '/_apis/build/builds' +
+                   '?definitions=' + $pipelineId +
+                   '&branchName=' + [uri]::EscapeDataString($branchName) +
+                   '&statusFilter=completed' +
+                   '&queryOrder=finishTimeDescending' +
+                   '&$top=' + $maxRuns +
+                   '&api-version=7.1'
+        $runs = @((Invoke-RestMethod -Uri $listUri -Headers $headers -Method Get).value)
+        Write-Host ('Looking for the newest run of pipeline ' + $pipelineId + ' on ' + $branchName +
+                    ' that publishes ''' + $artifactName + ''' (' + $runs.Count + ' completed runs returned, ' +
+                    $maxAgeDays + '-day limit).')
+
+        $cutoff = (Get-Date).ToUniversalTime().AddDays(-$maxAgeDays)
+        foreach ($run in $runs) {
+          $finishTime = $null
+          if ($run.finishTime) { $finishTime = ([datetime]$run.finishTime).ToUniversalTime() }
+          if ($null -ne $finishTime -and $finishTime -lt $cutoff) {
+            Write-Host ('  build ' + $run.id + ' finished ' + $finishTime.ToString('u') + ', past the ' + $maxAgeDays + '-day limit. Stopping.')
+            break
+          }
+
+          $names = @(Get-ArtifactNames $run.id)
+          $hasArtifact = ($names -contains $artifactName)
+          Write-Host ('  build ' + $run.id + ' (' + $run.buildNumber + ') result=' + $run.result +
+                      ' artifacts=' + $names.Count + ' hasArtifact=' + $hasArtifact)
+          if ($hasArtifact) {
+            $resolvedBuildId = [string]$run.id
+            break
+          }
+        }
+      }
+
+      if ([string]::IsNullOrWhiteSpace($resolvedBuildId)) {
+        Write-Host ('##vso[task.logissue type=error]No run of pipeline ' + $pipelineId + ' on ' + $branchName +
+                    ' in the last ' + $maxAgeDays + ' days publishes an artifact named ''' + $artifactName +
+                    '''. The nightly is not producing it (check its Aggregate stage), or the artifact was renamed. ' +
+                    'Queue with NightlyBuildIdOverride=<build id> to unblock with a known-good run.')
+        exit 1
+      }
+
+      Write-Host ('Resolved nightly build id: ' + $resolvedBuildId)
+      Write-Host ('##vso[task.setvariable variable=ResolvedNightlyBuildId]' + $resolvedBuildId)
+
+- task: DownloadPipelineArtifact@2
+  displayName: 'Download WindowsAppSDK From Latest Nightly'
+  inputs:
+    artifactName: ${{ parameters.artifactName }}
+    targetPath: '${{ parameters.targetPath }}'
+    source: 'specific'
+    project: $(System.TeamProjectId)
+    pipeline: ${{ parameters.nightlyPipelineId }}
+    runVersion: 'specific'
+    runId: $(ResolvedNightlyBuildId)


### PR DESCRIPTION
Port of the release/dev/monobuild fix. The two channels fail in opposite directions but for the same reason: `runVersion: 'latestFromBranch'` selects the nightly by WHOLE-BUILD result, which is not the property the download depends on. The monobuild nightly is routinely `failed` purely because of its Test Gate stage while its Aggregate stage still publishes a correctly named artifact.

  * release/dev/monobuild has allowFailedBuilds: false, so it rejects every Test-Gate-red nightly and falls back to a run old enough that retention has purged its artifacts. That is the reported break: "Artifact WindowsAppSDK-NuGet-And-MSIX was not found for build 150121328."
  * this branch has allowFailedBuilds: true, so it takes the newest run unconditionally - including runs whose Aggregate stage never produced the artifact. 7 of the 15 most recent nightlies on this branch publish no WindowsAppSDK-NuGet-And-MSIX at all, so the download is a coin flip today and fails with the same 404 whenever it lands on one of them.

Fix: resolve the build id from artifact presence instead. A new shared steps template probes the Build REST API for the newest completed run on the branch that publishes the exact artifact name, then downloads with `runVersion: 'specific'` / `runId`. It carries a recency guard (maxNightlyAgeInDays, default 7) that fails with "No run of pipeline ... in the last N days publishes an artifact named ..." rather than a confusing 404, and a NightlyBuildIdOverride queue-time variable to pin a known-good nightly.

The added lines are byte-identical to the release/dev/monobuild change and the new template file is the same blob; the only difference between the two commits is which allowFailedBuilds value and comment block was removed.

Note for reviewers, deliberately NOT changed here: NightlyBranchName still defaults to 'refs/heads/release/dev/monobuild', i.e. this branch's Foundation builds consume the MAIN monobuild channel's package even though the nightly does run on release/dev/monobuild-2.0-stable and does publish the artifact there. That looks wrong but it is a separate behavioural decision for the 2.0-stable owners, not part of this fix.

A microsoft employee must use /azp run to validate using the pipelines below.

WARNING:
Comments made by azure-pipelines bot maybe inaccurate.
Please see pipeline link to verify that the build is being ran.

For status checks on the main branch, please use TransportPackage-Foundation-PR
(https://microsoft.visualstudio.com/ProjectReunion/_build?definitionId=81063&_a=summary)
and run the build against your PR branch with the default parameters.
