### PR TITLE
Set ApplicationIcon in the C# app templates

### DIFF
--- a/dev/Templates/Dotnet/templates/reactor-blank-app/.template.config/template.json
+++ b/dev/Templates/Dotnet/templates/reactor-blank-app/.template.config/template.json
@@ -50,7 +50,7 @@
     "reactorVersion": {
       "type": "parameter",
       "datatype": "text",
-      "defaultValue": "0.1.0-preview.13",
+      "defaultValue": "0.1.0-preview.14",
       "replaces": "$ReactorVersion$",
       "description": "Microsoft.UI.Reactor (and Microsoft.UI.Reactor.Devtools) NuGet version to reference."
     },

--- a/dev/Templates/Dotnet/templates/reactor-mvu-app/.template.config/template.json
+++ b/dev/Templates/Dotnet/templates/reactor-mvu-app/.template.config/template.json
@@ -50,7 +50,7 @@
     "reactorVersion": {
       "type": "parameter",
       "datatype": "text",
-      "defaultValue": "0.1.0-preview.13",
+      "defaultValue": "0.1.0-preview.14",
       "replaces": "$ReactorVersion$",
       "description": "Microsoft.UI.Reactor (and Microsoft.UI.Reactor.Devtools) NuGet version to reference."
     },

--- a/dev/Templates/Dotnet/templates/reactor-navigation-app/.template.config/template.json
+++ b/dev/Templates/Dotnet/templates/reactor-navigation-app/.template.config/template.json
@@ -50,7 +50,7 @@
     "reactorVersion": {
       "type": "parameter",
       "datatype": "text",
-      "defaultValue": "0.1.0-preview.13",
+      "defaultValue": "0.1.0-preview.14",
       "replaces": "$ReactorVersion$",
       "description": "Microsoft.UI.Reactor (and Microsoft.UI.Reactor.Devtools) NuGet version to reference."
     },

--- a/dev/Templates/Dotnet/templates/reactor-tabview-app/.template.config/template.json
+++ b/dev/Templates/Dotnet/templates/reactor-tabview-app/.template.config/template.json
@@ -50,7 +50,7 @@
     "reactorVersion": {
       "type": "parameter",
       "datatype": "text",
-      "defaultValue": "0.1.0-preview.13",
+      "defaultValue": "0.1.0-preview.14",
       "replaces": "$ReactorVersion$",
       "description": "Microsoft.UI.Reactor (and Microsoft.UI.Reactor.Devtools) NuGet version to reference."
     },

--- a/dev/Templates/Source/ProjectTemplates/Desktop/CSharp/MvvmApp/ProjectTemplate.csproj
+++ b/dev/Templates/Source/ProjectTemplates/Desktop/CSharp/MvvmApp/ProjectTemplate.csproj
@@ -5,6 +5,7 @@
     <TargetPlatformMinVersion>10.0.17763.0</TargetPlatformMinVersion>
     <RootNamespace>$safeprojectname$</RootNamespace>
     <ApplicationManifest>app.manifest</ApplicationManifest>
+    <ApplicationIcon Condition="Exists('Assets\AppIcon.ico')">Assets\AppIcon.ico</ApplicationIcon>
     <Platforms>x86;x64;ARM64</Platforms>
     <RuntimeIdentifier Condition="'$(RuntimeIdentifier)' == ''">win-$([System.Runtime.InteropServices.RuntimeInformation]::ProcessArchitecture.ToString().ToLowerInvariant())</RuntimeIdentifier>
     <PublishProfile Condition="Exists('Properties\PublishProfiles\win-$(Platform).pubxml')">win-$(Platform).pubxml</PublishProfile>

--- a/dev/Templates/Source/ProjectTemplates/Desktop/CSharp/NavigationApp/ProjectTemplate.csproj
+++ b/dev/Templates/Source/ProjectTemplates/Desktop/CSharp/NavigationApp/ProjectTemplate.csproj
@@ -5,6 +5,7 @@
     <TargetPlatformMinVersion>10.0.17763.0</TargetPlatformMinVersion>
     <RootNamespace>$safeprojectname$</RootNamespace>
     <ApplicationManifest>app.manifest</ApplicationManifest>
+    <ApplicationIcon Condition="Exists('Assets\AppIcon.ico')">Assets\AppIcon.ico</ApplicationIcon>
     <Platforms>x86;x64;ARM64</Platforms>
     <RuntimeIdentifier Condition="'$(RuntimeIdentifier)' == ''">win-$([System.Runtime.InteropServices.RuntimeInformation]::ProcessArchitecture.ToString().ToLowerInvariant())</RuntimeIdentifier>
     <PublishProfile Condition="Exists('Properties\PublishProfiles\win-$(Platform).pubxml')">win-$(Platform).pubxml</PublishProfile>

