### PR TITLE
 Fix arm64ec vc_redist CodeSign break

### DIFF
--- a/build/AzurePipelinesTemplates/WindowsAppSDK-BuildFoundation-Steps.yml
+++ b/build/AzurePipelinesTemplates/WindowsAppSDK-BuildFoundation-Steps.yml
@@ -174,7 +174,10 @@ steps:
 
 - task: CopyFiles@2
   displayName: Stage redist files for publish
-  condition: always()
+  # arm64ec skips the redist downloads above (no arm64ec vc_redist/dotnet/VCLibs exist), so
+  # $(build.SourcesDirectory)\redist is never created for that leg; guard so CopyFiles doesn't
+  # fail with "Not found SourceFolder". Nothing consumes an arm64ec redist downstream.
+  condition: and(always(), ne(variables['buildPlatform'], 'arm64ec'))
   inputs:
     SourceFolder: '$(build.SourcesDirectory)\redist'
     TargetFolder: '$(ob_outputDirectory)\redist'

--- a/build/AzurePipelinesTemplates/WindowsAppSDK-SetupBuildEnvironment-Steps.yml
+++ b/build/AzurePipelinesTemplates/WindowsAppSDK-SetupBuildEnvironment-Steps.yml
@@ -70,9 +70,15 @@ steps:
       -ProductMajor "$(MajorVersion)"
       -ProductMinor "$(MinorVersion)"
 
+# ARM64EC has no dedicated third-party redist: Microsoft ships the .NET Desktop runtime,
+# VC++ redist (vc_redist.<arch>.exe) and Desktop VCLibs only as x86/x64/arm64. ARM64EC code
+# runs against the arm64/x64 redist, so these downloads are limited to x86/x64/arm64. Including
+# arm64ec made DownloadVCRedistInstaller.ps1 request a vc_redist.arm64ec.exe that does not exist;
+# the saved redist\vc_redist.arm64ec.exe then broke Guardian CodeSign (CodeSign.MissingSigningCert).
+# The arm64ec leg is build-only and consumes none of these redists.
 - task: PowerShell@2
   displayName: 'Download dotnet installer'
-  condition: or(eq(variables['buildPlatform'], 'x86'), eq(variables['buildPlatform'], 'x64'), eq(variables['buildPlatform'], 'arm64'), eq(variables['buildPlatform'], 'arm64ec'))
+  condition: or(eq(variables['buildPlatform'], 'x86'), eq(variables['buildPlatform'], 'x64'), eq(variables['buildPlatform'], 'arm64'))
   inputs:
     targetType: filePath
     filePath: '$(Build.SourcesDirectory)\build\scripts\DownloadDotNetRuntimeInstaller.ps1'
@@ -80,7 +86,7 @@ steps:
 
 - task: PowerShell@2
   displayName: 'Download vcredist installer'
-  condition: or(eq(variables['buildPlatform'], 'x86'), eq(variables['buildPlatform'], 'x64'), eq(variables['buildPlatform'], 'arm64'), eq(variables['buildPlatform'], 'arm64ec'))
+  condition: or(eq(variables['buildPlatform'], 'x86'), eq(variables['buildPlatform'], 'x64'), eq(variables['buildPlatform'], 'arm64'))
   inputs:
     targetType: filePath
     filePath: '$(Build.SourcesDirectory)\build\scripts\DownloadVCRedistInstaller.ps1'
@@ -88,7 +94,7 @@ steps:
 
 - task: PowerShell@2
   displayName: 'Download desktop bridge CRT'
-  condition: or(eq(variables['buildPlatform'], 'x86'), eq(variables['buildPlatform'], 'x64'), eq(variables['buildPlatform'], 'arm64'), eq(variables['buildPlatform'], 'arm64ec'))
+  condition: or(eq(variables['buildPlatform'], 'x86'), eq(variables['buildPlatform'], 'x64'), eq(variables['buildPlatform'], 'arm64'))
   inputs:
     targetType: filePath
     filePath: '$(Build.SourcesDirectory)\build\scripts\DownloadVCLibsDesktop.ps1'


### PR DESCRIPTION
Fix removes vc_redist/dotnet/VCLibs download for arm64ec

A microsoft employee must use /azp run to validate using the pipelines below.

WARNING:
Comments made by azure-pipelines bot maybe inaccurate.
Please see pipeline link to verify that the build is being ran.

For status checks on the main branch, please use TransportPackage-Foundation-PR
(https://microsoft.visualstudio.com/ProjectReunion/_build?definitionId=81063&_a=summary)
and run the build against your PR branch with the default parameters.
