### PR TITLE
Add 2.5.0 runtime compatibility enums

### DIFF
--- a/dev/RuntimeCompatibilityOptions/RuntimeCompatibilityOptions.cpp
+++ b/dev/RuntimeCompatibilityOptions/RuntimeCompatibilityOptions.cpp
@@ -55,7 +55,7 @@ namespace
         WinAppSDK_2_1_5 = WinAppSDKReleaseVersionFromValues(2, 1, 5),
         WinAppSDK_2_3_0 = WinAppSDKReleaseVersionFromValues(2, 3, 0),
         WinAppSDK_2_3_3 = WinAppSDKReleaseVersionFromValues(2, 3, 3),
-        WinAppSDK_2_4_2 = WinAppSDKReleaseVersionFromValues(2, 4, 2),
+        WinAppSDK_2_5_0 = WinAppSDKReleaseVersionFromValues(2, 5, 0),
         WinAppSDK_Latest = 999999999,
         WinAppSDK_Security = 0,
     };
@@ -177,7 +177,7 @@ namespace
         63264582, // AppContentSearchNewAPI_LafCheck
         63293066, // LanguageModel_LanguageDetectionStatus
     };
-    constexpr UINT32 s_changes_2_4_2[] = {
+    constexpr UINT32 s_changes_2_5_0[] = {
         62943243, // PointerInputProcessor_ReleaseCaptureOnDisposedIsland
         62995866, // NavigationView_UpdatePaneLayoutNegativeMaxHeight
         62998965, // PointerPositionPropertySet_UpdateWhilePressed
@@ -192,7 +192,7 @@ namespace
         MakeGroup(s_changes_2_1_5, WinAppSDKReleaseVersion::WinAppSDK_2_1_5),
         MakeGroup(s_changes_2_3_0, WinAppSDKReleaseVersion::WinAppSDK_2_3_0),
         MakeGroup(s_changes_2_3_3, WinAppSDKReleaseVersion::WinAppSDK_2_3_3),
-        MakeGroup(s_changes_2_4_2, WinAppSDKReleaseVersion::WinAppSDK_2_4_2),
+        MakeGroup(s_changes_2_5_0, WinAppSDKReleaseVersion::WinAppSDK_2_5_0),
     };
     constexpr size_t s_catalogGroupsProdCount{ std::size(s_catalogGroupsProd) };
 

--- a/dev/RuntimeCompatibilityOptions/RuntimeCompatibilityOptions.cpp
+++ b/dev/RuntimeCompatibilityOptions/RuntimeCompatibilityOptions.cpp
@@ -55,6 +55,7 @@ namespace
         WinAppSDK_2_1_5 = WinAppSDKReleaseVersionFromValues(2, 1, 5),
         WinAppSDK_2_3_0 = WinAppSDKReleaseVersionFromValues(2, 3, 0),
         WinAppSDK_2_3_3 = WinAppSDKReleaseVersionFromValues(2, 3, 3),
+        WinAppSDK_2_4_2 = WinAppSDKReleaseVersionFromValues(2, 4, 2),
         WinAppSDK_Latest = 999999999,
         WinAppSDK_Security = 0,
     };
@@ -176,11 +177,22 @@ namespace
         63264582, // AppContentSearchNewAPI_LafCheck
         63293066, // LanguageModel_LanguageDetectionStatus
     };
+    constexpr UINT32 s_changes_2_4_2[] = {
+        62943243, // PointerInputProcessor_ReleaseCaptureOnDisposedIsland
+        62995866, // NavigationView_UpdatePaneLayoutNegativeMaxHeight
+        62998965, // PointerPositionPropertySet_UpdateWhilePressed
+        63007686, // NavigationViewItem_DeferredFlyoutShowStaleState
+        63417306, // KeyboardAccelerator_OemKeyNoFailFast
+        63435928, // WindowsXamlManager_ActivationFactoryCacheResetRace
+        63435929, // CommandBar_SpuriousOverflowButtonAtFractionalScale
+        63494532, // CompositionEngine_SwitcherSeptemberFixes
+    };
     constexpr CatalogGroup s_catalogGroupsProd[] = {
         MakeGroup(s_changes_2_1_0, WinAppSDKReleaseVersion::WinAppSDK_2_1_0),
         MakeGroup(s_changes_2_1_5, WinAppSDKReleaseVersion::WinAppSDK_2_1_5),
         MakeGroup(s_changes_2_3_0, WinAppSDKReleaseVersion::WinAppSDK_2_3_0),
         MakeGroup(s_changes_2_3_3, WinAppSDKReleaseVersion::WinAppSDK_2_3_3),
+        MakeGroup(s_changes_2_4_2, WinAppSDKReleaseVersion::WinAppSDK_2_4_2),
     };
     constexpr size_t s_catalogGroupsProdCount{ std::size(s_catalogGroupsProd) };
 

--- a/dev/RuntimeCompatibilityOptions/RuntimeCompatibilityOptions.idl
+++ b/dev/RuntimeCompatibilityOptions/RuntimeCompatibilityOptions.idl
@@ -92,6 +92,16 @@ namespace Microsoft.Windows.ApplicationModel.WindowsAppRuntime
         WindowsAppRuntime_BaseDirectoryIsolation = 63098302,
         AppContentSearchNewAPI_LafCheck = 63264582,
         LanguageModel_LanguageDetectionStatus = 63293066,
+
+        // 2.4.2
+        PointerInputProcessor_ReleaseCaptureOnDisposedIsland = 62943243,
+        NavigationView_UpdatePaneLayoutNegativeMaxHeight = 62995866,
+        PointerPositionPropertySet_UpdateWhilePressed = 62998965,
+        NavigationViewItem_DeferredFlyoutShowStaleState = 63007686,
+        KeyboardAccelerator_OemKeyNoFailFast = 63417306,
+        WindowsXamlManager_ActivationFactoryCacheResetRace = 63435928,
+        CommandBar_SpuriousOverflowButtonAtFractionalScale = 63435929,
+        CompositionEngine_SwitcherSeptemberFixes = 63494532,
     };
 
     /// Represents a version of the Windows App Runtime.

--- a/dev/RuntimeCompatibilityOptions/RuntimeCompatibilityOptions.idl
+++ b/dev/RuntimeCompatibilityOptions/RuntimeCompatibilityOptions.idl
@@ -93,7 +93,7 @@ namespace Microsoft.Windows.ApplicationModel.WindowsAppRuntime
         AppContentSearchNewAPI_LafCheck = 63264582,
         LanguageModel_LanguageDetectionStatus = 63293066,
 
-        // 2.4.2
+        // 2.5.0
         PointerInputProcessor_ReleaseCaptureOnDisposedIsland = 62943243,
         NavigationView_UpdatePaneLayoutNegativeMaxHeight = 62995866,
         PointerPositionPropertySet_UpdateWhilePressed = 62998965,


### PR DESCRIPTION
A microsoft employee must use /azp run to validate using the pipelines below.

WARNING:
Comments made by azure-pipelines bot maybe inaccurate.
Please see pipeline link to verify that the build is being ran.

For status checks on the main branch, please use TransportPackage-Foundation-PR
(https://microsoft.visualstudio.com/ProjectReunion/_build?definitionId=81063&_a=summary)
and run the build against your PR branch with the default parameters.