### PR TITLE
[57514396] Use central TSA config for Foundation source analysis

### DIFF
--- a/build/WindowsAppSDK-Foundation-Official.yml
+++ b/build/WindowsAppSDK-Foundation-Official.yml
@@ -96,6 +96,11 @@ resources:
       type: git
       name: ProjectReunion/WindowsAppSDKConfig
       ref: refs/heads/main
+    # Data-only alias pinned to main so source analysis always uses the centrally maintained TSA config.
+    - repository: WindowsAppSDKTsaConfig
+      type: git
+      name: ProjectReunion/WindowsAppSDKConfig
+      ref: refs/heads/main
     - repository: WindowsAppSDKVersionConfig
       type: git
       name: ProjectReunion/WindowsAppSDKConfig
@@ -122,6 +127,13 @@ extends:
       enabled: false
 
     globalSdl: # Refer the wiki for more options in this parameter: https://aka.ms/obpipelines/sdl
+      # sdl_sources reads the central TSA area path from the WindowsAppSDKTsaConfig checkout (replicated by
+      # checkout_all_repos) instead of the committed root .config/tsaoptions.json; build-job TSA is unaffected.
+      perStage:
+        sdl_sources:
+          checkout_all_repos: true
+          tsa:
+            configFile: $(Build.SourcesDirectory)\ext_repos\WindowsAppSDKTsaConfig\TSAOptions\tsaoptions.foundation.json
       tsa:
         enabled: $(TsaEnabled) # onebranch publish all sdl results to TSA. If TSA is disabled all SDL tools will forced into 'break' build mode.  Please provide TSAOptions.json.
       isNativeCode: false #TODO turn back on when bug in CheckCFlags2.exe is fixed
@@ -151,6 +163,20 @@ extends:
         break: false
 
     stages:
+
+    # Compile-time discovery only: checkout_all_repos replicates repositories named in a checkout step into the
+    # injected sdl_sources job. condition:false keeps the discovery job from executing.
+    - stage: SourceAnalysisTsaConfig
+      dependsOn: []
+      jobs:
+      - job: DiscoverTsaConfigCheckout
+        condition: false
+        pool:
+          type: windows
+          isCustom: true
+          name: 'ProjectReunionESPool-2022'
+        steps:
+        - checkout: WindowsAppSDKTsaConfig
 
     - ${{ if eq(parameters.validateRuntimeCompatibility, 'true') }}:
       - stage: ManualValidation_RuntimeCompatibility


### PR DESCRIPTION
First consumer rollout of the centrally maintained TSA configuration for Bug 57514396, following the merged central Config foundation.

**What changes**
- Foundation source analysis (the injected `sdl_sources` job) now reads its TSA config from the centrally maintained `WindowsAppSDKConfig/TSAOptions/tsaoptions.foundation.json` instead of the committed root `.config/tsaoptions.json`.
- That central file is generated from the canonical WinAppSDK TSA area-path variable, so a future area-path change is a single edit in `WindowsAppSDKConfig` rather than a change in every consumer.
- A dedicated data-only repository alias `WindowsAppSDKTsaConfig` (→ `ProjectReunion/WindowsAppSDKConfig@refs/heads/main`) is replicated into the injected `sdl_sources` job via `checkout_all_repos`. A `condition: false` discovery job exists only so the compile-time checkout scan sees that repository; it never executes.

**Scope / deliberate non-changes**
- Only the `sdl_sources` TSA **config source** changes.
- `TSAUpload` behavior is unchanged: `globalSdl.tsa.enabled` is untouched and no `perStage.sdl_sources.tsa.enabled` is introduced.
- Build-job TSA / area-path materialization is unchanged.
- Root `.config/tsaoptions.json` is deliberately retained for now.

One file changed (`build/WindowsAppSDK-Foundation-Official.yml`), 26 insertions, no deletions.

Reference: Azure DevOps Bug 57514396 (tracking item — intentionally not auto-closed by this PR).