--- a/dev/Templates/Source/ProjectTemplates/Desktop/CSharp/ReactorBlankApp/App.cs
+++ b/dev/Templates/Source/ProjectTemplates/Desktop/CSharp/ReactorBlankApp/App.cs
@@ -14,7 +14,6 @@ class App : Component
     public override Element Render()
     {
         var titleBar = TitleBar("$projectname$")
-            .Icon("ms-appx:///Assets/AppIcon.ico")
             .Flex(shrink: 0);
 
         // This is the main content area of your application.

--- a/dev/Templates/Source/ProjectTemplates/Desktop/CSharp/ReactorBlankApp/ProjectTemplate.csproj
+++ b/dev/Templates/Source/ProjectTemplates/Desktop/CSharp/ReactorBlankApp/ProjectTemplate.csproj
@@ -6,6 +6,7 @@
     <SupportedOSPlatformVersion>10.0.17763.0</SupportedOSPlatformVersion>
     <RootNamespace>$safeprojectname$</RootNamespace>
     <ApplicationManifest>app.manifest</ApplicationManifest>
+    <ApplicationIcon Condition="Exists('Assets\AppIcon.ico')">Assets\AppIcon.ico</ApplicationIcon>
     <Platforms>x86;x64;ARM64</Platforms>
     <RuntimeIdentifier Condition="'$(RuntimeIdentifier)' == ''">win-$([System.Runtime.InteropServices.RuntimeInformation]::ProcessArchitecture.ToString().ToLowerInvariant())</RuntimeIdentifier>
     <PublishProfile Condition="Exists('Properties\PublishProfiles\win-$(Platform).pubxml')">win-$(Platform).pubxml</PublishProfile>

--- a/dev/Templates/Source/ProjectTemplates/Desktop/CSharp/ReactorMvuApp/App.cs
+++ b/dev/Templates/Source/ProjectTemplates/Desktop/CSharp/ReactorMvuApp/App.cs
@@ -34,7 +34,6 @@ class App : Component
         var (state, dispatch) = UseReducer<CounterState, CounterMessage>(Update, new CounterState(0));
 
         var titleBar = TitleBar("$projectname$")
-            .Icon("ms-appx:///Assets/AppIcon.ico")
             .Flex(shrink: 0);
 
         var content = VStack(16,

--- a/dev/Templates/Source/ProjectTemplates/Desktop/CSharp/ReactorMvuApp/ProjectTemplate.csproj
+++ b/dev/Templates/Source/ProjectTemplates/Desktop/CSharp/ReactorMvuApp/ProjectTemplate.csproj
@@ -6,6 +6,7 @@
     <SupportedOSPlatformVersion>10.0.17763.0</SupportedOSPlatformVersion>
     <RootNamespace>$safeprojectname$</RootNamespace>
     <ApplicationManifest>app.manifest</ApplicationManifest>
+    <ApplicationIcon Condition="Exists('Assets\AppIcon.ico')">Assets\AppIcon.ico</ApplicationIcon>
     <Platforms>x86;x64;ARM64</Platforms>
     <RuntimeIdentifier Condition="'$(RuntimeIdentifier)' == ''">win-$([System.Runtime.InteropServices.RuntimeInformation]::ProcessArchitecture.ToString().ToLowerInvariant())</RuntimeIdentifier>
     <PublishProfile Condition="Exists('Properties\PublishProfiles\win-$(Platform).pubxml')">win-$(Platform).pubxml</PublishProfile>

--- a/dev/Templates/Source/ProjectTemplates/Desktop/CSharp/ReactorNavigationApp/App.cs
+++ b/dev/Templates/Source/ProjectTemplates/Desktop/CSharp/ReactorNavigationApp/App.cs
@@ -47,7 +47,6 @@ class App : Component
         };
 
         var titleBar = TitleBar("$projectname$")
-            .Icon("ms-appx:///Assets/AppIcon.ico")
             .WithNavigation(nav)
             .PaneToggleButtonVisible(true)
             .PaneToggleRequested(() => setIsPaneOpen(!isPaneOpen))

--- a/dev/Templates/Source/ProjectTemplates/Desktop/CSharp/ReactorNavigationApp/ProjectTemplate.csproj
+++ b/dev/Templates/Source/ProjectTemplates/Desktop/CSharp/ReactorNavigationApp/ProjectTemplate.csproj
@@ -6,6 +6,7 @@
     <SupportedOSPlatformVersion>10.0.17763.0</SupportedOSPlatformVersion>
     <RootNamespace>$safeprojectname$</RootNamespace>
     <ApplicationManifest>app.manifest</ApplicationManifest>
+    <ApplicationIcon Condition="Exists('Assets\AppIcon.ico')">Assets\AppIcon.ico</ApplicationIcon>
     <Platforms>x86;x64;ARM64</Platforms>
     <RuntimeIdentifier Condition="'$(RuntimeIdentifier)' == ''">win-$([System.Runtime.InteropServices.RuntimeInformation]::ProcessArchitecture.ToString().ToLowerInvariant())</RuntimeIdentifier>
     <PublishProfile Condition="Exists('Properties\PublishProfiles\win-$(Platform).pubxml')">win-$(Platform).pubxml</PublishProfile>

--- a/dev/Templates/Source/ProjectTemplates/Desktop/CSharp/ReactorTabViewApp/ProjectTemplate.csproj
+++ b/dev/Templates/Source/ProjectTemplates/Desktop/CSharp/ReactorTabViewApp/ProjectTemplate.csproj
@@ -6,6 +6,7 @@
     <SupportedOSPlatformVersion>10.0.17763.0</SupportedOSPlatformVersion>
     <RootNamespace>$safeprojectname$</RootNamespace>
     <ApplicationManifest>app.manifest</ApplicationManifest>
+    <ApplicationIcon Condition="Exists('Assets\AppIcon.ico')">Assets\AppIcon.ico</ApplicationIcon>
     <Platforms>x86;x64;ARM64</Platforms>
     <RuntimeIdentifier Condition="'$(RuntimeIdentifier)' == ''">win-$([System.Runtime.InteropServices.RuntimeInformation]::ProcessArchitecture.ToString().ToLowerInvariant())</RuntimeIdentifier>
     <PublishProfile Condition="Exists('Properties\PublishProfiles\win-$(Platform).pubxml')">win-$(Platform).pubxml</PublishProfile>

--- a/dev/Templates/Source/ProjectTemplates/Desktop/CSharp/SingleProjectPackagedApp/ProjectTemplate.csproj
+++ b/dev/Templates/Source/ProjectTemplates/Desktop/CSharp/SingleProjectPackagedApp/ProjectTemplate.csproj
@@ -5,6 +5,7 @@
     <TargetPlatformMinVersion>10.0.17763.0</TargetPlatformMinVersion>
     <RootNamespace>$safeprojectname$</RootNamespace>
     <ApplicationManifest>app.manifest</ApplicationManifest>
+    <ApplicationIcon Condition="Exists('Assets\AppIcon.ico')">Assets\AppIcon.ico</ApplicationIcon>
     <Platforms>x86;x64;ARM64</Platforms>
     <RuntimeIdentifier Condition="'$(RuntimeIdentifier)' == ''">win-$([System.Runtime.InteropServices.RuntimeInformation]::ProcessArchitecture.ToString().ToLowerInvariant())</RuntimeIdentifier>
     <PublishProfile Condition="Exists('Properties\PublishProfiles\win-$(Platform).pubxml')">win-$(Platform).pubxml</PublishProfile>

--- a/dev/Templates/Source/ProjectTemplates/Desktop/CSharp/TabViewApp/ProjectTemplate.csproj
+++ b/dev/Templates/Source/ProjectTemplates/Desktop/CSharp/TabViewApp/ProjectTemplate.csproj
@@ -5,6 +5,7 @@
     <TargetPlatformMinVersion>10.0.17763.0</TargetPlatformMinVersion>
     <RootNamespace>$safeprojectname$</RootNamespace>
     <ApplicationManifest>app.manifest</ApplicationManifest>
+    <ApplicationIcon Condition="Exists('Assets\AppIcon.ico')">Assets\AppIcon.ico</ApplicationIcon>
     <Platforms>x86;x64;ARM64</Platforms>
     <RuntimeIdentifier Condition="'$(RuntimeIdentifier)' == ''">win-$([System.Runtime.InteropServices.RuntimeInformation]::ProcessArchitecture.ToString().ToLowerInvariant())</RuntimeIdentifier>
     <PublishProfile Condition="Exists('Properties\PublishProfiles\win-$(Platform).pubxml')">win-$(Platform).pubxml</PublishProfile>


### PR DESCRIPTION
Follow-up to #6620.

Two related template changes: embed the app icon into the built executable, and drop the now-redundant explicit title bar icon from the Reactor templates.

## 1. `<ApplicationIcon>` in all eight C# app templates

All eight ship `Assets\AppIcon.ico` and reference it from the window — `AppWindow.SetIcon(...)` in the WinUI XAML templates, `TitleBar(...)` in the Reactor ones — but none set `<ApplicationIcon>`, so the icon was never embedded into the executable as a Win32 icon resource. Explorer, shortcuts, and the taskbar for an unpackaged build showed the default .NET icon.

One line per template:

```xml
<ApplicationIcon Condition="Exists('Assets\AppIcon.ico')">Assets\AppIcon.ico</ApplicationIcon>
```

`Condition="Exists(...)"` skips the property rather than failing the build if a project lacks the asset, matching the `PublishProfile Condition="Exists(...)"` pattern already in these templates.

Applied to all eight app templates that ship the asset — the four WinUI XAML ones and the four Reactor ones — so the templates stay consistent with each other. `ClassLibrary`, `PackagedApp`, and `UnitTestApp` ship no `AppIcon.ico` and are untouched.

Only `ProjectTemplate.csproj` is modified: that is the file scaffolded for the user by both `dotnet new` and the VSIX (the `.vstemplate` references it via `<Project File="ProjectTemplate.csproj">`). The `WinUI.Desktop.Cs.*.csproj` files alongside are VSSDK packaging projects that build the VSIX itself, not scaffolded output.

## 2. Reactor `0.1.0-preview.14`, and removing the explicit title bar icon

Reactor `0.1.0-preview.14` makes `TitleBar(...)` inherit the window's icon (microsoft/microsoft-ui-reactor#1153), so `.Icon("ms-appx:///Assets/AppIcon.ico")` in the templates is redundant. Removing it keeps the scaffolded `App.cs` closer to the shape a starter template should have.

This affects the **three** templates that use a `TitleBar` element: `ReactorBlankApp`, `ReactorMvuApp`, `ReactorNavigationApp`. `ReactorTabViewApp` has no `TitleBar` — it extends content into the title bar with a custom drag region and renders its icon through `TabStripHeader = Image(...)`, a different surface the inherit behaviour does not cover — so it keeps its explicit reference and is intentionally untouched.

## Validation

**`<ApplicationIcon>`** — all eight templates scaffolded and built (Debug, x64); every one embeds the icon, confirmed with `Icon.ExtractAssociatedIcon` returning a 32x32 icon from each produced `.exe`. Also confirmed the condition behaves: with `Assets\AppIcon.ico` removed the build produces no `CS7064`, whereas removing the `Condition` reintroduces it.

**Title bar icon** — validated against the real `0.1.0-preview.14` package, four scaffolded apps, icon line present and absent:

| app | setup | title bar mark |
|---|---|---|
| control | `.Icon` present, preview.14 | shown |
| **acceptance** | **line removed, preview.14** | **shown** |
| discriminator | line removed + `icon:` argument, preview.14 | shown |
| **negative control** | **line removed, preview.13** | **absent** |

The last row is what makes this meaningful: identical source and identical capture method, only the package version differs, so the mark on preview.14 is caused by the inherit behaviour rather than by something incidental. The discriminator separately confirms the new `icon:` API compiles and works from a scaffolded template.

All four Reactor templates were then scaffolded from the built pack and built on x64 — Debug 0 warnings, Release 2 warnings. The Release warnings are pre-existing `IL2104` trim warnings from `Microsoft.Windows.SDK.NET` and `WinRT.Runtime`, present with or without these changes. The two `winui-mvvm` warnings seen earlier are likewise pre-existing `MVVMTK0045` diagnostics from the MVVM Toolkit.

## Note

`<ApplicationIcon>` does not by itself set a running window's `HICON`, which is what drives the caption and Alt-Tab. But microsoft/microsoft-ui-reactor#1145 adds a fallback that reads the executable's PE icon via `ExtractIconExW`, so it also becomes the last-resort source for the window icon: with `Assets\AppIcon.ico` deleted from the output, a template app still gets a correct caption/Alt-Tab icon from `<ApplicationIcon>` alone, verified across packaged/unpackaged x Debug/Release.

Separately: if `Assets\AppIcon.ico` is ever absent, the `<ApplicationIcon>` property is correctly skipped but the build still fails on the pre-existing `<Content Include="Assets\AppIcon.ico" />` item (`APPX0702`). Making the templates fully resilient to a missing icon would mean conditioning that item too — out of scope here, but relevant if unpackaged-app support is added later, since that would exclude the `Assets` folder.