### PR TITLE
Migrate dotnet template pipelines to OneBranch

### DIFF
--- a/build/AzurePipelinesTemplates/WindowsAppSDK-DotnetNewTemplates-Publish-Stage.yml
+++ b/build/AzurePipelinesTemplates/WindowsAppSDK-DotnetNewTemplates-Publish-Stage.yml
@@ -2,10 +2,16 @@ parameters:
 - name: pool
   type: object
   default:
-    vmImage: 'windows-latest'
+    type: windows
 - name: dependsOnStage
   type: string
   default: 'DotnetNewTemplates_Build'
+- name: buildPipelineId
+  type: number
+- name: buildRunId
+  type: number
+- name: artifactName
+  type: string
 
 stages:
 - stage: DotnetNewTemplates_Publish
@@ -17,15 +23,22 @@ stages:
     displayName: 'Publish dotnet new template pack to NuGet.org'
     pool: ${{ parameters.pool }}
     variables:
-      ob_outputDirectory: '$(Pipeline.Workspace)\drop_DotnetNewTemplates_Build_PackDotnetNewTemplates'
+      ob_outputDirectory: '$(Pipeline.Workspace)\BuildArtifact'
       ob_artifactBaseName: 'dotnet-new-template-pack'
-      dotnetTemplatesArtifactPath: '$(Pipeline.Workspace)\drop_DotnetNewTemplates_Build_PackDotnetNewTemplates'
+      dotnetTemplatesArtifactPath: '$(Pipeline.Workspace)\BuildArtifact'
     steps:
     - checkout: self
 
-    - download: current
+    - task: DownloadPipelineArtifact@2
       displayName: 'Download dotnet new template pack artifact'
-      artifact: 'drop_DotnetNewTemplates_Build_PackDotnetNewTemplates'
+      inputs:
+        source: 'specific'
+        project: '$(System.TeamProjectId)'
+        pipeline: ${{ parameters.buildPipelineId }}
+        runVersion: 'specific'
+        runId: ${{ parameters.buildRunId }}
+        artifact: '${{ parameters.artifactName }}'
+        targetPath: '$(dotnetTemplatesArtifactPath)'
 
     - task: PowerShell@2
       displayName: 'Verify dotnet new template pack artifact exists'
@@ -47,7 +60,7 @@ stages:
       displayName: 'Publish dotnet new templates to NuGet.org'
       inputs:
         command: 'push'
-        packagesToPush: '$(dotnetTemplatesArtifactPath)\*.nupkg'
+        packagesToPush: '$(dotnetTemplatesArtifactPath)\**\*.nupkg'
         verbosityPush: 'Detailed'
         nuGetFeedType: 'external'
         publishFeedCredentials: 'NugetOrg'

--- a/build/WindowsAppSDK-DotnetNewTemplates-Publish.yml
+++ b/build/WindowsAppSDK-DotnetNewTemplates-Publish.yml
@@ -1,9 +1,17 @@
-# Copyright (c) Microsoft Corporation.
-# Licensed under the MIT License.
-#
-# Standalone (non-OneBranch) pipeline for publishing dotnet new templates to NuGet.org.
-# This pipeline is separate from the OneBranch build pipeline because OneBranch agents
-# block outbound internet access, which prevents pushing packages to NuGet.org.
+#####################################################################################################################################
+#                                               OneBranch Pipelines - Official                                                      #
+#####################################################################################################################################
+#                                                                                                                                   #
+# This pipeline was created by EasyStart from a sample located at:                                                                  #
+#                               https://aka.ms/obpipelines/easystart/samples                                                        #
+#                                                                                                                                   #
+# Windows Undocked Wiki:        https://www.osgwiki.com/wiki/Windows_Undocked_Template                                              #
+# General OB Documentation:     https://aka.ms/obpipelines                                                                          #
+# Yaml Schema:                  https://aka.ms/obpipelines/yaml/schema                                                              #
+# Retail Tasks:                 https://aka.ms/obpipelines/tasks                                                                    #
+# Support:                      https://aka.ms/onebranchsup                                                                         #
+#                                                                                                                                   #
+#####################################################################################################################################
 #
 # Usage:
 #   1. Run the OneBranch build pipeline (WindowsAppSDK-DotnetNewTemplates.yml) first.
@@ -26,75 +34,88 @@ parameters:
   default: 'drop_DotnetNewTemplates_Build_PackDotnetNewTemplates'
 
 variables:
+- template: AzurePipelinesTemplates\WindowsAppSDK-TSAVariables.yml@WindowsAppSDKConfig
 - template: WindowsAppSDK-CommonVariables.yml
 
-pool:
-  vmImage: 'windows-latest'
+resources:
+  repositories:
+    - repository: templates
+      type: git
+      name: OneBranch.Pipelines/GovernedTemplates
+      ref: refs/heads/main
+    - repository: WindowsAppSDKConfig
+      type: git
+      name: ProjectReunion/WindowsAppSDKConfig
+      ref: refs/heads/main
 
