### PR TITLE
Remove dead PackageReferences from the C++ VSIX extension project

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -67,7 +67,6 @@
     <MicrosoftWebWebView2Version>1.0.2903.40</MicrosoftWebWebView2Version>
     <MicrosoftTelemetryInboxNativeVersion>10.0.19041.1-191206-1406.vb-release.x86fre</MicrosoftTelemetryInboxNativeVersion>
     <MicrosoftWindowsAppSDKProtobufVersion>3.21.12</MicrosoftWindowsAppSDKProtobufVersion>
-    <MicrosoftWindowsAppSDKVersion>1.6.250408002</MicrosoftWindowsAppSDKVersion>
   </PropertyGroup>
 
   <!-- ═══════════════════════════════════════════════════════════════════════
@@ -123,10 +122,5 @@
     <PackageVersion Include="NuGet.VisualStudio.Contracts" Version="17.14.0" />
     <PackageVersion Include="System.Net.Http" Version="4.3.4" />
     <PackageVersion Include="System.Text.Json" Version="8.0.5" />
-  </ItemGroup>
-
-  <!-- Self-reference for compat tests -->
-  <ItemGroup Label="Self-Reference">
-    <PackageVersion Include="Microsoft.WindowsAppSDK" Version="$(MicrosoftWindowsAppSDKVersion)" />
   </ItemGroup>
 </Project>

--- a/dev/Templates/VSIX/Extension/Cpp/Dev17/WindowsAppSDK.Cpp.Extension.Dev17.csproj
+++ b/dev/Templates/VSIX/Extension/Cpp/Dev17/WindowsAppSDK.Cpp.Extension.Dev17.csproj
@@ -67,18 +67,6 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.Windows.CppWinRT" GeneratePathProperty="true">
-      <ExcludeAssets>All</ExcludeAssets>
-    </PackageReference>
-    <PackageReference Include="Microsoft.WindowsAppSDK" GeneratePathProperty="true">
-      <ExcludeAssets>All</ExcludeAssets>
-    </PackageReference>
-    <PackageReference Include="Microsoft.Windows.SDK.BuildTools" GeneratePathProperty="true">
-      <ExcludeAssets>All</ExcludeAssets>
-    </PackageReference>
-    <PackageReference Include="Microsoft.Windows.ImplementationLibrary" GeneratePathProperty="true">
-      <ExcludeAssets>All</ExcludeAssets>
-    </PackageReference>
   </ItemGroup>
   <ItemGroup>
     <ExtensionDependencies Condition=" '$(ExcludeRestorePackageImports)' != 'true' " Include="$(PkgNuget_VisualStudio)\**\NuGet.VisualStudio.dll" />


### PR DESCRIPTION
Removes four `PackageReference` entries from the C++ Dev17 VSIX extension project that produce nothing, and the CPM entries that only existed to version one of them.

## What is dead about them

All four were declared as:

```xml
<PackageReference Include="..." GeneratePathProperty="true">
  <ExcludeAssets>All</ExcludeAssets>
</PackageReference>
```

`ExcludeAssets=All` flows no compile, runtime, build, native, contentfiles or analyzer assets. The only thing such a reference can contribute is the `$(Pkg<Id>)` path property that `GeneratePathProperty="true"` creates. None of the four properties is referenced anywhere in the repository:

| Path property | Uses (case-insensitive, repo-wide) |
|---|---|
| `PkgMicrosoft_WindowsAppSDK` | 0 |
| `PkgMicrosoft_Windows_CppWinRT` | 0 |
| `PkgMicrosoft_Windows_SDK_BuildTools` | 0 |
| `PkgMicrosoft_Windows_ImplementationLibrary` | 0 |

For contrast, the one path property this project *does* use is `PkgNuget_VisualStudio`, consumed two lines below by the `ExtensionDependencies` item that pulls `NuGet.VisualStudio.dll` into the VSIX. That reference is untouched.

So the four cost a package download on every build and contribute nothing to the produced `.vsix`.

## Why the WindowsAppSDK one matters more than the others

It is a self-reference, and it was pinned to the public **1.6.250408002** metapackage — an April 2025 release. It was declared in `Directory.Packages.props` under **"External Package Versions"**, next to WebView2 and TAEF, as a bare literal:

```xml
<MicrosoftWindowsAppSDKVersion>1.6.250408002</MicrosoftWindowsAppSDKVersion>
```

Note it was *not* in the `IsInternal="true"` "WindowsAppSDK Packages" group and *not* expressed via the `$([MSBuild]::ValueOrDefault('$(WindowsAppSDKVersionPinned)', ...))` pattern the internal packages use. Nothing could ever update it, by construction.

The visible symptom: the Windows App SDK mono-build's `CreateVSIX` stage downloads a 1.6 metapackage on every run while building 2.x bits —

```
Installed Microsoft.WindowsAppSDK 1.6.250408002 from https://microsoft.pkgs.visualstudio.com/ProjectReunion/...
```

Nothing consumed it, so no 1.6 content ever entered the shipping `.vsix`, but it is confusing to anyone auditing where package versions come from, and it is a stale public dependency recorded against a shipping component.

Removing the reference orphans its CPM entries, so this also drops the `Self-Reference` `ItemGroup` and the `MicrosoftWindowsAppSDKVersion` property.

## Deliberately not touched

- **`MicrosoftWindowsAppSDKVersionPackageVersion`** (`1.8.0`, line 32). Confusingly similar name, completely different purpose — `BuildAll.ps1` reads it for pipeline version metadata. Left alone.
- **`test/ABForward`** and **`test/TestApps/StoragePickersTestApp`**. These pin `1.6.250408002` through `packages.config`, which does not resolve through Central Package Management, so the compat-test self-reference the deleted `ItemGroup` comment referred to is unaffected by this change.
- **`dev/Templates/Source/ProjectTemplates/**/ProjectTemplate.csproj`**. Template payload, versioned by the `$WindowsAppSdkVersion$` token that gets substituted at template instantiation. Never restored by this build — they carry an explicit `Version=`, which would be an NU1008 error under CPM if they were.
- **The same dead `Microsoft.Windows.SDK.BuildTools` pattern in the sibling `WindowsAppSDK.Cs.Extension.Dev17.csproj`.** Same analysis applies, but it is not part of the issue that prompted this, so it is left for a separate change.

## Validation

Windows App SDK mono-build nightly (def 190463), `CreateVSIX` stage only, with the Foundation repo resource overridden to this branch and everything else reused from a known-good full run:

- `useBuildOutput_RebuildStage=CreateVSIX`, `useBuildOutput_BuildId=156949558`
- `resources.repositories.WindowsAppSDKFoundation.refName` = this branch, resolved at `5027d617`

Build: https://dev.azure.com/microsoft/OS/_build/results?buildId=157025355&view=results

Checking that restore still succeeds without the four references, all four `.vsix` files still build and sign, and `1.6.250408002` no longer appears in the logs. Result posted below.
