### PR TITLE
Configure monthly Dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,26 @@
+version: 2
+updates:
+  - package-ecosystem: "nuget"
+    directories:
+      - "/"
+      - "/dev/MRTCore/mrt"
+      - "/dev/Templates/VSIX"
+      - "/dev/Templates/Source/ProjectTemplates/Desktop/CSharp/*"
+      - "/dev/Templates/Source/ProjectTemplates/Desktop/CSharp/PackagedApp/BlankApp"
+      - "/test/StaticValidationTests"
+      - "/tools/ProjectTemplates/dev.cs.dll.projection"
+    schedule:
+      interval: "monthly"
+    groups:
+      minor-and-patch:
+        patterns: ["*"]
+        update-types: ["minor", "patch"]
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "monthly"
+    groups:
+      minor-and-patch:
+        patterns: ["*"]
+        update-types: ["minor", "patch"]

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,10 +3,10 @@ updates:
   - package-ecosystem: "nuget"
     directories:
       - "/"
-      - "/dev/MRTCore/mrt"
+      - "/dev/MRTCore/mrt/Microsoft.Windows.ApplicationModel.Resources/UnpackagedTests"
+      - "/dev/MRTCore/mrt/Microsoft.Windows.ApplicationModel.Resources/projection"
+      - "/dev/MRTCore/mrt/Microsoft.Windows.ApplicationModel.Resources/unittests"
       - "/dev/Templates/VSIX"
-      - "/dev/Templates/Source/ProjectTemplates/Desktop/CSharp/*"
-      - "/dev/Templates/Source/ProjectTemplates/Desktop/CSharp/PackagedApp/BlankApp"
       - "/test/StaticValidationTests"
       - "/tools/ProjectTemplates/dev.cs.dll.projection"
     schedule:


### PR DESCRIPTION
A microsoft employee must use /azp run to validate using the pipelines below.

WARNING:
Comments made by azure-pipelines bot maybe inaccurate.
Please see pipeline link to verify that the build is being ran.

For status checks on the main branch, please use TransportPackage-Foundation-PR
(https://microsoft.visualstudio.com/ProjectReunion/_build?definitionId=81063&_a=summary)
and run the build against your PR branch with the default parameters.

## Summary

Run monthly Dependabot version updates for NuGet and GitHub Actions. Minor and patch releases are grouped. Major releases remain separate.

The NuGet configuration uses seven explicit directories. Its solution and project entry points reach 67 unique .NET projects without overlap. Thirty-nine of those projects contain updateable package declarations. The jobs also cover the root `Directory.Packages.props`, `global.json` files with `msbuild-sdks` at the repository root and under `dev/MRTCore`, and the `packages.config` used by `MrtCoreUnpackagedTests`.

The GitHub Actions entry covers `.github/workflows/build.yml` and its three external action references.

## Validation

- Validated `.github/dependabot.yml` against the SchemaStore Dependabot v2 schema.
- Confirmed that all seven NuGet directories exist and contain a supported solution or .NET project entry point.
- Confirmed that the project graph has no duplicate coverage.
- Confirmed that the pull request changes only `.github/dependabot.yml`.

## Exclusions

Seven `ProjectTemplate.csproj` files use `$...$` package version placeholders, so Dependabot cannot update them. The correction removes their eight resolved template directories, including the redundant wrapper project coverage supplied by `dev/Templates/VSIX`.

The repository also has 92 non-empty `packages.config` files attached only to `.vcxproj` projects, two non-empty standalone files without a supported .NET entry point, and two empty files. Dependabot's NuGet updater cannot process those locations. The only `dotnet-sdk` candidate specifies .NET SDK 3.0, below Dependabot's supported range.