-stages:
-- stage: DotnetNewTemplates_Approval
-  displayName: 'Approve NuGet.org publish'
-  jobs:
-  - job: WaitForPublishApproval
-    displayName: 'Manual Approval'
-    pool: server
-    timeoutInMinutes: 1440
-    steps:
-    - task: ManualValidation@0
-      displayName: 'Verify artifacts before NuGet.org publish'
-      timeoutInMinutes: 1440
-      inputs:
-        notifyUsers: ''
-        instructions: |
-          Please verify the .nupkg in the ${{ parameters.ArtifactName }} folder before continuing the publish to NuGet.org:
-          https://dev.azure.com/microsoft/ProjectReunion/_build/results?buildId=${{ parameters.BuildRunId }}&view=artifacts&pathAsName=false&type=publishedArtifacts
+extends:
+  template: v2/Microsoft.Official.yml@templates # https://aka.ms/obpipelines/templates
+  parameters:
+    featureFlags:
+      EnableCDPxPAT: false
+      WindowsHostVersion:
+        Version: 2022
+        Network: R1
 
-- stage: DotnetNewTemplates_Publish
-  displayName: 'Publish dotnet new templates to NuGet.org'
-  dependsOn:
-  - DotnetNewTemplates_Approval
-  jobs:
-  - job: PublishNuGetOrg
-    displayName: 'Publish dotnet new template pack to NuGet.org'
-    pool:
-      vmImage: 'windows-latest'
-    variables:
-      dotnetTemplatesArtifactPath: '$(Pipeline.Workspace)\BuildArtifact'
-    steps:
-    - checkout: none
+    platform:
+      name: 'windows_undocked'
 
-    - task: DownloadPipelineArtifact@2
-      displayName: 'Download dotnet new template pack artifact'
-      inputs:
-        source: 'specific'
-        project: '$(System.TeamProjectId)'
-        pipeline: ${{ parameters.BuildPipelineId }}
-        runVersion: 'specific'
-        runId: ${{ parameters.BuildRunId }}
-        artifact: '${{ parameters.ArtifactName }}'
-        targetPath: '$(dotnetTemplatesArtifactPath)'
+    cloudvault:
+      enabled: false
 
-    - task: PowerShell@2
-      displayName: 'Verify dotnet new template pack artifact exists'
-      inputs:
-        targetType: inline
-        script: |
-          $artifactPath = '$(dotnetTemplatesArtifactPath)'
-          if (-not (Test-Path $artifactPath)) {
-            throw "Expected artifact directory '$artifactPath' was not found."
-          }
-          $packages = Get-ChildItem -Path $artifactPath -Filter *.nupkg -File -Recurse
-          if (-not $packages) {
-            throw "No .nupkg files were found under '$artifactPath'."
-          }
-          Write-Host "Found the following packages ready for publish:"
-          $packages | ForEach-Object { Write-Host " - $($_.FullName)" }
+    globalSdl:
+      tsa:
+        enabled: $(TsaEnabled)
+      isNativeCode: false
+      suppression:
+        suppressionFile: $(Build.SourcesDirectory)\.gdn\OneBranch.gdnsuppress
+      asyncSdl:
+        enabled: false
+      psscriptanalyzer:
+        enable: true
+        break: true
+      tsandjs:
+        enabled: true
+        break: true
+      python:
+        enabled: true
+        break: true
+      credscan:
+        enable: true
+        break: true
+      policheck:
+        enable: true
+        break: true
+      binskim:
+        enabled: false
+      prefast:
+        enabled: false
+      apiscan:
+        enabled: false
 
-    - task: 333b11bd-d341-40d9-afcf-b32d5ce6f23b@2
-      displayName: 'Publish dotnet new templates to NuGet.org'
-      inputs:
-        command: 'push'
-        packagesToPush: '$(dotnetTemplatesArtifactPath)\*.nupkg'
-        verbosityPush: 'Detailed'
-        nuGetFeedType: 'external'
-        publishFeedCredentials: 'NugetOrg'
+    stages:
+    - stage: DotnetNewTemplates_Approval
+      displayName: 'Approve NuGet.org publish'
+      jobs:
+      - job: WaitForPublishApproval
+        displayName: 'Manual Approval'
+        pool: server
+        timeoutInMinutes: 1440
+        steps:
+        - task: ManualValidation@0
+          displayName: 'Verify artifacts before NuGet.org publish'
+          timeoutInMinutes: 1440
+          inputs:
+            notifyUsers: ''
+            instructions: |
+              Please verify the .nupkg in the ${{ parameters.ArtifactName }} folder before continuing the publish to NuGet.org:
+              https://dev.azure.com/microsoft/ProjectReunion/_build/results?buildId=${{ parameters.BuildRunId }}&view=artifacts&pathAsName=false&type=publishedArtifacts
+
+    - template: AzurePipelinesTemplates\WindowsAppSDK-DotnetNewTemplates-Publish-Stage.yml@self
+      parameters:
+        pool:
+          type: windows
+        dependsOnStage: 'DotnetNewTemplates_Approval'
+        buildPipelineId: ${{ parameters.BuildPipelineId }}
+        buildRunId: ${{ parameters.BuildRunId }}
+        artifactName: ${{ parameters.ArtifactName }}

--- a/build/WindowsAppSDK-DotnetNewTemplates.yml
+++ b/build/WindowsAppSDK-DotnetNewTemplates.yml
@@ -118,7 +118,5 @@ extends:
           type: windows
         dependsOnStage: 'DotnetNewTemplates_Build'
 
-    # NuGet.org publishing is handled by the separate non-OneBranch pipeline:
+    # NuGet.org publishing is handled by the separate OneBranch pipeline:
     # WindowsAppSDK-DotnetNewTemplates-Publish.yml
-    # OneBranch agents block outbound internet, so a standalone pipeline with
-    # standard Azure-hosted agents is used for the NuGet.org push.


### PR DESCRIPTION
Updating the WinUI template pipelines on OneBranch template.

Co-authored by Copilot on Azure DevOps.