### PR TITLE
Fix missing-resource VersionInfo behavior on 2.0 stable

### DIFF
--- a/dev/Common/WindowsAppRuntime.SelfContained.cpp
+++ b/dev/Common/WindowsAppRuntime.SelfContained.cpp
@@ -13,15 +13,25 @@ STDAPI WindowsAppRuntime_IsSelfContained(
 {
     *isSelfContained = FALSE;
 
+    PCWSTR frameworkPackageFamilyName{};
+    const auto getFrameworkPackageFamilyNameResult{
+        WindowsAppRuntime_VersionInfo_MSIX_Framework_PackageFamilyName_Get(&frameworkPackageFamilyName) };
+    if (getFrameworkPackageFamilyNameResult == HRESULT_FROM_WIN32(ERROR_MOD_NOT_FOUND))
+    {
+        // The aggregate runtime resource is not deployed with component-only self-contained apps.
+        *isSelfContained = TRUE;
+        return S_OK;
+    }
+    RETURN_IF_FAILED(getFrameworkPackageFamilyNameResult);
+
     const UINT32 flags{ PACKAGE_FILTER_HEAD | PACKAGE_FILTER_DIRECT | PACKAGE_FILTER_STATIC | PACKAGE_FILTER_DYNAMIC | PACKAGE_INFORMATION_BASIC };
     uint32_t packageInfoCount{};
     const PACKAGE_INFO* packageInfo{};
     wil::unique_cotaskmem_ptr<BYTE[]> buffer;
     RETURN_IF_FAILED(::AppModel::PackageGraph::GetCurrentPackageGraph(flags, packageInfoCount, packageInfo, buffer));
-    const auto frameworkPackageFamilyName{ ::WindowsAppRuntime::VersionInfo::Framework::GetPackageFamilyName() };
     for (uint32_t index=0; index < packageInfoCount; ++index)
     {
-        if (CompareStringOrdinal(packageInfo[index].packageFamilyName, -1, frameworkPackageFamilyName.c_str(), -1, TRUE) == CSTR_EQUAL)
+        if (CompareStringOrdinal(packageInfo[index].packageFamilyName, -1, frameworkPackageFamilyName, -1, TRUE) == CSTR_EQUAL)
         {
             // Found the Windows App SDK framework package in the package graph. Not self-contained!
             return S_OK;

--- a/dev/Common/WindowsAppRuntime.VersionInfo.cpp
+++ b/dev/Common/WindowsAppRuntime.VersionInfo.cpp
@@ -53,7 +53,11 @@ public:
     {
         if (!g_versionInfo)
         {
-            static wil::unique_hmodule module{ LoadResourceModule() };
+            static wil::unique_hmodule module{ LoadResourceModule(false) };
+            if (!module)
+            {
+                return nullptr;
+            }
 
             auto getVersionInfo{ GetProcAddressByFunctionDeclaration(module.get(), WindowsAppRuntime_GetVersionInfo) };
             THROW_LAST_ERROR_IF_NULL(getVersionInfo);
@@ -72,7 +76,7 @@ private:
 
     static std::string LoadStringAFromResource(uint32_t id)
     {
-        static wil::unique_hmodule module{ LoadResourceModule() };
+        static wil::unique_hmodule module{ LoadResourceModule(true) };
 
         const uint32_t c_ResourceMaxLength{ 1024 };
         char resourceValue[c_ResourceMaxLength]{};
@@ -81,11 +85,19 @@ private:
         return resourceValue;
     }
 
-    static wil::unique_hmodule LoadResourceModule()
+    static wil::unique_hmodule LoadResourceModule(bool required)
     {
         const PCWSTR c_resourceDllName{ L"Microsoft.WindowsAppRuntime.Insights.Resource.dll" };
         wil::unique_hmodule resourceDllHandle(::LoadLibraryW(c_resourceDllName));
-        THROW_LAST_ERROR_IF_NULL_MSG(resourceDllHandle, "Unable to load resource dll. %ls", c_resourceDllName);
+        if (!resourceDllHandle)
+        {
+            const auto lastError{ ::GetLastError() };
+            if (!required && (lastError == ERROR_MOD_NOT_FOUND))
+            {
+                return {};
+            }
+            THROW_HR_MSG(HRESULT_FROM_WIN32(lastError), "Unable to load resource dll. %ls", c_resourceDllName);
+        }
         return resourceDllHandle;
     }
 };

--- a/dev/VersionInfo/VersionInfo.ReleaseInfo.cpp
+++ b/dev/VersionInfo/VersionInfo.ReleaseInfo.cpp
@@ -25,7 +25,8 @@ namespace winrt::Microsoft::Windows::ApplicationModel::WindowsAppRuntime::implem
     }
     hstring ReleaseInfo::VersionTag()
     {
-        return GetVersionInfo().Release.VersionTag;
+        PCWSTR versionTag{ GetVersionInfo().Release.VersionTag };
+        return versionTag ? winrt::hstring{ versionTag } : winrt::hstring{};
     }
     hstring ReleaseInfo::AsString()
     {

--- a/dev/VersionInfo/VersionInfo.idl
+++ b/dev/VersionInfo/VersionInfo.idl
@@ -10,19 +10,19 @@ namespace Microsoft.Windows.ApplicationModel.WindowsAppRuntime
     [contract(VersionInfoContract, 1)]
     static runtimeclass ReleaseInfo
     {
-        /// The major version of the Windows App SDK release.
+        /// The major version of the Windows App SDK release, or 0 if runtime version information is unavailable.
         static UInt16 Major{ get; };
 
-        /// The minor version of the Windows App SDK release.
+        /// The minor version of the Windows App SDK release, or 0 if runtime version information is unavailable.
         static UInt16 Minor{ get; };
 
-        /// The patch version of the Windows App SDK release.
+        /// The patch version of the Windows App SDK release, or 0 if runtime version information is unavailable.
         static UInt16 Patch{ get; };
 
-        /// The Windows App SDK release's version tag; for example, "preview2", or empty string for stable.
+        /// The Windows App SDK release's version tag; for example, "preview2", or empty if stable or runtime version information is unavailable.
         static String VersionTag{ get; };
 
-        /// The version of the Windows App SDK runtime; for example, "1.1-preview2" or "1.2.3".
+        /// The version of the Windows App SDK runtime; for example, "1.1-preview2" or "1.2.3", or "0.0.0" if runtime version information is unavailable.
         static String AsString{ get; };
     };
 
@@ -30,10 +30,10 @@ namespace Microsoft.Windows.ApplicationModel.WindowsAppRuntime
     [contract(VersionInfoContract, 1)]
     static runtimeclass RuntimeInfo
     {
-        /// The version of the Windows App SDK runtime; for example, { Major=1000, Minor=446, Build=804, Revision=0 }
+        /// The version of the Windows App SDK runtime; for example, { Major=1000, Minor=446, Build=804, Revision=0 }, or all zeros if runtime version information is unavailable.
         static Windows.ApplicationModel.PackageVersion Version{ get; };
 
-        /// The version of the Windows App SDK runtime; for example, "1000.446.804.0"
+        /// The version of the Windows App SDK runtime; for example, "1000.446.804.0", or empty if runtime version information is unavailable.
         static String AsString{ get; };
     };
 }

--- a/specs/VersionInfo/VersionInfo.md
+++ b/specs/VersionInfo/VersionInfo.md
@@ -110,6 +110,12 @@ Version information is compiled into `Microsoft.WindowsAppRuntime.Insights.Resou
 product is assembled (i.e. when the version is defined). The VersionInfo API retrieves this
 information via an internal API.
 
+This resource DLL is distributed by the Windows App SDK Runtime package because it describes the
+version of the assembled runtime, not the version of an individual component. If an application
+uses component packages without the Runtime package, runtime version information is unavailable.
+In that case numeric properties return zero, `RuntimeInfo.AsString` and `ReleaseInfo.VersionTag`
+return an empty string, and `ReleaseInfo.AsString` returns `0.0.0`.
+
 # 6. API Details
 
 ```c# (but really MIDL3)

--- a/test/VersionInfo/VersionInfoTests.cpp
+++ b/test/VersionInfo/VersionInfoTests.cpp
@@ -3,6 +3,10 @@
 
 #include "pch.h"
 
+#include <MddWin11.h>
+#include <WindowsAppRuntime.SelfContained.h>
+#include <WindowsAppRuntime.VersionInfo.h>
+
 namespace TB = ::Test::Bootstrap;
 namespace TP = ::Test::Packages;
 
@@ -30,28 +34,47 @@ namespace Test::VersionInfo
 
         TEST_METHOD(VersionInfo_Release)
         {
-            try
-            {
-                auto release{ winrt::Microsoft::Windows::ApplicationModel::WindowsAppRuntime::ReleaseInfo::AsString() };
-                VERIFY_FAIL(L"Success is not expected without Microsoft.WindowsAppRuntime.Insights.Resource.dll");
-            }
-            catch (winrt::hresult_error& e)
-            {
-                VERIFY_ARE_EQUAL(HRESULT_FROM_WIN32(ERROR_MOD_NOT_FOUND), e.code());
-            }
+            using ReleaseInfo = winrt::Microsoft::Windows::ApplicationModel::WindowsAppRuntime::ReleaseInfo;
+
+            VERIFY_ARE_EQUAL(uint16_t{}, ReleaseInfo::Major());
+            VERIFY_ARE_EQUAL(uint16_t{}, ReleaseInfo::Minor());
+            VERIFY_ARE_EQUAL(uint16_t{}, ReleaseInfo::Patch());
+            VERIFY_IS_TRUE(ReleaseInfo::VersionTag().empty());
+            VERIFY_ARE_EQUAL(L"0.0.0", ReleaseInfo::AsString());
         }
 
         TEST_METHOD(VersionInfo_Runtime)
         {
-            try
-            {
-                auto runtime{ winrt::Microsoft::Windows::ApplicationModel::WindowsAppRuntime::RuntimeInfo::AsString() };
-                VERIFY_FAIL(L"Success is not expected without Microsoft.WindowsAppRuntime.Insights.Resource.dll");
-            }
-            catch (winrt::hresult_error& e)
-            {
-                VERIFY_ARE_EQUAL(HRESULT_FROM_WIN32(ERROR_MOD_NOT_FOUND), e.code());
-            }
+            using RuntimeInfo = winrt::Microsoft::Windows::ApplicationModel::WindowsAppRuntime::RuntimeInfo;
+
+            const auto version{ RuntimeInfo::Version() };
+            VERIFY_ARE_EQUAL(uint16_t{}, version.Major);
+            VERIFY_ARE_EQUAL(uint16_t{}, version.Minor);
+            VERIFY_ARE_EQUAL(uint16_t{}, version.Build);
+            VERIFY_ARE_EQUAL(uint16_t{}, version.Revision);
+            VERIFY_IS_TRUE(RuntimeInfo::AsString().empty());
+        }
+
+        TEST_METHOD(VersionInfo_SelfContained)
+        {
+            // Bootstrap injects the framework package family name, bypassing the resource lookup.
+            // Clear it to exercise component-only deployment, then restore it for fixture cleanup.
+            auto restoreTestInitialization{ wil::scope_exit([] {
+                if (MddCore::Win11::IsSupported())
+                {
+                    ::WindowsAppRuntime::VersionInfo::TestInitialize(
+                        TP::WindowsAppRuntimeFramework::c_PackageFamilyName);
+                }
+                else
+                {
+                    ::WindowsAppRuntime::VersionInfo::TestInitialize(
+                        TP::WindowsAppRuntimeFramework::c_PackageFamilyName,
+                        TP::WindowsAppRuntimeMain::c_PackageFamilyName);
+                }
+            }) };
+
+            ::WindowsAppRuntime::VersionInfo::TestShutdown();
+            VERIFY_IS_TRUE(::WindowsAppRuntime::SelfContained::IsSelfContained());
         }
     };
 }

--- a/test/VersionInfo/VersionInfoTests.vcxproj
+++ b/test/VersionInfo/VersionInfoTests.vcxproj
@@ -85,6 +85,7 @@
       <AdditionalDependencies>onecore.lib;onecoreuap.lib;Microsoft.WindowsAppRuntime.lib;wex.common.lib;wex.logger.lib;te.common.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <AdditionalLibraryDirectories>$(VCInstallDir)UnitTest\lib;%(AdditionalLibraryDirectories);$(OutDir)\..\WindowsAppRuntime_DLL</AdditionalLibraryDirectories>
       <DelayLoadDLLs>Microsoft.WindowsAppRuntime.Bootstrap.dll;%(DelayLoadDLLs)</DelayLoadDLLs>
+      <DelayLoadDLLs>Microsoft.WindowsAppRuntime.dll;%(DelayLoadDLLs)</DelayLoadDLLs>
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)'=='Release'">


### PR DESCRIPTION
Ports the merged fix from #6737 to the Foundation 2.0-stable feeder branch.

This makes ReleaseInfo, RuntimeInfo, and self-contained detection resilient when Microsoft.WindowsAppRuntime.Insights.Resource.dll is unavailable to component-only self-contained applications. The patch is identical to the merged source change and is required before the paired WinAppSDK monorepo Runtime-package correction can land on release/dev/monobuild-2.0-stable.

Paired monorepo PR: https://dev.azure.com/microsoft/OS/_git/WinAppSDK/pullrequest/16785860
Focused aggregate validation: https://dev.azure.com/microsoft/OS/_build/results?buildId=157300060